### PR TITLE
Fix get wrong client ip when client running in linux with container t…

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
@@ -98,6 +98,9 @@ public class RemotingUtil {
             ArrayList<String> ipv6Result = new ArrayList<String>();
             while (enumeration.hasMoreElements()) {
                 final NetworkInterface networkInterface = enumeration.nextElement();
+                if (!networkInterface.isUp()) {
+                    continue;
+                }
                 final Enumeration<InetAddress> en = networkInterface.getInetAddresses();
                 while (en.hasMoreElements()) {
                     final InetAddress address = en.nextElement();


### PR DESCRIPTION
Fix get wrong client ip when client running in linux with container tech, like docker will create docker0 network interface, etc..

## What is the purpose of the change

Some linux container tech will create many network interface, like docker/k8s cni, when rocketmq client run within those machine will get wrong client ip to generate clientId.

## Brief changelog

Skip network inteface as clientIP candidate when it's status is not up