### PR TITLE
Removing redundant configurations

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingUtil.java
@@ -186,7 +186,6 @@ public class RemotingUtil {
         SocketChannel sc = null;
         try {
             sc = SocketChannel.open();
-            sc.configureBlocking(true);
             sc.socket().setSoLinger(false, -1);
             sc.socket().setTcpNoDelay(true);
             sc.socket().setReceiveBufferSize(1024 * 64);


### PR DESCRIPTION
去除多余配置，SocketChannel 创建出来默认就是阻塞的，并且后面又再次设置非阻塞的，所以这个设置阻塞是没有必要的
