### PR TITLE
[Issue #1519] Fix problem when queue of transaction check ExecutorService is full

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/AbstractTransactionalMessageCheckListener.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/AbstractTransactionalMessageCheckListener.java
@@ -42,7 +42,7 @@ public abstract class AbstractTransactionalMessageCheckListener {
     protected final static int TCMT_QUEUE_NUMS = 1;
     protected final Random random = new Random(System.currentTimeMillis());
 
-    private static ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+    static ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
             Thread thread = new Thread(r);

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -153,6 +153,11 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                 long newOffset = halfOffset;
                 long i = halfOffset;
                 while (true) {
+                    if (transactionalMessageBridge.getBrokerController().getTransactionalMessageCheckService().isStopped()) {
+                        log.info("exit transaction check loop because shutdown");
+                        listener.shutDown();
+                        break;
+                    }
                     if (System.currentTimeMillis() - startTime > MAX_PROCESS_TIME_LIMIT) {
                         log.info("Queue={} process time reach max={}", messageQueue, MAX_PROCESS_TIME_LIMIT);
                         break;

--- a/broker/src/test/java/org/apache/rocketmq/broker/transaction/AbstractTransactionalMessageCheckListenerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/transaction/AbstractTransactionalMessageCheckListenerTest.java
@@ -1,0 +1,54 @@
+package org.apache.rocketmq.broker.transaction;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractTransactionalMessageCheckListenerTest {
+
+    @Test
+    public void testResolveHalfMsg() throws Exception {
+        AtomicInteger execCount = new AtomicInteger(0);
+        AbstractTransactionalMessageCheckListener listener = new AbstractTransactionalMessageCheckListener() {
+            @Override
+            public void resolveDiscardMsg(MessageExt msgExt) {
+            }
+
+            @Override
+            public void sendCheckMessage(MessageExt msgExt) throws Exception {
+                Thread.sleep(10);
+                execCount.incrementAndGet();
+            }
+        };
+        ExecutorService old = AbstractTransactionalMessageCheckListener.executorService;
+        try {
+            MessageExt messageExt = new MessageExt();
+            ExecutorService es = new ThreadPoolExecutor(1, 1, 100,
+                    TimeUnit.SECONDS, new ArrayBlockingQueue<>(5),
+                    r -> {
+                        Thread thread = new Thread(r);
+                        thread.setName("Transaction-msg-check-thread");
+                        return thread;
+                    });
+            AbstractTransactionalMessageCheckListener.executorService = es;
+            int count = 10;
+            for (int i = 0; i < count; i++) {
+                listener.resolveHalfMsg(messageExt);
+            }
+            listener.shutDown();
+            listener.resolveHalfMsg(messageExt);
+            es.awaitTermination(5, TimeUnit.SECONDS);
+            Assert.assertEquals(count, execCount.get());
+        } finally {
+            AbstractTransactionalMessageCheckListener.executorService = old;
+        }
+    }
+}

--- a/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.transaction.queue;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.transaction.AbstractTransactionalMessageCheckListener;
 import org.apache.rocketmq.broker.transaction.OperationResult;
+import org.apache.rocketmq.broker.transaction.TransactionalMessageCheckService;
 import org.apache.rocketmq.broker.transaction.TransactionalMessageService;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
@@ -81,6 +82,8 @@ public class TransactionalMessageServiceImplTest {
         listener.setBrokerController(brokerController);
         queueTransactionMsgService = new TransactionalMessageServiceImpl(bridge);
         brokerController.getMessageStoreConfig().setFileReservedTime(3);
+        when(bridge.getBrokerController()).thenReturn(this.brokerController);
+        brokerController.setTransactionalMessageCheckService(new TransactionalMessageCheckService(brokerController));
     }
 
     @Test
@@ -132,7 +135,6 @@ public class TransactionalMessageServiceImplTest {
         when(bridge.getHalfMessage(0, 0, 1)).thenReturn(createPullResult(MixAll.RMQ_SYS_TRANS_HALF_TOPIC, 5, "hello", 1));
         when(bridge.getHalfMessage(0, 1, 1)).thenReturn(createPullResult(MixAll.RMQ_SYS_TRANS_HALF_TOPIC, 6, "hellp", 0));
         when(bridge.getOpMessage(anyInt(), anyLong(), anyInt())).thenReturn(createPullResult(MixAll.RMQ_SYS_TRANS_OP_HALF_TOPIC, 1, "5", 0));
-        when(bridge.getBrokerController()).thenReturn(this.brokerController);
         when(bridge.renewHalfMessageInner(any(MessageExtBrokerInner.class))).thenReturn(createMessageBrokerInner());
         when(bridge.putMessageReturnResult(any(MessageExtBrokerInner.class))).thenReturn(new PutMessageResult
             (PutMessageStatus.PUT_OK, new AppendMessageResult(AppendMessageStatus.PUT_OK)));


### PR DESCRIPTION
1. catch RejectedExecutionException and retry
2. add shutdown status detect in TransactionalMessageServiceImpl.check