### PR TITLE
[ISSUE #2670]Hide Client IP when there's no `-s true`  in command ConsumerProgress

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
@@ -111,17 +111,26 @@ public class ConsumerProgressSubCommand implements SubCommand {
                 if (showClientIP) {
                     messageQueueAllocationResult = getMessageQueueAllocationResult(defaultMQAdminExt, consumerGroup);
                 }
-
-                System.out.printf("%-32s  %-32s  %-4s  %-20s  %-20s  %-20s %-20s  %s%n",
-                    "#Topic",
-                    "#Broker Name",
-                    "#QID",
-                    "#Broker Offset",
-                    "#Consumer Offset",
-                    "#Client IP",
-                    "#Diff",
-                    "#LastTime");
-
+                if (showClientIP) {
+                    System.out.printf("%-32s  %-32s  %-4s  %-20s  %-20s  %-20s %-20s  %s%n",
+                            "#Topic",
+                            "#Broker Name",
+                            "#QID",
+                            "#Broker Offset",
+                            "#Consumer Offset",
+                            "#Client IP",
+                            "#Diff",
+                            "#LastTime");
+                } else {
+                    System.out.printf("%-32s  %-32s  %-4s  %-20s  %-20s  %-20s  %s%n",
+                            "#Topic",
+                            "#Broker Name",
+                            "#QID",
+                            "#Broker Offset",
+                            "#Consumer Offset",
+                            "#Diff",
+                            "#LastTime");
+                }
                 long diffTotal = 0L;
                 for (MessageQueue mq : mqList) {
                     OffsetWrapper offsetWrapper = consumeStats.getOffsetTable().get(mq);
@@ -141,17 +150,28 @@ public class ConsumerProgressSubCommand implements SubCommand {
                     if (showClientIP) {
                         clientIP = messageQueueAllocationResult.get(mq);
                     }
-
-                    System.out.printf("%-32s  %-32s  %-4d  %-20d  %-20d  %-20s %-20d  %s%n",
-                        UtilAll.frontStringAtLeast(mq.getTopic(), 32),
-                        UtilAll.frontStringAtLeast(mq.getBrokerName(), 32),
-                        mq.getQueueId(),
-                        offsetWrapper.getBrokerOffset(),
-                        offsetWrapper.getConsumerOffset(),
-                        null != clientIP ? clientIP : "N/A",
-                        diff,
-                        lastTime
-                    );
+                    if (showClientIP) {
+                        System.out.printf("%-32s  %-32s  %-4d  %-20d  %-20d  %-20s %-20d  %s%n",
+                                UtilAll.frontStringAtLeast(mq.getTopic(), 32),
+                                UtilAll.frontStringAtLeast(mq.getBrokerName(), 32),
+                                mq.getQueueId(),
+                                offsetWrapper.getBrokerOffset(),
+                                offsetWrapper.getConsumerOffset(),
+                                null != clientIP ? clientIP : "N/A",
+                                diff,
+                                lastTime
+                        );
+                    } else {
+                        System.out.printf("%-32s  %-32s  %-4d  %-20d  %-20d  %-20d  %s%n",
+                                UtilAll.frontStringAtLeast(mq.getTopic(), 32),
+                                UtilAll.frontStringAtLeast(mq.getBrokerName(), 32),
+                                mq.getQueueId(),
+                                offsetWrapper.getBrokerOffset(),
+                                offsetWrapper.getConsumerOffset(),
+                                diff,
+                                lastTime
+                        );
+                    }
                 }
 
                 System.out.printf("%n");


### PR DESCRIPTION
## What is the purpose of the change
https://github.com/apache/rocketmq/issues/2670
When there is no `-s true` in command ConsumerProgress,  the `N/A`s may make people confused. This change is to hiding `Client IP` when not necessary.

## Brief changelog

Hide` Client IP` when no `-s true`  appeared in command ConsumerProgress.
