### PR TITLE
message send into DLQ later 2 hours

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -198,8 +198,8 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
             if (0 == delayLevel) {
                 delayLevel = 3 + msgExt.getReconsumeTimes();
             }
-            msgExt.setDelayTimeLevel(delayLevel);
         }
+        msgExt.setDelayTimeLevel(delayLevel);
 
         MessageExtBrokerInner msgInner = new MessageExtBrokerInner();
         msgInner.setTopic(newTopic);


### PR DESCRIPTION

## What is the purpose of the change

when the message consumer fail at max reconsume times,  it will send into DLQ queue later 2 hours
because the retry message has delay property when schedule message service write into commitlog from PropertiesString

Brief changelog
coverage the message delay level when send into DLQ



