### PR TITLE
[ISSUE #354]Add thread-sleep for rebalance before producer send in the integration-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
     recipients:
       - dev@rocketmq.apache.org
   on_success: change
-  on_failure: never
+  on_failure: always
 
 language: java
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
     recipients:
       - dev@rocketmq.apache.org
   on_success: change
-  on_failure: always
+  on_failure: never
 
 language: java
 

--- a/test/src/test/java/org/apache/rocketmq/test/client/consumer/balance/NormalMsgDynamicBalanceIT.java
+++ b/test/src/test/java/org/apache/rocketmq/test/client/consumer/balance/NormalMsgDynamicBalanceIT.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.test.client.rmq.RMQNormalConsumer;
 import org.apache.rocketmq.test.client.rmq.RMQNormalProducer;
 import org.apache.rocketmq.test.listener.rmq.concurrent.RMQNormalListener;
 import org.apache.rocketmq.test.util.MQWait;
+import org.apache.rocketmq.test.util.TestUtils;
 import org.apache.rocketmq.test.util.VerifyUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -54,6 +55,7 @@ public class NormalMsgDynamicBalanceIT extends BaseConf {
         RMQNormalConsumer consumer1 = getConsumer(nsAddr, topic, "*", new RMQNormalListener());
         RMQNormalConsumer consumer2 = getConsumer(nsAddr, consumer1.getConsumerGroup(), topic,
             "*", new RMQNormalListener());
+        TestUtils.waitForSeconds(waitTime);
 
         producer.send(msgSize);
 
@@ -84,6 +86,7 @@ public class NormalMsgDynamicBalanceIT extends BaseConf {
             "*", new RMQNormalListener());
         RMQNormalConsumer consumer3 = getConsumer(nsAddr, consumer1.getConsumerGroup(), topic,
             "*", new RMQNormalListener());
+        TestUtils.waitForSeconds(waitTime);
 
         producer.send(msgSize);
 


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first. 

## What is the purpose of the change

Message will be consumed repeatedly when send before rebalance work finish. Adding a time delay before producer send message is necessary in the integration-test.

## Brief changelog
Adding a thread-sleep after consumer group enlarged to finish rebalance


## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).