### PR TITLE
add new allocate MessageQueue strategy

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java
@@ -220,13 +220,13 @@ public class QueryAssignmentProcessor implements NettyRequestProcessor {
                         } else {
                             if (cidAll.size() <= mqAll.size()) {
                                 //consumer working in pop mode could share the MessageQueues assigned to the N (N = popWorkGroupSize) consumer following it in the cid list
-                                allocateResult = allocateMessageQueueStrategy.allocate(consumerGroup, clientId, mqAll, cidAll);
+                                allocateResult = allocateMessageQueueStrategy.allocate(null, consumerGroup, clientId, mqAll, cidAll);
                                 int index = cidAll.indexOf(clientId);
                                 if (index >= 0) {
                                     for (int i = 1; i <= setMessageRequestModeRequestBody.getPopShareQueueNum(); i++) {
                                         index++;
                                         index = index % cidAll.size();
-                                        List<MessageQueue> tmp = allocateMessageQueueStrategy.allocate(consumerGroup, cidAll.get(index), mqAll, cidAll);
+                                        List<MessageQueue> tmp = allocateMessageQueueStrategy.allocate(null, consumerGroup, cidAll.get(index), mqAll, cidAll);
                                         allocateResult.addAll(tmp);
                                     }
                                 }
@@ -237,7 +237,7 @@ public class QueryAssignmentProcessor implements NettyRequestProcessor {
                         }
 
                     } else {
-                        allocateResult = allocateMessageQueueStrategy.allocate(consumerGroup, clientId, mqAll, cidAll);
+                        allocateResult = allocateMessageQueueStrategy.allocate(null, consumerGroup, clientId, mqAll, cidAll);
                     }
                 } catch (Throwable e) {
                     log.error("QueryLoad: no assignment for group[{}] topic[{}], allocate message queue exception. strategy name: {}, ex: {}", consumerGroup, topic, strategyName, e);

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/AllocateMessageQueueStrategy.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/AllocateMessageQueueStrategy.java
@@ -17,7 +17,10 @@
 package org.apache.rocketmq.client.consumer;
 
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 
 /**
  * Strategy Algorithm for message allocating between consumers
@@ -27,6 +30,8 @@ public interface AllocateMessageQueueStrategy {
     /**
      * Allocating by consumer id
      *
+     * @param topicRouteData runtime info of topic route data, use it when you need broker info to allocate,
+     *                       if don't use it, can be null.
      * @param consumerGroup current consumer group
      * @param currentCID current consumer id
      * @param mqAll message queue set in current topic
@@ -34,6 +39,7 @@ public interface AllocateMessageQueueStrategy {
      * @return The allocate result of given strategy
      */
     List<MessageQueue> allocate(
+        final Map<String, TopicRouteData> topicRouteData,
         final String consumerGroup,
         final String currentCID,
         final List<MessageQueue> mqAll,

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 
 /**
@@ -55,8 +56,9 @@ public class AllocateMachineRoomNearby implements AllocateMessageQueueStrategy {
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");
         }
@@ -111,13 +113,13 @@ public class AllocateMachineRoomNearby implements AllocateMessageQueueStrategy {
         List<MessageQueue> mqInThisMachineRoom = mr2Mq.remove(currentMachineRoom);
         List<String> consumerInThisMachineRoom = mr2c.get(currentMachineRoom);
         if (mqInThisMachineRoom != null && !mqInThisMachineRoom.isEmpty()) {
-            allocateResults.addAll(allocateMessageQueueStrategy.allocate(consumerGroup, currentCID, mqInThisMachineRoom, consumerInThisMachineRoom));
+            allocateResults.addAll(allocateMessageQueueStrategy.allocate(topicRouteData, consumerGroup, currentCID, mqInThisMachineRoom, consumerInThisMachineRoom));
         }
 
         //2.allocate the rest mq to each machine room if there are no consumer alive in that machine room
         for (String machineRoom : mr2Mq.keySet()) {
             if (!mr2c.containsKey(machineRoom)) { // no alive consumer in the corresponding machine room, so all consumers share these queues
-                allocateResults.addAll(allocateMessageQueueStrategy.allocate(consumerGroup, currentCID, mr2Mq.get(machineRoom), cidAll));
+                allocateResults.addAll(allocateMessageQueueStrategy.allocate(topicRouteData, consumerGroup, currentCID, mr2Mq.get(machineRoom), cidAll));
             }
         }
 

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragely.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragely.java
@@ -18,9 +18,12 @@ package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 
 /**
@@ -38,8 +41,9 @@ public class AllocateMessageQueueAveragely implements AllocateMessageQueueStrate
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");
         }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragelyByCircle.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragelyByCircle.java
@@ -18,9 +18,12 @@ package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 
 /**
@@ -38,8 +41,9 @@ public class AllocateMessageQueueAveragelyByCircle implements AllocateMessageQue
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");
         }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByConfig.java
@@ -17,15 +17,19 @@
 package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 
 public class AllocateMessageQueueByConfig implements AllocateMessageQueueStrategy {
     private List<MessageQueue> messageQueueList;
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         return this.messageQueueList;
     }
 

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachine.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachine.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer.rebalance;
+
+import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
+import org.apache.rocketmq.client.log.ClientLogger;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
+import org.apache.rocketmq.logging.InternalLogger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AllocateMessageQueueByMachine implements AllocateMessageQueueStrategy {
+    private InternalLogger log;
+    private AllocateMessageQueueStrategy delegtor;
+
+    public AllocateMessageQueueByMachine(AllocateMessageQueueStrategy strategy) {
+        this.log = ClientLogger.getLog();
+        this.delegtor = strategy;
+    }
+
+    public AllocateMessageQueueByMachine(InternalLogger log, AllocateMessageQueueStrategy strategy) {
+        this.log = log;
+        this.delegtor = strategy;
+    }
+
+    /**
+     *
+     * @param topicRouteData runtime info of topic route data,
+     *                       in client,topicRouteData will be update when start, and check every 30s in scheduledExecutorService
+     * @param consumerGroup  current consumer group
+     * @param currentCID     current consumer id
+     * @param mqAll          message queue set in current topic
+     * @param cidAll         consumer set in current consumer group
+     * @return
+     */
+    @Override
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll, List<String> cidAll) {
+        if (currentCID == null || currentCID.length() < 1) {
+            throw new IllegalArgumentException("currentCID is empty");
+        }
+        if (mqAll == null || mqAll.isEmpty()) {
+            throw new IllegalArgumentException("mqAll is null or mqAll empty");
+        }
+        if (cidAll == null || cidAll.isEmpty()) {
+            throw new IllegalArgumentException("cidAll is null or cidAll empty");
+        }
+
+
+        List<MessageQueue> result = new ArrayList<MessageQueue>();
+
+        if (!cidAll.contains(currentCID)) {
+            log.info("[BUG] ConsumerGroup: {} The consumerId: {} not in cidAll: {}",
+                    consumerGroup,
+                    currentCID,
+                    cidAll);
+            return result;
+        }
+
+        if (topicRouteData == null) {
+            return delegtor.allocate(null, consumerGroup, currentCID, mqAll, cidAll);
+        }
+
+
+        String[] split = currentCID.split("@");
+        String clientIp = split[0];
+
+
+        for (MessageQueue mq : mqAll) {
+            String topic = mq.getTopic();
+            TopicRouteData routeData = topicRouteData.get(topic);
+            List<BrokerData> brokerDatas = routeData.getBrokerDatas();
+
+            for (BrokerData brokerData : brokerDatas) {
+                if (brokerData.getBrokerName().equals(mq.getBrokerName())) {
+                    HashMap<Long, String> brokerAddrs = brokerData.getBrokerAddrs();
+
+                    for (Long brokerId : brokerAddrs.keySet()) {
+                        String brokerAddr = brokerAddrs.get(brokerId);
+                        if (brokerAddr.contains(clientIp)) {
+                            result.add(mq);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (result.size() == 0) {
+            return delegtor.allocate(topicRouteData, consumerGroup, currentCID, mqAll, cidAll);
+        } else {
+            return result;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "MACHINE";
+    }
+
+
+}

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineRoom.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineRoom.java
@@ -18,9 +18,11 @@ package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 
 /**
  * Computer room Hashing queue algorithm, such as Alipay logic room
@@ -29,8 +31,9 @@ public class AllocateMessageQueueByMachineRoom implements AllocateMessageQueueSt
     private Set<String> consumeridcs;
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         List<MessageQueue> result = new ArrayList<MessageQueue>();
         int currentIndex = cidAll.indexOf(currentCID);
         if (currentIndex < 0) {

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsistentHash.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsistentHash.java
@@ -19,11 +19,14 @@ package org.apache.rocketmq.client.consumer.rebalance;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.consistenthash.ConsistentHashRouter;
 import org.apache.rocketmq.common.consistenthash.HashFunction;
 import org.apache.rocketmq.common.consistenthash.Node;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
 
@@ -53,8 +56,9 @@ public class AllocateMessageQueueConsistentHash implements AllocateMessageQueueS
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(Map<String, TopicRouteData> topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
 
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
@@ -357,6 +357,7 @@ public abstract class RebalanceImpl {
                     List<MessageQueue> allocateResult = null;
                     try {
                         allocateResult = strategy.allocate(
+                            mQClientFactory.getTopicRouteTable(),
                             this.consumerGroup,
                             this.mQClientFactory.getClientId(),
                             mqAll,

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearByTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearByTest.java
@@ -107,7 +107,7 @@ public class AllocateMachineRoomNearByTest {
         List<MessageQueue> mqAll = prepareMQ(IDCSize, queueSize);
         List<MessageQueue> resAll = new ArrayList<MessageQueue>();
         for (String currentID : cidAll) {
-            List<MessageQueue> res = allocateMessageQueueStrategy.allocate("Test-C-G",currentID,mqAll,cidAll);
+            List<MessageQueue> res = allocateMessageQueueStrategy.allocate(null,"Test-C-G",currentID,mqAll,cidAll);
             if (print) {
                 System.out.println("cid: "+currentID+"--> res :" +res);
             }
@@ -136,7 +136,7 @@ public class AllocateMachineRoomNearByTest {
 
         List<MessageQueue> resAll = new ArrayList<MessageQueue>();
         for (String currentID : cidAll) {
-            List<MessageQueue> res = allocateMessageQueueStrategy.allocate("Test-C-G",currentID,mqAll,cidAll);
+            List<MessageQueue> res = allocateMessageQueueStrategy.allocate(null,"Test-C-G",currentID,mqAll,cidAll);
             if (print) {
                 System.out.println("cid: "+currentID+"--> res :" +res);
             }
@@ -169,7 +169,7 @@ public class AllocateMachineRoomNearByTest {
         Map<String, List<MessageQueue>> idc2Res = new TreeMap<String, List<MessageQueue>>();
         for (String currentID : cidAll) {
             String currentIDC = machineRoomResolver.consumerDeployIn(currentID);
-            List<MessageQueue> res = allocateMessageQueueStrategy.allocate("Test-C-G",currentID,mqAll,cidAll);
+            List<MessageQueue> res = allocateMessageQueueStrategy.allocate(null,"Test-C-G",currentID,mqAll,cidAll);
             if (print) {
                 System.out.println("cid: "+currentID+"--> res :" +res);
             }

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer.rebalance;
+
+import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
+import org.apache.rocketmq.common.protocol.route.QueueData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AllocateMessageQueueByMachineTest {
+    private final AllocateMessageQueueStrategy strategy = new AllocateMessageQueueAveragely();
+    private final AllocateMessageQueueByMachine allocateByMachine = new AllocateMessageQueueByMachine(new AllocateMessageQueueAveragely());
+    private final Map<String, TopicRouteData> topicRouteData = new HashMap<String, TopicRouteData>();
+    private final List<MessageQueue> mqAll = new ArrayList<MessageQueue>();
+    private final List<String> cidAll = new ArrayList<String>();
+
+    @Before
+    public void init() {
+        MessageQueue mq0 = new MessageQueue("mockTopic", "broker-a", 0);
+        MessageQueue mq1 = new MessageQueue("mockTopic", "broker-a", 1);
+        MessageQueue mq2 = new MessageQueue("mockTopic", "broker-a", 2);
+        MessageQueue mq3 = new MessageQueue("mockTopic", "broker-a", 3);
+
+        mqAll.add(mq0);
+        mqAll.add(mq1);
+        mqAll.add(mq2);
+        mqAll.add(mq3);
+
+        TopicRouteData routeData1 = new TopicRouteData();
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName("broker-a");
+        queueData1.setPerm(6);
+        queueData1.setReadQueueNums(4);
+        queueData1.setWriteQueueNums(4);
+        queueData1.setTopicSysFlag(0);
+        List<QueueData> arrayList1 = new ArrayList<QueueData>();
+        arrayList1.add(queueData1);
+
+        routeData1.setQueueDatas(arrayList1);
+
+        List<BrokerData> brokerDataList1 = new ArrayList<BrokerData>();
+        BrokerData brokerData1 = new BrokerData();
+        brokerData1.setBrokerName("broker-a");
+        brokerData1.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs1 = new HashMap<Long, String>();
+        brokerAddrs1.put(0L, "30.250.200.103:10911");
+        brokerAddrs1.put(1L, "30.250.200.102:10911");
+
+        brokerData1.setBrokerAddrs(brokerAddrs1);
+
+        brokerDataList1.add(brokerData1);
+
+        routeData1.setBrokerDatas(brokerDataList1);
+
+        topicRouteData.put("mockTopic", routeData1);
+
+        //=======================================
+
+        TopicRouteData routeData2 = new TopicRouteData();
+        QueueData queueData2 = new QueueData();
+        queueData2.setBrokerName("broker-a");
+        queueData2.setPerm(6);
+        queueData2.setReadQueueNums(4);
+        queueData2.setWriteQueueNums(4);
+        queueData2.setTopicSysFlag(0);
+        List<QueueData> arrayList2 = new ArrayList<QueueData>();
+        arrayList2.add(queueData2);
+
+        routeData2.setQueueDatas(arrayList2);
+
+        List<BrokerData> brokerDataList2 = new ArrayList<BrokerData>();
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("broker-b");
+        brokerData2.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs2 = new HashMap<Long, String>();
+        brokerAddrs2.put(0L, "30.250.200.104:10911");
+        brokerAddrs2.put(1L, "30.250.200.105:10911");
+
+        brokerData2.setBrokerAddrs(brokerAddrs2);
+
+        brokerDataList2.add(brokerData2);
+        routeData2.setBrokerDatas(brokerDataList2);
+        topicRouteData.put("mockTopic-1", routeData2);
+
+        cidAll.add("30.250.200.103@65862");
+        cidAll.add("30.250.200.102@1000");
+        cidAll.add("30.250.200.104@1000");
+        cidAll.add("30.250.200.105@1000");
+    }
+
+    @Test
+    public void test1() {
+        List<MessageQueue> allocate = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.103@65862", mqAll, cidAll);
+
+        Assert.assertEquals(4, allocate.size());
+    }
+
+}

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsitentHashTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsitentHashTest.java
@@ -53,7 +53,7 @@ public class AllocateMessageQueueConsitentHashTest {
         String currentCID = String.valueOf(Integer.MAX_VALUE);
         List<String> consumerIdList = createConsumerIdList(2);
         List<MessageQueue> messageQueueList = createMessageQueueList(6);
-        List<MessageQueue> result = new AllocateMessageQueueConsistentHash().allocate("", currentCID, messageQueueList, consumerIdList);
+        List<MessageQueue> result = new AllocateMessageQueueConsistentHash().allocate(null,"", currentCID, messageQueueList, consumerIdList);
         printMessageQueue(result, "testCurrentCIDNotExists");
         Assert.assertEquals(result.size(), 0);
     }
@@ -62,21 +62,21 @@ public class AllocateMessageQueueConsitentHashTest {
     public void testCurrentCIDIllegalArgument() {
         List<String> consumerIdList = createConsumerIdList(2);
         List<MessageQueue> messageQueueList = createMessageQueueList(6);
-        new AllocateMessageQueueConsistentHash().allocate("", "", messageQueueList, consumerIdList);
+        new AllocateMessageQueueConsistentHash().allocate(null,"", "", messageQueueList, consumerIdList);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMessageQueueIllegalArgument() {
         String currentCID = "0";
         List<String> consumerIdList = createConsumerIdList(2);
-        new AllocateMessageQueueConsistentHash().allocate("", currentCID, null, consumerIdList);
+        new AllocateMessageQueueConsistentHash().allocate(null,"", currentCID, null, consumerIdList);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConsumerIdIllegalArgument() {
         String currentCID = "0";
         List<MessageQueue> messageQueueList = createMessageQueueList(6);
-        new AllocateMessageQueueConsistentHash().allocate("", currentCID, messageQueueList, null);
+        new AllocateMessageQueueConsistentHash().allocate(null,"", currentCID, messageQueueList, null);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class AllocateMessageQueueConsitentHashTest {
 
             //System.out.println("cidAll:" + cidBegin.toString());
             for (String cid : cidBegin) {
-                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate("testConsumerGroup", cid, mqAll, cidBegin);
+                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate(null,"testConsumerGroup", cid, mqAll, cidBegin);
                 for (MessageQueue mq : rs) {
                     allocateToAllOrigin.put(mq, cid);
                 }
@@ -149,7 +149,7 @@ public class AllocateMessageQueueConsitentHashTest {
             //System.out.println("cidAll:" + cidAfterRemoveOne.toString());
             List<MessageQueue> allocatedResAllAfterRemove = new ArrayList<MessageQueue>();
             for (String cid : cidAfterRemoveOne) {
-                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate("testConsumerGroup", cid, mqAll, cidAfterRemoveOne);
+                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate(null,"testConsumerGroup", cid, mqAll, cidAfterRemoveOne);
                 allocatedResAllAfterRemove.addAll(rs);
                 for (MessageQueue mq : rs) {
                     allocateToAllAfterRemoveOne.put(mq, cid);
@@ -173,7 +173,7 @@ public class AllocateMessageQueueConsitentHashTest {
             List<MessageQueue> allocatedResAllAfterAdd = new ArrayList<MessageQueue>();
             Map<MessageQueue, String> allocateToAll3 = new TreeMap<MessageQueue, String>();
             for (String cid : cidAfterAdd) {
-                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate("testConsumerGroup", cid, mqAll, cidAfterAdd);
+                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate(null,"testConsumerGroup", cid, mqAll, cidAfterAdd);
                 allocatedResAllAfterAdd.addAll(rs);
                 for (MessageQueue mq : rs) {
                     allocateToAll3.put(mq, cid);


### PR DESCRIPTION
#3255 

add new strategy: AllocateMessageQueueByMachine

allocate message queue to client which local in the same machine preferentially, if the result is null, use the second strategy. 
