### PR TITLE
[ISSUE #1497] Reset queueId in MQClientAPIImpl#onExceptionImpl()

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -599,6 +599,16 @@ public class MQClientAPIImpl {
             if (topicPublishInfo != null) { //select one message queue accordingly, in order to determine which broker to send
                 MessageQueue mqChosen = producer.selectOneMessageQueue(topicPublishInfo, brokerName);
                 retryBrokerName = mqChosen.getBrokerName();
+                if (sendSmartMsg || msg instanceof MessageBatch) {
+                    SendMessageRequestHeaderV2 header = (SendMessageRequestHeaderV2) request.readCustomHeader();
+                    header.setE(mqChosen.getQueueId());
+                    request.writeCustomHeader(header);
+                } else {
+                    SendMessageRequestHeader header = (SendMessageRequestHeader) request.readCustomHeader();
+                    header.setQueueId(mqChosen.getQueueId());
+                    request.writeCustomHeader(header);
+                }
+
             }
             String addr = instance.findBrokerAddressInPublish(retryBrokerName);
             log.info("async send msg by retry {} times. topic={}, brokerAddr={}, brokerName={}", tmp, msg.getTopic(), addr,


### PR DESCRIPTION
## What is the purpose of the change

Fix  #1497 

## Brief changelog

Add the operation of reset queueId in in MQClientAPIImpl#onExceptionImpl().

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
