### PR TITLE
[issue #1404]motify the way to calculate the message span

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
@@ -169,7 +169,8 @@ public class ProcessQueue {
             this.lockTreeMap.readLock().lockInterruptibly();
             try {
                 if (!this.msgTreeMap.isEmpty()) {
-                    return this.msgTreeMap.lastKey() - this.msgTreeMap.firstKey();
+                    //return this.msgTreeMap.lastKey() - this.msgTreeMap.firstKey();
+                    return this.queueOffsetMax - this.msgTreeMap.firstKey();
                 }
             } finally {
                 this.lockTreeMap.readLock().unlock();

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
@@ -169,7 +169,6 @@ public class ProcessQueue {
             this.lockTreeMap.readLock().lockInterruptibly();
             try {
                 if (!this.msgTreeMap.isEmpty()) {
-                    //return this.msgTreeMap.lastKey() - this.msgTreeMap.firstKey();
                     return this.queueOffsetMax - this.msgTreeMap.firstKey();
                 }
             } finally {

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
@@ -95,6 +95,7 @@ public class ProcessQueueTest {
         ProcessQueue pq = new ProcessQueue();
         List<MessageExt> msgs=createMessageList(3001);
         pq.putMessage(msgs);
+        
         int ind=10;
         msgs.remove(ind);
         pq.removeMessage(msgs);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
@@ -90,6 +90,17 @@ public class ProcessQueueTest {
         assertThat(processQueueInfo.getCachedMsgSizeInMiB()).isEqualTo(0);
     }
 
+    @Test
+    public void testGetMaxSpan() {
+        ProcessQueue pq = new ProcessQueue();
+        List<MessageExt> msgs=createMessageList(3001);
+        pq.putMessage(msgs);
+        int ind=10;
+        msgs.remove(ind);
+        pq.removeMessage(msgs);
+        assertThat(pq.getMaxSpan()).isEqualTo(3000-ind);
+    }
+
     private List<MessageExt> createMessageList() {
         return createMessageList(100);
     }


### PR DESCRIPTION
## What is the purpose of the change

work for this [issue](https://github.com/apache/rocketmq/issues/1404),  modify getMaxSpan() function

## Brief changelog
use queueOffsetMax instead of msgTreeMap.lastKey()

## Verifying this change

XXXX