### PR TITLE
[ROCKETMQ-255] Fix offsetStore being null after consumers start()

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPullConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPullConsumerImpl.java
@@ -569,6 +569,7 @@ public class DefaultMQPullConsumerImpl implements MQConsumerInner {
                         default:
                             break;
                     }
+                    this.defaultMQPullConsumer.setOffsetStore(this.offsetStore);
                 }
 
                 this.offsetStore.load();

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPushConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPushConsumerImpl.java
@@ -577,6 +577,7 @@ public class DefaultMQPushConsumerImpl implements MQConsumerInner {
                         default:
                             break;
                     }
+                    this.defaultMQPushConsumer.setOffsetStore(this.offsetStore);
                 }
                 this.offsetStore.load();
 

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumerTest.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.protocol.header.PullMessageRequestHeader;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,6 +82,11 @@ public class DefaultMQPullConsumerTest {
     @After
     public void terminate() {
         pullConsumer.shutdown();
+    }
+
+    @Test
+    public void testOffsetShouldNotNUllAfterStart() {
+        Assert.assertNotNull(pullConsumer.getOffsetStore());
     }
 
     @Test

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumerTest.java
@@ -85,7 +85,7 @@ public class DefaultMQPullConsumerTest {
     }
 
     @Test
-    public void testOffsetShouldNotNUllAfterStart() {
+    public void testStart_OffsetShouldNotNUllAfterStart() {
         Assert.assertNotNull(pullConsumer.getOffsetStore());
     }
 

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumerTest.java
@@ -156,7 +156,7 @@ public class DefaultMQPushConsumerTest {
     }
 
     @Test
-    public void testOffsetShouldNotNUllAfterStart() {
+    public void testStart_OffsetShouldNotNUllAfterStart() {
         Assert.assertNotNull(pushConsumer.getOffsetStore());
     }
 

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumerTest.java
@@ -52,6 +52,7 @@ import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.protocol.header.PullMessageRequestHeader;
 import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -152,6 +153,11 @@ public class DefaultMQPushConsumerTest {
     @After
     public void terminate() {
         pushConsumer.shutdown();
+    }
+
+    @Test
+    public void testOffsetShouldNotNUllAfterStart() {
+        Assert.assertNotNull(pushConsumer.getOffsetStore());
     }
 
     @Test


### PR DESCRIPTION
Associated JIRA ticket is: https://issues.apache.org/jira/browse/ROCKETMQ-255
