### PR TITLE
[ISSUE #2283] Fix the spelling mistake in ProducerManager & some code optimization（CodeStyle）

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
@@ -33,7 +33,7 @@ import org.apache.rocketmq.remoting.common.RemotingUtil;
 public class ProducerManager {
     private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.BROKER_LOGGER_NAME);
     private static final long CHANNEL_EXPIRED_TIMEOUT = 1000 * 120;
-    private static final int GET_AVALIABLE_CHANNEL_RETRY_COUNT = 3;
+    private static final int GET_AVAILABLE_CHANNEL_RETRY_COUNT = 3;
     private final ConcurrentHashMap<String /* group name */, ConcurrentHashMap<Channel, ClientChannelInfo>> groupChannelTable =
         new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Channel> clientChannelTable = new ConcurrentHashMap<>();
@@ -131,16 +131,14 @@ public class ProducerManager {
         }
     }
 
-    public Channel getAvaliableChannel(String groupId) {
+    public Channel getAvailableChannel(String groupId) {
         if (groupId == null) {
             return null;
         }
-        List<Channel> channelList = new ArrayList<Channel>();
+        List<Channel> channelList;
         ConcurrentHashMap<Channel, ClientChannelInfo> channelClientChannelInfoHashMap = groupChannelTable.get(groupId);
         if (channelClientChannelInfoHashMap != null) {
-            for (Channel channel : channelClientChannelInfoHashMap.keySet()) {
-                channelList.add(channel);
-            }
+            channelList = new ArrayList<>(channelClientChannelInfoHashMap.keySet());
         } else {
             log.warn("Check transaction failed, channel table is empty. groupId={}", groupId);
             return null;
@@ -158,7 +156,7 @@ public class ProducerManager {
         Channel channel = channelList.get(index);
         int count = 0;
         boolean isOk = channel.isActive() && channel.isWritable();
-        while (count++ < GET_AVALIABLE_CHANNEL_RETRY_COUNT) {
+        while (count++ < GET_AVAILABLE_CHANNEL_RETRY_COUNT) {
             if (isOk) {
                 return channel;
             }

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/AbstractTransactionalMessageCheckListener.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/AbstractTransactionalMessageCheckListener.java
@@ -69,7 +69,7 @@ public abstract class AbstractTransactionalMessageCheckListener {
         msgExt.setQueueId(Integer.parseInt(msgExt.getUserProperty(MessageConst.PROPERTY_REAL_QUEUE_ID)));
         msgExt.setStoreSize(0);
         String groupId = msgExt.getProperty(MessageConst.PROPERTY_PRODUCER_GROUP);
-        Channel channel = brokerController.getProducerManager().getAvaliableChannel(groupId);
+        Channel channel = brokerController.getProducerManager().getAvailableChannel(groupId);
         if (channel != null) {
             brokerController.getBroker2Client().checkProducerTransactionState(groupId, channel, checkTransactionStateRequestHeader, msgExt);
         } else {

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -110,20 +110,20 @@ public class ProducerManagerTest {
     }
 
     @Test
-    public void testGetAvaliableChannel() {
+    public void testGetAvailableChannel() {
         producerManager.registerProducer(group, clientInfo);
 
         when(channel.isActive()).thenReturn(true);
         when(channel.isWritable()).thenReturn(true);
-        Channel c = producerManager.getAvaliableChannel(group);
+        Channel c = producerManager.getAvailableChannel(group);
         assertThat(c).isSameAs(channel);
 
         when(channel.isWritable()).thenReturn(false);
-        c = producerManager.getAvaliableChannel(group);
+        c = producerManager.getAvailableChannel(group);
         assertThat(c).isSameAs(channel);
 
         when(channel.isActive()).thenReturn(false);
-        c = producerManager.getAvaliableChannel(group);
+        c = producerManager.getAvailableChannel(group);
         assertThat(c).isNull();
     }
 


### PR DESCRIPTION
## What is the purpose of the change
spelling mistake  and code optimization

## Brief changelog

1. change the method name from "getAvaliableChannel" to "getAvailableChannel"
2. change the field name from "GET_AVALIABLE_CHANNEL_RETRY_COUNT" to "GET_AVAILABLE_CHANNEL_RETRY_COUNT"
3. optimizing “getAvailableChannel” 
```java
        List<Channel> channelList = new ArrayList<Channel>();
        ConcurrentHashMap<Channel, ClientChannelInfo> channelClientChannelInfoHashMap = groupChannelTable.get(groupId);
        if (channelClientChannelInfoHashMap != null) {
            for (Channel channel : channelClientChannelInfoHashMap.keySet()) {
                channelList.add(channel);
            }
        } else {
            log.warn("Check transaction failed, channel table is empty. groupId={}", groupId);
            return null;
        }
```

with
```java
        List<Channel> channelList;
        ConcurrentHashMap<Channel, ClientChannelInfo> channelClientChannelInfoHashMap = groupChannelTable.get(groupId);
        if (channelClientChannelInfoHashMap != null) {
            channelList = new ArrayList<>(channelClientChannelInfoHashMap.keySet());
        } else {
            log.warn("Check transaction failed, channel table is empty. groupId={}", groupId);
            return null;
        }
```