### PR TITLE
[ISSUE #1620]fix #1620 amout spell error

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/CLusterSendMsgRTCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/CLusterSendMsgRTCommand.java
@@ -53,7 +53,7 @@ public class CLusterSendMsgRTCommand implements SubCommand {
 
     @Override
     public Options buildCommandlineOptions(Options options) {
-        Option opt = new Option("a", "amout", true, "message amout | default 100");
+        Option opt = new Option("a", "amount", true, "message amount | default 100");
         opt.setRequired(false);
         options.addOption(opt);
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/CheckMsgSendRTCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/CheckMsgSendRTCommand.java
@@ -49,7 +49,7 @@ public class CheckMsgSendRTCommand implements SubCommand {
         opt.setRequired(true);
         options.addOption(opt);
 
-        opt = new Option("a", "amout", true, "message amout | default 100");
+        opt = new Option("a", "amount", true, "message amount | default 100");
         opt.setRequired(false);
         options.addOption(opt);
 


### PR DESCRIPTION
  mqadmin tools with command clusterRT/checkMsgSendRT, there are
  spell error for message amount in long format option type.
