### PR TITLE
Fix thread unsafe issue in `ConsumerFilterManager`

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterData.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterData.java
@@ -37,9 +37,9 @@ public class ConsumerFilterData {
     private String expressionType;
     private transient Expression compiledExpression;
     private long bornTime;
-    private long deadTime = 0;
+    private volatile long deadTime = 0;
     private BloomFilterData bloomFilterData;
-    private long clientVersion;
+    private volatile long clientVersion;
 
     public boolean isDead() {
         return this.deadTime >= this.bornTime;

--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
@@ -315,12 +315,12 @@ public class ConsumerFilterManager extends ConfigManager {
 
         for (String topicToRemove : topicsToRemove) {
             this.filterDataByTopic.compute(topicToRemove, (tp, filterDataMapByTopic) -> {
-               if (filterDataMapByTopic != null && filterDataMapByTopic.getGroupFilterData().isEmpty()) {
-                   log.info("Topic has no consumer, remove it! {}", topicToRemove);
-                   return null; //return null to remove this entry.
-               }
+                if (filterDataMapByTopic != null && filterDataMapByTopic.getGroupFilterData().isEmpty()) {
+                    log.info("Topic has no consumer, remove it! {}", topicToRemove);
+                    return null; //return null to remove this entry.
+                }
 
-               return filterDataMapByTopic;
+                return filterDataMapByTopic;
             });
         }
     }


### PR DESCRIPTION
`ConsumerFilterManager` is not thread safe:
`ConsumerFilterManager.clean` may remove entry of filterDataByTopic, when this occur, the following code may throw NullPointerException:

```

    public final Collection<ConsumerFilterData> get(final String topic) {
        if (!this.filterDataByTopic.containsKey(topic)) {
            return null;
        }
        //`this.filterDataByTopic.get(topic)` may be null here because it is removed in `ConsumerFilterManager.clean` by another thread.
        if (this.filterDataByTopic.get(topic).getGroupFilterData().isEmpty()) {
            return null;
        }

        return this.filterDataByTopic.get(topic).getGroupFilterData().values();
    }
```

I have also fixed some other places where may throw `NullPointerException`.



And `ConsumerFilterManager.register` may loss some registries:

```
public boolean register(final String topic, final String consumerGroup, final String expression,
        final String type, final long clientVersion) {
        if (ExpressionType.isTagType(type)) {
            return false;
        }

        if (expression == null || expression.length() == 0) {
            return false;
        }

        FilterDataMapByTopic filterDataMapByTopic = this.filterDataByTopic.get(topic);

        if (filterDataMapByTopic == null) { 
            FilterDataMapByTopic temp = new FilterDataMapByTopic(topic);
            FilterDataMapByTopic prev = this.filterDataByTopic.putIfAbsent(topic, temp);
            filterDataMapByTopic = prev != null ? prev : temp;
        }

// If filterDataMapByTopic.getGroupFilterData() is empty here, and another thread runs `clean`, filterDataMapByTopic will be removed from filterDataByTopic, the current registry will be lost.

        BloomFilterData bloomFilterData = bloomFilter.generate(consumerGroup + "#" + topic);

        return filterDataMapByTopic.register(consumerGroup, expression, type, bloomFilterData, clientVersion);
    }
```

Please notice the comment in the above code, it shows how the registry lost happens.
I modified the code to use `compute`, it will fix this. 


And also `ConsumerFilterData.deadTime/clientVersion` should be `volatile`.