### PR TITLE
[ISSUE #1727] fix RequestCallback executed multi times

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
@@ -280,7 +280,7 @@ public class ClientRemotingProcessor implements NettyRequestProcessor {
             RequestFutureTable.getRequestFutureTable().remove(correlationId);
 
             if (requestResponseFuture.getRequestCallback() != null) {
-                requestResponseFuture.getRequestCallback().onSuccess(replyMsg);
+                requestResponseFuture.executeRequestCallback();
             } else {
                 requestResponseFuture.putResponseMessage(replyMsg);
             }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -24,8 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -104,7 +102,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
     private final RPCHook rpcHook;
     private final BlockingQueue<Runnable> asyncSenderThreadPoolQueue;
     private final ExecutorService defaultAsyncSenderExecutor;
-    private final Timer timer = new Timer("RequestHouseKeepingService", true);
     protected BlockingQueue<Runnable> checkRequestQueue;
     protected ExecutorService checkExecutor;
     private ServiceState serviceState = ServiceState.CREATE_JUST;
@@ -218,17 +215,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         }
 
         this.mQClientFactory.sendHeartbeatToAllBrokerWithLock();
-
-        this.timer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                try {
-                    RequestFutureTable.scanExpiredRequest();
-                } catch (Throwable e) {
-                    log.error("scan RequestFutureTable exception", e);
-                }
-            }
-        }, 1000 * 3, 1000);
     }
 
     private void checkConfig() throws MQClientException {

--- a/client/src/main/java/org/apache/rocketmq/client/producer/RequestFutureTable.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/RequestFutureTable.java
@@ -32,10 +32,10 @@ import org.apache.rocketmq.logging.InternalLogger;
 public class RequestFutureTable {
     private static InternalLogger log = ClientLogger.getLog();
     private static ConcurrentHashMap<String, RequestResponseFuture> requestFutureTable = new ConcurrentHashMap<String, RequestResponseFuture>();
-    private static final Timer timer = new Timer("RequestHouseKeepingService", true);
+    private static final Timer CLEANER = new Timer("RequestHouseKeepingService", true);
 
     static {
-        timer.scheduleAtFixedRate(new TimerTask() {
+        CLEANER.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
                 try {

--- a/client/src/main/java/org/apache/rocketmq/client/producer/RequestResponseFuture.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/RequestResponseFuture.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.client.producer;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.rocketmq.common.message.Message;
 
 public class RequestResponseFuture {
@@ -27,6 +28,7 @@ public class RequestResponseFuture {
     private final long beginTimestamp = System.currentTimeMillis();
     private final Message requestMsg = null;
     private long timeoutMillis;
+    private AtomicBoolean executeCallbackOnlyOnce = new AtomicBoolean(false);
     private CountDownLatch countDownLatch = new CountDownLatch(1);
     private volatile Message responseMsg = null;
     private volatile boolean sendRequestOk = true;
@@ -39,7 +41,7 @@ public class RequestResponseFuture {
     }
 
     public void executeRequestCallback() {
-        if (requestCallback != null) {
+        if (requestCallback != null && executeCallbackOnlyOnce.compareAndSet(false, true)) {
             if (sendRequestOk && cause == null) {
                 requestCallback.onSuccess(responseMsg);
             } else {

--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -48,7 +48,6 @@ import org.apache.rocketmq.common.protocol.route.BrokerData;
 import org.apache.rocketmq.common.protocol.route.QueueData;
 import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.exception.RemotingException;
-import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.netty.NettyRemotingClient;
 import org.junit.After;
 import org.junit.Before;
@@ -56,9 +55,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
@@ -375,7 +372,8 @@ public class DefaultMQProducerTest {
             RequestResponseFuture future = entry.getValue();
             future.setSendReqeustOk(true);
             message.setFlag(1);
-            future.getRequestCallback().onSuccess(message);
+            future.putResponseMessage(message);
+            future.executeRequestCallback();
         }
         countDownLatch.await(3000L, TimeUnit.MILLISECONDS);
     }
@@ -409,7 +407,8 @@ public class DefaultMQProducerTest {
             assertThat(responseMap).isNotNull();
             for (Map.Entry<String, RequestResponseFuture> entry : responseMap.entrySet()) {
                 RequestResponseFuture future = entry.getValue();
-                future.getRequestCallback().onException(e);
+                future.setCause(e);
+                future.executeRequestCallback();
             }
         }
         countDownLatch.await(3000L, TimeUnit.MILLISECONDS);

--- a/client/src/test/java/org/apache/rocketmq/client/producer/RequestResponseFutureTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/RequestResponseFutureTest.java
@@ -42,4 +42,19 @@ public class RequestResponseFutureTest {
         assertThat(cc.get()).isEqualTo(1);
     }
 
+    @Test
+    public void testRequestResponseFutureTimeout() throws Exception {
+        final AtomicInteger cc = new AtomicInteger(0);
+        RequestResponseFuture future = new RequestResponseFuture(UUID.randomUUID().toString(), 3 * 1000L, new RequestCallback() {
+            @Override public void onSuccess(Message message) {
+            }
+
+            @Override public void onException(Throwable e) {
+                cc.incrementAndGet();
+            }
+        });
+        RequestFutureTable.getRequestFutureTable().put("123", future);
+        Thread.sleep(4*1000);
+        assertThat(cc.get()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
To fix problem mentioned in [ISSUE 1727](https://github.com/apache/rocketmq/issues/1727)
When there is more than one DefaultMQProducerImpl instance in one process, RequestCallback is possible to be executed multi times.

## Brief changelog

1. move  `DefaultMQProducerImpl.timer` to `RequestFutureTable.timer` to avoid multi timer scan the future table;
2. add flag to distinguish whether a ReqeustCallback has been executed or not;

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
