### PR TITLE
[ISSUE #379] FIX admin subcommand consumeMessage can pull message with timestamp greater than now

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/ConsumeMessageCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/ConsumeMessageCommand.java
@@ -142,7 +142,7 @@ public class ConsumeMessageCommand implements SubCommand {
             if (commandLine.hasOption('c')) {
                 messageCount = Long.parseLong(commandLine.getOptionValue('c').trim());
                 if (messageCount <= 0) {
-                    System.out.print("please input a positive messageNumber!");
+                    System.out.print("Please input a positive messageNumber!");
                     return;
                 }
             }
@@ -161,20 +161,33 @@ public class ConsumeMessageCommand implements SubCommand {
             }
             if (commandLine.hasOption('o')) {
                 if (consumeType != ConsumeType.BYQUEUE) {
-                    System.out.print("please set queueId before offset!");
+                    System.out.print("Please set queueId before offset!");
                     return;
                 }
                 offset = Long.parseLong(commandLine.getOptionValue('o').trim());
                 consumeType = ConsumeType.BYOFFSET;
             }
 
+            long now = System.currentTimeMillis();
             if (commandLine.hasOption('s')) {
                 String timestampStr = commandLine.getOptionValue('s').trim();
                 timeValueBegin = timestampFormat(timestampStr);
+                if (timeValueBegin > now) {
+                    System.out.print("Please set the beginTimestamp before now!");
+                    return;
+                }
             }
             if (commandLine.hasOption('e')) {
                 String timestampStr = commandLine.getOptionValue('e').trim();
                 timeValueEnd = timestampFormat(timestampStr);
+                if (timeValueEnd > now) {
+                    System.out.print("Please set the endTimestamp before now!");
+                    return;
+                }
+                if (timeValueBegin > timeValueEnd) {
+                    System.out.print("Please make sure that the beginTimestamp is less than or equal to the endTimestamp");
+                    return;
+                }
             }
 
             switch (consumeType) {


### PR DESCRIPTION
## What is the purpose of the change

FIX the issue described in  #379 .

## Brief changelog
Since the timestamp argument provided to the consumer(*beginTimestamp* or *endTimestamp*
) which is later than now is not valid, we should verify them before we actually pull a message from the broker.
And the following are corresponding changes:
- Add verification of command line argument *beginTimestamp* and *endTimestamp*
- exit the program if any of the arguments are invalid

By the way, I think we should print report messages in the same style, so I change the messages to capitalized.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exists. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
