### PR TITLE
[ISSUE #316] Topic removal inconsistency

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -259,8 +259,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         log.info("deleteTopic called by {}", RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
 
         this.brokerController.getTopicConfigManager().deleteTopicConfig(requestHeader.getTopic());
-        this.brokerController.getMessageStore()
-            .cleanUnusedTopic(this.brokerController.getTopicConfigManager().getTopicConfigTable().keySet());
+        this.brokerController.getMessageStore().cleanUnusedTopic(this.brokerController.getTopicConfigManager()
+            .getTopicConfigTable().keySet());
+
+        // Remove consume offsets
+        this.brokerController.getConsumerOffsetManager().removeConsumeOffsetsByTopic(requestHeader.getTopic());
 
         response.setCode(ResponseCode.SUCCESS);
         response.setRemark(null);
@@ -520,8 +523,8 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
 
         log.info("deleteSubscriptionGroup called by {}", RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
 
-        this.brokerController.getSubscriptionGroupManager().deleteSubscriptionGroupConfig(requestHeader.getGroupName());
-
+        brokerController.getSubscriptionGroupManager().deleteSubscriptionGroupConfig(requestHeader.getGroupName());
+        brokerController.getConsumerOffsetManager().removeConsumeOffsetsByConsumerGroup(requestHeader.getGroupName());
         response.setCode(ResponseCode.SUCCESS);
         response.setRemark(null);
         return response;


### PR DESCRIPTION
Remove consume queue and consume offsets in accordance with topic/consumer group removal in the master node

## What is the purpose of the change

Bug fix.

## Brief changelog

When topics in the master node are removed, logical consume queues in the slave node are correctly purged.

## Verifying this change

Logical consume queue files are actually removed after applying this patch.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
