### PR TITLE
use scheduledExecutorService replace timer

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/ThreadFactoryImpl.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/ThreadFactoryImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.common;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author zh
+ * @Date 2021/8/10 17:20
+ */
+public class ThreadFactoryImpl implements ThreadFactory {
+    private final AtomicLong threadIndex = new AtomicLong(0);
+    private final String threadNamePrefix;
+    private final boolean daemon;
+
+    public ThreadFactoryImpl(final String threadNamePrefix) {
+        this(threadNamePrefix, false);
+    }
+
+    public ThreadFactoryImpl(final String threadNamePrefix, boolean daemon) {
+        this.threadNamePrefix = threadNamePrefix;
+        this.daemon = daemon;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread thread = new Thread(r, threadNamePrefix + this.threadIndex.incrementAndGet());
+        thread.setDaemon(daemon);
+        return thread;
+    }
+}


### PR DESCRIPTION
When threads are processing timed tasks in parallel, when Timer runs multiple TimeTasks, as long as there is no timeout exception, other tasks may be automatically terminated. Using ScheduledExecutorService does not have this problem.