### PR TITLE
[ROCKETMQ-387]Standardize the startup class structure

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -79,6 +79,12 @@ public class BrokerStartup {
         return null;
     }
 
+    public static void shutdown(final BrokerController controller) {
+        if (null != controller) {
+            controller.shutdown();
+        }
+    }
+
     public static BrokerController createBrokerController(String[] args) {
         System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, Integer.toString(MQVersion.CURRENT_VERSION));
 

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvStartup.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvStartup.java
@@ -18,8 +18,10 @@ package org.apache.rocketmq.namesrv;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -40,92 +42,23 @@ import org.apache.rocketmq.srvutil.ShutdownHookThread;
 import org.slf4j.LoggerFactory;
 
 public class NamesrvStartup {
-    public static Properties properties = null;
-    public static CommandLine commandLine = null;
+
+    private static InternalLogger log;
+    private static Properties properties = null;
+    private static CommandLine commandLine = null;
 
     public static void main(String[] args) {
         main0(args);
     }
 
     public static NamesrvController main0(String[] args) {
-        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, Integer.toString(MQVersion.CURRENT_VERSION));
+
         try {
-            //PackageConflictDetect.detectFastjson();
-
-            Options options = ServerUtil.buildCommandlineOptions(new Options());
-            commandLine = ServerUtil.parseCmdLine("mqnamesrv", args, buildCommandlineOptions(options), new PosixParser());
-            if (null == commandLine) {
-                System.exit(-1);
-                return null;
-            }
-
-            final NamesrvConfig namesrvConfig = new NamesrvConfig();
-            final NettyServerConfig nettyServerConfig = new NettyServerConfig();
-            nettyServerConfig.setListenPort(9876);
-            if (commandLine.hasOption('c')) {
-                String file = commandLine.getOptionValue('c');
-                if (file != null) {
-                    InputStream in = new BufferedInputStream(new FileInputStream(file));
-                    properties = new Properties();
-                    properties.load(in);
-                    MixAll.properties2Object(properties, namesrvConfig);
-                    MixAll.properties2Object(properties, nettyServerConfig);
-
-                    namesrvConfig.setConfigStorePath(file);
-
-                    System.out.printf("load config properties file OK, %s%n", file);
-                    in.close();
-                }
-            }
-
-            if (commandLine.hasOption('p')) {
-                MixAll.printObjectProperties(null, namesrvConfig);
-                MixAll.printObjectProperties(null, nettyServerConfig);
-                System.exit(0);
-            }
-
-            MixAll.properties2Object(ServerUtil.commandLine2Properties(commandLine), namesrvConfig);
-
-            if (null == namesrvConfig.getRocketmqHome()) {
-                System.out.printf("Please set the %s variable in your environment to match the location of the RocketMQ installation%n", MixAll.ROCKETMQ_HOME_ENV);
-                System.exit(-2);
-            }
-
-            LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-            JoranConfigurator configurator = new JoranConfigurator();
-            configurator.setContext(lc);
-            lc.reset();
-            configurator.doConfigure(namesrvConfig.getRocketmqHome() + "/conf/logback_namesrv.xml");
-            final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.NAMESRV_LOGGER_NAME);
-
-            MixAll.printObjectProperties(log, namesrvConfig);
-            MixAll.printObjectProperties(log, nettyServerConfig);
-
-            final NamesrvController controller = new NamesrvController(namesrvConfig, nettyServerConfig);
-
-            // remember all configs to prevent discard
-            controller.getConfiguration().registerConfig(properties);
-
-            boolean initResult = controller.initialize();
-            if (!initResult) {
-                controller.shutdown();
-                System.exit(-3);
-            }
-
-            Runtime.getRuntime().addShutdownHook(new ShutdownHookThread(log, new Callable<Void>() {
-                @Override
-                public Void call() throws Exception {
-                    controller.shutdown();
-                    return null;
-                }
-            }));
-
-            controller.start();
-
+            NamesrvController controller = createNamesrvController(args);
+            start(controller);
             String tip = "The Name Server boot success. serializeType=" + RemotingCommand.getSerializeTypeConfigInThisServer();
             log.info(tip);
             System.out.printf("%s%n", tip);
-
             return controller;
         } catch (Throwable e) {
             e.printStackTrace();
@@ -133,6 +66,97 @@ public class NamesrvStartup {
         }
 
         return null;
+    }
+
+    public static NamesrvController createNamesrvController(String[] args) throws IOException, JoranException {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, Integer.toString(MQVersion.CURRENT_VERSION));
+        //PackageConflictDetect.detectFastjson();
+
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        commandLine = ServerUtil.parseCmdLine("mqnamesrv", args, buildCommandlineOptions(options), new PosixParser());
+        if (null == commandLine) {
+            System.exit(-1);
+            return null;
+        }
+
+        final NamesrvConfig namesrvConfig = new NamesrvConfig();
+        final NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setListenPort(9876);
+        if (commandLine.hasOption('c')) {
+            String file = commandLine.getOptionValue('c');
+            if (file != null) {
+                InputStream in = new BufferedInputStream(new FileInputStream(file));
+                properties = new Properties();
+                properties.load(in);
+                MixAll.properties2Object(properties, namesrvConfig);
+                MixAll.properties2Object(properties, nettyServerConfig);
+
+                namesrvConfig.setConfigStorePath(file);
+
+                System.out.printf("load config properties file OK, %s%n", file);
+                in.close();
+            }
+        }
+
+        if (commandLine.hasOption('p')) {
+            MixAll.printObjectProperties(null, namesrvConfig);
+            MixAll.printObjectProperties(null, nettyServerConfig);
+            System.exit(0);
+        }
+
+        MixAll.properties2Object(ServerUtil.commandLine2Properties(commandLine), namesrvConfig);
+
+        if (null == namesrvConfig.getRocketmqHome()) {
+            System.out.printf("Please set the %s variable in your environment to match the location of the RocketMQ installation%n", MixAll.ROCKETMQ_HOME_ENV);
+            System.exit(-2);
+        }
+
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(lc);
+        lc.reset();
+        configurator.doConfigure(namesrvConfig.getRocketmqHome() + "/conf/logback_namesrv.xml");
+
+        log = InternalLoggerFactory.getLogger(LoggerName.NAMESRV_LOGGER_NAME);
+
+        MixAll.printObjectProperties(log, namesrvConfig);
+        MixAll.printObjectProperties(log, nettyServerConfig);
+
+        final NamesrvController controller = new NamesrvController(namesrvConfig, nettyServerConfig);
+
+        // remember all configs to prevent discard
+        controller.getConfiguration().registerConfig(properties);
+
+        return controller;
+    }
+
+    public static NamesrvController start(final NamesrvController controller) throws Exception {
+
+        if (null == controller) {
+            throw new IllegalArgumentException("NamesrvController is null");
+        }
+
+        boolean initResult = controller.initialize();
+        if (!initResult) {
+            controller.shutdown();
+            System.exit(-3);
+        }
+
+        Runtime.getRuntime().addShutdownHook(new ShutdownHookThread(log, new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                controller.shutdown();
+                return null;
+            }
+        }));
+
+        controller.start();
+
+        return controller;
+    }
+
+    public static void shutdown(final NamesrvController controller) {
+        controller.shutdown();
     }
 
     public static Options buildCommandlineOptions(final Options options) {


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first. 

## What is the purpose of the change

Standardize the structure of the XxxStartup classes.

## Brief changelog

Divide current code into multiple methods so that NamesrvStartup has the same batch of methods as BrokerStartup

## Verifying this change

Nothing breaks after applying this changes

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x ] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
