### PR TITLE
[ISSUE #3333] Remove commons-codes dependency

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
             <version>0.33.0</version>

--- a/client/src/main/java/org/apache/rocketmq/client/trace/TraceView.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/TraceView.java
@@ -17,9 +17,9 @@
 
 package org.apache.rocketmq.client.trace;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.codec.Charsets;
 import org.apache.rocketmq.common.message.MessageExt;
 
 public class TraceView {
@@ -40,7 +40,7 @@ public class TraceView {
 
     public static List<TraceView> decodeFromTraceTransData(String key, MessageExt messageExt) {
         List<TraceView> messageTraceViewList = new ArrayList<TraceView>();
-        String messageBody = new String(messageExt.getBody(), Charsets.UTF_8);
+        String messageBody = new String(messageExt.getBody(), StandardCharsets.UTF_8);
         if (messageBody == null || messageBody.length() <= 0) {
             return messageTraceViewList;
         }

--- a/client/src/test/java/org/apache/rocketmq/client/trace/TraceViewTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/trace/TraceViewTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.rocketmq.client.trace;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class TraceViewTest {
@@ -46,7 +46,7 @@ public class TraceViewTest {
             .append(true).append(TraceConstants.FIELD_SPLITOR)
             .toString();
         MessageExt message = new MessageExt();
-        message.setBody(messageBody.getBytes(Charsets.UTF_8));
+        message.setBody(messageBody.getBytes(StandardCharsets.UTF_8));
         String key = "AC1415116D1418B4AAC217FE1B4E0000";
         List<TraceView> traceViews = TraceView.decodeFromTraceTransData(key, message);
         Assert.assertEquals(traceViews.size(), 1);


### PR DESCRIPTION
https://github.com/apache/rocketmq/issues/3333

There is only one class (org.apache.commons.codec.Charsets) of commons-codec is used in rocketmq, which can be replaced with java.nio.charset.StandardCharsets (java 7).

So the commons-codec can be removed.