### PR TITLE
[ISSUE #2570] Modify the truncateDirtyLogicFiles judgement, just execute it when maxPhyOffsetOfConsumeQueue > processOffset.

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -215,8 +215,8 @@ public class CommitLog {
             this.mappedFileQueue.truncateDirtyFiles(processOffset);
 
             // Clear ConsumeQueue redundant data
-            if (maxPhyOffsetOfConsumeQueue >= processOffset) {
-                log.warn("maxPhyOffsetOfConsumeQueue({}) >= processOffset({}), truncate dirty logic files", maxPhyOffsetOfConsumeQueue, processOffset);
+            if (maxPhyOffsetOfConsumeQueue > processOffset) {
+                log.warn("maxPhyOffsetOfConsumeQueue({}) > processOffset({}), truncate dirty logic files", maxPhyOffsetOfConsumeQueue, processOffset);
                 this.defaultMessageStore.truncateDirtyLogicFiles(processOffset);
             }
         } else {
@@ -493,8 +493,8 @@ public class CommitLog {
             this.mappedFileQueue.truncateDirtyFiles(processOffset);
 
             // Clear ConsumeQueue redundant data
-            if (maxPhyOffsetOfConsumeQueue >= processOffset) {
-                log.warn("maxPhyOffsetOfConsumeQueue({}) >= processOffset({}), truncate dirty logic files", maxPhyOffsetOfConsumeQueue, processOffset);
+            if (maxPhyOffsetOfConsumeQueue > processOffset) {
+                log.warn("maxPhyOffsetOfConsumeQueue({}) > processOffset({}), truncate dirty logic files", maxPhyOffsetOfConsumeQueue, processOffset);
                 this.defaultMessageStore.truncateDirtyLogicFiles(processOffset);
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

For-#2570.
Modify the truncateDirtyLogicFiles judgement, just execute it when maxPhyOffsetOfConsumeQueue > processOffset.