### PR TITLE
[ISSUE #2706]  Fix the problem of returning SEND_OK after flush failed 

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -467,6 +467,10 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
                 break;
 
             // Failed
+            case FLUSH_DISK_FAILED:
+                response.setCode(ResponseCode.FLUSH_DISK_FAILED);
+                response.setRemark("flush disk failed, disk or storage is broken.");
+                break;
             case CREATE_MAPEDFILE_FAILED:
                 response.setCode(ResponseCode.SYSTEM_ERROR);
                 response.setRemark("create mapped file failed, server is busy or broken.");

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -623,6 +623,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                         switch (e.getResponseCode()) {
                             case ResponseCode.TOPIC_NOT_EXIST:
                             case ResponseCode.SERVICE_NOT_AVAILABLE:
+                            case ResponseCode.FLUSH_DISK_FAILED:
                             case ResponseCode.SYSTEM_ERROR:
                             case ResponseCode.NO_PERMISSION:
                             case ResponseCode.NO_BUYER_ID:

--- a/client/src/main/java/org/apache/rocketmq/client/producer/SendStatus.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/SendStatus.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.client.producer;
 public enum SendStatus {
     SEND_OK,
     FLUSH_DISK_TIMEOUT,
+    FLUSH_DISK_FAILED,
     FLUSH_SLAVE_TIMEOUT,
     SLAVE_NOT_AVAILABLE,
 }

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
@@ -21,6 +21,8 @@ import org.apache.rocketmq.remoting.protocol.RemotingSysResponseCode;
 
 public class ResponseCode extends RemotingSysResponseCode {
 
+    public static final int FLUSH_DISK_FAILED = 9;
+
     public static final int FLUSH_DISK_TIMEOUT = 10;
 
     public static final int SLAVE_NOT_AVAILABLE = 11;

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFile.java
@@ -64,7 +64,7 @@ public class MappedFile extends ReferenceResource {
     private MappedByteBuffer mappedByteBuffer;
     private volatile long storeTimestamp = 0;
     private boolean firstCreateInQueue = false;
-
+    private boolean flushError = false;
     public MappedFile() {
     }
 
@@ -282,6 +282,7 @@ public class MappedFile extends ReferenceResource {
                     }
                 } catch (Throwable e) {
                     log.error("Error occurred when force data to disk.", e);
+                    this.flushError = true;
                 }
 
                 this.flushedPosition.set(value);
@@ -575,5 +576,9 @@ public class MappedFile extends ReferenceResource {
     @Override
     public String toString() {
         return this.fileName;
+    }
+
+    public boolean getflushError() {
+        return this.flushError;
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -47,6 +47,7 @@ public class MappedFileQueue {
     private long committedWhere = 0;
 
     private volatile long storeTimestamp = 0;
+    private boolean flushError = false ;
 
     public MappedFileQueue(final String storePath, int mappedFileSize,
         AllocateMappedFileService allocateMappedFileService) {
@@ -428,6 +429,9 @@ public class MappedFileQueue {
         if (mappedFile != null) {
             long tmpTimeStamp = mappedFile.getStoreTimestamp();
             int offset = mappedFile.flush(flushLeastPages);
+            if (mappedFile.getflushError()) {
+                this.flushError = true;
+            }
             long where = mappedFile.getFileFromOffset() + offset;
             result = where == this.flushedWhere;
             this.flushedWhere = where;
@@ -607,4 +611,9 @@ public class MappedFileQueue {
     public void setCommittedWhere(final long committedWhere) {
         this.committedWhere = committedWhere;
     }
+
+    public boolean isFlushError() {
+        return flushError;
+    }
+
 }

--- a/store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java
+++ b/store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store;
 public enum PutMessageStatus {
     PUT_OK,
     FLUSH_DISK_TIMEOUT,
+    FLUSH_DISK_FAILED,
     FLUSH_SLAVE_TIMEOUT,
     SLAVE_NOT_AVAILABLE,
     SERVICE_NOT_AVAILABLE,


### PR DESCRIPTION
        modified:  broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
	modified:   client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
	modified:   client/src/main/java/org/apache/rocketmq/client/producer/SendStatus.java
	modified:   common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
	modified:   store/src/main/java/org/apache/rocketmq/store/CommitLog.java
	modified:   store/src/main/java/org/apache/rocketmq/store/MappedFile.java
	modified:   store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
	modified:   store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java


**Make sure set the target branch to `develop`**

## What is the purpose of the change
You can see from the code below. When flush fails, only an error is reported, but the client is not notified 。
If there is an error, a try catch will be performed .Then log.error("Error occurred when force data to disk.", e);
But there is no error code returned to the client, and the client still thinks that the send is successful.

public int flush(final int flushLeastPages) {
        if (this.isAbleToFlush(flushLeastPages)) {
            if (this.hold()) {
                int value = getReadPosition();

                try {
                    //We only append data to fileChannel or mappedByteBuffer, never both.
                    if (writeBuffer != null || this.fileChannel.position() != 0) {
                        this.fileChannel.force(false);
                    } else {
                        this.mappedByteBuffer.force();
                    }
                } catch (Throwable e) {
                    log.error("Error occurred when force data to disk.", e);
                }

                this.flushedPosition.set(value);
                this.release();
            } else {
                log.warn("in flush, hold failed, flush offset = " + this.flushedPosition.get());
                this.flushedPosition.set(getReadPosition());
            }
        }
        return this.getFlushedPosition();
    }

## Brief changelog

So I add an error code FLUSH_DISK_FAILED, and then notify the client to deal with it 。

I have used mvn to package and run it locally, which can fix this problem 。


