### PR TITLE
[ROCKETMQ-270] Move flush position forward to first MappedFile whose start offset is non-zero

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -421,7 +421,7 @@ public class MappedFileQueue {
 
     public boolean flush(final int flushLeastPages) {
         boolean result = true;
-        MappedFile mappedFile = this.findMappedFileByOffset(this.flushedWhere, false);
+        MappedFile mappedFile = this.findMappedFileByOffset(this.flushedWhere, this.flushedWhere == 0);
         if (mappedFile != null) {
             long tmpTimeStamp = mappedFile.getStoreTimestamp();
             int offset = mappedFile.flush(flushLeastPages);
@@ -438,7 +438,7 @@ public class MappedFileQueue {
 
     public boolean commit(final int commitLeastPages) {
         boolean result = true;
-        MappedFile mappedFile = this.findMappedFileByOffset(this.committedWhere, false);
+        MappedFile mappedFile = this.findMappedFileByOffset(this.committedWhere, this.committedWhere == 0);
         if (mappedFile != null) {
             int offset = mappedFile.commit(commitLeastPages);
             long where = mappedFile.getFileFromOffset() + offset;

--- a/store/src/test/java/org/apache/rocketmq/store/MappedFileQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/MappedFileQueueTest.java
@@ -20,9 +20,7 @@ package org.apache.rocketmq.store;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-
 import org.apache.rocketmq.common.UtilAll;
-import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.After;
 import org.junit.Test;
 
@@ -47,7 +45,7 @@ public class MappedFileQueueTest {
     }
 
     @Test
-    public void test_findMappedFileByOffset() {
+    public void testFindMappedFileByOffset() {
         // four-byte string.
         final String fixedMsg = "abcd";
 
@@ -92,6 +90,28 @@ public class MappedFileQueueTest {
 
         mappedFile = mappedFileQueue.findMappedFileByOffset(1024 * 4 + 100);
         assertThat(mappedFile).isNull();
+
+        mappedFileQueue.shutdown(1000);
+        mappedFileQueue.destroy();
+    }
+
+    @Test
+    public void testFindMappedFileByOffset_StartOffsetIsNonZero() {
+        MappedFileQueue mappedFileQueue =
+            new MappedFileQueue("target/unit_test_store/b/", 1024, null);
+
+        //Start from a non-zero offset
+        MappedFile mappedFile = mappedFileQueue.getLastMappedFile(1024);
+        assertThat(mappedFile).isNotNull();
+
+        assertThat(mappedFileQueue.findMappedFileByOffset(1025)).isEqualTo(mappedFile);
+
+        assertThat(mappedFileQueue.findMappedFileByOffset(0)).isNull();
+        assertThat(mappedFileQueue.findMappedFileByOffset(123, false)).isNull();
+        assertThat(mappedFileQueue.findMappedFileByOffset(123, true)).isEqualTo(mappedFile);
+
+        assertThat(mappedFileQueue.findMappedFileByOffset(0, false)).isNull();
+        assertThat(mappedFileQueue.findMappedFileByOffset(0, true)).isEqualTo(mappedFile);
 
         mappedFileQueue.shutdown(1000);
         mappedFileQueue.destroy();


### PR DESCRIPTION
## What is the purpose of the change

To resolve the issue [ROCKETMQ-270](https://issues.apache.org/jira/browse/ROCKETMQ-270).

Slave Broker can't flush data to disk normally if the master broker has been cleaned commit log. 

## Brief changelog

When the flush position is zero and the first MappedFile's start offset is non-zero, move it forward to the first MappedFile's start offset. Otherwise, slave broker can't flush data to disk normally.

## Verifying this change

1. Start master broker, and write lots of messages until broker starts cleaning commit log.
2. When the first commit log file isn't 00000000000000, start slave broker.
3. Slave broker now can flush data normally.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/ROCKETMQ/issues/) filed for the change (usually before you start working on it). Trivial changes like typos do not require a JIRA issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [X] Format the pull request title like `[ROCKETMQ-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [X] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [X] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
