### PR TITLE
[ISSUE #2009]add body and head length field in RomotingCommand

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
@@ -82,6 +82,10 @@ public class RemotingCommand {
 
     private transient byte[] body;
 
+    private int bodyLength = 0;
+
+    private int headLength = 0;
+
     protected RemotingCommand() {
     }
 
@@ -152,12 +156,15 @@ public class RemotingCommand {
         RemotingCommand cmd = headerDecode(headerData, getProtocolType(oriHeaderLen));
 
         int bodyLength = length - 4 - headerLength;
+
         byte[] bodyData = null;
         if (bodyLength > 0) {
             bodyData = new byte[bodyLength];
             byteBuffer.get(bodyData);
         }
         cmd.body = bodyData;
+        cmd.headLength = headerLength;
+        cmd.bodyLength = bodyLength;
 
         return cmd;
     }
@@ -426,6 +433,10 @@ public class RemotingCommand {
 
         result.flip();
 
+        this.headLength = headerData.length;
+
+        this.bodyLength = bodyLength;
+
         return result;
     }
 
@@ -518,6 +529,14 @@ public class RemotingCommand {
     public void setExtFields(HashMap<String, String> extFields) {
         this.extFields = extFields;
     }
+
+    public static String getSerializeTypeProperty() {
+        return SERIALIZE_TYPE_PROPERTY;
+    }
+
+    public int getBodyLength() { return bodyLength; }
+
+    public int getHeadLength() { return headLength; }
 
     public void addExtField(String key, String value) {
         if (null == extFields) {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
@@ -530,10 +530,6 @@ public class RemotingCommand {
         this.extFields = extFields;
     }
 
-    public static String getSerializeTypeProperty() {
-        return SERIALIZE_TYPE_PROPERTY;
-    }
-
     public int getBodyLength() { return bodyLength; }
 
     public int getHeadLength() { return headLength; }


### PR DESCRIPTION
add body and head length field in RomotingCommand,so they can be get easily when call org.apache.rocketmq.remoting.RPCHook#doAfterResponse

## What is the purpose of the change

to get RomotingCommand head and body length easily

## Brief changelog

add bodyLength and headLength filed and public get method for them

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
