### PR TITLE
[ROCKETMQ-272] Fix sync slave timeout when using SYNC_MASTER

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -667,7 +667,7 @@ public class CommitLog {
                     service.putRequest(request);
                     service.getWaitNotifyObject().wakeupAll();
                     boolean flushOK =
-                        request.waitForFlush(this.defaultMessageStore.getMessageStoreConfig().getSyncFlushTimeout());
+                        request.waitForFlush(this.defaultMessageStore.getMessageStoreConfig().getSyncSlaveTimeout());
                     if (!flushOK) {
                         log.error("do sync transfer other node, wait return, but failed, topic: " + messageExt.getTopic() + " tags: "
                             + messageExt.getTags() + " client address: " + messageExt.getBornHostNameString());

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -126,6 +126,7 @@ public class MessageStoreConfig {
     @ImportantField
     private FlushDiskType flushDiskType = FlushDiskType.ASYNC_FLUSH;
     private int syncFlushTimeout = 1000 * 5;
+    private int syncSlaveTimeout = 1000 * 5;
     private String messageDelayLevel = "1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h";
     private long flushDelayOffsetInterval = 1000 * 10;
     @ImportantField
@@ -517,6 +518,14 @@ public class MessageStoreConfig {
 
     public int getSyncFlushTimeout() {
         return syncFlushTimeout;
+    }
+
+    public void setSyncSlaveTimeout(int syncSlaveTimeout) {
+        this.syncSlaveTimeout = syncSlaveTimeout;
+    }
+
+    public int getSyncSlaveTimeout() {
+        return syncSlaveTimeout;
     }
 
     public void setSyncFlushTimeout(int syncFlushTimeout) {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/ROCKETMQ-272

The timeout logic doesn't work correctly.
Thread waiting in GroupTransferService may frequently waked up by ReadSocketService in HAConnection.
So the transfer logic may return soon and wake up the thread waiting for the HA handling, which will make the timeout value in HA handling useless.

This patch repairs the timeout logic in syncing, and also introduces an option `syncSlaveTimeout` in `MessageStoreConfig` to distinguish from the disk flush timeout option.