### PR TITLE
[ISSUE #436] set JVM options according to JDK version

### DIFF
--- a/distribution/bin/runserver.sh
+++ b/distribution/bin/runserver.sh
@@ -36,8 +36,14 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 # JVM Configuration
 #===========================================================================================
+version=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ "$version" > "1.7" ]]; then
+  JAVA_OPT="${JAVA_OPT}" 
+else         
+  JAVA_OPT="${JAVA_OPT} -XX:-UseParNewGC -XX:+UseCMSCompactAtFullCollection"
+fi
 JAVA_OPT="${JAVA_OPT} -server -Xms4g -Xmx4g -Xmn2g -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
-JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
+JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT}  -XX:-UseLargePages"

--- a/distribution/bin/tools.sh
+++ b/distribution/bin/tools.sh
@@ -36,7 +36,13 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 # JVM Configuration
 #===========================================================================================
-JAVA_OPT="${JAVA_OPT} -server -Xms1g -Xmx1g -Xmn256m -XX:PermSize=128m -XX:MaxPermSize=128m"
+version=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ "$version" > "1.7" ]]; then
+  JAVA_OPT="${JAVA_OPT}" 
+else         
+  JAVA_OPT="${JAVA_OPT} -XX:PermSize=128m -XX:MaxPermSize=128m"
+fi
+JAVA_OPT="${JAVA_OPT} -server -Xms1g -Xmx1g -Xmn256m"
 JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${BASE_DIR}/lib:${JAVA_HOME}/jre/lib/ext"
 JAVA_OPT="${JAVA_OPT} -cp ${CLASSPATH}"
 


### PR DESCRIPTION
## What is the purpose of the change

Fix for ISSUE #436 

## Brief changelog

Add the java version check logic in tools.sh and runserver.sh

## Verifying this change

verified in macbook and Linux(centos)
To run the following cmds:
sh bin/mqnamesvr
sh bin/mqadmin