### PR TITLE
[ISSUE #2007]Fastjson has a serious security problem in 1.2.62,which will cause RCE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>fastjson</artifactId>
-                <version>1.2.62</version>
+                <version>1.2.68</version>
             </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>


### PR DESCRIPTION
Fastjson has a serious security problem in 1.2.62,which will cause RCE

Fix https://github.com/apache/rocketmq/issues/2007

## What is the purpose of the change

Fastjson has a serious security problem in 1.2.62,which will cause RCE

## Brief changelog

Fastjson has a serious security problem in 1.2.62,which will cause RCE

## Verifying this change

Fastjson has a serious security problem in 1.2.62,which will cause RCE

