### PR TITLE
Correct Topic permission when broker has permission.

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -913,7 +913,7 @@ public class BrokerController {
             for (TopicConfig topicConfig : topicConfigWrapper.getTopicConfigTable().values()) {
                 TopicConfig tmp =
                     new TopicConfig(topicConfig.getTopicName(), topicConfig.getReadQueueNums(), topicConfig.getWriteQueueNums(),
-                        this.brokerConfig.getBrokerPermission());
+                        this.brokerConfig.getBrokerPermission() & topicConfig.getPerm());
                 topicConfigTable.put(topicConfig.getTopicName(), tmp);
             }
             topicConfigWrapper.setTopicConfigTable(topicConfigTable);


### PR DESCRIPTION
When the broker has permission set, the topic's permission should be changed to `this.brokerConfig.getBrokerPermission() & topicConfig.getPerm())`, consider that if I set the broker's permission to `readable`, and topic's permission to `writeable`, the final permission of this topic should be neither `readable` nor `writeable`.