### PR TITLE
StringBuilder字串连接，substring另一个方法。

### DIFF
--- a/logging/src/main/java/org/apache/rocketmq/logging/InnerLoggerFactory.java
+++ b/logging/src/main/java/org/apache/rocketmq/logging/InnerLoggerFactory.java
@@ -258,29 +258,29 @@ public class InnerLoggerFactory extends InternalLoggerFactory {
                             return new FormattingTuple(messagePattern, argArray, throwableCandidate);
                         }
 
-                        sbuf.append(messagePattern.substring(i, messagePattern.length()));
+                        sbuf.append(messagePattern.substring(i));
                         return new FormattingTuple(sbuf.toString(), argArray, throwableCandidate);
                     }
 
                     if (isEscapeDelimeter(messagePattern, j)) {
                         if (!isDoubleEscaped(messagePattern, j)) {
                             --len;
-                            sbuf.append(messagePattern.substring(i, j - 1));
+                            sbuf.append(messagePattern, i, j - 1);
                             sbuf.append('{');
                             i = j + 1;
                         } else {
-                            sbuf.append(messagePattern.substring(i, j - 1));
+                            sbuf.append(messagePattern, i, j - 1);
                             deeplyAppendParameter(sbuf, argArray[len], null);
                             i = j + 2;
                         }
                     } else {
-                        sbuf.append(messagePattern.substring(i, j));
+                        sbuf.append(messagePattern, i, j);
                         deeplyAppendParameter(sbuf, argArray[len], null);
                         i = j + 2;
                     }
                 }
 
-                sbuf.append(messagePattern.substring(i, messagePattern.length()));
+                sbuf.append(messagePattern.substring(i));
                 if (len < argArray.length - 1) {
                     return new FormattingTuple(sbuf.toString(), argArray, throwableCandidate);
                 } else {


### PR DESCRIPTION
StringBuilder本身支持子串连接 可以不调用substring, 减少新数组拷贝性能。
substring可以调用另一个重载方法。