### PR TITLE
[ISSUE #1110] Fix wrong topic max length in rocketmq client.

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/Validators.java
+++ b/client/src/main/java/org/apache/rocketmq/client/Validators.java
@@ -33,6 +33,7 @@ public class Validators {
     public static final String VALID_PATTERN_STR = "^[%|a-zA-Z0-9_-]+$";
     public static final Pattern PATTERN = Pattern.compile(VALID_PATTERN_STR);
     public static final int CHARACTER_MAX_LENGTH = 255;
+    public static final int TOPIC_MAX_LENGTH = 127;
 
     /**
      * @return The resulting {@code String}
@@ -117,8 +118,9 @@ public class Validators {
                 VALID_PATTERN_STR), null);
         }
 
-        if (topic.length() > CHARACTER_MAX_LENGTH) {
-            throw new MQClientException("The specified topic is longer than topic max length 255.", null);
+        if (topic.length() > TOPIC_MAX_LENGTH) {
+            throw new MQClientException(
+                String.format("The specified topic is longer than topic max length %d.", TOPIC_MAX_LENGTH), null);
         }
 
         //whether the same with system reserved keyword

--- a/client/src/test/java/org/apache/rocketmq/client/ValidatorsTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/ValidatorsTest.java
@@ -71,13 +71,13 @@ public class ValidatorsTest {
 
     @Test
     public void testCheckTopic_TooLongTopic() {
-        String tooLongTopic = StringUtils.rightPad("TooLongTopic", Validators.CHARACTER_MAX_LENGTH + 1, "_");
-        assertThat(tooLongTopic.length()).isGreaterThan(Validators.CHARACTER_MAX_LENGTH);
+        String tooLongTopic = StringUtils.rightPad("TooLongTopic", Validators.TOPIC_MAX_LENGTH + 1, "_");
+        assertThat(tooLongTopic.length()).isGreaterThan(Validators.TOPIC_MAX_LENGTH);
         try {
             Validators.checkTopic(tooLongTopic);
             failBecauseExceptionWasNotThrown(MQClientException.class);
         } catch (MQClientException e) {
-            assertThat(e).hasMessageStartingWith("The specified topic is longer than topic max length 255.");
+            assertThat(e).hasMessageStartingWith("The specified topic is longer than topic max length");
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Fix #1110 
Max topic length in `org.apache.rocketmq.client.Validators#checkTopic` is 255, but is `Byte.MAX_VALUE`(127) in `org.apache.rocketmq.store.DefaultMessageStore#putMessage`.
Sending message with topic length between 128 and 255 will get a error with code 13.
It's better to reject the message when topic length is bigger than 127.

## Brief changelog
Change max topic length in client validators to 127.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
