### PR TITLE
更新并发创建mappedFile

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -563,10 +563,10 @@ public class CommitLog {
 
         long eclipseTimeInLock = 0;
         MappedFile unlockMappedFile = null;
-        MappedFile mappedFile = this.mappedFileQueue.getLastMappedFile();
 
         putMessageLock.lock(); //spin or ReentrantLock ,depending on store config
         try {
+            MappedFile mappedFile = this.mappedFileQueue.getLastMappedFile();
             long beginLockTimestamp = this.defaultMessageStore.getSystemClock().now();
             this.beginTimeInLock = beginLockTimestamp;
 


### PR DESCRIPTION
在CommitLog类中，putMessage的时候，
![image](https://user-images.githubusercontent.com/6373972/48544999-e02ab580-e8ff-11e8-81c3-ce43cdaf3303.png) 当2个同时进入的时候，第一步的时候都是null，那么在第二步的时候，就创建了2个了，
![image](https://user-images.githubusercontent.com/6373972/48545051-fcc6ed80-e8ff-11e8-98fd-3c1404f560b3.png)，修改改问题bug

