### PR TITLE
modify loginfo when visiting namesrv

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -374,15 +374,15 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                 doAfterRpcHooks(RemotingHelper.parseChannelRemoteAddr(channel), request, response);
                 return response;
             } catch (RemotingSendRequestException e) {
-                log.warn("invokeSync: send request exception, so close the channel[{}]", channel);
+                log.warn("invokeSync: send request exception, so close the channel[{}]", RemotingUtil.socketAddress2String(channel.remoteAddress()));
                 this.closeChannel(addr, channel);
                 throw e;
             } catch (RemotingTimeoutException e) {
                 if (nettyClientConfig.isClientCloseSocketIfTimeout()) {
                     this.closeChannel(addr, channel);
-                    log.warn("invokeSync: close socket because of timeout, {}ms, {}", timeoutMillis, channel);
+                    log.warn("invokeSync: close socket because of timeout, {}ms, {}", timeoutMillis, RemotingUtil.socketAddress2String(channel.remoteAddress()));
                 }
-                log.warn("invokeSync: wait response timeout exception, the channel[{}]", channel);
+                log.warn("invokeSync: wait response timeout exception, the channel[{}]", RemotingUtil.socketAddress2String(channel.remoteAddress()));
                 throw e;
             }
         } else {
@@ -522,7 +522,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                 }
                 this.invokeAsyncImpl(channel, request, timeoutMillis - costTime, invokeCallback);
             } catch (RemotingSendRequestException e) {
-                log.warn("invokeAsync: send request exception, so close the channel[{}]", channel);
+                log.warn("invokeAsync: send request exception, so close the channel[{}]", RemotingUtil.socketAddress2String(channel.remoteAddress()));
                 this.closeChannel(addr, channel);
                 throw e;
             }
@@ -541,7 +541,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                 doBeforeRpcHooks(addr, request);
                 this.invokeOnewayImpl(channel, request, timeoutMillis);
             } catch (RemotingSendRequestException e) {
-                log.warn("invokeOneway: send request exception, so close the channel[{}]", channel);
+                log.warn("invokeOneway: send request exception, so close the channel[{}]", RemotingUtil.socketAddress2String(channel.remoteAddress()));
                 this.closeChannel(addr, channel);
                 throw e;
             }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -374,15 +374,15 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                 doAfterRpcHooks(RemotingHelper.parseChannelRemoteAddr(channel), request, response);
                 return response;
             } catch (RemotingSendRequestException e) {
-                log.warn("invokeSync: send request exception, so close the channel[{}]", addr);
+                log.warn("invokeSync: send request exception, so close the channel[{}]", channel);
                 this.closeChannel(addr, channel);
                 throw e;
             } catch (RemotingTimeoutException e) {
                 if (nettyClientConfig.isClientCloseSocketIfTimeout()) {
                     this.closeChannel(addr, channel);
-                    log.warn("invokeSync: close socket because of timeout, {}ms, {}", timeoutMillis, addr);
+                    log.warn("invokeSync: close socket because of timeout, {}ms, {}", timeoutMillis, channel);
                 }
-                log.warn("invokeSync: wait response timeout exception, the channel[{}]", addr);
+                log.warn("invokeSync: wait response timeout exception, the channel[{}]", channel);
                 throw e;
             }
         } else {
@@ -522,7 +522,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                 }
                 this.invokeAsyncImpl(channel, request, timeoutMillis - costTime, invokeCallback);
             } catch (RemotingSendRequestException e) {
-                log.warn("invokeAsync: send request exception, so close the channel[{}]", addr);
+                log.warn("invokeAsync: send request exception, so close the channel[{}]", channel);
                 this.closeChannel(addr, channel);
                 throw e;
             }
@@ -541,7 +541,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                 doBeforeRpcHooks(addr, request);
                 this.invokeOnewayImpl(channel, request, timeoutMillis);
             } catch (RemotingSendRequestException e) {
-                log.warn("invokeOneway: send request exception, so close the channel[{}]", addr);
+                log.warn("invokeOneway: send request exception, so close the channel[{}]", channel);
                 this.closeChannel(addr, channel);
                 throw e;
             }


### PR DESCRIPTION
## What is the purpose of the change
work for this [issue](https://github.com/apache/rocketmq/issues/1477), the loginfo is ambiguity when visiting namesrv, so we modify the loginfo to make it clear.

## Brief changelog
use the variable channel to replace addr in the log statement.