### PR TITLE
[ROCKETMQ-286] Add a switch to decide whether to wake up commitLogService when put message

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -652,7 +652,9 @@ public class CommitLog {
             if (!this.defaultMessageStore.getMessageStoreConfig().isTransientStorePoolEnable()) {
                 flushCommitLogService.wakeup();
             } else {
-                commitLogService.wakeup();
+                if (this.defaultMessageStore.getMessageStoreConfig().isWakeCommitWhenPutMessage()) {
+                    commitLogService.wakeup();
+                }
             }
         }
     }

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -143,6 +143,9 @@ public class MessageStoreConfig {
     private int transientStorePoolSize = 5;
     private boolean fastFailIfNoBufferInStorePool = false;
 
+    @ImportantField
+    private boolean wakeCommitWhenPutMessage = true;
+
     public boolean isDebugLockEnable() {
         return debugLockEnable;
     }
@@ -666,4 +669,11 @@ public class MessageStoreConfig {
         this.commitCommitLogThoroughInterval = commitCommitLogThoroughInterval;
     }
 
+    public boolean isWakeCommitWhenPutMessage() {
+        return wakeCommitWhenPutMessage;
+    }
+
+    public void setWakeCommitWhenPutMessage(boolean wakeCommitWhenPutMessage) {
+        this.wakeCommitWhenPutMessage = wakeCommitWhenPutMessage;
+    }
 }


### PR DESCRIPTION
Wake up commitLogService will make messages consumed quicker when put message, but it may increase disk usage. So, add a switch to decide where to open this feature, described in https://issues.apache.org/jira/browse/ROCKETMQ-286.

### **Brief change log**

Add a config property to MessageStoreConfig

### **Verifying this change**

Just a switch, verifying is to change it's value.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/ROCKETMQ/issues/) filed for the change (usually before you start working on it). Trivial changes like typos do not require a JIRA issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[ROCKETMQ-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exists. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-rocketmq/tree/master/test
).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).