### PR TITLE
[Minor Fix] Modify Project Tools : remove duplicates initCommand and missing tag ")"

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -155,7 +155,7 @@ public class MQAdminStartup {
         initCommand(new QueryMsgByKeySubCommand());
         initCommand(new QueryMsgByUniqueKeySubCommand());
         initCommand(new QueryMsgByOffsetSubCommand());
-        initCommand(new QueryMsgByUniqueKeySubCommand());
+        
         initCommand(new PrintMessageSubCommand());
         initCommand(new PrintMessageByQueueCommand());
         initCommand(new SendMsgStatusCommand());

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateTopicSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateTopicSubCommand.java
@@ -67,15 +67,15 @@ public class UpdateTopicSubCommand implements SubCommand {
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("o", "order", true, "set topic's order(true|false");
+        opt = new Option("o", "order", true, "set topic's order(true|false)");
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("u", "unit", true, "is unit topic (true|false");
+        opt = new Option("u", "unit", true, "is unit topic (true|false)");
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("s", "hasUnitSub", true, "has unit sub (true|false");
+        opt = new Option("s", "hasUnitSub", true, "has unit sub (true|false)");
         opt.setRequired(false);
         options.addOption(opt);
 


### PR DESCRIPTION
#Resolve two coding errors：
path     : package org.apache.rocketmq.tools.command;
class    : MQAdminStartup.java
remove duplicates initCommand at line  158, remove "initCommand(new QueryMsgByUniqueKeySubCommand());"
path     : package org.apache.rocketmq.tools.command.topic;
class    : UpdateTopicSubCommand .java
Add tag ")" behind of  “true|false” in  lines 70/74/78