### PR TITLE
fix get broker method by consumer update offset to broker

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -1002,20 +1002,26 @@ public class MQClientInstance {
 
         HashMap<Long/* brokerId */, String/* address */> map = this.brokerAddrTable.get(brokerName);
         if (map != null && !map.isEmpty()) {
-            for (Map.Entry<Long, String> entry : map.entrySet()) {
-                Long id = entry.getKey();
-                brokerAddr = entry.getValue();
-                if (brokerAddr != null) {
-                    found = true;
-                    if (MixAll.MASTER_ID == id) {
-                        slave = false;
-                    } else {
-                        slave = true;
-                    }
-                    break;
+            if (map.containsKey(MixAll.MASTER_ID)) {
+                brokerAddr = map.get(MixAll.MASTER_ID);
+                found = true;
+                slave = true;
+            } else {
+                for (Map.Entry<Long, String> entry : map.entrySet()) {
+                    Long id = entry.getKey();
+                    brokerAddr = entry.getValue();
+                    if (brokerAddr != null) {
+                        found = true;
+                        if (MixAll.MASTER_ID == id) {
+                            slave = false;
+                        } else {
+                            slave = true;
+                        }
+                        break;
 
-                }
-            } // end of for
+                    }
+                } // end of for
+            }
         }
 
         if (found) {

--- a/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.admin.MQAdminExtInner;
 import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.impl.FindBrokerResult;
 import org.apache.rocketmq.client.impl.MQClientManager;
 import org.apache.rocketmq.client.impl.consumer.MQConsumerInner;
 import org.apache.rocketmq.client.impl.producer.DefaultMQProducerImpl;
@@ -111,5 +112,11 @@ public class MQClientInstanceTest {
         mqClientInstance.unregisterAdminExt(group);
         flag = mqClientInstance.registerAdminExt(group, mock(MQAdminExtInner.class));
         assertThat(flag).isTrue();
+    }
+
+    @Test
+    public void findBrokerAddressInAdmin() {
+        FindBrokerResult findBrokerResult = mqClientInstance.findBrokerAddressInAdmin("test");
+        assertThat(findBrokerResult);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

in cluster mode, when the consumer pull offset from broker or the consumer update offset to broker, the first thing is choose broker by broker name, I think this broker should be master broker if there is a surviving master，but now it is a random selection

## Brief changelog

I writer codes for choose master broker in this function
org.apache.rocketmq.client.impl.factory.MQClientInstance#findBrokerAddressInAdmin

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR.

  Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
  Format the pull request title like [ISSUE #123] Fix UnknownException when host config not exist. Each commit in the pull request should have a meaningful subject line and body.
  Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in test module.
  Run mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle to make sure basic checks pass. Run mvn clean install -DskipITs to make sure unit-test pass. Run mvn clean test-compile failsafe:integration-test to make sure integration-test pass.
  If this contribution is large, please file an Apache Individual Contributor License Agreement.
