### PR TITLE
Object's equals method is prone to null pointer exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-## Apache RocketMQ [![Build Status](https://travis-ci.org/apache/rocketmq.svg?branch=master)](https://travis-ci.org/apache/rocketmq) [![Coverage Status](https://coveralls.io/repos/github/apache/rocketmq/badge.svg?branch=master)](https://coveralls.io/github/apache/rocketmq?branch=master)
+## Apache RocketMQ 
+[![Build Status](https://travis-ci.org/apache/rocketmq.svg?branch=master)](https://travis-ci.org/apache/rocketmq) [![Coverage Status](https://coveralls.io/repos/github/apache/rocketmq/badge.svg?branch=master)](https://coveralls.io/github/apache/rocketmq?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.rocketmq/rocketmq-all/badge.svg)](http://search.maven.org/#search%7Cga%7C1%7Corg.apache.rocketmq)
 [![GitHub release](https://img.shields.io/badge/release-download-orange.svg)](https://rocketmq.apache.org/dowloading/releases)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/apache/rocketmq.svg)](http://isitmaintained.com/project/apache/rocketmq "Average time to resolve an issue")
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/apache/rocketmq.svg)](http://isitmaintained.com/project/apache/rocketmq "Percentage of issues still open")
+![Twitter Follow](https://img.shields.io/twitter/follow/ApacheRocketMQ?style=social)
 
 **[Apache RocketMQ](https://rocketmq.apache.org) is a distributed messaging and streaming platform with low latency, high performance and reliability, trillion-level capacity and flexible scalability.**
 
@@ -15,7 +19,7 @@ It offers a variety of features:
 * Versatile big-data and streaming ecosytem integration
 * Message retroactivity by time or offset
 * Reliable FIFO and strict ordered messaging in the same queue
-* Efficient pull&push consumption model
+* Efficient pull and push consumption model
 * Million-level message accumulation capacity in a single queue
 * Multiple messaging protocols like JMS and OpenMessaging
 * Flexible distributed scale-out deployment architecture

--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
     <artifactId>rocketmq-acl</artifactId>
     <name>rocketmq-acl ${project.version}</name>

--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
     <artifactId>rocketmq-acl</artifactId>
     <name>rocketmq-acl ${project.version}</name>

--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>rocketmq-acl</artifactId>
     <name>rocketmq-acl ${project.version}</name>

--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
     <artifactId>rocketmq-acl</artifactId>
     <name>rocketmq-acl ${project.version}</name>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
@@ -18,15 +18,11 @@ package org.apache.rocketmq.broker.client;
 
 import io.netty.channel.Channel;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import org.apache.rocketmq.broker.util.PositiveAtomicCounter;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.InternalLogger;
@@ -36,205 +32,145 @@ import org.apache.rocketmq.remoting.common.RemotingUtil;
 
 public class ProducerManager {
     private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.BROKER_LOGGER_NAME);
-    private static final long LOCK_TIMEOUT_MILLIS = 3000;
     private static final long CHANNEL_EXPIRED_TIMEOUT = 1000 * 120;
     private static final int GET_AVALIABLE_CHANNEL_RETRY_COUNT = 3;
-    private final Lock groupChannelLock = new ReentrantLock();
-    private final HashMap<String /* group name */, HashMap<Channel, ClientChannelInfo>> groupChannelTable =
-        new HashMap<String, HashMap<Channel, ClientChannelInfo>>();
+    private final ConcurrentHashMap<String /* group name */, ConcurrentHashMap<Channel, ClientChannelInfo>> groupChannelTable =
+        new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Channel> clientChannelTable = new ConcurrentHashMap<>();
     private PositiveAtomicCounter positiveAtomicCounter = new PositiveAtomicCounter();
 
     public ProducerManager() {
     }
 
-    public HashMap<String, HashMap<Channel, ClientChannelInfo>> getGroupChannelTable() {
-        HashMap<String /* group name */, HashMap<Channel, ClientChannelInfo>> newGroupChannelTable =
-            new HashMap<String, HashMap<Channel, ClientChannelInfo>>();
-        try {
-            if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-                try {
-                    Iterator<Map.Entry<String, HashMap<Channel, ClientChannelInfo>>> iter = groupChannelTable.entrySet().iterator();
-                    while (iter.hasNext()) {
-                        Map.Entry<String, HashMap<Channel, ClientChannelInfo>> entry = iter.next();
-                        String key = entry.getKey();
-                        HashMap<Channel, ClientChannelInfo> val = entry.getValue();
-                        HashMap<Channel, ClientChannelInfo> tmp = new HashMap<Channel, ClientChannelInfo>();
-                        tmp.putAll(val);
-                        newGroupChannelTable.put(key, tmp);
-                    }
-                } finally {
-                    groupChannelLock.unlock();
-                }
-            }
-        } catch (InterruptedException e) {
-            log.error("", e);
-        }
-        return newGroupChannelTable;
+    public ConcurrentHashMap<String, ConcurrentHashMap<Channel, ClientChannelInfo>> getGroupChannelTable() {
+        return groupChannelTable;
     }
 
     public void scanNotActiveChannel() {
-        try {
-            if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-                try {
-                    for (final Map.Entry<String, HashMap<Channel, ClientChannelInfo>> entry : this.groupChannelTable
-                        .entrySet()) {
-                        final String group = entry.getKey();
-                        final HashMap<Channel, ClientChannelInfo> chlMap = entry.getValue();
+        for (final Map.Entry<String, ConcurrentHashMap<Channel, ClientChannelInfo>> entry : this.groupChannelTable
+                .entrySet()) {
+            final String group = entry.getKey();
+            final ConcurrentHashMap<Channel, ClientChannelInfo> chlMap = entry.getValue();
 
-                        Iterator<Entry<Channel, ClientChannelInfo>> it = chlMap.entrySet().iterator();
-                        while (it.hasNext()) {
-                            Entry<Channel, ClientChannelInfo> item = it.next();
-                            // final Integer id = item.getKey();
-                            final ClientChannelInfo info = item.getValue();
+            Iterator<Entry<Channel, ClientChannelInfo>> it = chlMap.entrySet().iterator();
+            while (it.hasNext()) {
+                Entry<Channel, ClientChannelInfo> item = it.next();
+                // final Integer id = item.getKey();
+                final ClientChannelInfo info = item.getValue();
 
-                            long diff = System.currentTimeMillis() - info.getLastUpdateTimestamp();
-                            if (diff > CHANNEL_EXPIRED_TIMEOUT) {
-                                it.remove();
-                                clientChannelTable.remove(info.getClientId());
-                                log.warn(
-                                    "SCAN: remove expired channel[{}] from ProducerManager groupChannelTable, producer group name: {}",
-                                    RemotingHelper.parseChannelRemoteAddr(info.getChannel()), group);
-                                RemotingUtil.closeChannel(info.getChannel());
-                            }
-                        }
-                    }
-                } finally {
-                    this.groupChannelLock.unlock();
+                long diff = System.currentTimeMillis() - info.getLastUpdateTimestamp();
+                if (diff > CHANNEL_EXPIRED_TIMEOUT) {
+                    it.remove();
+                    clientChannelTable.remove(info.getClientId());
+                    log.warn(
+                            "SCAN: remove expired channel[{}] from ProducerManager groupChannelTable, producer group name: {}",
+                            RemotingHelper.parseChannelRemoteAddr(info.getChannel()), group);
+                    RemotingUtil.closeChannel(info.getChannel());
                 }
-            } else {
-                log.warn("ProducerManager scanNotActiveChannel lock timeout");
             }
-        } catch (InterruptedException e) {
-            log.error("", e);
         }
     }
 
-    public void doChannelCloseEvent(final String remoteAddr, final Channel channel) {
+    public synchronized void doChannelCloseEvent(final String remoteAddr, final Channel channel) {
         if (channel != null) {
-            try {
-                if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-                    try {
-                        for (final Map.Entry<String, HashMap<Channel, ClientChannelInfo>> entry : this.groupChannelTable
-                            .entrySet()) {
-                            final String group = entry.getKey();
-                            final HashMap<Channel, ClientChannelInfo> clientChannelInfoTable =
-                                entry.getValue();
-                            final ClientChannelInfo clientChannelInfo =
-                                clientChannelInfoTable.remove(channel);
-                            if (clientChannelInfo != null) {
-                                clientChannelTable.remove(clientChannelInfo.getClientId());
-                                log.info(
-                                    "NETTY EVENT: remove channel[{}][{}] from ProducerManager groupChannelTable, producer group: {}",
-                                    clientChannelInfo.toString(), remoteAddr, group);
-                            }
-
-                        }
-                    } finally {
-                        this.groupChannelLock.unlock();
-                    }
-                } else {
-                    log.warn("ProducerManager doChannelCloseEvent lock timeout");
+            for (final Map.Entry<String, ConcurrentHashMap<Channel, ClientChannelInfo>> entry : this.groupChannelTable
+                    .entrySet()) {
+                final String group = entry.getKey();
+                final ConcurrentHashMap<Channel, ClientChannelInfo> clientChannelInfoTable =
+                        entry.getValue();
+                final ClientChannelInfo clientChannelInfo =
+                        clientChannelInfoTable.remove(channel);
+                if (clientChannelInfo != null) {
+                    clientChannelTable.remove(clientChannelInfo.getClientId());
+                    log.info(
+                            "NETTY EVENT: remove channel[{}][{}] from ProducerManager groupChannelTable, producer group: {}",
+                            clientChannelInfo.toString(), remoteAddr, group);
                 }
-            } catch (InterruptedException e) {
-                log.error("", e);
+
             }
         }
     }
 
-    public void registerProducer(final String group, final ClientChannelInfo clientChannelInfo) {
-        try {
-            ClientChannelInfo clientChannelInfoFound = null;
+    public synchronized void registerProducer(final String group, final ClientChannelInfo clientChannelInfo) {
+        ClientChannelInfo clientChannelInfoFound = null;
 
-            if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-                try {
-                    HashMap<Channel, ClientChannelInfo> channelTable = this.groupChannelTable.get(group);
-                    if (null == channelTable) {
-                        channelTable = new HashMap<>();
-                        this.groupChannelTable.put(group, channelTable);
-                    }
+        ConcurrentHashMap<Channel, ClientChannelInfo> channelTable = this.groupChannelTable.get(group);
+        if (null == channelTable) {
+            channelTable = new ConcurrentHashMap<>();
+            this.groupChannelTable.put(group, channelTable);
+        }
 
-                    clientChannelInfoFound = channelTable.get(clientChannelInfo.getChannel());
-                    if (null == clientChannelInfoFound) {
-                        channelTable.put(clientChannelInfo.getChannel(), clientChannelInfo);
-                        clientChannelTable.put(clientChannelInfo.getClientId(), clientChannelInfo.getChannel());
-                        log.info("new producer connected, group: {} channel: {}", group,
-                            clientChannelInfo.toString());
-                    }
-                } finally {
-                    this.groupChannelLock.unlock();
-                }
+        clientChannelInfoFound = channelTable.get(clientChannelInfo.getChannel());
+        if (null == clientChannelInfoFound) {
+            channelTable.put(clientChannelInfo.getChannel(), clientChannelInfo);
+            clientChannelTable.put(clientChannelInfo.getClientId(), clientChannelInfo.getChannel());
+            log.info("new producer connected, group: {} channel: {}", group,
+                    clientChannelInfo.toString());
+        }
 
-                if (clientChannelInfoFound != null) {
-                    clientChannelInfoFound.setLastUpdateTimestamp(System.currentTimeMillis());
-                }
-            } else {
-                log.warn("ProducerManager registerProducer lock timeout");
-            }
-        } catch (InterruptedException e) {
-            log.error("", e);
+
+        if (clientChannelInfoFound != null) {
+            clientChannelInfoFound.setLastUpdateTimestamp(System.currentTimeMillis());
         }
     }
 
-    public void unregisterProducer(final String group, final ClientChannelInfo clientChannelInfo) {
-        try {
-            if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-                try {
-                    HashMap<Channel, ClientChannelInfo> channelTable = this.groupChannelTable.get(group);
-                    if (null != channelTable && !channelTable.isEmpty()) {
-                        ClientChannelInfo old = channelTable.remove(clientChannelInfo.getChannel());
-                        clientChannelTable.remove(clientChannelInfo.getClientId());
-                        if (old != null) {
-                            log.info("unregister a producer[{}] from groupChannelTable {}", group,
-                                clientChannelInfo.toString());
-                        }
-
-                        if (channelTable.isEmpty()) {
-                            this.groupChannelTable.remove(group);
-                            log.info("unregister a producer group[{}] from groupChannelTable", group);
-                        }
-                    }
-                } finally {
-                    this.groupChannelLock.unlock();
-                }
-            } else {
-                log.warn("ProducerManager unregisterProducer lock timeout");
+    public synchronized void unregisterProducer(final String group, final ClientChannelInfo clientChannelInfo) {
+        ConcurrentHashMap<Channel, ClientChannelInfo> channelTable = this.groupChannelTable.get(group);
+        if (null != channelTable && !channelTable.isEmpty()) {
+            ClientChannelInfo old = channelTable.remove(clientChannelInfo.getChannel());
+            clientChannelTable.remove(clientChannelInfo.getClientId());
+            if (old != null) {
+                log.info("unregister a producer[{}] from groupChannelTable {}", group,
+                        clientChannelInfo.toString());
             }
-        } catch (InterruptedException e) {
-            log.error("", e);
+
+            if (channelTable.isEmpty()) {
+                this.groupChannelTable.remove(group);
+                log.info("unregister a producer group[{}] from groupChannelTable", group);
+            }
         }
     }
 
     public Channel getAvaliableChannel(String groupId) {
-        HashMap<Channel, ClientChannelInfo> channelClientChannelInfoHashMap = groupChannelTable.get(groupId);
+        if (groupId == null) {
+            return null;
+        }
         List<Channel> channelList = new ArrayList<Channel>();
+        ConcurrentHashMap<Channel, ClientChannelInfo> channelClientChannelInfoHashMap = groupChannelTable.get(groupId);
         if (channelClientChannelInfoHashMap != null) {
             for (Channel channel : channelClientChannelInfoHashMap.keySet()) {
                 channelList.add(channel);
-            }
-            int size = channelList.size();
-            if (0 == size) {
-                log.warn("Channel list is empty. groupId={}", groupId);
-                return null;
-            }
-
-            int index = positiveAtomicCounter.incrementAndGet() % size;
-            Channel channel = channelList.get(index);
-            int count = 0;
-            boolean isOk = channel.isActive() && channel.isWritable();
-            while (count++ < GET_AVALIABLE_CHANNEL_RETRY_COUNT) {
-                if (isOk) {
-                    return channel;
-                }
-                index = (++index) % size;
-                channel = channelList.get(index);
-                isOk = channel.isActive() && channel.isWritable();
             }
         } else {
             log.warn("Check transaction failed, channel table is empty. groupId={}", groupId);
             return null;
         }
-        return null;
+
+        int size = channelList.size();
+        if (0 == size) {
+            log.warn("Channel list is empty. groupId={}", groupId);
+            return null;
+        }
+
+        Channel lastActiveChannel = null;
+
+        int index = positiveAtomicCounter.incrementAndGet() % size;
+        Channel channel = channelList.get(index);
+        int count = 0;
+        boolean isOk = channel.isActive() && channel.isWritable();
+        while (count++ < GET_AVALIABLE_CHANNEL_RETRY_COUNT) {
+            if (isOk) {
+                return channel;
+            }
+            if (channel.isActive()) {
+                lastActiveChannel = channel;
+            }
+            index = (++index) % size;
+            channel = channelList.get(index);
+            isOk = channel.isActive() && channel.isWritable();
+        }
+
+        return lastActiveChannel;
     }
 
     public Channel findChannel(String clientId) {

--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
@@ -53,7 +53,15 @@ public class ProducerManager {
         try {
             if (this.groupChannelLock.tryLock(LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
                 try {
-                    newGroupChannelTable.putAll(groupChannelTable);
+                    Iterator<Map.Entry<String, HashMap<Channel, ClientChannelInfo>>> iter = groupChannelTable.entrySet().iterator();
+                    while (iter.hasNext()) {
+                        Map.Entry<String, HashMap<Channel, ClientChannelInfo>> entry = iter.next();
+                        String key = entry.getKey();
+                        HashMap<Channel, ClientChannelInfo> val = entry.getValue();
+                        HashMap<Channel, ClientChannelInfo> tmp = new HashMap<Channel, ClientChannelInfo>();
+                        tmp.putAll(val);
+                        newGroupChannelTable.put(key, tmp);
+                    }
                 } finally {
                     groupChannelLock.unlock();
                 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
@@ -16,16 +16,16 @@
  */
 package org.apache.rocketmq.broker.processor;
 
+import io.netty.channel.ChannelHandlerContext;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-
-import io.netty.channel.ChannelHandlerContext;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.mqtrace.SendMessageContext;
 import org.apache.rocketmq.broker.mqtrace.SendMessageHook;
+import org.apache.rocketmq.broker.topic.TopicValidator;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.TopicFilterType;
@@ -171,11 +171,8 @@ public abstract class AbstractSendMessageProcessor implements NettyRequestProces
                 + "] sending message is forbidden");
             return response;
         }
-        if (!this.brokerController.getTopicConfigManager().isTopicCanSendMessage(requestHeader.getTopic())) {
-            String errorMsg = "the topic[" + requestHeader.getTopic() + "] is conflict with system reserved words.";
-            log.warn(errorMsg);
-            response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark(errorMsg);
+
+        if (!TopicValidator.validateTopic(requestHeader.getTopic(), response)) {
             return response;
         }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -815,7 +815,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             (GetProducerConnectionListRequestHeader) request.decodeCommandCustomHeader(GetProducerConnectionListRequestHeader.class);
 
         ProducerConnection bodydata = new ProducerConnection();
-        HashMap<Channel, ClientChannelInfo> channelInfoHashMap =
+        Map<Channel, ClientChannelInfo> channelInfoHashMap =
             this.brokerController.getProducerManager().getGroupChannelTable().get(requestHeader.getProducerGroup());
         if (channelInfoHashMap != null) {
             Iterator<Map.Entry<Channel, ClientChannelInfo>> it = channelInfoHashMap.entrySet().iterator();

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/EndTransactionProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/EndTransactionProcessor.java
@@ -132,6 +132,7 @@ public class EndTransactionProcessor implements NettyRequestProcessor {
                     msgInner.setQueueOffset(requestHeader.getTranStateTableOffset());
                     msgInner.setPreparedTransactionOffset(requestHeader.getCommitLogOffset());
                     msgInner.setStoreTimestamp(result.getPrepareMessage().getStoreTimestamp());
+                    MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_TRANSACTION_PREPARED);
                     RemotingCommand sendResult = sendFinalMessage(msgInner);
                     if (sendResult.getCode() == ResponseCode.SUCCESS) {
                         this.brokerController.getTransactionalMessageService().deletePrepareMessage(result.getPrepareMessage());

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryMessageProcessor.java
@@ -80,7 +80,7 @@ public class QueryMessageProcessor implements NettyRequestProcessor {
         response.setOpaque(request.getOpaque());
 
         String isUniqueKey = request.getExtFields().get(MixAll.UNIQUE_MSG_QUERY_FLAG);
-        if (isUniqueKey != null && isUniqueKey.equals("true")) {
+        if ("true".equals(isUniqueKey)) {
             requestHeader.setMaxNum(this.brokerController.getMessageStoreConfig().getDefaultQueryMaxNum());
         }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -353,7 +353,8 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
         PutMessageResult putMessageResult = null;
         Map<String, String> oriProps = MessageDecoder.string2messageProperties(requestHeader.getProperties());
         String traFlag = oriProps.get(MessageConst.PROPERTY_TRANSACTION_PREPARED);
-        if (traFlag != null && Boolean.parseBoolean(traFlag)) {
+        if (traFlag != null && Boolean.parseBoolean(traFlag)
+            && !(msgInner.getReconsumeTimes() > 0 && msgInner.getDelayTimeLevel() > 0)) { //For client under version 4.6.1
             if (this.brokerController.getBrokerConfig().isRejectTransactionMessage()) {
                 response.setCode(ResponseCode.NO_PERMISSION);
                 response.setRemark(

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -152,10 +152,6 @@ public class TopicConfigManager extends ConfigManager {
         return this.systemTopicList;
     }
 
-    public boolean isTopicCanSendMessage(final String topic) {
-        return !topic.equals(MixAll.AUTO_CREATE_TOPIC_KEY_TOPIC);
-    }
-
     public TopicConfig selectTopicConfig(final String topic) {
         return this.topicConfigTable.get(topic);
     }

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicValidator.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicValidator.java
@@ -27,7 +27,7 @@ public class TopicValidator {
 
     private static final String VALID_PATTERN_STR = "^[%|a-zA-Z0-9_-]+$";
     private static final Pattern PATTERN = Pattern.compile(VALID_PATTERN_STR);
-    private static final int CHARACTER_MAX_LENGTH = 255;
+    private static final int TOPIC_MAX_LENGTH = 127;
 
     private static boolean regularExpressionMatcher(String origin, Pattern pattern) {
         if (pattern == null) {
@@ -51,9 +51,9 @@ public class TopicValidator {
             return false;
         }
 
-        if (topic.length() > CHARACTER_MAX_LENGTH) {
+        if (topic.length() > TOPIC_MAX_LENGTH) {
             response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark("The specified topic is longer than topic max length 255.");
+            response.setRemark("The specified topic is longer than topic max length.");
             return false;
         }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicValidator.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicValidator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.broker.topic;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+
+public class TopicValidator {
+
+    private static final String VALID_PATTERN_STR = "^[%|a-zA-Z0-9_-]+$";
+    private static final Pattern PATTERN = Pattern.compile(VALID_PATTERN_STR);
+    private static final int CHARACTER_MAX_LENGTH = 255;
+
+    private static boolean regularExpressionMatcher(String origin, Pattern pattern) {
+        if (pattern == null) {
+            return true;
+        }
+        Matcher matcher = pattern.matcher(origin);
+        return matcher.matches();
+    }
+
+    public static boolean validateTopic(String topic, RemotingCommand response) {
+
+        if (UtilAll.isBlank(topic)) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("The specified topic is blank.");
+            return false;
+        }
+
+        if (!regularExpressionMatcher(topic, PATTERN)) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("The specified topic contains illegal characters, allowing only " + VALID_PATTERN_STR);
+            return false;
+        }
+
+        if (topic.length() > CHARACTER_MAX_LENGTH) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("The specified topic is longer than topic max length 255.");
+            return false;
+        }
+
+        //whether the same with system reserved keyword
+        if (topic.equals(MixAll.AUTO_CREATE_TOPIC_KEY_TOPIC)) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("The specified topic is conflict with AUTO_CREATE_TOPIC_KEY_TOPIC.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -19,7 +19,8 @@ package org.apache.rocketmq.broker.client;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import java.lang.reflect.Field;
-import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class ProducerManagerTest {
     @Test
     public void testRegisterProducer() throws Exception {
         producerManager.registerProducer(group, clientInfo);
-        HashMap<Channel, ClientChannelInfo> channelMap = producerManager.getGroupChannelTable().get(group);
+        Map<Channel, ClientChannelInfo> channelMap = producerManager.getGroupChannelTable().get(group);
         Channel channel1 = producerManager.findChannel("clientId");
         assertThat(channelMap).isNotNull();
         assertThat(channel1).isNotNull();
@@ -85,7 +86,7 @@ public class ProducerManagerTest {
     @Test
     public void unregisterProducer() throws Exception {
         producerManager.registerProducer(group, clientInfo);
-        HashMap<Channel, ClientChannelInfo> channelMap = producerManager.getGroupChannelTable().get(group);
+        Map<Channel, ClientChannelInfo> channelMap = producerManager.getGroupChannelTable().get(group);
         assertThat(channelMap).isNotNull();
         assertThat(channelMap.get(channel)).isEqualTo(clientInfo);
         Channel channel1 = producerManager.findChannel("clientId");
@@ -102,9 +103,28 @@ public class ProducerManagerTest {
     @Test
     public void testGetGroupChannelTable() throws Exception {
         producerManager.registerProducer(group, clientInfo);
-        HashMap<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
+        Map<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
         
         producerManager.unregisterProducer(group, clientInfo);
-        assertThat(oldMap.size()).isNotEqualTo(0);
+        assertThat(oldMap.size()).isEqualTo(0);
     }
+
+    @Test
+    public void testGetAvaliableChannel() {
+        producerManager.registerProducer(group, clientInfo);
+
+        when(channel.isActive()).thenReturn(true);
+        when(channel.isWritable()).thenReturn(true);
+        Channel c = producerManager.getAvaliableChannel(group);
+        assertThat(c).isSameAs(channel);
+
+        when(channel.isWritable()).thenReturn(false);
+        c = producerManager.getAvaliableChannel(group);
+        assertThat(c).isSameAs(channel);
+
+        when(channel.isActive()).thenReturn(false);
+        c = producerManager.getAvaliableChannel(group);
+        assertThat(c).isNull();
+    }
+
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -87,4 +87,12 @@ public class ProducerManagerTest {
         assertThat(channelMap).isNull();
     }
 
+    @Test
+    public void testGetGroupChannelTable() throws Exception {
+        producerManager.registerProducer(group, clientInfo);
+        HashMap<Channel, ClientChannelInfo> oldMap = producerManager.getGroupChannelTable().get(group);
+        
+        producerManager.unregisterProducer(group, clientInfo);
+        assertThat(oldMap.size()).isNotEqualTo(0);
+    }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/ClientManageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/ClientManageProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.processor;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.client.ClientChannelInfo;
@@ -81,7 +82,7 @@ public class ClientManageProcessorTest {
     @Test
     public void processRequest_UnRegisterProducer() throws Exception {
         brokerController.getProducerManager().registerProducer(group, clientChannelInfo);
-        HashMap<Channel, ClientChannelInfo> channelMap = brokerController.getProducerManager().getGroupChannelTable().get(group);
+        Map<Channel, ClientChannelInfo> channelMap = brokerController.getProducerManager().getGroupChannelTable().get(group);
         assertThat(channelMap).isNotNull();
         assertThat(channelMap.get(channel)).isEqualTo(clientChannelInfo);
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicValidatorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicValidatorTest.java
@@ -47,10 +47,10 @@ public class TopicValidatorTest {
         assertThat(response.getRemark()).contains("The specified topic is conflict with AUTO_CREATE_TOPIC_KEY_TOPIC.");
 
         clearResponse(response);
-        res = TopicValidator.validateTopic(generateString(255), response);
+        res = TopicValidator.validateTopic(generateString(128), response);
         assertThat(res).isFalse();
         assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
-        assertThat(response.getRemark()).contains("The specified topic is longer than topic max length 255.");
+        assertThat(response.getRemark()).contains("The specified topic is longer than topic max length.");
 
     }
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicValidatorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicValidatorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+package org.apache.rocketmq.broker.topic;
+
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TopicValidatorTest {
+
+    @Test
+    public void testTopicValidator_NotPass() {
+        RemotingCommand response = RemotingCommand.createResponseCommand(-1, "");
+
+        Boolean res = TopicValidator.validateTopic("", response);
+        assertThat(res).isFalse();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("The specified topic is blank");
+
+        clearResponse(response);
+        res = TopicValidator.validateTopic("../TopicTest", response);
+        assertThat(res).isFalse();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("The specified topic contains illegal characters");
+
+        clearResponse(response);
+        res = TopicValidator.validateTopic(MixAll.AUTO_CREATE_TOPIC_KEY_TOPIC, response);
+        assertThat(res).isFalse();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("The specified topic is conflict with AUTO_CREATE_TOPIC_KEY_TOPIC.");
+
+        clearResponse(response);
+        res = TopicValidator.validateTopic(generateString(255), response);
+        assertThat(res).isFalse();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("The specified topic is longer than topic max length 255.");
+
+    }
+
+    @Test
+    public void testTopicValidator_Pass() {
+        RemotingCommand response = RemotingCommand.createResponseCommand(-1, "");
+
+        Boolean res = TopicValidator.validateTopic("TestTopic", response);
+        assertThat(res).isTrue();
+        assertThat(response.getCode()).isEqualTo(-1);
+        assertThat(response.getRemark()).isEmpty();
+    }
+
+    private static void clearResponse(RemotingCommand response) {
+        response.setCode(-1);
+        response.setRemark("");
+    }
+
+    private static String generateString(int length) {
+        StringBuilder stringBuffer = new StringBuilder();
+        String tmpStr = "0123456789";
+        for (int i = 0; i < length; i++) {
+            stringBuffer.append(tmpStr);
+        }
+        return stringBuffer.toString();
+    }
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -93,7 +93,7 @@ public class ClientConfig {
     }
 
     public void changeInstanceNameToPID() {
-        if (this.instanceName.equals("DEFAULT")) {
+        if ("DEFAULT".equals(this.instanceName)) {
             this.instanceName = String.valueOf(UtilAll.getPid());
         }
     }

--- a/client/src/main/java/org/apache/rocketmq/client/Validators.java
+++ b/client/src/main/java/org/apache/rocketmq/client/Validators.java
@@ -77,9 +77,6 @@ public class Validators {
         return matcher.matches();
     }
 
-    /**
-     * Validate message
-     */
     public static void checkMessage(Message msg, DefaultMQProducer defaultMQProducer)
         throws MQClientException {
         if (null == msg) {
@@ -103,9 +100,6 @@ public class Validators {
         }
     }
 
-    /**
-     * Validate topic
-     */
     public static void checkTopic(String topic) throws MQClientException {
         if (UtilAll.isBlank(topic)) {
             throw new MQClientException("The specified topic is blank", null);
@@ -127,4 +121,5 @@ public class Validators {
                 String.format("The topic[%s] is conflict with AUTO_CREATE_TOPIC_KEY_TOPIC.", topic), null);
         }
     }
+
 }

--- a/client/src/main/java/org/apache/rocketmq/client/Validators.java
+++ b/client/src/main/java/org/apache/rocketmq/client/Validators.java
@@ -33,6 +33,7 @@ public class Validators {
     public static final String VALID_PATTERN_STR = "^[%|a-zA-Z0-9_-]+$";
     public static final Pattern PATTERN = Pattern.compile(VALID_PATTERN_STR);
     public static final int CHARACTER_MAX_LENGTH = 255;
+    public static final int TOPIC_MAX_LENGTH = 127;
 
     /**
      * @return The resulting {@code String}
@@ -111,8 +112,9 @@ public class Validators {
                 VALID_PATTERN_STR), null);
         }
 
-        if (topic.length() > CHARACTER_MAX_LENGTH) {
-            throw new MQClientException("The specified topic is longer than topic max length 255.", null);
+        if (topic.length() > TOPIC_MAX_LENGTH) {
+            throw new MQClientException(
+                String.format("The specified topic is longer than topic max length %d.", TOPIC_MAX_LENGTH), null);
         }
 
         //whether the same with system reserved keyword

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
@@ -26,6 +26,7 @@ import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.NamespaceUtil;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.apache.rocketmq.remoting.RPCHook;
 
@@ -186,6 +187,7 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
 
     @Override
     public void start() throws MQClientException {
+        setConsumerGroup(NamespaceUtil.wrapNamespace(this.getNamespace(), this.consumerGroup));
         this.defaultLitePullConsumerImpl.start();
     }
 
@@ -424,5 +426,9 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
 
     public void setTopicMetadataCheckIntervalMillis(long topicMetadataCheckIntervalMillis) {
         this.topicMetadataCheckIntervalMillis = topicMetadataCheckIntervalMillis;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
     }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
@@ -24,6 +24,8 @@ import org.apache.rocketmq.client.consumer.store.OffsetStore;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.protocol.NamespaceUtil;
@@ -137,6 +139,14 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
      * Interval time in in milliseconds for checking changes in topic metadata.
      */
     private long topicMetadataCheckIntervalMillis = 30 * 1000;
+
+    private ConsumeFromWhere consumeFromWhere = ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET;
+
+    /**
+     * Backtracking consumption time with second precision. Time format is 20131223171201<br> Implying Seventeen twelve
+     * and 01 seconds on December 23, 2013 year<br> Default backtracking consumption time Half an hour ago.
+     */
+    private String consumeTimestamp = UtilAll.timeMillisToHumanString3(System.currentTimeMillis() - (1000 * 60 * 30));
 
     /**
      * Default constructor.
@@ -430,5 +440,26 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
 
     public void setConsumerGroup(String consumerGroup) {
         this.consumerGroup = consumerGroup;
+    }
+
+    public ConsumeFromWhere getConsumeFromWhere() {
+        return consumeFromWhere;
+    }
+
+    public void setConsumeFromWhere(ConsumeFromWhere consumeFromWhere) {
+        if (consumeFromWhere != ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET
+            && consumeFromWhere != ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET
+            && consumeFromWhere != ConsumeFromWhere.CONSUME_FROM_TIMESTAMP) {
+            throw new RuntimeException("Invalid ConsumeFromWhere Value", null);
+        }
+        this.consumeFromWhere = consumeFromWhere;
+    }
+
+    public String getConsumeTimestamp() {
+        return consumeTimestamp;
+    }
+
+    public void setConsumeTimestamp(String consumeTimestamp) {
+        this.consumeTimestamp = consumeTimestamp;
     }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
@@ -18,7 +18,6 @@ package org.apache.rocketmq.client.consumer;
 
 import java.util.Collection;
 import java.util.List;
-
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
 import org.apache.rocketmq.client.consumer.store.OffsetStore;
@@ -35,12 +34,12 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
     private final DefaultLitePullConsumerImpl defaultLitePullConsumerImpl;
 
     /**
-     * Consumers belonging to the same consumer group share a group id. The consumers in a group then
-     * divides the topic as fairly amongst themselves as possible by establishing that each queue is only
-     * consumed by a single consumer from the group. If all consumers are from the same group, it functions
-     * as a traditional message queue. Each message would be consumed by one consumer of the group only.
-     * When multiple consumer groups exist, the flow of the data consumption model aligns with the traditional
-     * publish-subscribe model. The messages are broadcast to all consumer groups.
+     * Consumers belonging to the same consumer group share a group id. The consumers in a group then divides the topic
+     * as fairly amongst themselves as possible by establishing that each queue is only consumed by a single consumer
+     * from the group. If all consumers are from the same group, it functions as a traditional message queue. Each
+     * message would be consumed by one consumer of the group only. When multiple consumer groups exist, the flow of the
+     * data consumption model aligns with the traditional publish-subscribe model. The messages are broadcast to all
+     * consumer groups.
      */
     private String consumerGroup;
 
@@ -264,6 +263,21 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
     @Override
     public Long committed(MessageQueue messageQueue) throws MQClientException {
         return this.defaultLitePullConsumerImpl.committed(messageQueue);
+    }
+
+    @Override
+    public void updateNameServerAddress(String nameServerAddress) {
+        this.defaultLitePullConsumerImpl.updateNameServerAddr(nameServerAddress);
+    }
+
+    @Override
+    public void seekToBegin(MessageQueue messageQueue) throws MQClientException {
+        this.defaultLitePullConsumerImpl.seekToBegin(messageQueue);
+    }
+
+    @Override
+    public void seekToEnd(MessageQueue messageQueue) throws MQClientException {
+        this.defaultLitePullConsumerImpl.seekToEnd(messageQueue);
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumer.java
@@ -388,7 +388,7 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
         defaultMQPushConsumerImpl = new DefaultMQPushConsumerImpl(this, rpcHook);
         if (enableMsgTrace) {
             try {
-                AsyncTraceDispatcher dispatcher = new AsyncTraceDispatcher(customizedTraceTopic, rpcHook);
+                AsyncTraceDispatcher dispatcher = new AsyncTraceDispatcher(consumerGroup, TraceDispatcher.Type.CONSUME, customizedTraceTopic, rpcHook);
                 dispatcher.setHostConsumer(this.getDefaultMQPushConsumerImpl());
                 traceDispatcher = dispatcher;
                 this.getDefaultMQPushConsumerImpl().registerConsumeMessageHook(

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/LitePullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/LitePullConsumer.java
@@ -172,4 +172,27 @@ public interface LitePullConsumer {
      */
     void registerTopicMessageQueueChangeListener(String topic,
         TopicMessageQueueChangeListener topicMessageQueueChangeListener) throws MQClientException;
+
+    /**
+     * Update name server addresses.
+     */
+    void updateNameServerAddress(String nameServerAddress);
+
+    /**
+     * Overrides the fetch offsets with the begin offset that the consumer will use on the next poll. If this API is
+     * invoked for the same message queue more than once, the latest offset will be used on the next poll(). Note that
+     * you may lose data if this API is arbitrarily used in the middle of consumption.
+     *
+     * @param messageQueue
+     */
+    void seekToBegin(MessageQueue messageQueue)throws MQClientException;
+
+    /**
+     * Overrides the fetch offsets with the end offset that the consumer will use on the next poll. If this API is
+     * invoked for the same message queue more than once, the latest offset will be used on the next poll(). Note that
+     * you may lose data if this API is arbitrarily used in the middle of consumption.
+     *
+     * @param messageQueue
+     */
+    void seekToEnd(MessageQueue messageQueue)throws MQClientException;
 }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.rocketmq.client.QueryResult;
+import org.apache.rocketmq.client.Validators;
 import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
@@ -80,6 +81,7 @@ public class MQAdminImpl {
 
     public void createTopic(String key, String newTopic, int queueNum, int topicSysFlag) throws MQClientException {
         try {
+            Validators.checkTopic(newTopic);
             TopicRouteData topicRouteData = this.mQClientFactory.getMQClientAPIImpl().getTopicRouteInfoFromNameServer(key, timeoutMillis);
             List<BrokerData> brokerDataList = topicRouteData.getBrokerDatas();
             if (brokerDataList != null && !brokerDataList.isEmpty()) {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -43,12 +43,12 @@ import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.client.producer.SendCallback;
 import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.common.AclConfig;
 import org.apache.rocketmq.common.DataVersion;
 import org.apache.rocketmq.common.MQVersion;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.PlainAccessConfig;
 import org.apache.rocketmq.common.TopicConfig;
-import org.apache.rocketmq.common.AclConfig;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.admin.ConsumeStats;
 import org.apache.rocketmq.common.admin.TopicStatsTable;
@@ -305,8 +305,8 @@ public class MQClientAPIImpl {
         requestHeader.setDefaultGroupPerm(plainAccessConfig.getDefaultGroupPerm());
         requestHeader.setDefaultTopicPerm(plainAccessConfig.getDefaultTopicPerm());
         requestHeader.setWhiteRemoteAddress(plainAccessConfig.getWhiteRemoteAddress());
-        requestHeader.setTopicPerms(UtilAll.List2String(plainAccessConfig.getTopicPerms(), ","));
-        requestHeader.setGroupPerms(UtilAll.List2String(plainAccessConfig.getGroupPerms(), ","));
+        requestHeader.setTopicPerms(UtilAll.list2String(plainAccessConfig.getTopicPerms(), ","));
+        requestHeader.setGroupPerms(UtilAll.list2String(plainAccessConfig.getGroupPerms(), ","));
 
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.UPDATE_AND_CREATE_ACL_CONFIG, requestHeader);
 

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -694,7 +694,7 @@ public class MQClientAPIImpl {
                 if (regionId == null || regionId.isEmpty()) {
                     regionId = MixAll.DEFAULT_TRACE_REGION_ID;
                 }
-                if (traceOn != null && traceOn.equals("false")) {
+                if ("false".equals(traceOn)) {
                     sendResult.setTraceOn(false);
                 } else {
                     sendResult.setTraceOn(true);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/AssignedMessageQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/AssignedMessageQueue.java
@@ -90,7 +90,7 @@ public class AssignedMessageQueue {
         }
     }
 
-    public long getConusmerOffset(MessageQueue messageQueue) {
+    public long getConsumerOffset(MessageQueue messageQueue) {
         MessageQueueState messageQueueState = assignedMessageQueueState.get(messageQueue);
         if (messageQueueState != null) {
             return messageQueueState.getConsumeOffset();

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
@@ -374,6 +374,7 @@ public class ConsumeMessageOrderlyService implements ConsumeMessageService {
             MessageAccessor.putProperty(newMsg, MessageConst.PROPERTY_RETRY_TOPIC, msg.getTopic());
             MessageAccessor.setReconsumeTime(newMsg, String.valueOf(msg.getReconsumeTimes()));
             MessageAccessor.setMaxReconsumeTimes(newMsg, String.valueOf(getMaxReconsumeTimes()));
+            MessageAccessor.clearProperty(newMsg, MessageConst.PROPERTY_TRANSACTION_PREPARED);
             newMsg.setDelayTimeLevel(3 + msg.getReconsumeTimes());
 
             this.defaultMQPushConsumer.getDefaultMQPushConsumerImpl().getmQClientFactory().getDefaultMQProducer().send(newMsg);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
@@ -561,8 +561,8 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
     }
 
     public void seekToEnd(MessageQueue messageQueue) throws MQClientException {
-        long begin = maxOffset(messageQueue);
-        this.seek(messageQueue, begin);
+        long end = maxOffset(messageQueue);
+        this.seek(messageQueue, end);
     }
 
     private long maxOffset(MessageQueue messageQueue) throws MQClientException {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
@@ -211,10 +211,6 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
         }
     }
 
-    private int nextPullBatchSize() {
-        return Math.min(this.defaultLitePullConsumer.getPullBatchSize(), consumeRequestCache.remainingCapacity());
-    }
-
     public synchronized void shutdown() {
         switch (this.serviceState) {
             case CREATE_JUST:
@@ -775,7 +771,8 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
                         subscriptionData = FilterAPI.buildSubscriptionData(defaultLitePullConsumer.getConsumerGroup(),
                             topic, SubscriptionData.SUB_ALL);
                     }
-                    PullResult pullResult = pull(messageQueue, subscriptionData, offset, nextPullBatchSize());
+                    
+                    PullResult pullResult = pull(messageQueue, subscriptionData, offset, defaultLitePullConsumer.getPullBatchSize());
 
                     switch (pullResult.getPullStatus()) {
                         case FOUND:

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
@@ -424,7 +424,7 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
 
     public synchronized void subscribe(String topic, String subExpression) throws MQClientException {
         try {
-            if (topic == null || topic.equals("")) {
+            if (topic == null || "".equals(topic)) {
                 throw new IllegalArgumentException("Topic can not be null or empty.");
             }
             setSubscriptionType(SubscriptionType.SUBSCRIBE);
@@ -444,7 +444,7 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
 
     public synchronized void subscribe(String topic, MessageSelector messageSelector) throws MQClientException {
         try {
-            if (topic == null || topic.equals("")) {
+            if (topic == null || "".equals(topic)) {
                 throw new IllegalArgumentException("Topic can not be null or empty.");
             }
             setSubscriptionType(SubscriptionType.SUBSCRIBE);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPushConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultMQPushConsumerImpl.java
@@ -528,6 +528,7 @@ public class DefaultMQPushConsumerImpl implements MQConsumerInner {
             MessageAccessor.putProperty(newMsg, MessageConst.PROPERTY_RETRY_TOPIC, msg.getTopic());
             MessageAccessor.setReconsumeTime(newMsg, String.valueOf(msg.getReconsumeTimes() + 1));
             MessageAccessor.setMaxReconsumeTimes(newMsg, String.valueOf(getMaxReconsumeTimes()));
+            MessageAccessor.clearProperty(newMsg, MessageConst.PROPERTY_TRANSACTION_PREPARED);
             newMsg.setDelayTimeLevel(3 + msg.getReconsumeTimes());
 
             this.mQClientFactory.getDefaultMQProducer().send(newMsg);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
@@ -40,11 +40,6 @@ import org.apache.rocketmq.common.protocol.heartbeat.ConsumeType;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
 
-/**
- * This class will be removed in 2022, and a better implementation {@link RebalanceLitePullImpl} is recommend to use
- * in the scenario of actively pulling messages.
- */
-@Deprecated
 public abstract class RebalanceImpl {
     protected static final InternalLogger log = ClientLogger.getLog();
     protected final ConcurrentMap<MessageQueue, ProcessQueue> processQueueTable = new ConcurrentHashMap<MessageQueue, ProcessQueue>(64);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImpl.java
@@ -16,15 +16,19 @@
  */
 package org.apache.rocketmq.client.impl.consumer;
 
+import java.util.List;
+import java.util.Set;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.consumer.MessageQueueListener;
+import org.apache.rocketmq.client.consumer.store.ReadOffsetType;
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.protocol.heartbeat.ConsumeType;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
-
-import java.util.List;
-import java.util.Set;
 
 public class RebalanceLitePullImpl extends RebalanceImpl {
 
@@ -72,7 +76,66 @@ public class RebalanceLitePullImpl extends RebalanceImpl {
 
     @Override
     public long computePullFromWhere(MessageQueue mq) {
-        return 0;
+        ConsumeFromWhere consumeFromWhere = litePullConsumerImpl.getDefaultLitePullConsumer().getConsumeFromWhere();
+        long result = -1;
+        switch (consumeFromWhere) {
+            case CONSUME_FROM_LAST_OFFSET: {
+                long lastOffset = litePullConsumerImpl.getOffsetStore().readOffset(mq, ReadOffsetType.MEMORY_FIRST_THEN_STORE);
+                if (lastOffset >= 0) {
+                    result = lastOffset;
+                } else if (-1 == lastOffset) {
+                    if (mq.getTopic().startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) { // First start, no offset
+                        result = 0L;
+                    } else {
+                        try {
+                            result = this.mQClientFactory.getMQAdminImpl().maxOffset(mq);
+                        } catch (MQClientException e) {
+                            result = -1;
+                        }
+                    }
+                } else {
+                    result = -1;
+                }
+                break;
+            }
+            case CONSUME_FROM_FIRST_OFFSET: {
+                long lastOffset = litePullConsumerImpl.getOffsetStore().readOffset(mq, ReadOffsetType.MEMORY_FIRST_THEN_STORE);
+                if (lastOffset >= 0) {
+                    result = lastOffset;
+                } else if (-1 == lastOffset) {
+                    result = 0L;
+                } else {
+                    result = -1;
+                }
+                break;
+            }
+            case CONSUME_FROM_TIMESTAMP: {
+                long lastOffset = litePullConsumerImpl.getOffsetStore().readOffset(mq, ReadOffsetType.MEMORY_FIRST_THEN_STORE);
+                if (lastOffset >= 0) {
+                    result = lastOffset;
+                } else if (-1 == lastOffset) {
+                    if (mq.getTopic().startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) {
+                        try {
+                            result = this.mQClientFactory.getMQAdminImpl().maxOffset(mq);
+                        } catch (MQClientException e) {
+                            result = -1;
+                        }
+                    } else {
+                        try {
+                            long timestamp = UtilAll.parseDate(this.litePullConsumerImpl.getDefaultLitePullConsumer().getConsumeTimestamp(),
+                                UtilAll.YYYYMMDDHHMMSS).getTime();
+                            result = this.mQClientFactory.getMQAdminImpl().searchOffset(mq, timestamp);
+                        } catch (MQClientException e) {
+                            result = -1;
+                        }
+                    }
+                } else {
+                    result = -1;
+                }
+                break;
+            }
+        }
+        return result;
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -767,7 +767,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                     context.setMq(mq);
                     context.setNamespace(this.defaultMQProducer.getNamespace());
                     String isTrans = msg.getProperty(MessageConst.PROPERTY_TRANSACTION_PREPARED);
-                    if (isTrans != null && isTrans.equals("true")) {
+                    if ("true".equals(isTrans)) {
                         context.setMsgType(MessageType.Trans_Msg_Half);
                     }
 

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -161,7 +161,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
         //if client open the message trace feature
         if (enableMsgTrace) {
             try {
-                AsyncTraceDispatcher dispatcher = new AsyncTraceDispatcher(customizedTraceTopic, rpcHook);
+                AsyncTraceDispatcher dispatcher = new AsyncTraceDispatcher(producerGroup, TraceDispatcher.Type.PRODUCE, customizedTraceTopic, rpcHook);
                 dispatcher.setHostProducer(this.defaultMQProducerImpl);
                 traceDispatcher = dispatcher;
                 this.defaultMQProducerImpl.registerSendMessageHook(
@@ -246,7 +246,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
         //if client open the message trace feature
         if (enableMsgTrace) {
             try {
-                AsyncTraceDispatcher dispatcher = new AsyncTraceDispatcher(customizedTraceTopic, rpcHook);
+                AsyncTraceDispatcher dispatcher = new AsyncTraceDispatcher(producerGroup, TraceDispatcher.Type.PRODUCE, customizedTraceTopic, rpcHook);
                 dispatcher.setHostProducer(this.getDefaultMQProducerImpl());
                 traceDispatcher = dispatcher;
                 this.getDefaultMQProducerImpl().registerSendMessageHook(

--- a/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
@@ -73,14 +73,19 @@ public class AsyncTraceDispatcher implements TraceDispatcher {
     private String traceTopicName;
     private AtomicBoolean isStarted = new AtomicBoolean(false);
     private AccessChannel accessChannel = AccessChannel.LOCAL;
+    private String group;
+    private Type type;
 
-    public AsyncTraceDispatcher(String traceTopicName, RPCHook rpcHook) {
+    public AsyncTraceDispatcher(String group, Type type,String traceTopicName, RPCHook rpcHook) {
         // queueSize is greater than or equal to the n power of 2 of value
         this.queueSize = 2048;
         this.batchSize = 100;
         this.maxMsgSize = 128000;
         this.discardCount = new AtomicLong(0L);
         this.traceContextQueue = new ArrayBlockingQueue<TraceContext>(1024);
+        this.group = group;
+        this.type = type;
+
         this.appenderQueue = new ArrayBlockingQueue<Runnable>(queueSize);
         if (!UtilAll.isBlank(traceTopicName)) {
             this.traceTopicName = traceTopicName;
@@ -150,13 +155,17 @@ public class AsyncTraceDispatcher implements TraceDispatcher {
         DefaultMQProducer traceProducerInstance = this.traceProducer;
         if (traceProducerInstance == null) {
             traceProducerInstance = new DefaultMQProducer(rpcHook);
-            traceProducerInstance.setProducerGroup(TraceConstants.GROUP_NAME);
+            traceProducerInstance.setProducerGroup(genGroupNameForTrace());
             traceProducerInstance.setSendMsgTimeout(5000);
             traceProducerInstance.setVipChannelEnabled(false);
             // The max size of message is 128K
             traceProducerInstance.setMaxMessageSize(maxMsgSize - 10 * 1000);
         }
         return traceProducerInstance;
+    }
+
+    private String genGroupNameForTrace() {
+        return TraceConstants.GROUP_NAME_PREFIX + "-" + this.group + "-" + this.type ;
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/trace/TraceConstants.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/TraceConstants.java
@@ -20,7 +20,7 @@ import org.apache.rocketmq.common.MixAll;
 
 public class TraceConstants {
 
-    public static final String GROUP_NAME = "_INNER_TRACE_PRODUCER";
+    public static final String GROUP_NAME_PREFIX = "_INNER_TRACE_PRODUCER";
     public static final char CONTENT_SPLITOR = (char) 1;
     public static final char FIELD_SPLITOR = (char) 2;
     public static final String TRACE_INSTANCE_NAME = "PID_CLIENT_INNER_TRACE_PRODUCER";

--- a/client/src/main/java/org/apache/rocketmq/client/trace/TraceDispatcher.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/TraceDispatcher.java
@@ -24,7 +24,10 @@ import java.io.IOException;
  * Interface of asynchronous transfer data
  */
 public interface TraceDispatcher {
-
+    enum Type {
+        PRODUCE,
+        CONSUME
+    }
     /**
      * Initialize asynchronous transfer data module
      */

--- a/client/src/main/java/org/apache/rocketmq/client/trace/hook/ConsumeMessageTraceHookImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/hook/ConsumeMessageTraceHookImpl.java
@@ -61,7 +61,7 @@ public class ConsumeMessageTraceHookImpl implements ConsumeMessageHook {
             String regionId = msg.getProperty(MessageConst.PROPERTY_MSG_REGION);
             String traceOn = msg.getProperty(MessageConst.PROPERTY_TRACE_SWITCH);
 
-            if (traceOn != null && traceOn.equals("false")) {
+            if (traceOn != null && "false".equals(traceOn)) {
                 // If trace switch is false ,skip it
                 continue;
             }

--- a/client/src/test/java/org/apache/rocketmq/client/ValidatorsTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/ValidatorsTest.java
@@ -71,13 +71,13 @@ public class ValidatorsTest {
 
     @Test
     public void testCheckTopic_TooLongTopic() {
-        String tooLongTopic = StringUtils.rightPad("TooLongTopic", Validators.CHARACTER_MAX_LENGTH + 1, "_");
-        assertThat(tooLongTopic.length()).isGreaterThan(Validators.CHARACTER_MAX_LENGTH);
+        String tooLongTopic = StringUtils.rightPad("TooLongTopic", Validators.TOPIC_MAX_LENGTH + 1, "_");
+        assertThat(tooLongTopic.length()).isGreaterThan(Validators.TOPIC_MAX_LENGTH);
         try {
             Validators.checkTopic(tooLongTopic);
             failBecauseExceptionWasNotThrown(MQClientException.class);
         } catch (MQClientException e) {
-            assertThat(e).hasMessageStartingWith("The specified topic is longer than topic max length 255.");
+            assertThat(e).hasMessageStartingWith("The specified topic is longer than topic max length");
         }
     }
 }

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumerTest.java
@@ -190,6 +190,36 @@ public class DefaultLitePullConsumerTest {
     }
 
     @Test
+    public void testSeek_SeekToBegin() throws Exception {
+        DefaultLitePullConsumer litePullConsumer = createStartLitePullConsumer();
+        when(mQAdminImpl.minOffset(any(MessageQueue.class))).thenReturn(0L);
+        when(mQAdminImpl.maxOffset(any(MessageQueue.class))).thenReturn(500L);
+        MessageQueue messageQueue = createMessageQueue();
+        litePullConsumer.assign(Collections.singletonList(messageQueue));
+        litePullConsumer.seekToBegin(messageQueue);
+        Field field = DefaultLitePullConsumerImpl.class.getDeclaredField("assignedMessageQueue");
+        field.setAccessible(true);
+        AssignedMessageQueue assignedMessageQueue = (AssignedMessageQueue) field.get(litePullConsumerImpl);
+        assertEquals(assignedMessageQueue.getSeekOffset(messageQueue), 0L);
+        litePullConsumer.shutdown();
+    }
+
+    @Test
+    public void testSeek_SeekToEnd() throws Exception {
+        DefaultLitePullConsumer litePullConsumer = createStartLitePullConsumer();
+        when(mQAdminImpl.minOffset(any(MessageQueue.class))).thenReturn(0L);
+        when(mQAdminImpl.maxOffset(any(MessageQueue.class))).thenReturn(500L);
+        MessageQueue messageQueue = createMessageQueue();
+        litePullConsumer.assign(Collections.singletonList(messageQueue));
+        litePullConsumer.seekToEnd(messageQueue);
+        Field field = DefaultLitePullConsumerImpl.class.getDeclaredField("assignedMessageQueue");
+        field.setAccessible(true);
+        AssignedMessageQueue assignedMessageQueue = (AssignedMessageQueue) field.get(litePullConsumerImpl);
+        assertEquals(assignedMessageQueue.getSeekOffset(messageQueue), 500L);
+        litePullConsumer.shutdown();
+    }
+
+    @Test
     public void testSeek_SeekOffsetIllegal() throws Exception {
         DefaultLitePullConsumer litePullConsumer = createStartLitePullConsumer();
         when(mQAdminImpl.minOffset(any(MessageQueue.class))).thenReturn(0L);

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumerTest.java
@@ -41,6 +41,7 @@ import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
 import org.apache.rocketmq.client.impl.consumer.RebalanceService;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.common.message.MessageClientExt;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -417,6 +418,50 @@ public class DefaultLitePullConsumerTest {
             litePullConsumer.shutdown();
         }
 
+    }
+
+    @Test
+    public void testComputePullFromWhereReturnedNotFound() throws Exception{
+        DefaultLitePullConsumer defaultLitePullConsumer = createStartLitePullConsumer();
+        defaultLitePullConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
+        MessageQueue messageQueue = createMessageQueue();
+        when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(-1L);
+        long offset = rebalanceImpl.computePullFromWhere(messageQueue);
+        assertThat(offset).isEqualTo(0);
+    }
+
+    @Test
+    public void testComputePullFromWhereReturned() throws Exception{
+        DefaultLitePullConsumer defaultLitePullConsumer = createStartLitePullConsumer();
+        defaultLitePullConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
+        MessageQueue messageQueue = createMessageQueue();
+        when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(100L);
+        long offset = rebalanceImpl.computePullFromWhere(messageQueue);
+        assertThat(offset).isEqualTo(100);
+    }
+
+
+    @Test
+    public void testComputePullFromLast() throws Exception{
+        DefaultLitePullConsumer defaultLitePullConsumer = createStartLitePullConsumer();
+        defaultLitePullConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+        MessageQueue messageQueue = createMessageQueue();
+        when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(-1L);
+        when(mQClientFactory.getMQAdminImpl().maxOffset(any(MessageQueue.class))).thenReturn(100L);
+        long offset = rebalanceImpl.computePullFromWhere(messageQueue);
+        assertThat(offset).isEqualTo(100);
+    }
+
+    @Test
+    public void testComputePullByTimeStamp() throws Exception{
+        DefaultLitePullConsumer defaultLitePullConsumer = createStartLitePullConsumer();
+        defaultLitePullConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_TIMESTAMP);
+        defaultLitePullConsumer.setConsumeTimestamp("20191024171201");
+        MessageQueue messageQueue = createMessageQueue();
+        when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(-1L);
+        when(mQClientFactory.getMQAdminImpl().searchOffset(any(MessageQueue.class),anyLong())).thenReturn(100L);
+        long offset = rebalanceImpl.computePullFromWhere(messageQueue);
+        assertThat(offset).isEqualTo(100);
     }
 
     private void initDefaultLitePullConsumer(DefaultLitePullConsumer litePullConsumer) throws Exception {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
@@ -18,7 +18,7 @@ package org.apache.rocketmq.common;
 
 public class MQVersion {
 
-    public static final int CURRENT_VERSION = Version.V4_6_0.ordinal();
+    public static final int CURRENT_VERSION = Version.V4_6_1.ordinal();
 
     public static String getVersionDesc(int value) {
         int length = Version.values().length;

--- a/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
@@ -18,7 +18,7 @@ package org.apache.rocketmq.common;
 
 public class MQVersion {
 
-    public static final int CURRENT_VERSION = Version.V4_5_2.ordinal();
+    public static final int CURRENT_VERSION = Version.V4_6_0.ordinal();
 
     public static String getVersionDesc(int value) {
         int length = Version.values().length;

--- a/common/src/main/java/org/apache/rocketmq/common/MixAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MixAll.java
@@ -419,7 +419,7 @@ public class MixAll {
                 if (address.isLoopbackAddress()) {
                     continue;
                 }
-                //ip4 highter priority
+                //ip4 higher priority
                 if (address instanceof Inet6Address) {
                     candidatesHost.add(address.getHostAddress());
                     continue;

--- a/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
@@ -580,7 +580,7 @@ public class UtilAll {
         }
     }
 
-    public static String List2String(List<String> list, String splitor) {
+    public static String list2String(List<String> list, String splitor) {
         if (list == null || list.size() == 0) {
             return null;
         }
@@ -595,7 +595,7 @@ public class UtilAll {
         return str.toString();
     }
 
-    public static List<String> String2List(String str, String splitor) {
+    public static List<String> string2List(String str, String splitor) {
         if (StringUtils.isEmpty(str)) {
             return null;
         }

--- a/common/src/main/java/org/apache/rocketmq/common/stats/StatsItem.java
+++ b/common/src/main/java/org/apache/rocketmq/common/stats/StatsItem.java
@@ -152,6 +152,9 @@ public class StatsItem {
 
     public void samplingInSeconds() {
         synchronized (this.csListMinute) {
+            if (this.csListMinute.size() == 0) {
+                this.csListMinute.add(new CallSnapshot(System.currentTimeMillis() - 10 * 1000, 0, 0));
+            }
             this.csListMinute.add(new CallSnapshot(System.currentTimeMillis(), this.times.get(), this.value
                 .get()));
             if (this.csListMinute.size() > 7) {
@@ -162,6 +165,9 @@ public class StatsItem {
 
     public void samplingInMinutes() {
         synchronized (this.csListHour) {
+            if (this.csListHour.size() == 0) {
+                this.csListHour.add(new CallSnapshot(System.currentTimeMillis() - 10 * 60 * 1000, 0, 0));
+            }
             this.csListHour.add(new CallSnapshot(System.currentTimeMillis(), this.times.get(), this.value
                 .get()));
             if (this.csListHour.size() > 7) {
@@ -172,6 +178,9 @@ public class StatsItem {
 
     public void samplingInHour() {
         synchronized (this.csListDay) {
+            if (this.csListDay.size() == 0) {
+                this.csListDay.add(new CallSnapshot(System.currentTimeMillis() - 1 * 60 * 60 * 1000, 0, 0));
+            }
             this.csListDay.add(new CallSnapshot(System.currentTimeMillis(), this.times.get(), this.value
                 .get()));
             if (this.csListDay.size() > 25) {

--- a/common/src/main/java/org/apache/rocketmq/common/sysflag/PullSysFlag.java
+++ b/common/src/main/java/org/apache/rocketmq/common/sysflag/PullSysFlag.java
@@ -21,6 +21,7 @@ public class PullSysFlag {
     private final static int FLAG_SUSPEND = 0x1 << 1;
     private final static int FLAG_SUBSCRIPTION = 0x1 << 2;
     private final static int FLAG_CLASS_FILTER = 0x1 << 3;
+    private final static int FLAG_LITE_PULL_MESSAGE = 0x1 << 4;
 
     public static int buildSysFlag(final boolean commitOffset, final boolean suspend,
         final boolean subscription, final boolean classFilter) {
@@ -45,6 +46,17 @@ public class PullSysFlag {
         return flag;
     }
 
+    public static int buildSysFlag(final boolean commitOffset, final boolean suspend,
+        final boolean subscription, final boolean classFilter, final boolean litePull) {
+        int flag = buildSysFlag(commitOffset, suspend, subscription, classFilter);
+
+        if (litePull) {
+            flag |= FLAG_LITE_PULL_MESSAGE;
+        }
+
+        return flag;
+    }
+
     public static int clearCommitOffsetFlag(final int sysFlag) {
         return sysFlag & (~FLAG_COMMIT_OFFSET);
     }
@@ -63,5 +75,9 @@ public class PullSysFlag {
 
     public static boolean hasClassFilterFlag(final int sysFlag) {
         return (sysFlag & FLAG_CLASS_FILTER) == FLAG_CLASS_FILTER;
+    }
+
+    public static boolean hasLitePullFlag(final int sysFlag) {
+        return (sysFlag & FLAG_LITE_PULL_MESSAGE) == FLAG_LITE_PULL_MESSAGE;
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/stats/StatsItemSetTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/stats/StatsItemSetTest.java
@@ -44,6 +44,35 @@ public class StatsItemSetTest {
         assertEquals(10, test_unit_moment().longValue());
     }
 
+    @Test
+    public void test_statsOfFirstStatisticsCycle() throws InterruptedException {
+        final StatsItemSet statsItemSet = new StatsItemSet("topicTest", scheduler, null);
+        executor = new ThreadPoolExecutor(10, 20, 10, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<Runnable>(100), new ThreadFactoryImpl("testMultiThread"));
+        for (int i = 0; i < 10; i++) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    statsItemSet.addValue("topicTest", 2, 1);
+                }
+            });
+        }
+        while (true) {
+            if (executor.getCompletedTaskCount() == 10) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        // simulate schedule task execution
+        statsItemSet.getStatsItem("topicTest").samplingInSeconds();
+        statsItemSet.getStatsItem("topicTest").samplingInMinutes();
+        statsItemSet.getStatsItem("topicTest").samplingInHour();
+
+        assertEquals(20L, statsItemSet.getStatsDataInMinute("topicTest").getSum());
+        assertEquals(20L, statsItemSet.getStatsDataInHour("topicTest").getSum());
+        assertEquals(20L, statsItemSet.getStatsDataInDay("topicTest").getSum());
+    }
+
     private AtomicLong test_unit() throws InterruptedException {
         final StatsItemSet statsItemSet = new StatsItemSet("topicTest", scheduler, null);
         executor = new ThreadPoolExecutor(10, 20, 10, TimeUnit.SECONDS,

--- a/common/src/test/java/org/apache/rocketmq/common/sysflag/PullSysFlagTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/sysflag/PullSysFlagTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common.sysflag;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PullSysFlagTest {
+
+    @Test
+    public void testLitePullFlag() {
+        int flag = PullSysFlag.buildSysFlag(false, false, false, false, true);
+        assertThat(PullSysFlag.hasLitePullFlag(flag)).isTrue();
+    }
+
+    @Test
+    public void testLitePullFlagFalse() {
+        int flag = PullSysFlag.buildSysFlag(false, false, false, false, false);
+        assertThat(PullSysFlag.hasLitePullFlag(flag)).isFalse();
+    }
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
     <artifactId>rocketmq-distribution</artifactId>
     <name>rocketmq-distribution ${project.version}</name>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
     <artifactId>rocketmq-distribution</artifactId>
     <name>rocketmq-distribution ${project.version}</name>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>rocketmq-distribution</artifactId>
     <name>rocketmq-distribution ${project.version}</name>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
     <artifactId>rocketmq-distribution</artifactId>
     <name>rocketmq-distribution ${project.version}</name>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -51,12 +51,12 @@
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-openmessaging</artifactId>
-            <version>4.6.1-SNAPSHOT</version>
+            <version>4.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-acl</artifactId>
-            <version>4.6.1-SNAPSHOT</version>
+            <version>4.6.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -51,12 +51,12 @@
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-openmessaging</artifactId>
-            <version>4.6.1</version>
+            <version>4.7.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-acl</artifactId>
-            <version>4.6.1</version>
+            <version>4.7.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -51,12 +51,12 @@
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-openmessaging</artifactId>
-            <version>4.6.0</version>
+            <version>4.6.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-acl</artifactId>
-            <version>4.6.0</version>
+            <version>4.6.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -51,12 +51,12 @@
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-openmessaging</artifactId>
-            <version>4.6.0-SNAPSHOT</version>
+            <version>4.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-acl</artifactId>
-            <version>4.6.0-SNAPSHOT</version>
+            <version>4.6.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/example/src/main/java/org/apache/rocketmq/example/benchmark/TransactionProducer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/benchmark/TransactionProducer.java
@@ -18,11 +18,19 @@
 package org.apache.rocketmq.example.benchmark;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.cli.CommandLine;
@@ -30,35 +38,44 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 import org.apache.rocketmq.client.exception.MQClientException;
-import org.apache.rocketmq.client.producer.LocalTransactionExecuter;
 import org.apache.rocketmq.client.producer.LocalTransactionState;
 import org.apache.rocketmq.client.producer.SendResult;
-import org.apache.rocketmq.client.producer.TransactionCheckListener;
+import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.client.producer.TransactionListener;
 import org.apache.rocketmq.client.producer.TransactionMQProducer;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
-import org.apache.rocketmq.remoting.common.RemotingHelper;
 import org.apache.rocketmq.srvutil.ServerUtil;
 
 public class TransactionProducer {
+    private static final long START_TIME = System.currentTimeMillis();
+    private static final AtomicLong MSG_COUNT = new AtomicLong(0);
+
+    //broker max check times should less than this value
+    static final int MAX_CHECK_RESULT_IN_MSG = 20;
 
     public static void main(String[] args) throws MQClientException, UnsupportedEncodingException {
         Options options = ServerUtil.buildCommandlineOptions(new Options());
         CommandLine commandLine = ServerUtil.parseCmdLine("TransactionProducer", args, buildCommandlineOptions(options), new PosixParser());
+        TxSendConfig config = new TxSendConfig();
+        config.topic = commandLine.hasOption('t') ? commandLine.getOptionValue('t').trim() : "BenchmarkTest";
+        config.threadCount = commandLine.hasOption('w') ? Integer.parseInt(commandLine.getOptionValue('w')) : 32;
+        config.messageSize = commandLine.hasOption('s') ? Integer.parseInt(commandLine.getOptionValue('s')) : 2048;
+        config.sendRollbackRate = commandLine.hasOption("sr") ? Double.parseDouble(commandLine.getOptionValue("sr")) : 0.0;
+        config.sendUnknownRate = commandLine.hasOption("su") ? Double.parseDouble(commandLine.getOptionValue("su")) : 0.0;
+        config.checkRollbackRate = commandLine.hasOption("cr") ? Double.parseDouble(commandLine.getOptionValue("cr")) : 0.0;
+        config.checkUnknownRate = commandLine.hasOption("cu") ? Double.parseDouble(commandLine.getOptionValue("cu")) : 0.0;
+        config.batchId = commandLine.hasOption("b") ? Long.parseLong(commandLine.getOptionValue("b")) : System.currentTimeMillis();
+        config.sendInterval = commandLine.hasOption("i") ? Integer.parseInt(commandLine.getOptionValue("i")) : 0;
 
-        final String topic = commandLine.hasOption('t') ? commandLine.getOptionValue('t').trim() : "BenchmarkTest";
-        final int threadCount = commandLine.hasOption('w') ? Integer.parseInt(commandLine.getOptionValue('w')) : 32;
-        final int messageSize = commandLine.hasOption('s') ? Integer.parseInt(commandLine.getOptionValue('s')) : 2048;
-        final boolean ischeck = commandLine.hasOption('c') ? Boolean.parseBoolean(commandLine.getOptionValue('c')) : false;
-        final boolean ischeckffalse = commandLine.hasOption('r') ? Boolean.parseBoolean(commandLine.getOptionValue('r')) : true;
-
-        final ExecutorService sendThreadPool = Executors.newFixedThreadPool(threadCount);
+        final ExecutorService sendThreadPool = Executors.newFixedThreadPool(config.threadCount);
 
         final StatsBenchmarkTProducer statsBenchmark = new StatsBenchmarkTProducer();
 
         final Timer timer = new Timer("BenchmarkTimerThread", true);
 
-        final LinkedList<Long[]> snapshotList = new LinkedList<Long[]>();
+        final LinkedList<Snapshot> snapshotList = new LinkedList<>();
 
         timer.scheduleAtFixedRate(new TimerTask() {
             @Override
@@ -73,16 +90,24 @@ public class TransactionProducer {
         timer.scheduleAtFixedRate(new TimerTask() {
             private void printStats() {
                 if (snapshotList.size() >= 10) {
-                    Long[] begin = snapshotList.getFirst();
-                    Long[] end = snapshotList.getLast();
+                    Snapshot begin = snapshotList.getFirst();
+                    Snapshot end = snapshotList.getLast();
 
-                    final long sendTps =
-                        (long) (((end[3] - begin[3]) / (double) (end[0] - begin[0])) * 1000L);
-                    final double averageRT = (end[5] - begin[5]) / (double) (end[3] - begin[3]);
+                    final long sendCount = (end.sendRequestSuccessCount - begin.sendRequestSuccessCount)
+                            + (end.sendRequestFailedCount - begin.sendRequestFailedCount);
+                    final long sendTps = (sendCount * 1000L) / (end.endTime - begin.endTime);
+                    final double averageRT = (end.sendMessageTimeTotal - begin.sendMessageTimeTotal) / (double) (end.sendRequestSuccessCount - begin.sendRequestSuccessCount);
+
+                    final long failCount = end.sendRequestFailedCount - begin.sendRequestFailedCount;
+                    final long checkCount = end.checkCount - begin.checkCount;
+                    final long unexpectedCheck = end.unexpectedCheckCount - begin.unexpectedCheckCount;
+                    final long dupCheck = end.duplicatedCheck - begin.duplicatedCheck;
 
                     System.out.printf(
-                        "Send TPS: %d Max RT: %d Average RT: %7.3f Send Failed: %d Response Failed: %d transaction checkCount: %d %n",
-                        sendTps, statsBenchmark.getSendMessageMaxRT().get(), averageRT, end[2], end[4], end[6]);
+                        "Send TPS:%5d Max RT:%5d AVG RT:%3.1f Send Failed: %d check: %d unexpectedCheck: %d duplicatedCheck: %d %n",
+                            sendTps, statsBenchmark.getSendMessageMaxRT().get(), averageRT, failCount, checkCount,
+                            unexpectedCheck, dupCheck);
+                    statsBenchmark.getSendMessageMaxRT().set(0);
                 }
             }
 
@@ -96,11 +121,10 @@ public class TransactionProducer {
             }
         }, 10000, 10000);
 
-        final TransactionCheckListener transactionCheckListener =
-            new TransactionCheckListenerBImpl(ischeckffalse, statsBenchmark);
+        final TransactionListener transactionCheckListener = new TransactionListenerImpl(statsBenchmark, config);
         final TransactionMQProducer producer = new TransactionMQProducer("benchmark_transaction_producer");
         producer.setInstanceName(Long.toString(System.currentTimeMillis()));
-        producer.setTransactionCheckListener(transactionCheckListener);
+        producer.setTransactionListener(transactionCheckListener);
         producer.setDefaultTopicQueueNums(1000);
         if (commandLine.hasOption('n')) {
             String ns = commandLine.getOptionValue('n');
@@ -108,37 +132,42 @@ public class TransactionProducer {
         }
         producer.start();
 
-        final TransactionExecuterBImpl tranExecuter = new TransactionExecuterBImpl(ischeck);
-
-        for (int i = 0; i < threadCount; i++) {
+        for (int i = 0; i < config.threadCount; i++) {
             sendThreadPool.execute(new Runnable() {
                 @Override
                 public void run() {
                     while (true) {
+                        boolean success = false;
+                        final long beginTimestamp = System.currentTimeMillis();
                         try {
-                            // Thread.sleep(1000);
-                            final long beginTimestamp = System.currentTimeMillis();
                             SendResult sendResult =
-                                producer.sendMessageInTransaction(buildMessage(messageSize, topic), tranExecuter, null);
-                            if (sendResult != null) {
-                                statsBenchmark.getSendRequestSuccessCount().incrementAndGet();
-                                statsBenchmark.getReceiveResponseSuccessCount().incrementAndGet();
-                            }
-
+                                    producer.sendMessageInTransaction(buildMessage(config), null);
+                            success = sendResult != null && sendResult.getSendStatus() == SendStatus.SEND_OK;
+                        } catch (Throwable e) {
+                            success = false;
+                        } finally {
                             final long currentRT = System.currentTimeMillis() - beginTimestamp;
-                            statsBenchmark.getSendMessageSuccessTimeTotal().addAndGet(currentRT);
+                            statsBenchmark.getSendMessageTimeTotal().addAndGet(currentRT);
                             long prevMaxRT = statsBenchmark.getSendMessageMaxRT().get();
                             while (currentRT > prevMaxRT) {
-                                boolean updated =
-                                    statsBenchmark.getSendMessageMaxRT().compareAndSet(prevMaxRT,
-                                        currentRT);
+                                boolean updated = statsBenchmark.getSendMessageMaxRT()
+                                        .compareAndSet(prevMaxRT, currentRT);
                                 if (updated)
                                     break;
 
                                 prevMaxRT = statsBenchmark.getSendMessageMaxRT().get();
                             }
-                        } catch (MQClientException e) {
-                            statsBenchmark.getSendRequestFailedCount().incrementAndGet();
+                            if (success) {
+                                statsBenchmark.getSendRequestSuccessCount().incrementAndGet();
+                            } else {
+                                statsBenchmark.getSendRequestFailedCount().incrementAndGet();
+                            }
+                            if (config.sendInterval > 0) {
+                                try {
+                                    Thread.sleep(config.sendInterval);
+                                } catch (InterruptedException e) {
+                                }
+                            }
                         }
                     }
                 }
@@ -146,20 +175,42 @@ public class TransactionProducer {
         }
     }
 
-    private static Message buildMessage(final int messageSize, String topic) {
-        try {
-            Message msg = new Message();
-            msg.setTopic(topic);
+    private static Message buildMessage(TxSendConfig config) {
+        byte[] bs = new byte[config.messageSize];
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        r.nextBytes(bs);
 
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < messageSize; i += 10) {
-                sb.append("hello baby");
-            }
-            msg.setBody(sb.toString().getBytes(RemotingHelper.DEFAULT_CHARSET));
-            return msg;
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+        ByteBuffer buf = ByteBuffer.wrap(bs);
+        buf.putLong(config.batchId);
+        long sendMachineId = START_TIME << 32;
+        long msgId = sendMachineId | MSG_COUNT.getAndIncrement();
+        buf.putLong(msgId);
+
+        // save send tx result in message
+        if (r.nextDouble() < config.sendRollbackRate) {
+            buf.put((byte) LocalTransactionState.ROLLBACK_MESSAGE.ordinal());
+        } else if (r.nextDouble() < config.sendUnknownRate) {
+            buf.put((byte) LocalTransactionState.UNKNOW.ordinal());
+        } else {
+            buf.put((byte) LocalTransactionState.COMMIT_MESSAGE.ordinal());
         }
+
+        // save check tx result in message
+        for (int i = 0; i < MAX_CHECK_RESULT_IN_MSG; i++) {
+            if (r.nextDouble() < config.checkRollbackRate) {
+                buf.put((byte) LocalTransactionState.ROLLBACK_MESSAGE.ordinal());
+            } else if (r.nextDouble() < config.checkUnknownRate) {
+                buf.put((byte) LocalTransactionState.UNKNOW.ordinal());
+            } else {
+                buf.put((byte) LocalTransactionState.COMMIT_MESSAGE.ordinal());
+            }
+        }
+
+        Message msg = new Message();
+        msg.setTopic(config.topic);
+
+        msg.setBody(bs);
+        return msg;
     }
 
     public static Options buildCommandlineOptions(final Options options) {
@@ -175,56 +226,143 @@ public class TransactionProducer {
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("c", "check", true, "Check the message, Default: false");
+        opt = new Option("sr", "send rollback rate", true, "Send rollback rate, Default: 0.0");
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("r", "checkResult", true, "Message check result, Default: true");
+        opt = new Option("su", "send unknown rate", true, "Send unknown rate, Default: 0.0");
         opt.setRequired(false);
         options.addOption(opt);
 
+        opt = new Option("cr", "check rollback rate", true, "Check rollback rate, Default: 0.0");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("cu", "check unknown rate", true, "Check unknown rate, Default: 0.0");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("b", "test batch id", true, "test batch id, Default: System.currentMillis()");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("i", "send interval", true, "sleep interval in millis between messages, Default: 0");
+        opt.setRequired(false);
+        options.addOption(opt);
 
         return options;
     }
 }
 
-class TransactionExecuterBImpl implements LocalTransactionExecuter {
+class TransactionListenerImpl implements TransactionListener {
+    private StatsBenchmarkTProducer statBenchmark;
+    private TxSendConfig sendConfig;
+    private final LRUMap<Long, Integer> cache = new LRUMap<>(200000);
 
-    private boolean ischeck;
+    private class MsgMeta {
+        long batchId;
+        long msgId;
+        LocalTransactionState sendResult;
+        List<LocalTransactionState> checkResult;
+    }
 
-    public TransactionExecuterBImpl(boolean ischeck) {
-        this.ischeck = ischeck;
+    public TransactionListenerImpl(StatsBenchmarkTProducer statsBenchmark, TxSendConfig sendConfig) {
+        this.statBenchmark = statsBenchmark;
+        this.sendConfig = sendConfig;
     }
 
     @Override
-    public LocalTransactionState executeLocalTransactionBranch(final Message msg, final Object arg) {
-        if (ischeck) {
-            return LocalTransactionState.UNKNOW;
+    public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
+        return parseFromMsg(msg).sendResult;
+    }
+
+    private MsgMeta parseFromMsg(Message msg) {
+        byte[] bs = msg.getBody();
+        ByteBuffer buf = ByteBuffer.wrap(bs);
+        MsgMeta msgMeta = new MsgMeta();
+        msgMeta.batchId = buf.getLong();
+        msgMeta.msgId = buf.getLong();
+        msgMeta.sendResult = LocalTransactionState.values()[buf.get()];
+        msgMeta.checkResult = new ArrayList<>();
+        for (int i = 0; i < TransactionProducer.MAX_CHECK_RESULT_IN_MSG; i++) {
+            msgMeta.checkResult.add(LocalTransactionState.values()[buf.get()]);
         }
-        return LocalTransactionState.COMMIT_MESSAGE;
+        return msgMeta;
+    }
+
+    @Override
+    public LocalTransactionState checkLocalTransaction(MessageExt msg) {
+        MsgMeta msgMeta = parseFromMsg(msg);
+        if (msgMeta.batchId != sendConfig.batchId) {
+            // message not generated in this test
+            return LocalTransactionState.ROLLBACK_MESSAGE;
+        }
+        statBenchmark.getCheckCount().incrementAndGet();
+
+        int times = 0;
+        try {
+            String checkTimes = msg.getUserProperty(MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES);
+            times = Integer.parseInt(checkTimes);
+        } catch (Exception e) {
+            return LocalTransactionState.ROLLBACK_MESSAGE;
+        }
+        times = times <= 0 ? 1 : times;
+
+        boolean dup;
+        synchronized (cache) {
+            Integer oldCheckLog = cache.get(msgMeta.msgId);
+            Integer newCheckLog;
+            if (oldCheckLog == null) {
+                newCheckLog = 1 << (times - 1);
+            } else {
+                newCheckLog = oldCheckLog | (1 << (times - 1));
+            }
+            dup = newCheckLog.equals(oldCheckLog);
+        }
+        if (dup) {
+            statBenchmark.getDuplicatedCheckCount().incrementAndGet();
+        }
+        if (msgMeta.sendResult != LocalTransactionState.UNKNOW) {
+            System.out.printf("%s unexpected check: msgId=%s,txId=%s,checkTimes=%s,sendResult=%s\n",
+                    new SimpleDateFormat("HH:mm:ss,SSS").format(new Date()),
+                    msg.getMsgId(), msg.getTransactionId(),
+                    msg.getUserProperty(MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES),
+                    msgMeta.sendResult.toString());
+            statBenchmark.getUnexpectedCheckCount().incrementAndGet();
+            return msgMeta.sendResult;
+        }
+
+        for (int i = 0; i < times - 1; i++) {
+            LocalTransactionState s = msgMeta.checkResult.get(i);
+            if (s != LocalTransactionState.UNKNOW) {
+                System.out.printf("%s unexpected check: msgId=%s,txId=%s,checkTimes=%s,sendResult,lastCheckResult=%s\n",
+                        new SimpleDateFormat("HH:mm:ss,SSS").format(new Date()),
+                        msg.getMsgId(), msg.getTransactionId(),
+                        msg.getUserProperty(MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES), s);
+                statBenchmark.getUnexpectedCheckCount().incrementAndGet();
+                return s;
+            }
+        }
+        return msgMeta.checkResult.get(times - 1);
     }
 }
 
-class TransactionCheckListenerBImpl implements TransactionCheckListener {
-    private boolean ischeckffalse;
-    private StatsBenchmarkTProducer statsBenchmarkTProducer;
+class Snapshot {
+    long endTime;
 
-    public TransactionCheckListenerBImpl(boolean ischeckffalse,
-        StatsBenchmarkTProducer statsBenchmarkTProducer) {
-        this.ischeckffalse = ischeckffalse;
-        this.statsBenchmarkTProducer = statsBenchmarkTProducer;
-    }
+    long sendRequestSuccessCount;
 
-    @Override
-    public LocalTransactionState checkLocalTransactionState(MessageExt msg) {
-        statsBenchmarkTProducer.getCheckRequestSuccessCount().incrementAndGet();
-        if (ischeckffalse) {
+    long sendRequestFailedCount;
 
-            return LocalTransactionState.ROLLBACK_MESSAGE;
-        }
+    long sendMessageTimeTotal;
 
-        return LocalTransactionState.COMMIT_MESSAGE;
-    }
+    long sendMessageMaxRT;
+
+    long checkCount;
+
+    long unexpectedCheckCount;
+
+    long duplicatedCheck;
 }
 
 class StatsBenchmarkTProducer {
@@ -232,27 +370,27 @@ class StatsBenchmarkTProducer {
 
     private final AtomicLong sendRequestFailedCount = new AtomicLong(0L);
 
-    private final AtomicLong receiveResponseSuccessCount = new AtomicLong(0L);
-
-    private final AtomicLong receiveResponseFailedCount = new AtomicLong(0L);
-
-    private final AtomicLong sendMessageSuccessTimeTotal = new AtomicLong(0L);
+    private final AtomicLong sendMessageTimeTotal = new AtomicLong(0L);
 
     private final AtomicLong sendMessageMaxRT = new AtomicLong(0L);
 
-    private final AtomicLong checkRequestSuccessCount = new AtomicLong(0L);
+    private final AtomicLong checkCount = new AtomicLong(0L);
 
-    public Long[] createSnapshot() {
-        Long[] snap = new Long[] {
-            System.currentTimeMillis(),
-            this.sendRequestSuccessCount.get(),
-            this.sendRequestFailedCount.get(),
-            this.receiveResponseSuccessCount.get(),
-            this.receiveResponseFailedCount.get(),
-            this.sendMessageSuccessTimeTotal.get(),
-            this.checkRequestSuccessCount.get()};
+    private final AtomicLong unexpectedCheckCount = new AtomicLong(0L);
 
-        return snap;
+    private final AtomicLong duplicatedCheckCount = new AtomicLong(0);
+
+    public Snapshot createSnapshot() {
+        Snapshot s = new Snapshot();
+        s.endTime = System.currentTimeMillis();
+        s.sendRequestSuccessCount = sendRequestSuccessCount.get();
+        s.sendRequestFailedCount = sendRequestFailedCount.get();
+        s.sendMessageTimeTotal = sendMessageTimeTotal.get();
+        s.sendMessageMaxRT = sendMessageMaxRT.get();
+        s.checkCount = checkCount.get();
+        s.unexpectedCheckCount = unexpectedCheckCount.get();
+        s.duplicatedCheck = duplicatedCheckCount.get();
+        return s;
     }
 
     public AtomicLong getSendRequestSuccessCount() {
@@ -263,23 +401,49 @@ class StatsBenchmarkTProducer {
         return sendRequestFailedCount;
     }
 
-    public AtomicLong getReceiveResponseSuccessCount() {
-        return receiveResponseSuccessCount;
-    }
-
-    public AtomicLong getReceiveResponseFailedCount() {
-        return receiveResponseFailedCount;
-    }
-
-    public AtomicLong getSendMessageSuccessTimeTotal() {
-        return sendMessageSuccessTimeTotal;
+    public AtomicLong getSendMessageTimeTotal() {
+        return sendMessageTimeTotal;
     }
 
     public AtomicLong getSendMessageMaxRT() {
         return sendMessageMaxRT;
     }
 
-    public AtomicLong getCheckRequestSuccessCount() {
-        return checkRequestSuccessCount;
+    public AtomicLong getCheckCount() {
+        return checkCount;
+    }
+
+    public AtomicLong getUnexpectedCheckCount() {
+        return unexpectedCheckCount;
+    }
+
+    public AtomicLong getDuplicatedCheckCount() {
+        return duplicatedCheckCount;
+    }
+}
+
+class TxSendConfig {
+    String topic;
+    int threadCount;
+    int messageSize;
+    double sendRollbackRate;
+    double sendUnknownRate;
+    double checkRollbackRate;
+    double checkUnknownRate;
+    long batchId;
+    int sendInterval;
+}
+
+class LRUMap<K, V> extends LinkedHashMap<K, V> {
+
+    private int maxSize;
+
+    public LRUMap(int maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry eldest) {
+        return size() > maxSize;
     }
 }

--- a/example/src/main/java/org/apache/rocketmq/example/simple/LitePullConsumerSubscribe.java
+++ b/example/src/main/java/org/apache/rocketmq/example/simple/LitePullConsumerSubscribe.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.example.simple;
 
 import java.util.List;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.common.message.MessageExt;
 
 public class LitePullConsumerSubscribe {
@@ -25,7 +26,8 @@ public class LitePullConsumerSubscribe {
     public static volatile boolean running = true;
 
     public static void main(String[] args) throws Exception {
-        DefaultLitePullConsumer litePullConsumer = new DefaultLitePullConsumer("please_rename_unique_group_name");
+        DefaultLitePullConsumer litePullConsumer = new DefaultLitePullConsumer("lite_pull_consumer_test");
+        litePullConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
         litePullConsumer.subscribe("TopicTest", "*");
         litePullConsumer.start();
         try {

--- a/filter/pom.xml
+++ b/filter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/filter/pom.xml
+++ b/filter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/filter/pom.xml
+++ b/filter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/filter/pom.xml
+++ b/filter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/logappender/pom.xml
+++ b/logappender/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rocketmq-logappender</artifactId>

--- a/logappender/pom.xml
+++ b/logappender/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rocketmq-logappender</artifactId>

--- a/logappender/pom.xml
+++ b/logappender/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rocketmq-logappender</artifactId>

--- a/logappender/pom.xml
+++ b/logappender/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rocketmq-logappender</artifactId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/namesrv/pom.xml
+++ b/namesrv/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/namesrv/pom.xml
+++ b/namesrv/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/namesrv/pom.xml
+++ b/namesrv/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/namesrv/pom.xml
+++ b/namesrv/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/openmessaging/pom.xml
+++ b/openmessaging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmessaging/pom.xml
+++ b/openmessaging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmessaging/pom.xml
+++ b/openmessaging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmessaging/pom.xml
+++ b/openmessaging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <inceptionYear>2012</inceptionYear>
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-all</artifactId>
-    <version>4.6.1-SNAPSHOT</version>
+    <version>4.6.1</version>
     <packaging>pom</packaging>
     <name>Apache RocketMQ ${project.version}</name>
     <url>http://rocketmq.apache.org/</url>
@@ -42,7 +42,7 @@
         <url>git@github.com:apache/rocketmq.git</url>
         <connection>scm:git:git@github.com:apache/rocketmq.git</connection>
         <developerConnection>scm:git:git@github.com:apache/rocketmq.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rocketmq-all-4.6.1</tag>
     </scm>
 
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <inceptionYear>2012</inceptionYear>
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-all</artifactId>
-    <version>4.6.1</version>
+    <version>4.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Apache RocketMQ ${project.version}</name>
     <url>http://rocketmq.apache.org/</url>
@@ -42,7 +42,7 @@
         <url>git@github.com:apache/rocketmq.git</url>
         <connection>scm:git:git@github.com:apache/rocketmq.git</connection>
         <developerConnection>scm:git:git@github.com:apache/rocketmq.git</developerConnection>
-        <tag>rocketmq-all-4.6.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <inceptionYear>2012</inceptionYear>
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-all</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Apache RocketMQ ${project.version}</name>
     <url>http://rocketmq.apache.org/</url>
@@ -42,7 +42,7 @@
         <url>git@github.com:apache/rocketmq.git</url>
         <connection>scm:git:git@github.com:apache/rocketmq.git</connection>
         <developerConnection>scm:git:git@github.com:apache/rocketmq.git</developerConnection>
-        <tag>rocketmq-all-4.6.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
   limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
         <groupId>org.apache</groupId>
@@ -30,7 +29,7 @@
     <inceptionYear>2012</inceptionYear>
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-all</artifactId>
-    <version>4.6.0-SNAPSHOT</version>
+    <version>4.6.0</version>
     <packaging>pom</packaging>
     <name>Apache RocketMQ ${project.version}</name>
     <url>http://rocketmq.apache.org/</url>
@@ -43,7 +42,7 @@
         <url>git@github.com:apache/rocketmq.git</url>
         <connection>scm:git:git@github.com:apache/rocketmq.git</connection>
         <developerConnection>scm:git:git@github.com:apache/rocketmq.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rocketmq-all-4.6.0</tag>
     </scm>
 
     <mailingLists>
@@ -160,7 +159,7 @@
                 </executions>
                 <configuration>
                     <rules>
-                        <banCircularDependencies/>
+                        <banCircularDependencies />
                     </rules>
                     <fail>true</fail>
                 </configuration>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/srvutil/pom.xml
+++ b/srvutil/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/srvutil/pom.xml
+++ b/srvutil/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/srvutil/pom.xml
+++ b/srvutil/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/srvutil/pom.xml
+++ b/srvutil/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/srvutil/src/main/java/org/apache/rocketmq/srvutil/ServerUtil.java
+++ b/srvutil/src/main/java/org/apache/rocketmq/srvutil/ServerUtil.java
@@ -49,10 +49,11 @@ public class ServerUtil {
             commandLine = parser.parse(options, args);
             if (commandLine.hasOption('h')) {
                 hf.printHelp(appName, options, true);
-                return null;
+                System.exit(0);
             }
         } catch (ParseException e) {
             hf.printHelp(appName, options, true);
+            System.exit(1);
         }
 
         return commandLine;

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.rocketmq.common.ConfigManager;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicFilterType;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.InternalLogger;
@@ -305,6 +306,11 @@ public class ScheduleMessageService extends ConfigManager {
                                 if (msgExt != null) {
                                     try {
                                         MessageExtBrokerInner msgInner = this.messageTimeup(msgExt);
+                                        if (MixAll.RMQ_SYS_TRANS_HALF_TOPIC.equals(msgInner.getTopic())) {
+                                            log.error("[BUG] the real topic of schedule msg is {}, discard the msg. msg={}",
+                                                    msgInner.getTopic(), msgInner);
+                                            continue;
+                                        }
                                         PutMessageResult putMessageResult =
                                             ScheduleMessageService.this.writeMessageStore
                                                 .putMessage(msgInner);

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rocketmq-all</artifactId>
         <groupId>org.apache.rocketmq</groupId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-all</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
the equals method of Object is prone to null pointer exceptions and should be invoked using constants or objects that determine values