### PR TITLE
[ROCKETMQ-351] Add a default value to expressionType and polish the j…

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/filter/ExpressionType.java
+++ b/common/src/main/java/org/apache/rocketmq/common/filter/ExpressionType.java
@@ -59,7 +59,7 @@ public class ExpressionType {
     public static final String TAG = "TAG";
 
     public static boolean isTagType(String type) {
-        if (type == null || TAG.equals(type)) {
+        if (type == null || "".equals(type) || TAG.equals(type)) {
             return true;
         }
         return false;

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/heartbeat/SubscriptionData.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/heartbeat/SubscriptionData.java
@@ -21,6 +21,8 @@
 package org.apache.rocketmq.common.protocol.heartbeat;
 
 import com.alibaba.fastjson.annotation.JSONField;
+import org.apache.rocketmq.common.filter.ExpressionType;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -32,7 +34,7 @@ public class SubscriptionData implements Comparable<SubscriptionData> {
     private Set<String> tagsSet = new HashSet<String>();
     private Set<Integer> codeSet = new HashSet<Integer>();
     private long subVersion = System.currentTimeMillis();
-    private String expressionType;
+    private String expressionType = ExpressionType.TAG;
 
     @JSONField(serialize = false)
     private String filterClassSource;


### PR DESCRIPTION
## What is the purpose of the change

Make the _expressionType_ has a definite value.

## Brief changelog

1. Add a default value to _expressionType_ of _SubscriptionData_.
3. Empty check in _isTagType_ of _ExpressionType_.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/ROCKETMQ/issues/ROCKETMQ-351?filter=allopenissues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a JIRA issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ROCKETMQ-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
