### PR TITLE
[ISSUE #1400]do disk space detection in another thread

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -295,7 +295,7 @@ public class DefaultMessageStore implements MessageStore {
             this.shutdown = true;
 
             this.scheduledExecutorService.shutdown();
-
+            this.diskCheckScheduledExecutorService.shutdown();
             try {
 
                 Thread.sleep(1000);

--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreCleanFilesTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreCleanFilesTest.java
@@ -66,7 +66,7 @@ public class DefaultMessageStoreCleanFilesTest {
     }
 
     @Test
-    public void testIsSpaceFullFunction() throws Exception {
+    public void testIsSpaceFullFunctionEmpty2Full() throws Exception {
         String deleteWhen = "04";
         // the min value of diskMaxUsedSpaceRatio.
         int diskMaxUsedSpaceRatio = 1;
@@ -85,16 +85,19 @@ public class DefaultMessageStoreCleanFilesTest {
         messageStore.shutdown();
         messageStore.destroy();
 
+    }
+
+    @Test
+    public void testIsSpaceFullFunctionFull2Empty() throws Exception {
+        String deleteWhen = "04";
+        // the min value of diskMaxUsedSpaceRatio.
+        int diskMaxUsedSpaceRatio = 1;
         //use to reset diskfull flag
-        diskSpaceCleanForciblyRatio = 0.999D;
+        double diskSpaceCleanForciblyRatio = 0.999D;
         initMessageStore(deleteWhen, diskMaxUsedSpaceRatio, diskSpaceCleanForciblyRatio);
-        // build and put 55 messages, exactly one message per CommitLog file.
-        buildAndPutMessagesToMessageStore(msgCount);
-        commitLogQueue = getMappedFileQueueCommitLog();
-        assertEquals(fileCountCommitLog, commitLogQueue.getMappedFiles().size());
-        fileCountConsumeQueue = getFileCountConsumeQueue();
-        consumeQueue = getMappedFileQueueConsumeQueue();
-        assertEquals(fileCountConsumeQueue, consumeQueue.getMappedFiles().size());
+        //set disk full
+        messageStore.getRunningFlags().getAndMakeDiskFull();
+
         cleanCommitLogService.isSpaceFull();
         assertEquals(0, messageStore.getRunningFlags().getFlagBits() & (1 << 4));
     }

--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreCleanFilesTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreCleanFilesTest.java
@@ -70,7 +70,7 @@ public class DefaultMessageStoreCleanFilesTest {
         String deleteWhen = "04";
         // the min value of diskMaxUsedSpaceRatio.
         int diskMaxUsedSpaceRatio = 1;
-        // used to ensure set diskfull flag
+        // used to  set disk-full flag
         double diskSpaceCleanForciblyRatio = 0.01D;
         initMessageStore(deleteWhen, diskMaxUsedSpaceRatio, diskSpaceCleanForciblyRatio);
         // build and put 55 messages, exactly one message per CommitLog file.
@@ -92,7 +92,7 @@ public class DefaultMessageStoreCleanFilesTest {
         String deleteWhen = "04";
         // the min value of diskMaxUsedSpaceRatio.
         int diskMaxUsedSpaceRatio = 1;
-        //use to reset diskfull flag
+        //use to reset disk-full flag
         double diskSpaceCleanForciblyRatio = 0.999D;
         initMessageStore(deleteWhen, diskMaxUsedSpaceRatio, diskSpaceCleanForciblyRatio);
         //set disk full


### PR DESCRIPTION
## What is the purpose of the change
work for this [issue](https://github.com/apache/rocketmq/issues/1400), add a thread to do disk space detection

## Brief changelog

add another ScheduledExecutorService to do disk space detection

## Verifying this change

XXXX
