### PR TITLE
[ISSUE#515]Solve multi-thread problem of StatsItemSet#getAndCreateStatsItem

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerStatsManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerStatsManagerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.broker;
+
+import static org.apache.rocketmq.store.stats.BrokerStatsManager.TOPIC_PUT_NUMS;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.common.ThreadFactoryImpl;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BrokerStatsManagerTest {
+
+    private BrokerStatsManager brokerStatsManager;
+    private ThreadPoolExecutor executor;
+    @Before
+    public void init() {
+        brokerStatsManager = new BrokerStatsManager("DefaultCluster");
+        executor = new ThreadPoolExecutor(100, 200, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1000), new ThreadFactoryImpl("testMultiThread"));
+    }
+
+    @Test
+    public void test_getAndCreateStatsItem_multiThread() throws InterruptedException {
+
+        for(int i =0; i < 10000; i++) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    brokerStatsManager.incTopicPutNums("topicTest", 2, 1);
+                }
+            });
+        }
+        Thread.sleep(5000);
+        System.out.println(brokerStatsManager.getStatsItem(TOPIC_PUT_NUMS,"topicTest").getValue());
+    }
+}

--- a/common/src/main/java/org/apache/rocketmq/common/stats/MomentStatsItemSet.java
+++ b/common/src/main/java/org/apache/rocketmq/common/stats/MomentStatsItemSet.java
@@ -79,10 +79,10 @@ public class MomentStatsItemSet {
         if (null == statsItem) {
             statsItem =
                 new MomentStatsItem(this.statsName, statsKey, this.scheduledExecutorService, this.log);
-            MomentStatsItem prev = this.statsItemTable.put(statsKey, statsItem);
+            MomentStatsItem prev = this.statsItemTable.putIfAbsent(statsKey, statsItem);
 
-            if (null == prev) {
-
+            if (null != prev) {
+                statsItem = prev;
                 // statsItem.init();
             }
         }

--- a/common/src/main/java/org/apache/rocketmq/common/stats/StatsItemSet.java
+++ b/common/src/main/java/org/apache/rocketmq/common/stats/StatsItemSet.java
@@ -162,10 +162,10 @@ public class StatsItemSet {
         StatsItem statsItem = this.statsItemTable.get(statsKey);
         if (null == statsItem) {
             statsItem = new StatsItem(this.statsName, statsKey, this.scheduledExecutorService, this.log);
-            StatsItem prev = this.statsItemTable.put(statsKey, statsItem);
+            StatsItem prev = this.statsItemTable.putIfAbsent(statsKey, statsItem);
 
-            if (null == prev) {
-
+            if (null != prev) {
+                statsItem = prev;
                 // statsItem.init();
             }
         }


### PR DESCRIPTION
Fix #515 

### What is the purpose of the change

to solve multi-thread problem of StatsItemSet#getAndCreateStatsItem.

### Brief changelog

1. use putIfAbsent instead  #of put method of ConcurrentHashMap and 
2. if the prev is not null then use get method
to avoid multi-thread problem.

### Verifying this change
test case:
```
/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package org.apache.rocketmq.broker;

import org.apache.rocketmq.common.ThreadFactoryImpl;
import org.apache.rocketmq.store.stats.BrokerStatsManager;
import org.junit.Before;
import org.junit.Test;

import java.util.concurrent.ArrayBlockingQueue;
import java.util.concurrent.ThreadPoolExecutor;
import java.util.concurrent.TimeUnit;

import static org.apache.rocketmq.store.stats.BrokerStatsManager.TOPIC_PUT_NUMS;

public class BrokerStatsManagerTest {

    private BrokerStatsManager brokerStatsManager;
    private ThreadPoolExecutor executor;
    @Before
    public void init() {
        brokerStatsManager = new BrokerStatsManager("DefaultCluster");
        executor = new ThreadPoolExecutor(100, 200, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1000), new ThreadFactoryImpl("testMultiThread"));
    }

    @Test
    public void testBrokerStatsManager() throws InterruptedException {

        for(int i =0; i < 10000; i++) {
            executor.submit(new Runnable() {
                @Override
                public void run() {
                    brokerStatsManager.incTopicPutNums("topicTest", 2, 1);
                }
            });
        }
        Thread.sleep(5000);
        System.out.println(brokerStatsManager.getStatsItem(TOPIC_PUT_NUMS,"topicTest").getValue());
    }
}
```