### PR TITLE
[ISSUE #1486] fix CleanUnusedTopicCommand performs wrong

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
@@ -399,7 +399,7 @@ public class DefaultMQAdminExt extends ClientConfig implements MQAdminExt {
     @Override
     public boolean cleanUnusedTopic(String cluster) throws RemotingConnectException, RemotingSendRequestException,
         RemotingTimeoutException, MQClientException, InterruptedException {
-        return defaultMQAdminExtImpl.cleanUnusedTopicByAddr(cluster);
+        return defaultMQAdminExtImpl.cleanUnusedTopic(cluster);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/broker/CleanUnusedTopicCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/broker/CleanUnusedTopicCommand.java
@@ -66,7 +66,7 @@ public class CleanUnusedTopicCommand implements SubCommand {
                 String cluster = commandLine.getOptionValue('c');
                 if (null != cluster)
                     cluster = cluster.trim();
-                result = defaultMQAdminExt.cleanUnusedTopicByAddr(cluster);
+                result = defaultMQAdminExt.cleanUnusedTopic(cluster);
             }
             System.out.printf(result ? "success" : "false");
         } catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

Fixes #1486 
## Brief changelog
1）update defaultMQAdminExt.cleanUnusedTopicByAddr(addr) to defaultMQAdminExt.cleanUnusedTopic(cluster) in CleanUnusedTopicCommand line 69
2）update defaultMQAdminExtImpl.cleanUnusedTopicByAddr(addr) to defaultMQAdminExtImpl.cleanUnusedTopic(cluster) in DefaultMQAdminExt line 402
## Verifying this change

run testcase in DefaultMQAdminExtTest#testCleanUnusedTopic
Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).