### PR TITLE
FIX: HmacSHA1 not found if JAVA_HOME set to JRE

### DIFF
--- a/distribution/bin/tools.cmd
+++ b/distribution/bin/tools.cmd
@@ -29,7 +29,7 @@ rem ============================================================================
 rem JVM Configuration
 rem ===========================================================================================
 set "JAVA_OPT=%JAVA_OPT% -server -Xms1g -Xmx1g -Xmn256m -XX:PermSize=128m -XX:MaxPermSize=128m"
-set "JAVA_OPT=%JAVA_OPT% -Djava.ext.dirs="%BASE_DIR%\lib";"%JAVA_HOME%\jre\lib\ext""
+set "JAVA_OPT=%JAVA_OPT% -Djava.ext.dirs="%BASE_DIR%\lib";"%JAVA_HOME%\jre\lib\ext";"%JAVA_HOME%\lib\ext""
 set "JAVA_OPT=%JAVA_OPT% -cp "%CLASSPATH%""
 
 "%JAVA%" %JAVA_OPT% %*

--- a/distribution/bin/tools.sh
+++ b/distribution/bin/tools.sh
@@ -37,7 +37,7 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 # JVM Configuration
 #===========================================================================================
 JAVA_OPT="${JAVA_OPT} -server -Xms1g -Xmx1g -Xmn256m -XX:PermSize=128m -XX:MaxPermSize=128m"
-JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${BASE_DIR}/lib:${JAVA_HOME}/jre/lib/ext"
+JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${BASE_DIR}/lib:${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"
 JAVA_OPT="${JAVA_OPT} -cp ${CLASSPATH}"
 
 $JAVA ${JAVA_OPT} $@


### PR DESCRIPTION
## What is the purpose of the change

when JAVA_HOME is set to JRE, errors throw out as below:
```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option PermSize=128m; support was removed in 8.0
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=128m; support was removed in 8.0
org.apache.rocketmq.tools.command.SubCommandException: ClusterListSubCommand command failed
	at org.apache.rocketmq.tools.command.cluster.ClusterListSubCommand.execute(ClusterListSubCommand.java:93)
	at org.apache.rocketmq.tools.command.MQAdminStartup.main0(MQAdminStartup.java:135)
	at org.apache.rocketmq.tools.command.MQAdminStartup.main(MQAdminStartup.java:86)
Caused by: org.apache.rocketmq.acl.common.AclException: [10015:signature-failed] unable to calculate a request signature. error=[10015:signaturerithm HmacSHA1 not available
	at org.apache.rocketmq.acl.common.AclSigner.signAndBase64Encode(AclSigner.java:84)
	at org.apache.rocketmq.acl.common.AclSigner.calSignature(AclSigner.java:73)
	at org.apache.rocketmq.acl.common.AclSigner.calSignature(AclSigner.java:68)
	at org.apache.rocketmq.acl.common.AclUtils.calSignature(AclUtils.java:58)
	at org.apache.rocketmq.acl.common.AclClientRPCHook.doBeforeRequest(AclClientRPCHook.java:44)
	at org.apache.rocketmq.remoting.netty.NettyRemotingAbstract.doBeforeRpcHooks(NettyRemotingAbstract.java:172)
	at org.apache.rocketmq.remoting.netty.NettyRemotingClient.invokeSync(NettyRemotingClient.java:370)
	at org.apache.rocketmq.client.impl.MQClientAPIImpl.getBrokerClusterInfo(MQClientAPIImpl.java:1180)
	at org.apache.rocketmq.tools.admin.DefaultMQAdminExtImpl.examineBrokerClusterInfo(DefaultMQAdminExtImpl.java:275)
	at org.apache.rocketmq.tools.admin.DefaultMQAdminExt.examineBrokerClusterInfo(DefaultMQAdminExt.java:222)
	at org.apache.rocketmq.tools.command.cluster.ClusterListSubCommand.printClusterBaseInfo(ClusterListSubCommand.java:172)
	at org.apache.rocketmq.tools.command.cluster.ClusterListSubCommand.execute(ClusterListSubCommand.java:88)
	... 2 more
Caused by: org.apache.rocketmq.acl.common.AclException: [10015:signature-failed] unable to calculate a request signature. error=Algorithm HmacSH
	at org.apache.rocketmq.acl.common.AclSigner.sign(AclSigner.java:63)
	at org.apache.rocketmq.acl.common.AclSigner.signAndBase64Encode(AclSigner.java:79)
	... 13 more
Caused by: java.security.NoSuchAlgorithmException: Algorithm HmacSHA1 not available
	at javax.crypto.Mac.getInstance(Mac.java:181)
	at org.apache.rocketmq.acl.common.AclSigner.sign(AclSigner.java:57)
	... 14 more
```

This is cause by `Djava.ext.dirs` pointing to a location without `sunjce_provider.jar`, which should be at `${JAVA_HOME}/lib/ext` in JRE.


## Brief changelog

Add correct ext dir for JRE in tools.sh / tools.cmd

same fix was push as  #1134 but messed with branch.

## Verifying this change

