### PR TITLE
[ISSUE #1159]resetOffset not work when use cpp client or python #1892

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
@@ -344,7 +344,8 @@ public class DefaultMQAdminExt extends ClientConfig implements MQAdminExt {
     @Override
     public Map<MessageQueue, Long> resetOffsetByTimestamp(String topic, String group, long timestamp, boolean isForce)
         throws RemotingException, MQBrokerException, InterruptedException, MQClientException {
-        return resetOffsetByTimestamp(topic, group, timestamp, isForce, false);
+        boolean isJavaInstancesOnline = defaultMQAdminExtImpl.isAllInstancesInGroupJava(group);
+        return resetOffsetByTimestamp(topic, group, timestamp, isForce, !isJavaInstancesOnline);
     }
 
     public Map<MessageQueue, Long> resetOffsetByTimestamp(String topic, String group, long timestamp, boolean isForce,

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -1065,15 +1065,15 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
      * @return true: all is java instances, false: not sure
      */
     public boolean isAllInstancesInGroupJava(String group) throws InterruptedException, RemotingException, MQClientException, MQBrokerException {
-        ConsumerConnection connection =  this.examineConsumerConnectionInfo(group);;
-        boolean isJava = false;
-
-        if (connection == null || connection.getConnectionSet().isEmpty()) {
-            return isJava;
+        ConsumerConnection connection =  this.examineConsumerConnectionInfo(group);
+        if (connection.getConnectionSet().isEmpty()) {
+            return false;
         }
+        boolean isJava = false;
         for (Connection con : connection.getConnectionSet()) {
             if (LanguageCode.JAVA == con.getLanguage()) {
-                isJava = true;//if >=2 languages used in instances, it can't be judged
+                //if >=2 languages used in instances, it can't be judged
+                isJava = true;
                 break;
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

fix bug
resetOffset not work when use cpp client or python

## Brief changelog

when doing resetOffset, should check language of consumer instance,
cause of broker wrap different requests for cpp and java consumer to tell them should commit new consumer offset again

## Verifying this change

run a python client  to consume, do reset offset in console, check consumer offset and python logs in local.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
