### PR TITLE
[ROCKETMQ-306] Improve thread name

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageClientIDSetter;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -121,7 +122,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             producer.getCheckThreadPoolMaxSize(),
             1000 * 60,
             TimeUnit.MILLISECONDS,
-            this.checkRequestQueue);
+            this.checkRequestQueue,new ThreadFactoryImpl("CheckRequestThread_"));
     }
 
     public void destroyTransactionEnv() {


### PR DESCRIPTION
## What is the purpose of the change

Assign a name of thread created by checkExecutor to help tracing errors,eg: jstack




