### PR TITLE
[ISSUE #2541] Add a TravisCI job to build and test on ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 
 notifications:
   email:
@@ -9,23 +9,38 @@ notifications:
 
 language: java
 
-jdk:
-  - oraclejdk8
-
 matrix:
   include:
   # On OSX, run with default JDK only.
   # - os: osx
-  # On Linux, run with specific JDKs only.
-  - os: linux
-    env: CUSTOM_JDK="oraclejdk8"
-
+  # On Linux we install latest OpenJDK 1.8 from Ubuntu repositories
+  - name: Linux x86_64
+    arch: amd64
+  - name: Linux aarch64
+    arch: arm64
+    
+cache:
+  directories:
+    - $HOME/.m2/repository
+    
 before_install:
+  - lscpu
   - echo 'MAVEN_OPTS="$MAVEN_OPTS -Xmx1024m -XX:MaxPermSize=512m -XX:+BytecodeVerificationLocal"' >> ~/.mavenrc
   - cat ~/.mavenrc
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then jdk_switcher use "$CUSTOM_JDK"; fi
 
+install: |
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then 
+    sudo apt update
+    sudo apt install -y openjdk-8-jdk maven
+    export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-${TRAVIS_CPU_ARCH}/"
+    export PATH="$JAVA_HOME/bin:/usr/share/maven/bin:$PATH"
+  fi
+  
+before_script:
+  - java -version
+  - mvn -version
+  
 script:
   - travis_retry mvn -B clean apache-rat:check
   - travis_retry mvn -B package jacoco:report coveralls:report


### PR DESCRIPTION
## What is the purpose of the change

More and more software development is being done on ARM64 CPU architecture.
It would be good if RocketMQ is being regularly tested on ARM64.

## Brief changelog

Add a TravisCI job that runs the build on ARM64 architecture.

The ARM64 nodes at TravisCI are available only for Ubuntu 18.04+, i.e. `bionic` and `focal`. 
There is no `jdk: oraclejdk8` for `bionic` so I needed to install it manually from Ubuntu repositories. The extra benefit is the newer JDK build. Travis `oraclejdk8` image comes with 1.8.0_151, while the Ubuntu repository installs 1.8.0_275 (the latest available at the moment). 
I've also added caching for the downloaded Maven dependencies. This reduces a bit the job execution time.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a Github issue - this PR does not modify RocketMQ anyhow, so I guess there is no need of a separate issue 
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) - no need of new tests
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass - both the unit and IT tests are executed by TravisCI on x86_64 and aarch64 CPU architectures.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas) - the PR is not large, but also I am an Apache member (Apache id: mgrigorov).
