### PR TITLE
[ISSUE #1425]  Set NameServer Setting For Example PerformanceTest Consumer

### DIFF
--- a/example/src/main/java/org/apache/rocketmq/example/benchmark/Consumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/benchmark/Consumer.java
@@ -105,6 +105,11 @@ public class Consumer {
         DefaultMQPushConsumer consumer = new DefaultMQPushConsumer(group);
         consumer.setInstanceName(Long.toString(System.currentTimeMillis()));
 
+        if (commandLine.hasOption('n')) {
+            String ns = commandLine.getOptionValue('n');
+            consumer.setNamesrvAddr(ns);
+        }
+
         if (filterType == null || expression == null) {
             consumer.subscribe(topic, "*");
         } else {


### PR DESCRIPTION
## What is the purpose of the change

To Solve The [ISSUE #1425] 

https://github.com/apache/rocketmq/issues/1425

## Brief changelog

Set the nameServer to consumer If cmd option has '-n'

## Verifying this change

./consumer.sh -n localhost:9876

works after this commit
