### PR TITLE
if broadcasting consumer's offset file cannot write, read offset strategy change to MEMORY_FIRST_THEN_STORE when rebalancing.

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImpl.java
@@ -142,12 +142,16 @@ public class RebalancePushImpl extends RebalanceImpl {
         long result = -1;
         final ConsumeFromWhere consumeFromWhere = this.defaultMQPushConsumerImpl.getDefaultMQPushConsumer().getConsumeFromWhere();
         final OffsetStore offsetStore = this.defaultMQPushConsumerImpl.getOffsetStore();
+        ReadOffsetType readOffsetType = ReadOffsetType.READ_FROM_STORE;
+        if (MessageModel.BROADCASTING == defaultMQPushConsumerImpl.messageModel()) {
+            readOffsetType = ReadOffsetType.MEMORY_FIRST_THEN_STORE;
+        }
         switch (consumeFromWhere) {
             case CONSUME_FROM_LAST_OFFSET_AND_FROM_MIN_WHEN_BOOT_FIRST:
             case CONSUME_FROM_MIN_OFFSET:
             case CONSUME_FROM_MAX_OFFSET:
             case CONSUME_FROM_LAST_OFFSET: {
-                long lastOffset = offsetStore.readOffset(mq, ReadOffsetType.READ_FROM_STORE);
+                long lastOffset = offsetStore.readOffset(mq, readOffsetType);
                 if (lastOffset >= 0) {
                     result = lastOffset;
                 }
@@ -168,7 +172,7 @@ public class RebalancePushImpl extends RebalanceImpl {
                 break;
             }
             case CONSUME_FROM_FIRST_OFFSET: {
-                long lastOffset = offsetStore.readOffset(mq, ReadOffsetType.READ_FROM_STORE);
+                long lastOffset = offsetStore.readOffset(mq, readOffsetType);
                 if (lastOffset >= 0) {
                     result = lastOffset;
                 } else if (-1 == lastOffset) {
@@ -179,7 +183,7 @@ public class RebalancePushImpl extends RebalanceImpl {
                 break;
             }
             case CONSUME_FROM_TIMESTAMP: {
-                long lastOffset = offsetStore.readOffset(mq, ReadOffsetType.READ_FROM_STORE);
+                long lastOffset = offsetStore.readOffset(mq, readOffsetType);
                 if (lastOffset >= 0) {
                     result = lastOffset;
                 } else if (-1 == lastOffset) {


### PR DESCRIPTION
## What is the purpose of the change

Restarted Broadcasting consumer can use broker's  max offset if cannot persist offset to local file.

## Brief changelog

Broadcasting consumer reads offset from memory first then from store when rebalancing.

## Verifying this change

I have testd this like bellow:
1 Use user 'www' to consume message broadcasting.
2 Modify one record of offset file to smaller than broker and chmod local offset file to user 'root' and change permission to read only.
3 Use my modified code, the consumer can consume message normally.

github issue: https://github.com/apache/rocketmq/issues/719
