### PR TITLE
[ISSUE #2883] [Part A] Improve produce performance in M/S mode.

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -164,7 +164,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                         break;
                     }
                     if (removeMap.containsKey(i)) {
-                        log.info("Half offset {} has been committed/rolled back", i);
+                        log.debug("Half offset {} has been committed/rolled back", i);
                         Long removedOpOffset = removeMap.remove(i);
                         doneOpOffset.add(removedOpOffset);
                     } else {


### PR DESCRIPTION
1. **Change log level to debug: "Half offset {} has been committed/rolled back"**
2. Optimise lock in WaitNotifyObject
3. Remove lock in HAService
4. Remove lock in GroupCommitService
5. Eliminate array copy in HA
6. Remove putMessage/putMessages method in CommitLog which has too many duplicated code.
7. Change default value of some parameters: sendMessageThreadPoolNums/useReentrantLockWhenPutMessage/flushCommitLogTimed/endTransactionThreadPoolNums
8. Optimise performance of asyncPutMessage (extract some code out of putMessage lock)
9. extract generation of msgId out of lock in CommitLog (now only for single message processor)
10. extract generation of topicQueueTable key out of sync code
11. extract generation of msgId out of lock in CommitLog (for batch)