### PR TITLE
#issues-242# new consumer may consume all message 

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ConsumerManageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ConsumerManageProcessor.java
@@ -134,19 +134,8 @@ public class ConsumerManageProcessor implements NettyRequestProcessor {
             response.setCode(ResponseCode.SUCCESS);
             response.setRemark(null);
         } else {
-            long minOffset =
-                this.brokerController.getMessageStore().getMinOffsetInQueue(requestHeader.getTopic(),
-                    requestHeader.getQueueId());
-            if (minOffset <= 0
-                && !this.brokerController.getMessageStore().checkInDiskByConsumeOffset(
-                requestHeader.getTopic(), requestHeader.getQueueId(), 0)) {
-                responseHeader.setOffset(0L);
-                response.setCode(ResponseCode.SUCCESS);
-                response.setRemark(null);
-            } else {
-                response.setCode(ResponseCode.QUERY_NOT_FOUND);
-                response.setRemark("Not found, V3_0_6_SNAPSHOT maybe this group consumer boot first");
-            }
+            response.setCode(ResponseCode.QUERY_NOT_FOUND);
+            response.setRemark("Not found, V3_0_6_SNAPSHOT maybe this group consumer boot first");
         }
 
         return response;

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/ConsumerManageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/ConsumerManageProcessorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.broker.processor;
+
+import io.netty.channel.ChannelHandlerContext;
+import java.lang.reflect.Method;
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.broker.offset.ConsumerOffsetManager;
+import org.apache.rocketmq.common.protocol.RequestCode;
+import org.apache.rocketmq.common.protocol.ResponseCode;
+import org.apache.rocketmq.common.protocol.header.QueryConsumerOffsetRequestHeader;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConsumerManageProcessorTest {
+
+    private BrokerController brokerController;
+    private ConsumerOffsetManager consumerOffsetManager;
+    private String normaCid = "normalCid";
+    private String exceptionCid = "exceptionCid";
+
+    @Test
+    public void test_queryConsumerOffset_normal() throws Exception {
+
+        when(brokerController.getConsumerOffsetManager()).thenReturn(consumerOffsetManager);
+        when(consumerOffsetManager.queryOffset(eq(normaCid), anyString(), anyInt())).thenReturn(10L);
+
+        ConsumerManageProcessor consumerManageProcessor = new ConsumerManageProcessor(brokerController);
+
+        RemotingCommand request = buildQueryCommond(normaCid);
+
+        Method method = ConsumerManageProcessor.class.getDeclaredMethod("queryConsumerOffset", ChannelHandlerContext.class, RemotingCommand.class);
+        method.setAccessible(true);
+
+        final Object invoke = method.invoke(consumerManageProcessor, null, request);
+
+        RemotingCommand response = (RemotingCommand) invoke;
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+
+    }
+
+    @Test
+    public void test_queryConsumerOffset_not_exists() throws Exception {
+
+        when(brokerController.getConsumerOffsetManager()).thenReturn(consumerOffsetManager);
+        when(consumerOffsetManager.queryOffset(eq(exceptionCid), anyString(), anyInt())).thenReturn(-1L);
+
+        ConsumerManageProcessor consumerManageProcessor = new ConsumerManageProcessor(brokerController);
+
+        RemotingCommand request = buildQueryCommond(exceptionCid);
+
+        Method method = ConsumerManageProcessor.class.getDeclaredMethod("queryConsumerOffset", ChannelHandlerContext.class, RemotingCommand.class);
+        method.setAccessible(true);
+
+        final Object invoke = method.invoke(consumerManageProcessor, null, request);
+
+        RemotingCommand response = (RemotingCommand) invoke;
+
+        assertEquals(ResponseCode.QUERY_NOT_FOUND, response.getCode());
+
+    }
+
+    @Before
+    public void initMock() throws Exception {
+        brokerController = mock(BrokerController.class);
+        consumerOffsetManager = mock(ConsumerOffsetManager.class);
+    }
+
+    private RemotingCommand buildQueryCommond(String cid) {
+        QueryConsumerOffsetRequestHeader requestHeader = new QueryConsumerOffsetRequestHeader();
+        requestHeader.setConsumerGroup(cid);
+        requestHeader.setTopic("topic");
+        requestHeader.setQueueId(0);
+        RemotingCommand requestCommand = RemotingCommand.createRequestCommand(RequestCode.GET_CONSUMER_LIST_BY_GROUP, requestHeader);
+        requestCommand.makeCustomHeaderToNet();
+        return requestCommand;
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

assume one MQ Broker cluster,the broker commitLog min offset is zero , a new consumer start ,
the consumer will starting consume queue's offset zero messages，it's a problem。


## Brief changelog
org.apache.rocketmq.broker.processor.ConsumerManageProcessor#queryConsumerOffset

## Verifying this change

org.apache.rocketmq.broker.processor.ConsumerManageProcessor#queryConsumerOffset

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
