### PR TITLE
feat(store): remove extra flush of StoreCheckpoint

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -314,7 +314,6 @@ public class DefaultMessageStore implements MessageStore {
             this.reputMessageService.shutdown();
             this.flushConsumeQueueService.shutdown();
             this.allocateMappedFileService.shutdown();
-            this.storeCheckpoint.flush();
             this.storeCheckpoint.shutdown();
 
             if (this.runningFlags.isWriteable() && dispatchBehindBytes() == 0) {


### PR DESCRIPTION
motivation:

after review code, I found DefaultMessageStore#shutdown will call storeCheckpoint#flush and storeCheckpoint#shutdown, but storeCheckpoint#shutdown will call storeCheckpoint#flush again, which is extra 