### PR TITLE
[ISSUE #260] Fix Concurrent issue of StoreStatsService

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/StoreStatsService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/StoreStatsService.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.rocketmq.common.ServiceThread;
@@ -42,9 +43,9 @@ public class StoreStatsService extends ServiceThread {
 
     private final AtomicLong putMessageFailedTimes = new AtomicLong(0);
 
-    private final Map<String, AtomicLong> putMessageTopicTimesTotal =
+    private final ConcurrentMap<String, AtomicLong> putMessageTopicTimesTotal =
         new ConcurrentHashMap<String, AtomicLong>(128);
-    private final Map<String, AtomicLong> putMessageTopicSizeTotal =
+    private final ConcurrentMap<String, AtomicLong> putMessageTopicSizeTotal =
         new ConcurrentHashMap<String, AtomicLong>(128);
 
     private final AtomicLong getMessageTimesTotalFound = new AtomicLong(0);
@@ -545,7 +546,10 @@ public class StoreStatsService extends ServiceThread {
         AtomicLong rs = putMessageTopicSizeTotal.get(topic);
         if (null == rs) {
             rs = new AtomicLong(0);
-            putMessageTopicSizeTotal.put(topic, rs);
+            AtomicLong previous = putMessageTopicSizeTotal.putIfAbsent(topic, rs);
+            if(previous != null){
+                rs = previous;
+            }
         }
         return rs;
     }
@@ -554,7 +558,10 @@ public class StoreStatsService extends ServiceThread {
         AtomicLong rs = putMessageTopicTimesTotal.get(topic);
         if (null == rs) {
             rs = new AtomicLong(0);
-            putMessageTopicTimesTotal.put(topic, rs);
+            AtomicLong previous = putMessageTopicTimesTotal.putIfAbsent(topic, rs);
+            if(previous != null){
+                rs = previous;
+            }
         }
         return rs;
     }

--- a/store/src/test/java/org/apache/rocketmq/store/StoreStatsServiceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/StoreStatsServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.rocketmq.store;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -7,9 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
-/**
- * @author song
- */
+
 public class StoreStatsServiceTest {
 
   @Test

--- a/store/src/test/java/org/apache/rocketmq/store/StoreStatsServiceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/StoreStatsServiceTest.java
@@ -1,0 +1,77 @@
+package org.apache.rocketmq.store;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * @author song
+ */
+public class StoreStatsServiceTest {
+
+  @Test
+  public void getSinglePutMessageTopicSizeTotal() throws Exception {
+    final StoreStatsService storeStatsService = new StoreStatsService();
+    int num = Runtime.getRuntime().availableProcessors() * 2;
+    for (int j = 0; j < 100; j++) {
+      final AtomicReference<AtomicLong> reference = new AtomicReference<>(null);
+      final CountDownLatch latch = new CountDownLatch(num);
+      final CyclicBarrier barrier = new CyclicBarrier(num);
+      for (int i = 0; i < num; i++) {
+        new Thread(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              barrier.await();
+              AtomicLong atomicLong = storeStatsService.getSinglePutMessageTopicSizeTotal("test");
+              if(reference.compareAndSet(null,atomicLong)){
+              }else if (reference.get() != atomicLong){
+                throw new RuntimeException("Reference should be same!");
+              }
+            } catch (InterruptedException | BrokenBarrierException e) {
+              e.printStackTrace();
+            }finally {
+              latch.countDown();
+            }
+          }
+        }).start();
+      }
+      latch.await();
+    }
+  }
+
+  @Test
+  public void getSinglePutMessageTopicTimesTotal() throws Exception {
+    final StoreStatsService storeStatsService = new StoreStatsService();
+    int num = Runtime.getRuntime().availableProcessors() * 2;
+    for (int j = 0; j < 100; j++) {
+      final AtomicReference<AtomicLong> reference = new AtomicReference<>(null);
+      final CountDownLatch latch = new CountDownLatch(num);
+      final CyclicBarrier barrier = new CyclicBarrier(num);
+      for (int i = 0; i < num; i++) {
+        new Thread(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              barrier.await();
+              AtomicLong atomicLong = storeStatsService.getSinglePutMessageTopicTimesTotal("test");
+              if(reference.compareAndSet(null,atomicLong)){
+              }else if (reference.get() != atomicLong){
+                throw new RuntimeException("Reference should be same!");
+              }
+            } catch (InterruptedException | BrokenBarrierException e) {
+              e.printStackTrace();
+            }finally {
+              latch.countDown();
+            }
+          }
+        }).start();
+      }
+      latch.await();
+    }
+  }
+
+}


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first. 

## What is the purpose of the change
Fix Concurrent issue of StoreStatsService

## Brief changelog

StoreStatsService#getSinglePutMessageTopicSizeTotal and StoreStatsService#getSinglePutMessageTopicTimesTotal are not thread safe which could return a different instance under high concurrent scenario ,normally this won't happen ,because the cost of creating a AtomicLong and put it into a map can be ignored ,but when that happens, Stats could be inaccuracy
## Verifying this change

Fix Concurrent issue of StoreStatsService

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [ ] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
