### PR TITLE
[ISSUE-2452] Provide a handy machine room nearby producer selector

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/producer/selector/SelectMessageQueueByMachineRoomNearBy.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/selector/SelectMessageQueueByMachineRoomNearBy.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.producer.selector;
+
+import org.apache.rocketmq.client.producer.MessageQueueSelector;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class SelectMessageQueueByMachineRoomNearBy implements MessageQueueSelector {
+    private final MessageQueueSelector inner;
+    private final MachineRoomResolver machineRoomResolver;
+
+    public SelectMessageQueueByMachineRoomNearBy(MachineRoomResolver machineRoomResolver) {
+        this(machineRoomResolver, new SelectMessageQueueByRandom());
+    }
+
+    public SelectMessageQueueByMachineRoomNearBy(MachineRoomResolver machineRoomResolver, MessageQueueSelector inner) {
+        this.machineRoomResolver = machineRoomResolver;
+        this.inner = inner;
+    }
+
+    @Override
+    public MessageQueue select(List<MessageQueue> mqs, Message msg, Object arg) {
+        List<MessageQueue> candidateMqs = new ArrayList<>();
+        for  (MessageQueue mq: mqs) {
+            if (machineRoomResolver.brokerDeployIn(mq).equals(machineRoomResolver.producerDeployIn())) {
+                candidateMqs.add(mq);
+            }
+        }
+
+        //no nearby broker queues, use the rest anyway
+        if (candidateMqs.isEmpty()) {
+            candidateMqs = mqs;
+        }
+
+
+        return inner.select(candidateMqs, msg, arg);
+    }
+
+    /**
+     * A resolver object to determine which machine room do the message queues or producers are deployed in.
+     *
+     * SelectMessageQueueByMachineRoomNearBy will prefer to selecting to message queues which has the same machine room name with the producer's
+     *
+     * The result returned from the implemented method CANNOT be null.
+     */
+    public interface MachineRoomResolver {
+        String brokerDeployIn(MessageQueue messageQueue);
+
+        String producerDeployIn();
+    }
+}

--- a/client/src/test/java/org/apache/rocketmq/client/producer/selector/SelectMessageQueueByMachineRoomNearBTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/selector/SelectMessageQueueByMachineRoomNearBTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.producer.selector;
+
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SelectMessageQueueByMachineRoomNearBTest {
+
+    private String topic = "FooBar";
+
+    private final SelectMessageQueueByMachineRoomNearBy selector = new SelectMessageQueueByMachineRoomNearBy(new SelectMessageQueueByMachineRoomNearBy.MachineRoomResolver() {
+        @Override
+        public String brokerDeployIn(MessageQueue messageQueue) {
+            return messageQueue.getBrokerName().split("-")[0];
+        }
+
+        @Override
+        public String producerDeployIn() {
+            return "IDC1";
+        }
+    });
+
+    @Test
+    public void testSelectNearByNormal() throws Exception {
+        Message message = new Message(topic, new byte[] {});
+
+        List<MessageQueue> messageQueues = new ArrayList<>();
+        messageQueues.addAll(createMessageQueueList("IDC1",3));
+        messageQueues.addAll(createMessageQueueList("IDC2",3));
+        messageQueues.addAll(createMessageQueueList("IDC3",3));
+
+        String orderId = "123";
+
+        //select for 100times, only IDC1's queue should be selected
+        for (int i = 0; i< 100; i++) {
+            MessageQueue selected = selector.select(messageQueues, message, orderId);
+            assertThat(selected.getBrokerName()).contains("IDC1");
+        }
+
+    }
+
+
+    @Test
+    public void testSelectNearByNearByMachineRoomOffline() throws Exception {
+        Message message = new Message(topic, new byte[] {});
+
+        List<MessageQueue> messageQueues = new ArrayList<>();
+        messageQueues.addAll(createMessageQueueList("IDC2",3));
+        messageQueues.addAll(createMessageQueueList("IDC3",3));
+        String orderId = "123";
+
+        //IDC1's broker is offline, other IDC's queue should be selected
+        for (int i = 0; i< 100; i++) {
+            MessageQueue selected = selector.select(messageQueues, message, orderId);
+            assertThat(selected).isNotNull();
+        }
+
+    }
+
+    private List<MessageQueue> createMessageQueueList(String machineRoom, int size) {
+        List<MessageQueue> messageQueueList = new ArrayList<MessageQueue>(size);
+        for (int i = 0; i < size; i++) {
+            MessageQueue mq = new MessageQueue(topic, machineRoom+"-brokerName", i);
+            messageQueueList.add(mq);
+        }
+        return messageQueueList;
+    }
+
+}


### PR DESCRIPTION
#2452 For now, rocketmq has already supported machine room nearby for consumer rebalance strategy. But in practice, when user has more than one logic machine room in one city, they may use a near by consumer strategy alone with producer selector, so this is a issue request provide a handy selector for user to use.

## Brief changelog

Add a `SelectMessageQueueByMachineRoomNearBy` to provide user to use directly when they need to send message to a message queue where deployed in the same machine room with the producer's

