### PR TITLE
[ROCKETMQ-141]Make producer client connect to new-joined brokers eagerly

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -32,7 +32,7 @@ public class ClientConfig {
     /**
      * Pulling topic information interval from the named server
      */
-    private int pollNameServerInteval = 1000 * 30;
+    private int pollNameServerInterval = 1000 * 30;
     /**
      * Heartbeat interval in microseconds with message broker
      */
@@ -86,7 +86,7 @@ public class ClientConfig {
         this.clientIP = cc.clientIP;
         this.instanceName = cc.instanceName;
         this.clientCallbackExecutorThreads = cc.clientCallbackExecutorThreads;
-        this.pollNameServerInteval = cc.pollNameServerInteval;
+        this.pollNameServerInterval = cc.pollNameServerInterval;
         this.heartbeatBrokerInterval = cc.heartbeatBrokerInterval;
         this.persistConsumerOffsetInterval = cc.persistConsumerOffsetInterval;
         this.unitMode = cc.unitMode;
@@ -100,7 +100,7 @@ public class ClientConfig {
         cc.clientIP = clientIP;
         cc.instanceName = instanceName;
         cc.clientCallbackExecutorThreads = clientCallbackExecutorThreads;
-        cc.pollNameServerInteval = pollNameServerInteval;
+        cc.pollNameServerInterval = pollNameServerInterval;
         cc.heartbeatBrokerInterval = heartbeatBrokerInterval;
         cc.persistConsumerOffsetInterval = persistConsumerOffsetInterval;
         cc.unitMode = unitMode;
@@ -125,12 +125,12 @@ public class ClientConfig {
         this.clientCallbackExecutorThreads = clientCallbackExecutorThreads;
     }
 
-    public int getPollNameServerInteval() {
-        return pollNameServerInteval;
+    public int getPollNameServerInterval() {
+        return pollNameServerInterval;
     }
 
-    public void setPollNameServerInteval(int pollNameServerInteval) {
-        this.pollNameServerInteval = pollNameServerInteval;
+    public void setPollNameServerInterval(int pollNameServerInterval) {
+        this.pollNameServerInterval = pollNameServerInterval;
     }
 
     public int getHeartbeatBrokerInterval() {
@@ -176,7 +176,7 @@ public class ClientConfig {
     @Override
     public String toString() {
         return "ClientConfig [namesrvAddr=" + namesrvAddr + ", clientIP=" + clientIP + ", instanceName=" + instanceName
-            + ", clientCallbackExecutorThreads=" + clientCallbackExecutorThreads + ", pollNameServerInteval=" + pollNameServerInteval
+            + ", clientCallbackExecutorThreads=" + clientCallbackExecutorThreads + ", pollNameServerInterval=" + pollNameServerInterval
             + ", heartbeatBrokerInterval=" + heartbeatBrokerInterval + ", persistConsumerOffsetInterval="
             + persistConsumerOffsetInterval + ", unitMode=" + unitMode + ", unitName=" + unitName + ", vipChannelEnabled="
             + vipChannelEnabled + "]";

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -329,7 +329,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         if (info != null && topic != null) {
             TopicPublishInfo prev = this.topicPublishInfoTable.put(topic, info);
             if (prev != null) {
-                log.info("updateTopicPublishInfo prev is not null, " + prev.toString());
+                log.info("#updateTopicPublishInfo for topic: {}, previous topicPublishInfo is: {}", topic, prev);
             }
         }
     }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/RemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/RemotingClient.java
@@ -27,24 +27,26 @@ import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 
 public interface RemotingClient extends RemotingService {
 
-    public void updateNameServerAddressList(final List<String> addrs);
+    void updateNameServerAddressList(final List<String> addrs);
 
-    public List<String> getNameServerAddressList();
+    List<String> getNameServerAddressList();
 
-    public RemotingCommand invokeSync(final String addr, final RemotingCommand request,
+    RemotingCommand invokeSync(final String addr, final RemotingCommand request,
         final long timeoutMillis) throws InterruptedException, RemotingConnectException,
         RemotingSendRequestException, RemotingTimeoutException;
 
-    public void invokeAsync(final String addr, final RemotingCommand request, final long timeoutMillis,
+    void invokeAsync(final String addr, final RemotingCommand request, final long timeoutMillis,
         final InvokeCallback invokeCallback) throws InterruptedException, RemotingConnectException,
         RemotingTooMuchRequestException, RemotingTimeoutException, RemotingSendRequestException;
 
-    public void invokeOneway(final String addr, final RemotingCommand request, final long timeoutMillis)
+    void invokeOneway(final String addr, final RemotingCommand request, final long timeoutMillis)
         throws InterruptedException, RemotingConnectException, RemotingTooMuchRequestException,
         RemotingTimeoutException, RemotingSendRequestException;
 
-    public void registerProcessor(final int requestCode, final NettyRequestProcessor processor,
+    void registerProcessor(final int requestCode, final NettyRequestProcessor processor,
         final ExecutorService executor);
 
-    public boolean isChannelWriteable(final String addr);
+    boolean isChannelWritable(final String addr);
+
+    boolean connect(final String address);
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -527,12 +527,24 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
     }
 
     @Override
-    public boolean isChannelWriteable(String addr) {
+    public boolean isChannelWritable(String addr) {
         ChannelWrapper cw = this.channelTables.get(addr);
         if (cw != null && cw.isOK()) {
             return cw.isWriteable();
         }
         return true;
+    }
+
+    @Override
+    public boolean connect(String address) {
+        try {
+            Channel channel = getAndCreateChannel(address);
+            if (null != channel) {
+                return true;
+            }
+        } catch (InterruptedException ignore) {
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
When new brokers joins the cluster, MQ producer clients polls name server and add the new-joined brokers to topicPublishInfo in case the new-joined broker bears the topic. Later on, the producers may send messages to the new-joined brokers.
This achieves part of scalable goals and works fine for most cases. However, we ran an issue in this process. The problem is when new broker joins the cluster, the producer clients blocks for quite a while even if when asynchronous send method is employed, which is very miserable for latency sensitive scenarios.
After analyzing the root cause, it turns out that producer clients need to establish a connection to the new-joined brokers the first time it sends a message, as is blocking.
This issue is to establish a connection to new-joined brokers immediately after polling name server and make them available to send methods thereafter. Thus, when send is called against new-joined brokers, there is a writable channel readily available.