### PR TITLE
[ISSUE #603] Print full stack trace when an error occurs in consuming messages

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageConcurrentlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageConcurrentlyService.java
@@ -184,7 +184,7 @@ public class ConsumeMessageConcurrentlyService implements ConsumeMessageService 
             result.setRemark(RemotingHelper.exceptionSimpleDesc(e));
 
             log.warn(String.format("consumeMessageDirectly exception: %s Group: %s Msgs: %s MQ: %s",
-                RemotingHelper.exceptionSimpleDesc(e),
+                RemotingHelper.exceptionExactDesc(e),
                 ConsumeMessageConcurrentlyService.this.consumerGroup,
                 msgs,
                 mq), e);
@@ -417,7 +417,7 @@ public class ConsumeMessageConcurrentlyService implements ConsumeMessageService 
                 status = listener.consumeMessage(Collections.unmodifiableList(msgs), context);
             } catch (Throwable e) {
                 log.warn("consumeMessage exception: {} Group: {} Msgs: {} MQ: {}",
-                    RemotingHelper.exceptionSimpleDesc(e),
+                    RemotingHelper.exceptionExactDesc(e),
                     ConsumeMessageConcurrentlyService.this.consumerGroup,
                     msgs,
                     messageQueue);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
@@ -173,7 +173,7 @@ public class ConsumeMessageOrderlyService implements ConsumeMessageService {
             result.setRemark(RemotingHelper.exceptionSimpleDesc(e));
 
             log.warn(String.format("consumeMessageDirectly exception: %s Group: %s Msgs: %s MQ: %s",
-                RemotingHelper.exceptionSimpleDesc(e),
+                RemotingHelper.exceptionExactDesc(e),
                 ConsumeMessageOrderlyService.this.consumerGroup,
                 msgs,
                 mq), e);
@@ -471,7 +471,7 @@ public class ConsumeMessageOrderlyService implements ConsumeMessageService {
                                 status = messageListener.consumeMessage(Collections.unmodifiableList(msgs), context);
                             } catch (Throwable e) {
                                 log.warn("consumeMessage exception: {} Group: {} Msgs: {} MQ: {}",
-                                    RemotingHelper.exceptionSimpleDesc(e),
+                                    RemotingHelper.exceptionExactDesc(e),
                                     ConsumeMessageOrderlyService.this.consumerGroup,
                                     msgs,
                                     messageQueue);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
@@ -52,6 +52,23 @@ public class RemotingHelper {
         return sb.toString();
     }
 
+    public static String exceptionExactDesc(final Throwable e) {
+        StringBuffer sb = new StringBuffer();
+        if (e != null) {
+            sb.append(e.toString());
+
+            StackTraceElement[] stackTrace = e.getStackTrace();
+            if (stackTrace != null && stackTrace.length > 0) {
+                for (StackTraceElement element : stackTrace) {
+                    sb.append(", ");
+                    sb.append(element.toString());
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
     public static SocketAddress string2SocketAddress(final String addr) {
         String[] s = addr.split(":");
         InetSocketAddress isa = new InetSocketAddress(s[0], Integer.parseInt(s[1]));

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
@@ -37,7 +37,26 @@ public class RemotingHelperTest {
         }
 
         assertThat(exceptionExactDesc).contains("RemotingHelperTest.generateNumberFormatException");
+        assertThat(exceptionExactDesc).contains("NumberFormatException");
     }
+
+    /**
+     * This unit test case ensures that {@link RemotingHelper#exceptionSimpleDesc(Throwable)} could not return the root cause of the exception.
+     */
+    @Test
+    public void testExceptionSimpleDesc() {
+        String exceptionExactDesc = null;
+
+        try {
+            generateNumberFormatException();
+        } catch (Throwable t) {
+            exceptionExactDesc = RemotingHelper.exceptionSimpleDesc(t);
+        }
+
+        assertThat(exceptionExactDesc).doesNotContain("RemotingHelperTest.generateNumberFormatException");
+        assertThat(exceptionExactDesc).contains("NumberFormatException");
+    }
+
 
     /**
      * Generate a {@link NumberFormatException}.
@@ -46,5 +65,4 @@ public class RemotingHelperTest {
         String emptyStr = null;
         Long.parseLong(emptyStr);
     }
-
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
@@ -19,6 +19,9 @@ package org.apache.rocketmq.remoting.common;
 
 import org.junit.Test;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemotingHelperTest {
@@ -64,5 +67,25 @@ public class RemotingHelperTest {
     private static void generateNumberFormatException() {
         String emptyStr = null;
         Long.parseLong(emptyStr);
+    }
+
+    /**
+     * This unit test case ensures that {@link RemotingHelper#string2SocketAddress(String)} could parse the string to the correct socket address.
+     */
+    @Test
+    public void testString2SocketAddress() {
+        String address = "127.0.0.1:9876";
+        InetSocketAddress inetSocketAddress = (InetSocketAddress) RemotingHelper.string2SocketAddress(address);
+        assertThat(inetSocketAddress.getPort()).isEqualTo(9876);
+    }
+
+    /**
+     * This unit test case ensures that {@link RemotingHelper#parseSocketAddressAddr(SocketAddress)} could parse the socket address to the correct string.
+     */
+    @Test
+    public void testParseSocketAddressAddr() {
+        SocketAddress inetSocketAddress = new InetSocketAddress("127.0.0.1", 9876);
+        String address = RemotingHelper.parseSocketAddressAddr(inetSocketAddress);
+        assertThat(address).isEqualTo("127.0.0.1:9876");
     }
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.remoting.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemotingHelperTest {
+
+    /**
+     * This unit test case ensures that {@link RemotingHelper#exceptionExactDesc(Throwable)} could return the root cause of the exception.
+     */
+    @Test
+    public void testExceptionExactDesc() {
+        String exceptionExactDesc = null;
+
+        try {
+            generateNumberFormatException();
+        } catch (Throwable t) {
+            exceptionExactDesc = RemotingHelper.exceptionExactDesc(t);
+        }
+
+        assertThat(exceptionExactDesc).contains("RemotingHelperTest.generateNumberFormatException");
+    }
+
+    /**
+     * Generate a {@link NumberFormatException}.
+     */
+    private static void generateNumberFormatException() {
+        String emptyStr = null;
+        Long.parseLong(emptyStr);
+    }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Print full stack trace when an error occurs in consuming messages.

## Brief changelog

Full stack trace will be printed when an error occurs in consuming messages.
