### PR TITLE
[RIP-10]Add test cases for UpdateNamesrvConfigCommand

### DIFF
--- a/tools/src/test/java/org/apache/rocketmq/tools/command/namesrv/UpdateNamesrvConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/namesrv/UpdateNamesrvConfigCommandTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.namesrv;
+
+import java.lang.reflect.Field;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.PosixParser;
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.impl.MQClientAPIImpl;
+import org.apache.rocketmq.client.impl.MQClientManager;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExtImpl;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+
+public class UpdateNamesrvConfigCommandTest {
+	 private static DefaultMQAdminExt defaultMQAdminExt;
+	    private static DefaultMQAdminExtImpl defaultMQAdminExtImpl;
+	    private static MQClientInstance mqClientInstance = MQClientManager.getInstance().getAndCreateMQClientInstance(new ClientConfig());
+	    private static MQClientAPIImpl mQClientAPIImpl;
+
+	    @BeforeClass
+	    public static void init() throws NoSuchFieldException, IllegalAccessException {
+	        mQClientAPIImpl = mock(MQClientAPIImpl.class);
+	        defaultMQAdminExt = new DefaultMQAdminExt();
+	        defaultMQAdminExtImpl = new DefaultMQAdminExtImpl(defaultMQAdminExt, 1000);
+
+	        Field field = DefaultMQAdminExtImpl.class.getDeclaredField("mqClientInstance");
+	        field.setAccessible(true);
+	        field.set(defaultMQAdminExtImpl, mqClientInstance);
+	        field = MQClientInstance.class.getDeclaredField("mQClientAPIImpl");
+	        field.setAccessible(true);
+	        field.set(mqClientInstance, mQClientAPIImpl);
+	        field = DefaultMQAdminExt.class.getDeclaredField("defaultMQAdminExtImpl");
+	        field.setAccessible(true);
+	        field.set(defaultMQAdminExt, defaultMQAdminExtImpl);
+	    }
+
+    @AfterClass
+    public static void terminate() {
+        defaultMQAdminExt.shutdown();
+    }
+
+    @Test
+    public void testExecute() throws SubCommandException {
+    	UpdateNamesrvConfigCommand cmd = new UpdateNamesrvConfigCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = new String[]{"-k topicname", "-v unit_test","-n namespace"};
+        final CommandLine commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs, cmd.buildCommandlineOptions(options), new PosixParser());
+        cmd.execute(commandLine, options, null);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

unit test for UpdateNamesrvConfigCommand

## Brief changelog

add unit test for UpdateNamesrvConfigCommand


## Verifying this change

UpdateNamesrvConfigCommand is not friendly to be injected the mock class. I just have finished part of the unit test.
