### PR TITLE
[ISSUE #3105] [ISSUE #3108]fix the method of getting 'now' timestamp and fix the wrong word in comment.

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -123,7 +123,7 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
                 if (!registerOK) {
                     this.serviceState = ServiceState.CREATE_JUST;
                     throw new MQClientException("The adminExt group[" + this.defaultMQAdminExt.getAdminExtGroup()
-                        + "] has created already, specifed another name please."
+                        + "] has created already, specified another name please."
                         + FAQUrl.suggestTodo(FAQUrl.GROUP_NAME_DUPLICATE_URL), null);
                 }
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java
@@ -75,7 +75,8 @@ public class ResetOffsetByTimeCommand implements SubCommand {
             String group = commandLine.getOptionValue("g").trim();
             String topic = commandLine.getOptionValue("t").trim();
             String timeStampStr = commandLine.getOptionValue("s").trim();
-            long timestamp = timeStampStr.equals("now") ? System.currentTimeMillis() : 0;
+            //when the param "timestamp" is set to now,it should return the max offset of this queue
+            long timestamp = timeStampStr.equals("now") ? -1 : 0;
 
             try {
                 if (timestamp == 0) {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java
@@ -33,6 +33,8 @@ import org.apache.rocketmq.tools.command.SubCommandException;
 
 public class ResetOffsetByTimeCommand implements SubCommand {
 
+    private static int TIMESTAMP_BY_NOW = -1;
+
     @Override
     public String commandName() {
         return "resetOffsetByTime";
@@ -76,7 +78,7 @@ public class ResetOffsetByTimeCommand implements SubCommand {
             String topic = commandLine.getOptionValue("t").trim();
             String timeStampStr = commandLine.getOptionValue("s").trim();
             //when the param "timestamp" is set to now,it should return the max offset of this queue
-            long timestamp = timeStampStr.equals("now") ? -1 : 0;
+            long timestamp = timeStampStr.equals("now") ? TIMESTAMP_BY_NOW : 0;
 
             try {
                 if (timestamp == 0) {


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

[ISSUES #3105]
[ISSUES #3108]

## What is the purpose of the change
 1. When the set time is equal to string now, the offset of rollback should be consistent with the current maximum consumption offset.
 
 2. So if the time set by user is now, the timestamp should be directly set to -1 to call the method getMaxOffsetInQueue() in the Broker2Clitent.class as shown below,and if when the timestamp is "now" with calling getOffsetInQueueByTime(), because of the algorithm of binary search in method, the returned offset will not equal to the maximum offset and will only returns the offset of the second-to-last message that is not up to expectations.
 
3.Fixed wrong words in comment.[ISSUES #3108]
![image](https://user-images.githubusercontent.com/44564641/123760613-9d248180-d8f3-11eb-8604-e9c850420fef.png)

## Brief changelog
1. Added comment content of the reason why the timestamp is set to -1 when it's equal to string "now".

2. When the set time is equal to "now", in order to call method getMaxOffsetInQueue(), it will assigned a value of -1.
## Verifying this change

When the timestamp is set to now, the offset returned by the console will be less than the actual maximum offset that is not up to expectations.

As shown below:
![image](https://user-images.githubusercontent.com/44564641/123760557-8b42de80-d8f3-11eb-9bb5-92384be15b50.png)

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
