### PR TITLE
[ISSUE #1233] Fix CVE-2011-1473

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/TlsHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/TlsHelper.java
@@ -133,7 +133,7 @@ public class TlsHelper {
                 SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
                 return SslContextBuilder
                     .forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
-                    .sslProvider(SslProvider.JDK)
+                    .sslProvider(provider)
                     .clientAuth(ClientAuth.OPTIONAL)
                     .build();
             } else {


### PR DESCRIPTION
fix #1233

Tested with OpenSSL 1.1.1
before fixing：
openssl s_client -connect 172.16.41.1:9876
...
R
RENEGOTIATING
depth=0 CN = example.com
verify error:num=18:self signed certificate
verify return:1
depth=0 CN = example.com
verify return:1

after fixing：
openssl s_client -connect 172.16.41.1:9876
...
R
RENEGOTIATING
140672690749888:error:1409444C:SSL routines:ssl3_read_bytes:tlsv1 alert no renegotiation:../ssl/record/rec_layer_s3.c:1528:SSL alert number 100