### PR TITLE
[ISSUE #2883] [Part D] Improve produce performance in M/S mode. 

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -57,10 +57,9 @@ public class BrokerConfig {
     @ImportantField
     private boolean traceTopicEnable = false;
     /**
-     * thread numbers for send message thread pool, since spin lock will be used by default since 4.0.x, the default
-     * value is 1.
+     * thread numbers for send message thread pool.
      */
-    private int sendMessageThreadPoolNums = 1; //16 + Runtime.getRuntime().availableProcessors() * 4;
+    private int sendMessageThreadPoolNums = Math.min(Runtime.getRuntime().availableProcessors(), 4);
     private int pullMessageThreadPoolNums = 16 + Runtime.getRuntime().availableProcessors() * 2;
     private int processReplyMessageThreadPoolNums = 16 + Runtime.getRuntime().availableProcessors() * 2;
     private int queryMessageThreadPoolNums = 8 + Runtime.getRuntime().availableProcessors();
@@ -73,7 +72,8 @@ public class BrokerConfig {
     /**
      * Thread numbers for EndTransactionProcessor
      */
-    private int endTransactionThreadPoolNums = 8 + Runtime.getRuntime().availableProcessors() * 2;
+    private int endTransactionThreadPoolNums = Math.max(8 + Runtime.getRuntime().availableProcessors() * 2,
+            sendMessageThreadPoolNums * 4);
 
     private int flushConsumerOffsetInterval = 1000 * 5;
 

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -54,13 +54,12 @@ public class MessageStoreConfig {
 
     /**
      * introduced since 4.0.x. Determine whether to use mutex reentrantLock when putting message.<br/>
-     * By default it is set to false indicating using spin lock when putting message.
      */
-    private boolean useReentrantLockWhenPutMessage = false;
+    private boolean useReentrantLockWhenPutMessage = true;
 
-    // Whether schedule flush,default is real-time
+    // Whether schedule flush
     @ImportantField
-    private boolean flushCommitLogTimed = false;
+    private boolean flushCommitLogTimed = true;
     // ConsumeQueue flush interval
     private int flushIntervalConsumeQueue = 1000;
     // Resource reclaim interval


### PR DESCRIPTION
1. Change log level to debug: "Half offset {} has been committed/rolled back"
2. Optimise lock in WaitNotifyObject
3. Remove lock in HAService
4. Remove lock in GroupCommitService
5. Eliminate array copy in HA
6. Remove putMessage/putMessages method in CommitLog which has too many duplicated code.
7. **Change default value of some parameters: sendMessageThreadPoolNums/useReentrantLockWhenPutMessage/flushCommitLogTimed/endTransactionThreadPoolNums**
8. Optimise performance of asyncPutMessage (extract some code out of putMessage lock)
9. extract generation of msgId out of lock in CommitLog (now only for single message processor)
10. extract generation of topicQueueTable key out of sync code
11. extract generation of msgId out of lock in CommitLog (for batch)