### PR TITLE
[ISSUE #1105] Support Timed Delivery

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
@@ -45,6 +45,7 @@ public class MessageConst {
     public static final String PROPERTY_TRANSACTION_CHECK_TIMES = "TRANSACTION_CHECK_TIMES";
     public static final String PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS = "CHECK_IMMUNITY_TIME_IN_SECONDS";
     public static final String PROPERTY_INSTANCE_ID = "INSTANCE_ID";
+    public static final String PROPERTY_DELIVERY_TIME = "DELIVERY_TIME";
 
     public static final String KEY_SEPARATOR = " ";
 

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
@@ -45,7 +45,7 @@ public class MessageConst {
     public static final String PROPERTY_TRANSACTION_CHECK_TIMES = "TRANSACTION_CHECK_TIMES";
     public static final String PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS = "CHECK_IMMUNITY_TIME_IN_SECONDS";
     public static final String PROPERTY_INSTANCE_ID = "INSTANCE_ID";
-    public static final String PROPERTY_DELIVERY_TIME = "DELIVERY_TIME";
+    public static final String PROPERTY_DELIVERY_TIME_MILLIS = "DELIVERY_TIME";
 
     public static final String KEY_SEPARATOR = " ";
 

--- a/example/src/main/java/org/apache/rocketmq/example/delay/DelayConsumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/delay/DelayConsumer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.example.delay;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.message.MessageExt;
+
+import java.util.List;
+
+/**
+ * This example shows how to subscribe and consume messages using providing {@link DefaultMQPushConsumer}.
+ */
+public class DelayConsumer {
+
+    public static void main(String[] args) throws InterruptedException, MQClientException {
+
+        /*
+         * Instantiate with specified consumer group name.
+         */
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("delay-message-test-consumer");
+
+        /*
+         * Specify name server addresses.
+         * <p/>
+         *
+         * Alternatively, you may specify name server addresses via exporting environmental variable: NAMESRV_ADDR
+         * <pre>
+         * {@code
+         * consumer.setNamesrvAddr("name-server1-ip:9876;name-server2-ip:9876");
+         * }
+         * </pre>
+         */
+
+        /*
+         * Specify where to start in case the specified consumer group is a brand new one.
+         */
+        consumer.setNamesrvAddr("localhost:9876");
+        consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
+
+        /*
+         * Subscribe one more more topics to consume.
+         */
+        consumer.subscribe("TopicTest", "*");
+
+        /*
+         *  Register callback to execute on arrival of messages fetched from brokers.
+         */
+        consumer.registerMessageListener(new MessageListenerConcurrently() {
+
+            @Override
+            public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                ConsumeConcurrentlyContext context) {
+                for (MessageExt msg : msgs) {
+
+                    System.out.printf("%s-%s \n", System.currentTimeMillis(), new String(msg.getBody()));
+                }
+                return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+            }
+        });
+
+        /*
+         *  Launch the consumer instance.
+         */
+        consumer.start();
+
+        System.out.printf("Consumer Started.%n");
+    }
+}

--- a/example/src/main/java/org/apache/rocketmq/example/delay/DelayProducer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/delay/DelayProducer.java
@@ -69,7 +69,7 @@ public class DelayProducer {
                     (System.currentTimeMillis() + " Hello RocketMQ " + i + "  " + delay).getBytes(RemotingHelper.DEFAULT_CHARSET) /* Message body */
                 );
 
-                msg.putUserProperty(MessageConst.PROPERTY_DELIVERY_TIME, String.valueOf(System.currentTimeMillis() + delay));
+                msg.putUserProperty(MessageConst.PROPERTY_DELIVERY_TIME_MILLIS, String.valueOf(System.currentTimeMillis() + delay));
                 /*
                  * Call send message to deliver message to one of brokers.
                  */

--- a/example/src/main/java/org/apache/rocketmq/example/delay/DelayProducer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/delay/DelayProducer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.example.delay;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.remoting.common.RemotingHelper;
+
+import java.util.Random;
+
+/**
+ * This class demonstrates how to send messages to brokers using provided {@link DefaultMQProducer}.
+ */
+public class DelayProducer {
+    public static void main(String[] args) throws MQClientException, InterruptedException {
+
+        /*
+         * Instantiate with a producer group name.
+         */
+        DefaultMQProducer producer = new DefaultMQProducer("please_rename_unique_group_name");
+
+        /*
+         * Specify name server addresses.
+         * <p/>
+         *
+         * Alternatively, you may specify name server addresses via exporting environmental variable: NAMESRV_ADDR
+         * <pre>
+         * {@code
+         * producer.setNamesrvAddr("name-server1-ip:9876;name-server2-ip:9876");
+         * }
+         * </pre>
+         */
+
+        /*
+         * Launch the instance.
+         */
+        producer.setNamesrvAddr("localhost:9876");
+        producer.start();
+
+        Random r = new Random();
+
+        for (int i = 0; i < 1000; i++) {
+            try {
+
+                /*
+                 * Create a message instance, specifying topic, tag and message body.
+                 */
+                long delay = r.nextInt(10_000_000);
+
+                Message msg = new Message("TopicTest" /* Topic */,
+                    "TagA" /* Tag */,
+                    (System.currentTimeMillis() + " Hello RocketMQ " + i + "  " + delay).getBytes(RemotingHelper.DEFAULT_CHARSET) /* Message body */
+                );
+
+                msg.putUserProperty(MessageConst.PROPERTY_DELIVERY_TIME, String.valueOf(System.currentTimeMillis() + delay));
+                /*
+                 * Call send message to deliver message to one of brokers.
+                 */
+                SendResult sendResult = producer.send(msg);
+
+                System.out.printf("%s%n", sendResult);
+            } catch (Exception e) {
+                e.printStackTrace();
+                Thread.sleep(1000);
+            }
+        }
+
+        /*
+         * Shut down once the producer instance is not longer in use.
+         */
+        producer.shutdown();
+    }
+}

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -551,7 +551,7 @@ public class CommitLog {
         if (tranType == MessageSysFlag.TRANSACTION_NOT_TYPE
             || tranType == MessageSysFlag.TRANSACTION_COMMIT_TYPE) {
 
-            String userSpecifiedDeliveryTime = msg.getUserProperty(MessageConst.PROPERTY_DELIVERY_TIME);
+            String userSpecifiedDeliveryTime = msg.getUserProperty(MessageConst.PROPERTY_DELIVERY_TIME_MILLIS);
             if (userSpecifiedDeliveryTime != null) {
                 try {
                     long deliveryTime = Long.parseLong(userSpecifiedDeliveryTime);

--- a/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
@@ -18,8 +18,8 @@ package org.apache.rocketmq.store.schedule;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.TreeMap;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;

--- a/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
@@ -401,4 +401,26 @@ public class ScheduleMessageService extends ConfigManager {
             return msgInner;
         }
     }
+
+    public int computeDelayLevel(long deliveryTimeInMills) {
+        long timeToElapse = deliveryTimeInMills - System.currentTimeMillis();
+
+        if (timeToElapse <= 0) {
+            return 0;
+        }
+
+        Integer mostSuitableLevel = null;
+        for (Map.Entry<Integer, Long> levelTime : delayLevelTable.entrySet()) {
+            if (mostSuitableLevel == null) {
+                mostSuitableLevel = levelTime.getKey();
+            }
+
+            if (timeToElapse > levelTime.getValue()) {
+                mostSuitableLevel = levelTime.getKey();
+            } else {
+                return mostSuitableLevel;
+            }
+        }
+        return this.getMaxDelayLevel();
+    }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store.schedule;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,8 +53,8 @@ public class ScheduleMessageService extends ConfigManager {
     private static final long DELAY_FOR_A_WHILE = 100L;
     private static final long DELAY_FOR_A_PERIOD = 10000L;
 
-    private final ConcurrentMap<Integer /* level */, Long/* delay timeMillis */> delayLevelTable =
-        new ConcurrentHashMap<Integer, Long>(32);
+    private final Map<Integer /* level */, Long/* delay timeMillis */> delayLevelTable =
+        new TreeMap<>();
 
     private final ConcurrentMap<Integer /* level */, Long/* offset */> offsetTable =
         new ConcurrentHashMap<Integer, Long>(32);
@@ -189,7 +190,7 @@ public class ScheduleMessageService extends ConfigManager {
         return delayOffsetSerializeWrapper.toJson(prettyFormat);
     }
 
-    public boolean parseDelayLevel() {
+    public synchronized boolean parseDelayLevel() {
         HashMap<String, Long> timeUnitTable = new HashMap<String, Long>();
         timeUnitTable.put("s", 1000L);
         timeUnitTable.put("m", 1000L * 60);


### PR DESCRIPTION
## What is the purpose of the change

add the feature of timed delivery. [ISSUE #1105 ](https://github.com/apache/rocketmq/issues/1105)

## Brief changelog

Add a simple implementation using the delay queue.  The producer set the delivery time via adding a user property PROPERTY_DELIVERY_TIME_MILLIS ,  The CommitLog check the current time and send it to the appropriate SCHEDULE_QUEUE or a normal ConsumerQueue.

## Verifying this change

