### PR TITLE
[ISSUE #1960] Get real and effective min offset in queue

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -695,6 +695,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             (GetTopicStatsInfoRequestHeader) request.decodeCommandCustomHeader(GetTopicStatsInfoRequestHeader.class);
 
         final String topic = requestHeader.getTopic();
+        final boolean realOffset = requestHeader.getRealOffset();
         TopicConfig topicConfig = this.brokerController.getTopicConfigManager().selectTopicConfig(topic);
         if (null == topicConfig) {
             response.setCode(ResponseCode.TOPIC_NOT_EXIST);
@@ -710,7 +711,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             mq.setQueueId(i);
 
             TopicOffset topicOffset = new TopicOffset();
-            long min = this.brokerController.getMessageStore().getMinOffsetInQueue(topic, i);
+            long min = this.brokerController.getMessageStore().getMinOffsetInQueue(topic, i, realOffset);
             if (min < 0)
                 min = 0;
 

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -1139,13 +1139,21 @@ public class MQClientAPIImpl {
     public TopicStatsTable getTopicStatsInfo(final String addr, final String topic,
         final long timeoutMillis) throws InterruptedException,
         RemotingTimeoutException, RemotingSendRequestException, RemotingConnectException, MQBrokerException {
+
+        return getTopicStatsInfo(addr, topic, false, timeoutMillis);
+    }
+
+    public TopicStatsTable getTopicStatsInfo(final String addr, final String topic, final boolean realOffset,
+                                             final long timeoutMillis) throws InterruptedException,
+            RemotingTimeoutException, RemotingSendRequestException, RemotingConnectException, MQBrokerException {
         GetTopicStatsInfoRequestHeader requestHeader = new GetTopicStatsInfoRequestHeader();
         requestHeader.setTopic(topic);
+        requestHeader.setRealOffset(realOffset);
 
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_TOPIC_STATS_INFO, requestHeader);
 
         RemotingCommand response = this.remotingClient.invokeSync(MixAll.brokerVIPChannel(this.clientConfig.isVipChannelEnabled(), addr),
-            request, timeoutMillis);
+                request, timeoutMillis);
         switch (response.getCode()) {
             case ResponseCode.SUCCESS: {
                 TopicStatsTable topicStatsTable = TopicStatsTable.decode(response.getBody(), TopicStatsTable.class);

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/header/GetTopicStatsInfoRequestHeader.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/header/GetTopicStatsInfoRequestHeader.java
@@ -24,6 +24,8 @@ import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 public class GetTopicStatsInfoRequestHeader implements CommandCustomHeader {
     @CFNotNull
     private String topic;
+    @CFNotNull
+    private Boolean realOffset;
 
     @Override
     public void checkFields() throws RemotingCommandException {
@@ -35,5 +37,13 @@ public class GetTopicStatsInfoRequestHeader implements CommandCustomHeader {
 
     public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+    public Boolean getRealOffset() {
+        return realOffset;
+    }
+
+    public void setRealOffset(Boolean realOffset) {
+        this.realOffset = realOffset;
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -672,11 +672,11 @@ public class DefaultMessageStore implements MessageStore {
             long consumeQueueOffset = logic.getMinOffsetInQueue();
             long commitLogOffset = 0L;
             if (realOffset) {
-                long minCommitoffset = this.commitLog.getMinOffset();
+                long minCommitLogOffset = this.commitLog.getMinOffset();
                 long maxOffsetInQueue = getMaxOffsetInQueue(topic,queueId);
                 for (;consumeQueueOffset <= maxOffsetInQueue;consumeQueueOffset++) {
                     commitLogOffset = getCommitLogOffsetInQueue(topic, queueId, consumeQueueOffset);
-                    if (commitLogOffset >= minCommitoffset) {
+                    if (commitLogOffset >= minCommitLogOffset) {
                         return consumeQueueOffset;
                     }
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -670,13 +670,13 @@ public class DefaultMessageStore implements MessageStore {
         ConsumeQueue logic = this.findConsumeQueue(topic, queueId);
         if (logic != null) {
             long consumeQueueOffset = logic.getMinOffsetInQueue();
-            MessageExt msgExt = null;
             long commitLogOffset = 0L;
             if (realOffset) {
-                for (;consumeQueueOffset <= getMaxOffsetInQueue(topic,queueId);consumeQueueOffset++) {
+                long minCommitoffset = this.commitLog.getMinOffset();
+                long maxOffsetInQueue = getMaxOffsetInQueue(topic,queueId);
+                for (;consumeQueueOffset <= maxOffsetInQueue;consumeQueueOffset++) {
                     commitLogOffset = getCommitLogOffsetInQueue(topic, queueId, consumeQueueOffset);
-                    msgExt = lookMessageByOffset(commitLogOffset);
-                    if (null != msgExt) {
+                    if (commitLogOffset >= minCommitoffset) {
                         return consumeQueueOffset;
                     }
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -680,6 +680,7 @@ public class DefaultMessageStore implements MessageStore {
                         return consumeQueueOffset;
                     }
                 }
+                return consumeQueueOffset;
             } else {
                 return consumeQueueOffset;
             }

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -672,15 +672,15 @@ public class DefaultMessageStore implements MessageStore {
             long consumeQueueOffset = logic.getMinOffsetInQueue();
             MessageExt msgExt = null;
             long commitLogOffset = 0L;
-            if(realOffset){
-                for( ;consumeQueueOffset < getMaxOffsetInQueue(topic,queueId); consumeQueueOffset++){
+            if (realOffset) {
+                for (;consumeQueueOffset <= getMaxOffsetInQueue(topic,queueId);consumeQueueOffset++) {
                     commitLogOffset = getCommitLogOffsetInQueue(topic, queueId, consumeQueueOffset);
                     msgExt = lookMessageByOffset(commitLogOffset);
-                    if(null != msgExt){
+                    if (null != msgExt) {
                         return consumeQueueOffset;
                     }
                 }
-            }else {
+            } else {
                 return consumeQueueOffset;
             }
         }

--- a/store/src/main/java/org/apache/rocketmq/store/MessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageStore.java
@@ -103,6 +103,16 @@ public interface MessageStore {
     long getMinOffsetInQueue(final String topic, final int queueId);
 
     /**
+     * Get the minimum offset of the topic queue.
+     *
+     * @param topic Topic name.
+     * @param queueId Queue ID.
+     * @param realOffset real offset
+     * @return Minimum offset at present.
+     */
+    long getMinOffsetInQueue(final String topic, final int queueId, final boolean realOffset);
+
+    /**
      * Get the offset of the message in the commit log, which is also known as physical offset.
      *
      * @param topic Topic of the message to lookup.

--- a/store/src/test/java/org/apache/rocketmq/store/dledger/MixCommitlogTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/dledger/MixCommitlogTest.java
@@ -38,7 +38,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
             doPutMessages(originalStore, topic, 0, 1000, 0);
             Assert.assertEquals(11, originalStore.getMaxPhyOffset()/originalStore.getMessageStoreConfig().getMappedFileSizeCommitLog());
             Thread.sleep(500);
-            Assert.assertEquals(0, originalStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, originalStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(1000, originalStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, originalStore.dispatchBehindBytes());
             doGetMessages(originalStore, topic, 0, 1000, 0);
@@ -51,13 +51,13 @@ public class MixCommitlogTest extends MessageStoreTestBase {
         {
             DefaultMessageStore dledgerStore = createDledgerMessageStore(base, group, "n0", peers, null, true, 0);
             Thread.sleep(2000);
-            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(1000, dledgerStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, dledgerStore.dispatchBehindBytes());
             doGetMessages(dledgerStore, topic, 0, 1000, 0);
             doPutMessages(dledgerStore, topic, 0, 1000, 1000);
             Thread.sleep(500);
-            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(2000, dledgerStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, dledgerStore.dispatchBehindBytes());
             doGetMessages(dledgerStore, topic, 0, 2000, 0);
@@ -79,7 +79,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
             DefaultMessageStore originalStore = createMessageStore(base, false);
             doPutMessages(originalStore, topic, 0, 1000, 0);
             Thread.sleep(500);
-            Assert.assertEquals(0, originalStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, originalStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(1000, originalStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, originalStore.dispatchBehindBytes());
             dividedOffset = originalStore.getCommitLog().getMaxOffset();
@@ -90,7 +90,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
         {
             DefaultMessageStore recoverOriginalStore = createMessageStore(base, true);
             Thread.sleep(500);
-            Assert.assertEquals(0, recoverOriginalStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, recoverOriginalStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(1000, recoverOriginalStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, recoverOriginalStore.dispatchBehindBytes());
             doGetMessages(recoverOriginalStore, topic, 0, 1000, 0);
@@ -106,7 +106,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
             Thread.sleep(2000);
             doPutMessages(dledgerStore, topic, 0, 1000, 1000);
             Thread.sleep(500);
-            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(2000, dledgerStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, dledgerStore.dispatchBehindBytes());
             doGetMessages(dledgerStore, topic, 0, 2000, 0);
@@ -120,7 +120,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
             Thread.sleep(2000);
             doPutMessages(recoverDledgerStore, topic, 0, 1000, 2000);
             Thread.sleep(500);
-            Assert.assertEquals(0, recoverDledgerStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, recoverDledgerStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(3000, recoverDledgerStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, recoverDledgerStore.dispatchBehindBytes());
             doGetMessages(recoverDledgerStore, topic, 0, 3000, 0);
@@ -140,7 +140,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
             DefaultMessageStore originalStore = createMessageStore(base, false);
             doPutMessages(originalStore, topic, 0, 1000, 0);
             Thread.sleep(500);
-            Assert.assertEquals(0, originalStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, originalStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(1000, originalStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, originalStore.dispatchBehindBytes());
             dividedOffset = originalStore.getCommitLog().getMaxOffset();
@@ -157,7 +157,7 @@ public class MixCommitlogTest extends MessageStoreTestBase {
             Thread.sleep(2000);
             doPutMessages(dledgerStore, topic, 0, 1000, 1000);
             Thread.sleep(500);
-            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0));
+            Assert.assertEquals(0, dledgerStore.getMinOffsetInQueue(topic, 0,true));
             Assert.assertEquals(2000, dledgerStore.getMaxOffsetInQueue(topic, 0));
             Assert.assertEquals(0, dledgerStore.dispatchBehindBytes());
             Assert.assertEquals(0, dledgerStore.getMinPhyOffset());

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
@@ -204,7 +204,14 @@ public class DefaultMQAdminExt extends ClientConfig implements MQAdminExt {
     public TopicStatsTable examineTopicStats(
         String topic) throws RemotingException, MQClientException, InterruptedException,
         MQBrokerException {
-        return defaultMQAdminExtImpl.examineTopicStats(topic);
+        return examineTopicStats(topic,false);
+    }
+
+    @Override
+    public TopicStatsTable examineTopicStats(
+            String topic, boolean realOffset) throws RemotingException, MQClientException, InterruptedException,
+            MQBrokerException {
+        return defaultMQAdminExtImpl.examineTopicStats(topic, realOffset);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -223,13 +223,21 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
     public TopicStatsTable examineTopicStats(
         String topic) throws RemotingException, MQClientException, InterruptedException,
         MQBrokerException {
+
+        return examineTopicStats(topic,false);
+    }
+
+    @Override
+    public TopicStatsTable examineTopicStats(
+            String topic, boolean realOffset) throws RemotingException, MQClientException, InterruptedException,
+            MQBrokerException {
         TopicRouteData topicRouteData = this.examineTopicRouteInfo(topic);
         TopicStatsTable topicStatsTable = new TopicStatsTable();
 
         for (BrokerData bd : topicRouteData.getBrokerDatas()) {
             String addr = bd.selectBrokerAddr();
             if (addr != null) {
-                TopicStatsTable tst = this.mqClientInstance.getMQClientAPIImpl().getTopicStatsInfo(addr, topic, timeoutMillis);
+                TopicStatsTable tst = this.mqClientInstance.getMQClientAPIImpl().getTopicStatsInfo(addr, topic, realOffset, timeoutMillis);
                 topicStatsTable.getOffsetTable().putAll(tst.getOffsetTable());
             }
         }

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/MQAdminExt.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/MQAdminExt.java
@@ -94,6 +94,10 @@ public interface MQAdminExt extends MQAdmin {
         final String topic) throws RemotingException, MQClientException, InterruptedException,
         MQBrokerException;
 
+    TopicStatsTable examineTopicStats(
+            final String topic, final boolean realOffset) throws RemotingException, MQClientException, InterruptedException,
+            MQBrokerException;
+
     TopicList fetchAllTopicList() throws RemotingException, MQClientException, InterruptedException;
 
     TopicList fetchTopicsByCLuster(

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/topic/TopicStatusSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/topic/TopicStatusSubCommand.java
@@ -85,7 +85,7 @@ public class TopicStatusSubCommand implements SubCommand {
             for (MessageQueue mq : mqList) {
                 TopicOffset topicOffset = topicStatsTable.getOffsetTable().get(mq);
 
-                total += topicOffset.getMaxOffset()-topicOffset.getMinOffset();
+                total += topicOffset.getMaxOffset() - topicOffset.getMinOffset();
 
                 String humanTimestamp = "";
                 if (topicOffset.getLastUpdateTimestamp() > 0) {
@@ -99,7 +99,7 @@ public class TopicStatusSubCommand implements SubCommand {
                     topicOffset.getMaxOffset(),
                     humanTimestamp
                 );
-                if(topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX)){
+                if (topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX)) {
                     System.out.printf("Total: %d%n", total);
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

Can obtain the number of real and effective dead letter topic messages。because the message corresponding to the smallest position of the consume queue has been deleted，therefore, you need to use this displacement point to determine whether the message exists.

## Brief changelog

are some refactoring methods and calling ready-made methods

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
