### PR TITLE
Security issue: upgrade fastjson version to 1.2.68 for security reason 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>fastjson</artifactId>
-                <version>1.2.62</version>
+                <version>1.2.68</version>
             </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>


### PR DESCRIPTION
## What is the purpose of the change

Upgrade fastjson version to 1.2.68 (https://github.com/alibaba/fastjson/releases/tag/1.2.68) to eliminate the security issue

Security issue:
https://help.aliyun.com/noticelist/articleid/1060253179.html

## Brief changelog
1. Upgrade fastjson version from 1.2.62 to 1.2.68