### PR TITLE
[ISSUE #XXXX] Update rocketmq client maven version

### DIFF
--- a/docs/cn/RocketMQ_Example.md
+++ b/docs/cn/RocketMQ_Example.md
@@ -54,7 +54,7 @@
 <dependency>
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-client</artifactId>
-    <version>4.3.0</version>
+    <version>4.9.1</version>
 </dependency>
 ```
 `gradle`


### PR DESCRIPTION
 当使用 4.3.0 版本依赖时，当调用同步发送消息代码时，提示：Exception in thread "main" org.apache.rocketmq.client.exception.MQClientException: No route info of this topic，修改为当前最新版本 4.9.1 后问题解决。
