### PR TITLE
[ISSUE #577] fix lastFlushTimestamp usage

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -431,7 +431,7 @@ public class MappedFileQueue {
             long where = mappedFile.getFileFromOffset() + offset;
             result = where == this.flushedWhere;
             this.flushedWhere = where;
-            if (0 == flushLeastPages) {
+            if (!result) { // Has flushed data
                 this.storeTimestamp = tmpTimeStamp;
             }
         }

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -604,7 +604,7 @@ public class MessageStoreConfig {
     }
 
     /**
-     * Enable transient commitLog store poll only if transientStorePoolEnable is true and the FlushDiskType is
+     * Enable transient commitLog store pool only if transientStorePoolEnable is true and the FlushDiskType is
      * ASYNC_FLUSH
      *
      * @return <tt>true</tt> or <tt>false</tt>


### PR DESCRIPTION
## What is the purpose of the change

lastFlushTimestamp usage error, it should be the last time to flush. But now it does not express this meaning.

The change I made is to allow it to express its precise meaning.

## Brief changelog

Let lastFlushTimestamp express its precise meaning.

## Verifying this change

1. `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` success;
2. `mvn clean install -DskipITs` success;
![image](https://user-images.githubusercontent.com/19816362/49489847-d5709a00-f887-11e8-9975-216c6f6f0b7a.png)
3. `mvn clean test-compile failsafe:integration-test` success;
![image](https://user-images.githubusercontent.com/19816362/49490173-9e02ed00-f889-11e8-9db9-5932cd64317c.png)
