### PR TITLE
并发问题

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/ServiceThread.java
+++ b/common/src/main/java/org/apache/rocketmq/common/ServiceThread.java
@@ -132,8 +132,7 @@ public abstract class ServiceThread implements Runnable {
             return;
         }
 
-        //entry to wait
-        waitPoint.reset();
+
 
         try {
             waitPoint.await(interval, TimeUnit.MILLISECONDS);
@@ -141,6 +140,8 @@ public abstract class ServiceThread implements Runnable {
             log.error("Interrupted", e);
         } finally {
             hasNotified.set(false);
+            //entry to wait
+            waitPoint.reset();
             this.onWaitEnd();
         }
     }


### PR DESCRIPTION
org.apache.rocketmq.common.ServiceThread

public void wakeup() {
        if (hasNotified.compareAndSet(false, true)) {
            waitPoint.countDown(); // notify
        }
    }

    protected void waitForRunning(long interval) {
        if (hasNotified.compareAndSet(true, false)) {
            this.onWaitEnd();
            return;
        }//(1)

        //entry to wait
        waitPoint.reset();//（2）

        try {
            waitPoint.await(interval, TimeUnit.MILLISECONDS);
        } catch (InterruptedException e) {
            log.error("Interrupted", e);
        } finally {
            hasNotified.set(false);
            this.onWaitEnd();
        }
    }
这段代码在并发环境下会有问题，假设线程a执行到（1）和（2）之间，然后现在线程b调用wakeup()，之后线程a执行 waitPoint.reset();，则之后在执行waitPoint.await(interval, TimeUnit.MILLISECONDS);的时候，线程a依旧会等待。 改变下waitPoint.reset();的位置可以修复该bug