### PR TITLE
[RIP-10] Add test case for QueryCorrectionOffsetBody & ResetOffsetBody

### DIFF
--- a/common/src/test/java/org/apache/rocketmq/common/protocol/QueryCorrectionOffsetBodyTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/protocol/QueryCorrectionOffsetBodyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.protocol;
+
+import org.apache.rocketmq.common.protocol.body.QueryCorrectionOffsetBody;
+import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryCorrectionOffsetBodyTest {
+
+    @Test
+    public void testFromJson() throws Exception {
+        QueryCorrectionOffsetBody qcob = new QueryCorrectionOffsetBody();
+        Map<Integer, Long> offsetMap = new HashMap<Integer, Long>();
+        offsetMap.put(1, 100L);
+        offsetMap.put(2, 200L);
+        qcob.setCorrectionOffsets(offsetMap);
+        String json = RemotingSerializable.toJson(qcob, true);
+        QueryCorrectionOffsetBody fromJson = RemotingSerializable.fromJson(json, QueryCorrectionOffsetBody.class);
+        assertThat(fromJson.getCorrectionOffsets().get(1)).isEqualTo(100L);
+        assertThat(fromJson.getCorrectionOffsets().get(2)).isEqualTo(200L);
+        assertThat(fromJson.getCorrectionOffsets().size()).isEqualTo(2);
+    }
+}

--- a/common/src/test/java/org/apache/rocketmq/common/protocol/ResetOffsetBodyTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/protocol/ResetOffsetBodyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.protocol;
+
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.body.QueryCorrectionOffsetBody;
+import org.apache.rocketmq.common.protocol.body.ResetOffsetBody;
+import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+public class ResetOffsetBodyTest {
+
+    @Test
+    public void testFromJson() throws Exception {
+        ResetOffsetBody rob = new ResetOffsetBody();
+        Map<MessageQueue, Long> offsetMap = new HashMap<MessageQueue, Long>();
+        MessageQueue queue = new MessageQueue();
+        queue.setQueueId(1);
+        queue.setBrokerName("brokerName");
+        queue.setTopic("topic");
+        offsetMap.put(queue, 100L);
+        rob.setOffsetTable(offsetMap);
+        String json = RemotingSerializable.toJson(rob, true);
+        ResetOffsetBody fromJson = RemotingSerializable.fromJson(json, ResetOffsetBody.class);
+        assertThat(fromJson.getOffsetTable().get(queue)).isEqualTo(100L);
+        assertThat(fromJson.getOffsetTable().size()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add test case for org.apache.rocketmq.common.protocol.body.QueryCorrectionOffsetBody.java and org.apache.rocketmq.common.protocol.body.ResetOffsetBody.java 

## Brief changelog 

Add test case for QueryCorrectionOffsetBody & ResetOffsetBody to test the correction of the serialization and deserialization.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
