### PR TITLE
[ISSUE #1798]Remove group of deleted sub info when queryTopicConsumeB…

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -419,7 +419,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
 
         final RemotingCommand response = RemotingCommand.createResponseCommand(GetBrokerAclConfigResponseHeader.class);
 
-        final GetBrokerAclConfigResponseHeader responseHeader = (GetBrokerAclConfigResponseHeader)response.readCustomHeader();
+        final GetBrokerAclConfigResponseHeader responseHeader = (GetBrokerAclConfigResponseHeader) response.readCustomHeader();
 
         try {
             AccessValidator accessValidator = this.brokerController.getAccessValidatorMap().get(PlainAccessValidator.class);
@@ -428,7 +428,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             responseHeader.setBrokerAddr(this.brokerController.getBrokerAddr());
             responseHeader.setBrokerName(this.brokerController.getBrokerConfig().getBrokerName());
             responseHeader.setClusterName(this.brokerController.getBrokerConfig().getBrokerClusterName());
-            
+
             response.setCode(ResponseCode.SUCCESS);
             response.setRemark(null);
             return response;
@@ -1027,10 +1027,14 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         }
 
         HashSet<String> filteredGroups = new HashSet<String>();
-        for (String group : groups) {
-            if (this.brokerController.getSubscriptionGroupManager().getSubscriptionGroupTable().containsKey(group)) {
-                filteredGroups.add(group);
+        if (requestHeader.isIgnoreDeteled()) {
+            for (String group : groups) {
+                if (this.brokerController.getSubscriptionGroupManager().getSubscriptionGroupTable().containsKey(group)) {
+                    filteredGroups.add(group);
+                }
             }
+        } else {
+            filteredGroups = groups;
         }
 
         GroupList groupList = new GroupList();

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+
 import org.apache.rocketmq.acl.AccessValidator;
 import org.apache.rocketmq.acl.plain.PlainAccessValidator;
 import org.apache.rocketmq.broker.BrokerController;
@@ -1025,8 +1026,15 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             groups.addAll(groupInOffset);
         }
 
+        HashSet<String> filteredGroups = new HashSet<String>();
+        for (String group : groups) {
+            if (this.brokerController.getSubscriptionGroupManager().getSubscriptionGroupTable().containsKey(group)) {
+                filteredGroups.add(group);
+            }
+        }
+
         GroupList groupList = new GroupList();
-        groupList.setGroupList(groups);
+        groupList.setGroupList(filteredGroups);
         byte[] body = groupList.encode();
 
         response.setBody(body);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -394,7 +394,8 @@ public class MQClientAPIImpl {
 
     }
 
-    public AclConfig getBrokerClusterConfig(final String addr, final long timeoutMillis) throws RemotingCommandException, InterruptedException, RemotingTimeoutException,
+    public AclConfig getBrokerClusterConfig(final String addr,
+        final long timeoutMillis) throws RemotingCommandException, InterruptedException, RemotingTimeoutException,
         RemotingSendRequestException, RemotingConnectException, MQBrokerException {
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_BROKER_CLUSTER_ACL_CONFIG, null);
 
@@ -404,7 +405,7 @@ public class MQClientAPIImpl {
             case ResponseCode.SUCCESS: {
                 if (response.getBody() != null) {
                     GetBrokerClusterAclConfigResponseBody body =
-                            GetBrokerClusterAclConfigResponseBody.decode(response.getBody(), GetBrokerClusterAclConfigResponseBody.class);
+                        GetBrokerClusterAclConfigResponseBody.decode(response.getBody(), GetBrokerClusterAclConfigResponseBody.class);
                     AclConfig aclConfig = new AclConfig();
                     aclConfig.setGlobalWhiteAddrs(body.getGlobalWhiteAddrs());
                     aclConfig.setPlainAccessConfigs(body.getPlainAccessConfigs());
@@ -1660,8 +1661,16 @@ public class MQClientAPIImpl {
     public GroupList queryTopicConsumeByWho(final String addr, final String topic, final long timeoutMillis)
         throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException,
         MQBrokerException {
+        return queryTopicConsumeByWho(addr, topic, true, timeoutMillis);
+    }
+
+    public GroupList queryTopicConsumeByWho(final String addr, final String topic, final boolean ignoreDeletedGroup,
+        final long timeoutMillis)
+        throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException,
+        MQBrokerException {
         QueryTopicConsumeByWhoRequestHeader requestHeader = new QueryTopicConsumeByWhoRequestHeader();
         requestHeader.setTopic(topic);
+        requestHeader.setIgnoreDeteled(ignoreDeletedGroup);
 
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.QUERY_TOPIC_CONSUME_BY_WHO, requestHeader);
 

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/header/QueryTopicConsumeByWhoRequestHeader.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/header/QueryTopicConsumeByWhoRequestHeader.java
@@ -28,6 +28,8 @@ public class QueryTopicConsumeByWhoRequestHeader implements CommandCustomHeader 
     @CFNotNull
     private String topic;
 
+    private boolean ignoreDeteled;
+
     @Override
     public void checkFields() throws RemotingCommandException {
 
@@ -39,5 +41,13 @@ public class QueryTopicConsumeByWhoRequestHeader implements CommandCustomHeader 
 
     public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+    public boolean isIgnoreDeteled() {
+        return ignoreDeteled;
+    }
+
+    public void setIgnoreDeteled(boolean ignore) {
+        this.ignoreDeteled = ignore;
     }
 }


### PR DESCRIPTION
when use `mqadmin deleteSubGroup` to delte subInfo, broker will
remove subInfo from SubscriptionGroupManager. but when admin use
`queryTopicConsumeByWho` to get consumer info, the delted group
of sub will back, which is not expected.

- use SubscriptionGroupManager to filter groups

Closes #1798
 