### PR TITLE
[ROCKETMQ-296] fix DefaultMessageStoreTest bug: wait more time for consume queue build

### DIFF
--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
@@ -73,6 +73,7 @@ public class DefaultMessageStoreTest {
         messageStoreConfig.setMaxHashSlotNum(10000);
         messageStoreConfig.setMaxIndexNum(100 * 100);
         messageStoreConfig.setFlushDiskType(FlushDiskType.SYNC_FLUSH);
+        messageStoreConfig.setFlushIntervalConsumeQueue(1);
         return new DefaultMessageStore(messageStoreConfig, new BrokerStatsManager("simpleTest"), new MyMessageArrivingListener(), new BrokerConfig());
     }
 
@@ -148,8 +149,10 @@ public class DefaultMessageStoreTest {
             messageExtBrokerInner.setQueueId(0);
             messageStore.putMessage(messageExtBrokerInner);
         }
-        //wait for consume queue build
-        Thread.sleep(10);
+        // wait for consume queue build
+        // the sleep time should be great than
+        // commit log flush interval plus consume queue flush interval
+        Thread.sleep(100);
         String group = "simple";
         GetMessageResult getMessageResult32 = messageStore.getMessage(group, topic, 0, 0, 32, null);
         assertThat(getMessageResult32.getMessageBufferList().size()).isEqualTo(32);

--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
@@ -150,8 +150,7 @@ public class DefaultMessageStoreTest {
             messageStore.putMessage(messageExtBrokerInner);
         }
         // wait for consume queue build
-        // the sleep time should be great than
-        // commit log flush interval plus consume queue flush interval
+        // the sleep time should be great than consume queue flush interval
         Thread.sleep(100);
         String group = "simple";
         GetMessageResult getMessageResult32 = messageStore.getMessage(group, topic, 0, 0, 32, null);


### PR DESCRIPTION
when run DefaultMessageStoreTest::testPullSize, it should wait  more time to build consume queue.
The sleep time should be greater than commit log flush interval plus consume queue flush interval.