### PR TITLE
[ISSUE #1057]Filter out docker0 when finding a local address

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
@@ -99,6 +99,10 @@ public class RemotingUtil {
             ArrayList<String> ipv6Result = new ArrayList<String>();
             while (enumeration.hasMoreElements()) {
                 final NetworkInterface networkInterface = enumeration.nextElement();
+                if ("docker0".equals(networkInterface.getName())) {
+                    continue;
+                }
+
                 final Enumeration<InetAddress> en = networkInterface.getInetAddresses();
                 while (en.hasMoreElements()) {
                     final InetAddress address = en.nextElement();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.remoting.common;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.Inet6Address;
@@ -99,7 +100,7 @@ public class RemotingUtil {
             ArrayList<String> ipv6Result = new ArrayList<String>();
             while (enumeration.hasMoreElements()) {
                 final NetworkInterface networkInterface = enumeration.nextElement();
-                if ("docker0".equals(networkInterface.getName())) {
+                if (isBridge(networkInterface)) {
                     continue;
                 }
 
@@ -161,6 +162,19 @@ public class RemotingUtil {
         sb.append(":");
         sb.append(inetSocketAddress.getPort());
         return sb.toString();
+    }
+
+    private static boolean isBridge(NetworkInterface networkInterface) {
+        try {
+            if (isLinuxPlatform()) {
+                String interfaceName = networkInterface.getName();
+                File file = new File("/sys/class/net/" + interfaceName + "/bridge");
+                return file.exists();
+            }
+        } catch (SecurityException e) {
+            //Ignore
+        }
+        return false;
     }
 
     public static SocketChannel connect(SocketAddress remote) {


### PR DESCRIPTION
## What is the purpose of the change

To filter out docker0 when finding a local address

If the address of docker0 bridge was set as brokerIP1 or brokerIP2 of the master node, the client or slave couldn't establish a connection with it.

## Brief changelog

Filter out docker0 when finding a local address

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
