### PR TITLE
[ISSUE #711]Fixed RemotingUtil.getLocalAddress select down interface

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
@@ -98,6 +98,10 @@ public class RemotingUtil {
             ArrayList<String> ipv6Result = new ArrayList<String>();
             while (enumeration.hasMoreElements()) {
                 final NetworkInterface networkInterface = enumeration.nextElement();
+                // Skipping Network interface which is down.
+                if (!networkInterface.isUp()) {
+                    continue;
+                }
                 final Enumeration<InetAddress> en = networkInterface.getInetAddresses();
                 while (en.hasMoreElements()) {
                     final InetAddress address = en.nextElement();


### PR DESCRIPTION
 Skipping Network interface which is down, in RemotingUtil.getLocalAddress.