### PR TITLE
[issue #670]change the way to create newGroupChannelTable

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
@@ -53,7 +53,15 @@ public class ProducerManager {
         try {
             if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
                 try {
-                    newGroupChannelTable.putAll(groupChannelTable);
+                    Iterator<Map.Entry<String, HashMap<Channel, ClientChannelInfo>>> iter = groupChannelTable.entrySet().iterator();
+                    while (iter.hasNext()) {
+                        Map.Entry<String, HashMap<Channel, ClientChannelInfo>> entry = iter.next();
+                        String key = entry.getKey();
+                        HashMap<Channel, ClientChannelInfo> val = entry.getValue();
+                        HashMap<Channel, ClientChannelInfo> tmp = new HashMap<Channel, ClientChannelInfo>();
+                        tmp.putAll(val);
+                        newGroupChannelTable.put(key, tmp);
+                    }
                 } finally {
                     groupChannelLock.unlock();
                 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -87,4 +87,11 @@ public class ProducerManagerTest {
         assertThat(channelMap).isNull();
     }
 
+    @Test
+    public void testGetGroupChannelTable() throws Exception {
+        producerManager.registerProducer(group, clientInfo);
+        HashMap<Channel, ClientChannelInfo> oldchannelMap = producerManager.getGroupChannelTable().get(group);
+        producerManager.unregisterProducer(group, clientInfo);
+        assertThat(oldchannelMap.size()).isNotEqualTo(0);
+    }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -91,6 +91,7 @@ public class ProducerManagerTest {
     public void testGetGroupChannelTable() throws Exception {
         producerManager.registerProducer(group, clientInfo);
         HashMap<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
+        
         producerManager.unregisterProducer(group, clientInfo);
         assertThat(oldMap.size()).isNotEqualTo(0);
     }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -90,8 +90,8 @@ public class ProducerManagerTest {
     @Test
     public void testGetGroupChannelTable() throws Exception {
         producerManager.registerProducer(group, clientInfo);
-        HashMap<Channel, ClientChannelInfo> oldChannelMap = producerManager.getGroupChannelTable().get(group);
+        HashMap<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
         producerManager.unregisterProducer(group, clientInfo);
-        assertThat(oldChannelMap.size()).isNotEqualTo(0);
+        assertThat(oldMap.size()).isNotEqualTo(0);
     }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -86,12 +86,4 @@ public class ProducerManagerTest {
         channelMap = producerManager.getGroupChannelTable().get(group);
         assertThat(channelMap).isNull();
     }
-
-    @Test
-    public void testGetGroupChannelTable() throws Exception {
-        producerManager.registerProducer(group, clientInfo);
-        HashMap<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
-        producerManager.unregisterProducer(group, clientInfo);
-        assertThat(oldMap.size()).isNotEqualTo(0);
-    }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -86,4 +86,12 @@ public class ProducerManagerTest {
         channelMap = producerManager.getGroupChannelTable().get(group);
         assertThat(channelMap).isNull();
     }
+
+    @Test
+    public void testGetGroupChannelTable() throws Exception {
+        producerManager.registerProducer(group, clientInfo);
+        HashMap<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
+        producerManager.unregisterProducer(group, clientInfo);
+        assertThat(oldMap.size()).isNotEqualTo(0);
+    }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -90,8 +90,8 @@ public class ProducerManagerTest {
     @Test
     public void testGetGroupChannelTable() throws Exception {
         producerManager.registerProducer(group, clientInfo);
-        HashMap<Channel, ClientChannelInfo> oldchannelMap = producerManager.getGroupChannelTable().get(group);
+        HashMap<Channel, ClientChannelInfo> oldChannelMap = producerManager.getGroupChannelTable().get(group);
         producerManager.unregisterProducer(group, clientInfo);
-        assertThat(oldchannelMap.size()).isNotEqualTo(0);
+        assertThat(oldChannelMap.size()).isNotEqualTo(0);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

work for this [issue](https://github.com/apache/rocketmq/issues/670),  avoid ConcurrentModificationException which caused by access groupChannelTable and newGroupChannelTable at the same time

## Brief changelog
modify the way to create newGroupChannelTable in fuction getGroupChannelTable()

## Verifying this change
XXXX