### PR TITLE
[RIP-10]optimized DefaultMessageStoreTest: invoke flush consume queue instead of sleeping few seconds

### DIFF
--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
@@ -132,7 +132,7 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_look_message_successfully_when_offset_is_first() {
+    public void test_lookMessageByOffset_firstOffset() {
         final int totalCount = 10;
         int queueId = new Random().nextInt(10);
         String topic = "FooBar";
@@ -148,7 +148,7 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_look_message_successfully_when_offset_is_last() {
+    public void test_lookMessageByOffset_lastOffset() {
         final int totalCount = 10;
         int queueId = new Random().nextInt(10);
         String topic = "FooBar";
@@ -162,7 +162,7 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_look_message_failed_and_return_null_when_offset_is_out_of_bound() {
+    public void test_lookMessageByOffset_offsetOutOfBound() {
         final int totalCount = 10;
         int queueId = new Random().nextInt(10);
         String topic = "FooBar";
@@ -175,12 +175,12 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_get_consume_queue_offset_successfully_when_incomming_by_timestamp() throws InterruptedException {
+    public void test_getOffsetInQueueByTime_success() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         String topic = "FooBar";
-        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, true);
-        Thread.sleep(10);
+        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
 
         ConsumeQueue consumeQueue = getDefaultMessageStore().findConsumeQueue(topic, queueId);
         for (AppendMessageResult appendMessageResult : appendMessageResults) {
@@ -193,13 +193,13 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_get_consume_queue_offset_successfully_when_timestamp_is_skewing() throws InterruptedException {
+    public void test_getOffsetInQueueByTime_timestampIsSkewing() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         String topic = "FooBar";
-        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, true);
-        Thread.sleep(10);
-        int skewing = 2;
+        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, 10);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
+        int skewing = 1;
 
         ConsumeQueue consumeQueue = getDefaultMessageStore().findConsumeQueue(topic, queueId);
         for (AppendMessageResult appendMessageResult : appendMessageResults) {
@@ -217,12 +217,12 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_get_min_of_max_consume_queue_offset_when_timestamp_s_skewing_is_large() throws InterruptedException {
+    public void test_getOffsetInQueueByTime_timestampIsLargeDeviation() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         String topic = "FooBar";
-        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, true);
-        Thread.sleep(10);
+        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
         int skewing = 20000;
 
         ConsumeQueue consumeQueue = getDefaultMessageStore().findConsumeQueue(topic, queueId);
@@ -239,13 +239,13 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_return_zero_when_consume_queue_not_found() throws InterruptedException {
+    public void test_getOffsetInQueueByTime_queueIdIsWrong() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         int wrongQueueId = 1;
         String topic = "FooBar";
-        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, false);
-        Thread.sleep(10);
+        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
 
         long offset = messageStore.getOffsetInQueueByTime(topic, wrongQueueId, appendMessageResults[0].getStoreTimestamp());
 
@@ -253,13 +253,13 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_return_negative_one_when_invoke_getMessageStoreTimeStamp_if_consume_queue_not_found() throws InterruptedException {
+    public void test_getMessageStoreTimeStamp_queueIdIsWrong() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         int wrongQueueId = 1;
         String topic = "FooBar";
-        putMessages(totalCount, topic, queueId, false);
-        Thread.sleep(10);
+        putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
 
         long messageStoreTimeStamp = messageStore.getMessageStoreTimeStamp(topic, wrongQueueId, 0);
 
@@ -267,13 +267,13 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_return_negative_one_when_invoke_getMessageStoreTimeStamp_if_consumeQueueOffset_not_exist() throws InterruptedException {
+    public void test_getMessageStoreTimeStamp_consumeQueueOffsetNotExist() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         int wrongQueueId = 1;
         String topic = "FooBar";
-        putMessages(totalCount, topic, queueId, true);
-        Thread.sleep(10);
+        putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
 
         long messageStoreTimeStamp = messageStore.getMessageStoreTimeStamp(topic, wrongQueueId, -1);
 
@@ -282,12 +282,12 @@ public class DefaultMessageStoreTest {
 
 
     @Test
-    public void should_get_message_store_timestamp_successfully_when_incomming_by_topic_queueId_and_consumeQueueOffset() throws InterruptedException {
+    public void test_getMessageStoreTimeStamp_success() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         String topic = "FooBar";
-        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, false);
-        Thread.sleep(10);
+        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
 
         ConsumeQueue consumeQueue = getDefaultMessageStore().findConsumeQueue(topic, queueId);
         int minOffsetInQueue = (int)consumeQueue.getMinOffsetInQueue();
@@ -298,19 +298,19 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_return_negative_one_when_invoke_getStoreTime_if_incomming_param_is_null() {
+    public void test_getStoreTime_paramIsnull() {
         long storeTime = getStoreTime(null);
 
         assertThat(storeTime).isEqualTo(-1);
     }
 
     @Test
-    public void should_get_store_time_successfully_when_invoke_getStoreTime_if_everything_is_ok() throws InterruptedException {
+    public void test_getStoreTime_success() throws Exception {
         final int totalCount = 10;
         int queueId = 0;
         String topic = "FooBar";
-        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId, false);
-        Thread.sleep(10);
+        AppendMessageResult[] appendMessageResults = putMessages(totalCount, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
         ConsumeQueue consumeQueue = messageStore.getConsumeQueue(topic, queueId);
 
         for (int i = 0; i < totalCount; i++) {
@@ -322,7 +322,7 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void should_return_negative_one_when_invoke_getStoreTime_if_phyOffset_is_less_than_commitLog_s_minOffset() {
+    public void test_getStoreTime_phyOffsetIsLessThanCommitLogMinOffset() {
         long phyOffset = -10;
         int size = 138;
         ByteBuffer byteBuffer = ByteBuffer.allocate(100);
@@ -343,10 +343,10 @@ public class DefaultMessageStoreTest {
     }
 
     private AppendMessageResult[] putMessages(int totalCount, String topic, int queueId) {
-        return putMessages(totalCount, topic, queueId, false);
+        return putMessages(totalCount, topic, queueId, 1);
     }
 
-    private AppendMessageResult[] putMessages(int totalCount, String topic, int queueId, boolean interval) {
+    private AppendMessageResult[] putMessages(int totalCount, String topic, int queueId, int millis) {
         AppendMessageResult[] appendMessageResultArray = new AppendMessageResult[totalCount];
         for (int i = 0; i < totalCount; i++) {
             String messageBody = buildMessageBodyByOffset(StoreMessage, i);
@@ -355,22 +355,25 @@ public class DefaultMessageStoreTest {
             PutMessageResult result = messageStore.putMessage(msgInner);
             appendMessageResultArray[i] = result.getAppendMessageResult();
             assertThat(result.getPutMessageStatus()).isEqualTo(PutMessageStatus.PUT_OK);
-            if (interval) {
-                try {
-                    Thread.sleep(10);
-                } catch (InterruptedException e) {
-                    throw  new RuntimeException("Thread sleep ERROR");
-                }
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
         }
         return appendMessageResultArray;
     }
 
     private long getMaxOffset(AppendMessageResult[] appendMessageResultArray) {
+        int lastIndex = appendMessageResultArray.length - 1;
+        return getMessageOffset(appendMessageResultArray, lastIndex);
+    }
+
+    private long getMessageOffset(AppendMessageResult[] appendMessageResultArray, int index) {
         if (appendMessageResultArray == null) {
             return 0;
         }
-        AppendMessageResult last = appendMessageResultArray[appendMessageResultArray.length - 1];
+        AppendMessageResult last = appendMessageResultArray[index];
         return last.getWroteOffset() + last.getWroteBytes();
     }
 
@@ -421,101 +424,80 @@ public class DefaultMessageStoreTest {
     }
 
     @Test
-    public void testPullSize() throws Exception {
+    public void test_getMessage_success() throws Exception {
         String topic = "pullSizeTopic";
-
-        for (int i = 0; i < 32; i++) {
-            MessageExtBrokerInner messageExtBrokerInner = buildMessage();
-            messageExtBrokerInner.setTopic(topic);
-            messageExtBrokerInner.setQueueId(0);
-            messageStore.putMessage(messageExtBrokerInner);
-        }
-        // wait for consume queue build
-        // the sleep time should be great than consume queue flush interval
-        Thread.sleep(100);
+        int queueId = 0;
         String group = "simple";
+        putMessages(32, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
+
         GetMessageResult getMessageResult32 = messageStore.getMessage(group, topic, 0, 0, 32, null);
-        assertThat(getMessageResult32.getMessageBufferList().size()).isEqualTo(32);
-
         GetMessageResult getMessageResult20 = messageStore.getMessage(group, topic, 0, 0, 20, null);
-        assertThat(getMessageResult20.getMessageBufferList().size()).isEqualTo(20);
-
         GetMessageResult getMessageResult45 = messageStore.getMessage(group, topic, 0, 0, 10, null);
+
+        assertThat(getMessageResult32.getMessageBufferList().size()).isEqualTo(32);
+        assertThat(getMessageResult20.getMessageBufferList().size()).isEqualTo(20);
         assertThat(getMessageResult45.getMessageBufferList().size()).isEqualTo(10);
     }
 
     @Test
-    public void testRecover() throws Exception {
+    public void test_recover_justRestart() throws Exception {
         String topic = "recoverTopic";
-        MessageBody = StoreMessage.getBytes();
-        for (int i = 0; i < 100; i++) {
-            MessageExtBrokerInner messageExtBrokerInner = buildMessage();
-            messageExtBrokerInner.setTopic(topic);
-            messageExtBrokerInner.setQueueId(0);
-            messageStore.putMessage(messageExtBrokerInner);
-        }
+        int queueId = 0;
+        int messageAmount = 100;
+        AppendMessageResult[] appendMessageResults = putMessages(messageAmount, topic, queueId);
+        long maxOffset = getMaxOffset(appendMessageResults);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
 
-        Thread.sleep(100);//wait for build consumer queue
-        long maxPhyOffset = messageStore.getMaxPhyOffset();
-        long maxCqOffset = messageStore.getMaxOffsetInQueue(topic, 0);
+        long lastPhyOffset = messageStore.getMaxPhyOffset();
+        long lastCqOffset = messageStore.getMaxOffsetInQueue(topic, queueId);
+
+        assertThat(lastPhyOffset).isEqualTo(maxOffset);
+        assertThat(lastCqOffset).isEqualTo(messageAmount);
 
         //1.just reboot
         messageStore.shutdown();
         messageStore = buildMessageStore();
-        boolean load = messageStore.load();
-        assertTrue(load);
+        assertTrue(messageStore.load());
         messageStore.start();
-        assertTrue(maxPhyOffset == messageStore.getMaxPhyOffset());
-        assertTrue(maxCqOffset == messageStore.getMaxOffsetInQueue(topic, 0));
 
-        //2.damage commitlog and reboot normal
-        for (int i = 0; i < 100; i++) {
-            MessageExtBrokerInner messageExtBrokerInner = buildMessage();
-            messageExtBrokerInner.setTopic(topic);
-            messageExtBrokerInner.setQueueId(0);
-            messageStore.putMessage(messageExtBrokerInner);
-        }
-        Thread.sleep(100);
-        long secondLastPhyOffset = messageStore.getMaxPhyOffset();
-        long secondLastCqOffset = messageStore.getMaxOffsetInQueue(topic, 0);
+        assertThat(messageStore.getMaxPhyOffset()).isEqualTo(maxOffset);
+        assertThat(messageStore.getMaxOffsetInQueue(topic, queueId)).isEqualTo(messageAmount);
+    }
 
-        MessageExtBrokerInner messageExtBrokerInner = buildMessage();
-        messageExtBrokerInner.setTopic(topic);
-        messageExtBrokerInner.setQueueId(0);
-        messageStore.putMessage(messageExtBrokerInner);
+    @Test
+    public void test_recover_damageLastMessage() throws Exception {
+        String topic = "recoverTopic";
+        int queueId = 0;
+        int messageAmount = 100;
+        AppendMessageResult[] appendMessageResults = putMessages(messageAmount + 1, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
+        long lastPhyOffset = getMessageOffset(appendMessageResults, messageAmount - 1);
 
         messageStore.shutdown();
-
-        //damage last message
-        damageCommitlog(secondLastPhyOffset);
-
-        //reboot
+        damageCommitlog(lastPhyOffset);
         messageStore = buildMessageStore();
-        load = messageStore.load();
-        assertTrue(load);
+        assertTrue(messageStore.load());
         messageStore.start();
-        assertTrue(secondLastPhyOffset == messageStore.getMaxPhyOffset());
-        assertTrue(secondLastCqOffset == messageStore.getMaxOffsetInQueue(topic, 0));
 
-        //3.damage commitlog and reboot abnormal
-        for (int i = 0; i < 100; i++) {
-            messageExtBrokerInner = buildMessage();
-            messageExtBrokerInner.setTopic(topic);
-            messageExtBrokerInner.setQueueId(0);
-            messageStore.putMessage(messageExtBrokerInner);
-        }
-        Thread.sleep(100);
-        secondLastPhyOffset = messageStore.getMaxPhyOffset();
-        secondLastCqOffset = messageStore.getMaxOffsetInQueue(topic, 0);
+        assertThat(messageStore.getMaxPhyOffset()).isEqualTo(lastPhyOffset);
+        assertThat(messageStore.getMaxOffsetInQueue(topic, queueId)).isEqualTo(messageAmount);
+    }
 
-        messageExtBrokerInner = buildMessage();
-        messageExtBrokerInner.setTopic(topic);
-        messageExtBrokerInner.setQueueId(0);
-        messageStore.putMessage(messageExtBrokerInner);
+    @Test
+    public void test_recover_abort() throws Exception {
+        String topic = "recoverTopic";
+        int queueId = 0;
+        int messageAmount = 100;
+
+        AppendMessageResult[] appendMessageResults = putMessages(messageAmount + 1, topic, queueId);
+        StoreTestUtil.flushConsumeQueue(getDefaultMessageStore());
+        long lastPhyOffset = getMessageOffset(appendMessageResults, messageAmount - 1);
+
         messageStore.shutdown();
 
         //damage last message
-        damageCommitlog(secondLastPhyOffset);
+        damageCommitlog(lastPhyOffset);
         //add abort file
         String fileName = StorePathConfigHelper.getAbortFile(((DefaultMessageStore) messageStore).getMessageStoreConfig().getStorePathRootDir());
         File file = new File(fileName);
@@ -523,19 +505,13 @@ public class DefaultMessageStoreTest {
         file.createNewFile();
 
         messageStore = buildMessageStore();
-        load = messageStore.load();
-        assertTrue(load);
+        assertTrue(messageStore.load());
         messageStore.start();
-        assertTrue(secondLastPhyOffset == messageStore.getMaxPhyOffset());
-        assertTrue(secondLastCqOffset == messageStore.getMaxOffsetInQueue(topic, 0));
+        assertThat(messageStore.getMaxPhyOffset()).isEqualTo(lastPhyOffset);
+        assertThat(messageStore.getMaxOffsetInQueue(topic, queueId)).isEqualTo(messageAmount);
 
-        //message write again
-        for (int i = 0; i < 100; i++) {
-            messageExtBrokerInner = buildMessage();
-            messageExtBrokerInner.setTopic(topic);
-            messageExtBrokerInner.setQueueId(0);
-            messageStore.putMessage(messageExtBrokerInner);
-        }
+        AppendMessageResult[] results = putMessages(1, topic, queueId);
+        assertThat(results[0].getStatus()).isEqualTo(AppendMessageStatus.PUT_OK);
     }
 
     private void damageCommitlog(long offset) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

optimized DefaultMessageStoreTest: invoke flush consume queue instead of sleeping few seconds

## Brief changelog
1. call StoreTestUtil.flushConsumeQueue instead of Thread.sleep.
2. modify method names of test cases.
3. arrange private method  that appending to the end of the file.
4. divide one `testRecover` into three smaller cases.

## Verifying this change
All tests include DefaultMessageStoreTest run pass.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
