### PR TITLE
[ISSUE #2821] Overriding the ServiceThread#shutdown in HAClient class, In order to call closeMaster method after HAClient#shutdown is called

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ha/HAService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/HAService.java
@@ -590,6 +590,13 @@ public class HAService {
 
             log.info(this.getServiceName() + " service end");
         }
+
+        @Override
+        public void shutdown() {
+            super.shutdown();
+            closeMaster();
+        }
+
         // private void disableWriteFlag() {
         // if (this.socketChannel != null) {
         // SelectionKey sk = this.socketChannel.keyFor(this.selector);


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

Overriding the ServiceThread#shutdown in HAClient class, In order to call closeMaster method after HAClient#shutdown is called

for issue #2821