### PR TITLE
add the Dynamic flow control of Default DefaultMQPushConsumer,and give a sample

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/consumer/MQReactiveAdjustFlow.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/MQReactiveAdjustFlow.java
@@ -69,8 +69,9 @@ public class MQReactiveAdjustFlow {
         long defaultCheckTime,
         long defaultStep,
         long initInterval) {
+        //check the params
         if (minPullInterval > MAX_PULL_INTERVAL_TIME) {
-            maxPullInterval = 100;
+            maxPullInterval = 1000;
         }
         if (maxPullInterval > MAX_PULL_INTERVAL_TIME) {
             maxPullInterval = MAX_PULL_INTERVAL_TIME;
@@ -100,7 +101,7 @@ public class MQReactiveAdjustFlow {
                             maxQueueOffset = value;
                         }
                     }
-
+                    //change the PullInterval
                     if (maxQueueOffset > fullSize) {
                         if (flow.currentPullInterval - defaultStep <= minPullInterval) {
                             flow.currentPullInterval = minPullInterval;
@@ -114,7 +115,6 @@ public class MQReactiveAdjustFlow {
                             flow.currentPullInterval = flow.currentPullInterval + defaultStep;
                         }
                     }
-
                     if (lastPullInterval != flow.currentPullInterval) {
                         synchronized (consumer) {
                             consumer.setPullInterval(flow.currentPullInterval);

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/MQReactiveAdjustFlow.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/MQReactiveAdjustFlow.java
@@ -1,0 +1,138 @@
+package org.apache.rocketmq.client.consumer;
+
+import java.security.Key;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.rocketmq.client.log.ClientLogger;
+import org.apache.rocketmq.logging.InternalLogger;
+
+/**
+ *flow controller be measured in consumer,just like the sliding window of tcp
+ */
+public class MQReactiveAdjustFlow {
+    /**
+     * the max and the min time to check
+     */
+    public static final int MAX_CHECK_TIME = 60000;
+    public static final int MIN_CHECK_SAMPLE = 10;
+    private volatile long lastTimeCheck = System.currentTimeMillis();
+
+    private static final InternalLogger log = ClientLogger.getLog();
+
+    /**
+     * local cache
+     */
+    private static final ConcurrentHashMap<String/*GroupName*/, MQReactiveAdjustFlow> HOLDER_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * store the num of message in this queue in broker
+     */
+    public ConcurrentHashMap<Integer, Long> allQueueAccumulation = new ConcurrentHashMap<>();
+
+    /**
+     * the interval time to pull the message from broker
+     */
+    private volatile long currentPullInterval = 0;
+
+    /**
+     * The maximum of interval time allowed by the system
+     */
+    public static final int MAX_PULL_INTERVAL_TIME = 60000;
+
+    private AtomicBoolean isProcess = new AtomicBoolean(false);
+
+
+    public MQReactiveAdjustFlow(long concurrentPullInterval) {
+        this.currentPullInterval = concurrentPullInterval;
+    }
+
+    /**
+     *
+     * @param consumer comsumer
+     * @param queueId the id of queue
+     * @param offset the offset of the first message in the list
+     * @param queueMaxOffSet the max offset of this queue
+     * @param fullSize the maximum amount of the stacked message that can be tolerated
+     * @param minPullInterval the min interval time
+     * @param maxPullInterval the max interval time
+     * @param defaultCheckTime the time that you want to check the Consumption rate
+     * @param defaultStep the step
+     */
+    public static void adjustFlow(
+        DefaultMQPushConsumer consumer,
+        int queueId,
+        long offset,
+        long queueMaxOffSet,
+        long fullSize,
+        int minPullInterval,
+        int maxPullInterval,
+        long defaultCheckTime,
+        long defaultStep,
+        long initInterval) {
+        if (minPullInterval > MAX_PULL_INTERVAL_TIME) {
+            maxPullInterval = 100;
+        }
+        if (maxPullInterval > MAX_PULL_INTERVAL_TIME) {
+            maxPullInterval = MAX_PULL_INTERVAL_TIME;
+        }
+        if (minPullInterval >= maxPullInterval) {
+            minPullInterval = maxPullInterval / 2;
+        }
+
+        if (defaultCheckTime < MIN_CHECK_SAMPLE || defaultCheckTime > MAX_CHECK_TIME) {
+            defaultCheckTime = 1000;
+        }
+
+        MQReactiveAdjustFlow flow = HOLDER_CACHE.computeIfAbsent(consumer.getInstanceName(),
+            key -> new MQReactiveAdjustFlow(initInterval));
+
+        flow.allQueueAccumulation.put(queueId, queueMaxOffSet - offset);
+        if (System.currentTimeMillis() - flow.lastTimeCheck > defaultCheckTime) {
+            System.out.printf("the queueId is: %s, the num of the message that not be comsumed: %s, the currentPullInterval: %s \n",
+                queueId,queueMaxOffSet-offset,flow.currentPullInterval);
+
+            if (flow.isProcess.compareAndSet(false, true)) {
+                try {
+                    long lastPullInterval = consumer.getPullInterval();
+                    long maxQueueOffset = 0;
+                    for (Long value : flow.allQueueAccumulation.values()) {
+                        if (value > maxQueueOffset) {
+                            maxQueueOffset = value;
+                        }
+                    }
+
+                    if (maxQueueOffset > fullSize) {
+                        if (flow.currentPullInterval - defaultStep <= minPullInterval) {
+                            flow.currentPullInterval = minPullInterval;
+                        } else {
+                            flow.currentPullInterval = flow.currentPullInterval - defaultStep;
+                        }
+                    } else {
+                        if (flow.currentPullInterval + defaultStep >= maxPullInterval) {
+                            flow.currentPullInterval = maxPullInterval;
+                        } else {
+                            flow.currentPullInterval = flow.currentPullInterval + defaultStep;
+                        }
+                    }
+
+                    if (lastPullInterval != flow.currentPullInterval) {
+                        synchronized (consumer) {
+                            consumer.setPullInterval(flow.currentPullInterval);
+                        }
+                        log.warn("adjusting MQ consumer-thread:{}, group:{}, queueId:{}, lastPullInterval:{}, " +
+                                "currentPullInterval:{}, " + "defaultStep:{}",
+                            Thread.currentThread().getName(), consumer.getConsumerGroup(), queueId,
+                            lastPullInterval, flow.currentPullInterval, defaultStep);
+                    }
+                } catch (Exception e) {
+                    log.error("adjusting MQ consumer-thread:{}, group:{}, queueId:{}, exception:{}",
+                        Thread.currentThread().getName(), consumer.getConsumerGroup(), queueId, e);
+                } finally {
+                    flow.lastTimeCheck = System.currentTimeMillis();
+                    flow.isProcess.set(false);
+                }
+            }
+        }
+    }
+
+}

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/MQReactiveAdjustFlow.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/MQReactiveAdjustFlow.java
@@ -89,8 +89,8 @@ public class MQReactiveAdjustFlow {
 
         flow.allQueueAccumulation.put(queueId, queueMaxOffSet - offset);
         if (System.currentTimeMillis() - flow.lastTimeCheck > defaultCheckTime) {
-            System.out.printf("the queueId is: %s, the num of the message that not be comsumed: %s, the currentPullInterval: %s \n",
-                queueId,queueMaxOffSet-offset,flow.currentPullInterval);
+//            System.out.printf("the queueId is: %s, the num of the message that not be comsumed: %s, the currentPullInterval: %s \n",
+//                queueId,queueMaxOffSet-offset,flow.currentPullInterval);
 
             if (flow.isProcess.compareAndSet(false, true)) {
                 try {

--- a/example/src/main/java/org/apache/rocketmq/example/adjustflow/AdjustFlowConsumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/adjustflow/AdjustFlowConsumer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.example.adjustflow;
+
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.MQReactiveAdjustFlow;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.message.MessageExt;
+
+/**
+ * This example shows how to subscribe and consume messages using providing {@link DefaultMQPushConsumer}.
+ */
+public class AdjustFlowConsumer {
+
+    public static void main(String[] args) throws InterruptedException, MQClientException {
+
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("please_rename_unique_group_name");
+        consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+
+        consumer.subscribe("TopicTest01", "*");
+        consumer.setNamesrvAddr("127.0.0.1:9876");
+        consumer.setPullBatchSize(32);
+        consumer.setConsumeMessageBatchMaxSize(32);
+        consumer.registerMessageListener(new MessageListenerConcurrently() {
+
+            @Override
+            public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                ConsumeConcurrentlyContext context) {
+                if (CollectionUtils.isEmpty(msgs)) {
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                }
+                MessageExt msg = msgs.get(0);
+                //you can dynamic allocation
+                MQReactiveAdjustFlow.adjustFlow(consumer, context.getMessageQueue().getQueueId(),msg.getQueueOffset(),
+                    Long.parseLong(msg.getProperties().get("MAX_OFFSET")),2000,10,
+                    6000,1000,10,300);
+//                System.out.printf("%s Receive New Messages:%s %n",Thread.currentThread().getName(), msgs);
+                return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+            }
+        });
+
+        consumer.start();
+
+        System.out.printf("Consumer Started.%n");
+    }
+}

--- a/example/src/main/java/org/apache/rocketmq/example/adjustflow/Producer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/adjustflow/Producer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.example.adjustflow;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.remoting.common.RemotingHelper;
+
+/**
+ * This class demonstrates how to send messages to brokers using provided {@link DefaultMQProducer}.
+ */
+public class Producer {
+    public static void main(String[] args) throws MQClientException, InterruptedException {
+
+
+        DefaultMQProducer producer = new DefaultMQProducer("please_rename_unique_group_name");
+        producer.setNamesrvAddr("127.0.0.1:9876");
+        producer.start();
+
+        for (int i = 0; i < 12000; i++) {
+            try {
+
+                Message msg = new Message("TopicTest01" /* Topic */,
+                    "TagA" /* Tag */,
+                    ("Hello RocketMQ " + i).getBytes(RemotingHelper.DEFAULT_CHARSET) /* Message body */
+                );
+
+                SendResult sendResult = producer.send(msg);
+
+                System.out.printf("%s%n", sendResult);
+            } catch (Exception e) {
+                e.printStackTrace();
+                Thread.sleep(1000);
+            }
+        }
+        producer.shutdown();
+    }
+}


### PR DESCRIPTION
利用tcp滑动窗口的原理，为批量消费提供了一个动态窗口，可以根据阈值以及上下限，实时调整DefaultMQPushConsumer到broker拉取数据的间隔时间，根据与阈值比较每次加或减固定的步长，并为之提供了使用例子。

如图：
![SE77%D@L4K@JE(3}}98@M(U](https://user-images.githubusercontent.com/52808040/123278929-f7ab8f80-d539-11eb-8565-41103cd6348c.png)
允许堆积的最大值为2000，并设定其它参数。
![M}CUX8Y_(M) H3P~X9KTNYM](https://user-images.githubusercontent.com/52808040/123278984-05f9ab80-d53a-11eb-948c-17686cd448f6.png)
每次有消息push到客户端，会判断是否到了用户设置的检验间隔时间，如果是，则采集数据动态调整拉取间隔。当堆积数量超过阈值，每次缩短拉取时间。
![Uploading 56AMTK%JSE2%[1R~~R@1%RJ.png…]()
如果少于阈值，则增加。
如果没有消息到达，则不做处理不影响拉取间隔。
