### PR TITLE
[ROCKETMQ-290] Fix memory leak in WaitNotifyObject#waitingThreadTable

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ha/HAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/HAConnection.java
@@ -300,6 +300,8 @@ public class HAConnection {
                 }
             }
 
+            HAConnection.this.haService.getWaitNotifyObject().removeFromWaitingThreadTable();
+
             if (this.selectMappedBufferResult != null) {
                 this.selectMappedBufferResult.release();
             }

--- a/store/src/main/java/org/apache/rocketmq/store/ha/WaitNotifyObject.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/WaitNotifyObject.java
@@ -96,4 +96,11 @@ public class WaitNotifyObject {
             }
         }
     }
+
+    public void removeFromWaitingThreadTable() {
+        long currentThreadId = Thread.currentThread().getId();
+        synchronized (this) {
+            this.waitingThreadTable.remove(currentThreadId);
+        }
+    }
 }

--- a/store/src/test/java/org/apache/rocketmq/store/ha/WaitNotifyObjectTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/ha/WaitNotifyObjectTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.store.ha;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Jason918 on 2017/11/19.
+ */
+public class WaitNotifyObjectTest {
+    @Test
+    public void removeFromWaitingThreadTable() throws Exception {
+        final WaitNotifyObject waitNotifyObject = new WaitNotifyObject();
+        for (int i = 0; i < 5; i++) {
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    waitNotifyObject.allWaitForRunning(100);
+                    waitNotifyObject.removeFromWaitingThreadTable();
+                }
+            });
+            t.start();
+            t.join();
+        }
+        Assert.assertEquals(0, waitNotifyObject.waitingThreadTable.size());
+    }
+
+}

--- a/store/src/test/java/org/apache/rocketmq/store/ha/WaitNotifyObjectTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/ha/WaitNotifyObjectTest.java
@@ -22,9 +22,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-/**
- * Created by Jason918 on 2017/11/19.
- */
 public class WaitNotifyObjectTest {
     @Test
     public void removeFromWaitingThreadTable() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix the memory leak problem in org.apache.rocketmq.store.ha.WaitNotifyObject#waitingThreadTable

## Brief changelog

Remove item from WaitNotifyObject#waitingThreadTable when a slave disconnect from master.

## Verifying this change

This is a trivial change.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/ROCKETMQ/issues/) filed for the change (usually before you start working on it). Trivial changes like typos do not require a JIRA issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ROCKETMQ-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
