### PR TITLE
[ISSUE #522]Fix warm-up method is Ineffective code and result double io in the sync flush.

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
@@ -190,13 +190,12 @@ public class AllocateMappedFileService extends ServiceThread {
                         + " " + req.getFilePath() + " " + req.getFileSize());
                 }
 
-                // pre write mappedFile
+                // mlock address mapping to mappedFile
                 if (mappedFile.getFileSize() >= this.messageStore.getMessageStoreConfig()
                     .getMapedFileSizeCommitLog()
                     &&
                     this.messageStore.getMessageStoreConfig().isWarmMapedFileEnable()) {
-                    mappedFile.warmMappedFile(this.messageStore.getMessageStoreConfig().getFlushDiskType(),
-                        this.messageStore.getMessageStoreConfig().getFlushLeastPagesWhenWarmMapedFile());
+                    mappedFile.mlock();
                 }
 
                 req.setMappedFile(mappedFile);


### PR DESCRIPTION
1.What is the purpose of the change?

In the part of RocketMQ store,the goal of the warm-up mappedFile is that prewrite some random value into memory page corresponding to the mappedFile,so the target memory will swap to the physical memory in advance.But in fact,this action will result in double IO to the operation system.First IO is in the warm-up MappedFile,and secode IO is in the process of write message data into pagecache.

2.Optimization change action
Because of the above reason,we can remove the part of write some random value,prevent-gc and force flush codes in the warm-up method.In the mmapOperation,we can call mlock() method directly.