### PR TITLE
[ISSUE #1931]duplicate doAfterRpcHooks bugfix

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -226,7 +226,6 @@ public abstract class NettyRemotingAbstract {
                         } else {
                             NettyRequestProcessor processor = pair.getObject1();
                             RemotingCommand response = processor.processRequest(ctx, cmd);
-                            doAfterRpcHooks(RemotingHelper.parseChannelRemoteAddr(ctx.channel()), cmd, response);
                             callback.callback(response);
                         }
                     } catch (Throwable e) {


### PR DESCRIPTION
fix bug: doAfterRpcHooks execute twice.

## What is the purpose of the change

bug fix

## Brief changelog

doAfterRpcHooks only called in callback

