### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_script:
   - ulimit -c unlimited
 
 script:
-  - travis_retry mvn -B clean apache-rat:check
-  - travis_retry mvn -B package jacoco:report coveralls:report
+  - mvn -B clean apache-rat:check
+  - mvn -B package jacoco:report coveralls:report
 
 after_success:
   - mvn clean install -Pit-test


### PR DESCRIPTION
#3273 
recreate this PR
According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.
