### PR TITLE
[ISSUE #3366] Allocate MessageQueue to client first by same Machine IP.

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java
@@ -220,13 +220,13 @@ public class QueryAssignmentProcessor implements NettyRequestProcessor {
                         } else {
                             if (cidAll.size() <= mqAll.size()) {
                                 //consumer working in pop mode could share the MessageQueues assigned to the N (N = popWorkGroupSize) consumer following it in the cid list
-                                allocateResult = allocateMessageQueueStrategy.allocate(consumerGroup, clientId, mqAll, cidAll);
+                                allocateResult = allocateMessageQueueStrategy.allocate(null, consumerGroup, clientId, mqAll, cidAll);
                                 int index = cidAll.indexOf(clientId);
                                 if (index >= 0) {
                                     for (int i = 1; i <= setMessageRequestModeRequestBody.getPopShareQueueNum(); i++) {
                                         index++;
                                         index = index % cidAll.size();
-                                        List<MessageQueue> tmp = allocateMessageQueueStrategy.allocate(consumerGroup, cidAll.get(index), mqAll, cidAll);
+                                        List<MessageQueue> tmp = allocateMessageQueueStrategy.allocate(null, consumerGroup, cidAll.get(index), mqAll, cidAll);
                                         allocateResult.addAll(tmp);
                                     }
                                 }
@@ -237,7 +237,7 @@ public class QueryAssignmentProcessor implements NettyRequestProcessor {
                         }
 
                     } else {
-                        allocateResult = allocateMessageQueueStrategy.allocate(consumerGroup, clientId, mqAll, cidAll);
+                        allocateResult = allocateMessageQueueStrategy.allocate(null, consumerGroup, clientId, mqAll, cidAll);
                     }
                 } catch (Throwable e) {
                     log.error("QueryLoad: no assignment for group[{}] topic[{}], allocate message queue exception. strategy name: {}, ex: {}", consumerGroup, topic, strategyName, e);

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/AllocateMessageQueueStrategy.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/AllocateMessageQueueStrategy.java
@@ -17,7 +17,10 @@
 package org.apache.rocketmq.client.consumer;
 
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 
 /**
  * Strategy Algorithm for message allocating between consumers
@@ -27,6 +30,8 @@ public interface AllocateMessageQueueStrategy {
     /**
      * Allocating by consumer id
      *
+     * @param topicRouteData runtime info of topic route data, use it when you need broker info to allocate,
+     *                       if don't use it, can be null.
      * @param consumerGroup current consumer group
      * @param currentCID current consumer id
      * @param mqAll message queue set in current topic
@@ -34,6 +39,7 @@ public interface AllocateMessageQueueStrategy {
      * @return The allocate result of given strategy
      */
     List<MessageQueue> allocate(
+        final TopicRouteData topicRouteData,
         final String consumerGroup,
         final String currentCID,
         final List<MessageQueue> mqAll,

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 
 /**
@@ -55,8 +56,9 @@ public class AllocateMachineRoomNearby implements AllocateMessageQueueStrategy {
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");
         }
@@ -111,13 +113,13 @@ public class AllocateMachineRoomNearby implements AllocateMessageQueueStrategy {
         List<MessageQueue> mqInThisMachineRoom = mr2Mq.remove(currentMachineRoom);
         List<String> consumerInThisMachineRoom = mr2c.get(currentMachineRoom);
         if (mqInThisMachineRoom != null && !mqInThisMachineRoom.isEmpty()) {
-            allocateResults.addAll(allocateMessageQueueStrategy.allocate(consumerGroup, currentCID, mqInThisMachineRoom, consumerInThisMachineRoom));
+            allocateResults.addAll(allocateMessageQueueStrategy.allocate(topicRouteData, consumerGroup, currentCID, mqInThisMachineRoom, consumerInThisMachineRoom));
         }
 
         //2.allocate the rest mq to each machine room if there are no consumer alive in that machine room
         for (String machineRoom : mr2Mq.keySet()) {
             if (!mr2c.containsKey(machineRoom)) { // no alive consumer in the corresponding machine room, so all consumers share these queues
-                allocateResults.addAll(allocateMessageQueueStrategy.allocate(consumerGroup, currentCID, mr2Mq.get(machineRoom), cidAll));
+                allocateResults.addAll(allocateMessageQueueStrategy.allocate(topicRouteData, consumerGroup, currentCID, mr2Mq.get(machineRoom), cidAll));
             }
         }
 

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragely.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragely.java
@@ -18,9 +18,12 @@ package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 
 /**
@@ -38,8 +41,9 @@ public class AllocateMessageQueueAveragely implements AllocateMessageQueueStrate
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");
         }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragelyByCircle.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueAveragelyByCircle.java
@@ -18,9 +18,12 @@ package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 
 /**
@@ -38,8 +41,9 @@ public class AllocateMessageQueueAveragelyByCircle implements AllocateMessageQue
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");
         }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByConfig.java
@@ -17,15 +17,19 @@
 package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 
 public class AllocateMessageQueueByConfig implements AllocateMessageQueueStrategy {
     private List<MessageQueue> messageQueueList;
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         return this.messageQueueList;
     }
 

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachine.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachine.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer.rebalance;
+
+import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
+import org.apache.rocketmq.client.log.ClientLogger;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
+import org.apache.rocketmq.logging.InternalLogger;
+
+import java.util.*;
+
+
+public class AllocateMessageQueueByMachine implements AllocateMessageQueueStrategy {
+    private InternalLogger log;
+    private final AllocateMessageQueueStrategy delegator;
+
+    public AllocateMessageQueueByMachine(AllocateMessageQueueStrategy strategy) {
+        this.log = ClientLogger.getLog();
+        this.delegator = strategy;
+    }
+
+    public AllocateMessageQueueByMachine(InternalLogger log, AllocateMessageQueueStrategy strategy) {
+        this.log = log;
+        this.delegator = strategy;
+    }
+
+    /**
+     * @param topicRouteData runtime info of topic route data,
+     *                       in client,topicRouteData will be update when start, and check every 30s in scheduledExecutorService
+     * @param consumerGroup  current consumer group
+     * @param currentCID     current consumer id
+     * @param mqAll          message queue set in current topic
+     * @param cidAll         consumer set in current consumer group
+     * @return
+     */
+    @Override
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll, List<String> cidAll) {
+        if (currentCID == null || currentCID.length() < 1) {
+            throw new IllegalArgumentException("currentCID is empty");
+        }
+        if (mqAll == null || mqAll.isEmpty()) {
+            throw new IllegalArgumentException("mqAll is null or mqAll empty");
+        }
+        if (cidAll == null || cidAll.isEmpty()) {
+            throw new IllegalArgumentException("cidAll is null or cidAll empty");
+        }
+
+
+        List<MessageQueue> result = new ArrayList<MessageQueue>();
+
+        if (!cidAll.contains(currentCID)) {
+            log.info("[BUG] ConsumerGroup: {} The consumerId: {} not in cidAll: {}",
+                    consumerGroup,
+                    currentCID,
+                    cidAll);
+            return result;
+        }
+
+        if (topicRouteData == null) {
+            return delegator.allocate(null, consumerGroup, currentCID, mqAll, cidAll);
+        }
+
+
+        String[] split = currentCID.split("@");
+        String currentClientIp = split[0];
+
+        List<String> allClientIp = new ArrayList<String>();
+        for (String cid : cidAll) {
+            String[] cidArray = cid.split("@");
+            allClientIp.add(cidArray[0]);
+        }
+
+        List<BrokerData> brokerDatas = topicRouteData.getBrokerDatas();
+
+        /**
+         * MessageQueue Grouped by br brokerAddr
+         */
+        Map<String/*brokerAddr ip:port*/, List<MessageQueue>> brokerAddrAndMq = new HashMap<String, List<MessageQueue>>();
+        for (MessageQueue mq : mqAll) {
+            for (BrokerData brokerData : brokerDatas) {
+                if (brokerData.getBrokerName().equals(mq.getBrokerName())) {
+                    HashMap<Long, String> brokerAddrs = brokerData.getBrokerAddrs();
+
+                    String mqAddr = brokerAddrs.get(MixAll.MASTER_ID);
+
+                    List<MessageQueue> messageQueues = brokerAddrAndMq.get(mqAddr);
+                    if (messageQueues == null) {
+                        messageQueues = new ArrayList<MessageQueue>();
+                        brokerAddrAndMq.put(mqAddr, messageQueues);
+                    }
+
+                    messageQueues.add(mq);
+                }
+            }
+        }
+
+        /**
+         * if clientIp same as brokerAddr, find corresponding MessageQueue.
+         */
+        Map<String/*clientIp*/, List<MessageQueue>> clientIpAndMq = new HashMap<String, List<MessageQueue>>();
+
+        for (String clientIp : allClientIp) {
+            for (String brokerIpAndPort : brokerAddrAndMq.keySet()) {
+                if (brokerIpAndPort.contains(clientIp)) {
+                    List<MessageQueue> messageQueues = brokerAddrAndMq.get(brokerIpAndPort);
+                    if (messageQueues != null) {
+                        List<MessageQueue> queueList = clientIpAndMq.get(clientIp);
+                        if (queueList == null) {
+                            clientIpAndMq.put(clientIp, messageQueues);
+                        } else {
+                            queueList.addAll(messageQueues);
+                        }
+
+                    }
+                }
+            }
+        }
+
+        if (clientIpAndMq.size() == 0) {
+            return delegator.allocate(topicRouteData, consumerGroup, currentCID, mqAll, cidAll);
+        }
+
+
+        Iterator<Map.Entry<String, List<MessageQueue>>> iterator = brokerAddrAndMq.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, List<MessageQueue>> entry = iterator.next();
+
+            for (String clientIp : clientIpAndMq.keySet()) {
+                if (entry.getKey().contains(clientIp)) {
+                    iterator.remove();
+                }
+            }
+        }
+
+
+        /**
+         * remain messageQueues which brokerAddr have no equal clientIp
+         */
+        List<MessageQueue> mqRemain = null;
+        if (brokerAddrAndMq.size() != 0) {
+            mqRemain = new ArrayList<MessageQueue>();
+            for (List<MessageQueue> list : brokerAddrAndMq.values()) {
+                mqRemain.addAll(list);
+            }
+        }
+
+        double avgNum = mqAll.size() / (cidAll.size() * 1.0);
+        //If a clientIp in clientIpAndMq consumes too much mq, it will be divided.
+        for (List<MessageQueue> queues : clientIpAndMq.values()) {
+            int size = queues.size();
+            if (size > avgNum) {
+                if (mqRemain == null) {
+                    mqRemain = new ArrayList<MessageQueue>();
+                }
+
+                Iterator<MessageQueue> queueIterator = queues.iterator();
+
+                double avgRemain = 0.0;
+                int remainCidWithoutEqualBrokerAddrNum = cidAll.size() - clientIpAndMq.size();
+                if (remainCidWithoutEqualBrokerAddrNum != 0) {
+                    avgRemain = mqRemain.size() / (remainCidWithoutEqualBrokerAddrNum * 1.0);
+                }
+                while (queues.size() > avgNum && ((queues.size() - 1) >= avgNum || queues.size() - Math.floor(avgRemain) > 1)) {
+                    mqRemain.add(queueIterator.next());
+                    queueIterator.remove();
+                    avgRemain = mqRemain.size() / (remainCidWithoutEqualBrokerAddrNum * 1.0);
+                }
+            }
+        }
+
+
+        List<MessageQueue> messageQueues = clientIpAndMq.get(currentClientIp);
+        if (messageQueues == null) {
+            if (mqRemain == null || mqRemain.size() == 0) {
+                return result;
+            } else {
+                //Exclude cid that has been assigned mq
+                List<String> copy = new ArrayList<String>(cidAll);
+                Iterator<String> cidIterator = copy.iterator();
+                while (cidIterator.hasNext()) {
+                    String cid = cidIterator.next();
+                    for (String clientIp : clientIpAndMq.keySet()) {
+                        if (cid.contains(clientIp)) {
+                            cidIterator.remove();
+                        }
+                    }
+
+                }
+
+                return delegator.allocate(topicRouteData, consumerGroup, currentCID, mqRemain, copy);
+            }
+        } else {//If currentClientIp has a corresponding nearby consumer object
+            result.addAll(messageQueues);
+            if (messageQueues.size() < Math.floor(avgNum) && mqRemain != null && mqRemain.size() != 0) {
+                //If the allocated number is less than the average number, allocate some from the remaining mq
+                List<MessageQueue> allocated = delegator.allocate(topicRouteData, consumerGroup, currentCID, mqRemain, cidAll);
+                result.addAll(allocated);
+            }
+            return result;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "MACHINE_IP";
+    }
+
+
+}

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineRoom.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineRoom.java
@@ -18,9 +18,11 @@ package org.apache.rocketmq.client.consumer.rebalance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 
 /**
  * Computer room Hashing queue algorithm, such as Alipay logic room
@@ -29,8 +31,9 @@ public class AllocateMessageQueueByMachineRoom implements AllocateMessageQueueSt
     private Set<String> consumeridcs;
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
         List<MessageQueue> result = new ArrayList<MessageQueue>();
         int currentIndex = cidAll.indexOf(currentCID);
         if (currentIndex < 0) {

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsistentHash.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsistentHash.java
@@ -19,11 +19,14 @@ package org.apache.rocketmq.client.consumer.rebalance;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
 import org.apache.rocketmq.common.consistenthash.ConsistentHashRouter;
 import org.apache.rocketmq.common.consistenthash.HashFunction;
 import org.apache.rocketmq.common.consistenthash.Node;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 import org.apache.rocketmq.common.message.MessageQueue;
 
@@ -53,8 +56,9 @@ public class AllocateMessageQueueConsistentHash implements AllocateMessageQueueS
     }
 
     @Override
-    public List<MessageQueue> allocate(String consumerGroup, String currentCID, List<MessageQueue> mqAll,
-        List<String> cidAll) {
+    public List<MessageQueue> allocate(TopicRouteData topicRouteData, String consumerGroup,
+                                       String currentCID, List<MessageQueue> mqAll,
+                                       List<String> cidAll) {
 
         if (currentCID == null || currentCID.length() < 1) {
             throw new IllegalArgumentException("currentCID is empty");

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
@@ -43,6 +43,7 @@ import org.apache.rocketmq.common.protocol.body.UnlockBatchRequestBody;
 import org.apache.rocketmq.common.protocol.heartbeat.ConsumeType;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.logging.InternalLogger;
 import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 
@@ -355,8 +356,10 @@ public abstract class RebalanceImpl {
                     AllocateMessageQueueStrategy strategy = this.allocateMessageQueueStrategy;
 
                     List<MessageQueue> allocateResult = null;
+                    TopicRouteData topicRouteData = mQClientFactory.getTopicRouteTable().get(topic);
                     try {
                         allocateResult = strategy.allocate(
+                                topicRouteData,
                             this.consumerGroup,
                             this.mQClientFactory.getClientId(),
                             mqAll,

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
@@ -357,6 +357,10 @@ public abstract class RebalanceImpl {
 
                     List<MessageQueue> allocateResult = null;
                     TopicRouteData topicRouteData = mQClientFactory.getTopicRouteTable().get(topic);
+                    if (topicRouteData == null) {
+                        mQClientFactory.updateTopicRouteInfoFromNameServer();
+                        topicRouteData = mQClientFactory.getTopicRouteTable().get(topic);
+                    }
                     try {
                         allocateResult = strategy.allocate(
                                 topicRouteData,

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearByTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearByTest.java
@@ -107,7 +107,7 @@ public class AllocateMachineRoomNearByTest {
         List<MessageQueue> mqAll = prepareMQ(IDCSize, queueSize);
         List<MessageQueue> resAll = new ArrayList<MessageQueue>();
         for (String currentID : cidAll) {
-            List<MessageQueue> res = allocateMessageQueueStrategy.allocate("Test-C-G",currentID,mqAll,cidAll);
+            List<MessageQueue> res = allocateMessageQueueStrategy.allocate(null,"Test-C-G",currentID,mqAll,cidAll);
             if (print) {
                 System.out.println("cid: "+currentID+"--> res :" +res);
             }
@@ -136,7 +136,7 @@ public class AllocateMachineRoomNearByTest {
 
         List<MessageQueue> resAll = new ArrayList<MessageQueue>();
         for (String currentID : cidAll) {
-            List<MessageQueue> res = allocateMessageQueueStrategy.allocate("Test-C-G",currentID,mqAll,cidAll);
+            List<MessageQueue> res = allocateMessageQueueStrategy.allocate(null,"Test-C-G",currentID,mqAll,cidAll);
             if (print) {
                 System.out.println("cid: "+currentID+"--> res :" +res);
             }
@@ -169,7 +169,7 @@ public class AllocateMachineRoomNearByTest {
         Map<String, List<MessageQueue>> idc2Res = new TreeMap<String, List<MessageQueue>>();
         for (String currentID : cidAll) {
             String currentIDC = machineRoomResolver.consumerDeployIn(currentID);
-            List<MessageQueue> res = allocateMessageQueueStrategy.allocate("Test-C-G",currentID,mqAll,cidAll);
+            List<MessageQueue> res = allocateMessageQueueStrategy.allocate(null,"Test-C-G",currentID,mqAll,cidAll);
             if (print) {
                 System.out.println("cid: "+currentID+"--> res :" +res);
             }

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueByMachineTest.java
@@ -1,0 +1,644 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer.rebalance;
+
+import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
+import org.apache.rocketmq.common.protocol.route.QueueData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AllocateMessageQueueByMachineTest {
+    private final AllocateMessageQueueStrategy strategy = new AllocateMessageQueueAveragely();
+    private final AllocateMessageQueueByMachine allocateByMachine = new AllocateMessageQueueByMachine(strategy);
+    private TopicRouteData topicRouteData = null;
+    private final List<MessageQueue> mqAll = new ArrayList<MessageQueue>();
+    private final List<String> cidAll = new ArrayList<String>();
+
+    /**
+     * 4 messageQueue
+     * 4 cid
+     */
+    public void init1() {
+        MessageQueue mq0 = new MessageQueue("mockTopic", "broker-a", 0);
+        MessageQueue mq1 = new MessageQueue("mockTopic", "broker-a", 1);
+
+        mqAll.add(mq0);
+        mqAll.add(mq1);
+
+        MessageQueue mq10 = new MessageQueue("mockTopic", "broker-b", 0);
+        MessageQueue mq11 = new MessageQueue("mockTopic", "broker-b", 1);
+        mqAll.add(mq10);
+        mqAll.add(mq11);
+
+        TopicRouteData routeData1 = new TopicRouteData();
+
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName("broker-a");
+        queueData1.setPerm(6);
+        queueData1.setReadQueueNums(4);
+        queueData1.setWriteQueueNums(4);
+        queueData1.setTopicSysFlag(0);
+
+        List<QueueData> arrayList = new ArrayList<QueueData>();
+        arrayList.add(queueData1);
+
+        QueueData queueData2 = new QueueData();
+        queueData2.setBrokerName("broker-b");
+        queueData2.setPerm(6);
+        queueData2.setReadQueueNums(2);
+        queueData2.setWriteQueueNums(2);
+        queueData2.setTopicSysFlag(0);
+
+        arrayList.add(queueData2);
+
+        routeData1.setQueueDatas(arrayList);
+
+        List<BrokerData> brokerDataList1 = new ArrayList<BrokerData>();
+        BrokerData brokerData1 = new BrokerData();
+        brokerData1.setBrokerName("broker-a");
+        brokerData1.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs1 = new HashMap<Long, String>();
+        brokerAddrs1.put(0L, "30.250.200.103:10911");
+        brokerAddrs1.put(1L, "30.250.200.102:10911");
+        brokerData1.setBrokerAddrs(brokerAddrs1);
+
+        brokerDataList1.add(brokerData1);
+
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("broker-b");
+        brokerData2.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs2 = new HashMap<Long, String>();
+        brokerAddrs2.put(0L, "30.250.200.109:10911");
+        brokerAddrs2.put(1L, "30.250.200.108:10911");
+        brokerData2.setBrokerAddrs(brokerAddrs2);
+
+        brokerDataList1.add(brokerData2);
+
+
+        routeData1.setBrokerDatas(brokerDataList1);
+
+        topicRouteData = routeData1;
+
+        cidAll.add("30.250.200.103@1000");
+        cidAll.add("30.250.200.107@1000");
+        cidAll.add("30.250.200.104@1000");
+        cidAll.add("30.250.200.109@1000");
+    }
+
+    @Test
+    public void test1(){
+        init1();
+
+        List<MessageQueue> allocate1 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.103@1000", mqAll, cidAll);
+
+        System.out.println("=======30.250.200.103@1000======");
+        for (MessageQueue messageQueue : allocate1) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate1.size());
+        Assert.assertEquals("broker-a",allocate1.get(0).getBrokerName());
+
+        System.out.println("======30.250.200.107@1000=======");
+        List<MessageQueue> allocate2 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.107@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate2) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate2.size());
+
+
+        System.out.println("=======30.250.200.104@1000======");
+        List<MessageQueue> allocate3 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.104@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate3) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate3.size());
+
+        System.out.println("======30.250.200.109@1000=======");
+        List<MessageQueue> allocate4 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.109@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate4) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate4.size());
+        Assert.assertEquals("broker-b",allocate4.get(0).getBrokerName());
+    }
+
+
+    /**
+     * 9 messageQueue
+     * 4 cid
+     */
+    public void init2() {
+        MessageQueue mq0 = new MessageQueue("mockTopic", "broker-a", 0);
+        MessageQueue mq1 = new MessageQueue("mockTopic", "broker-a", 1);
+        MessageQueue mq2 = new MessageQueue("mockTopic", "broker-a", 2);
+        MessageQueue mq3 = new MessageQueue("mockTopic", "broker-a", 3);
+        MessageQueue mq4 = new MessageQueue("mockTopic", "broker-a", 4);
+        MessageQueue mq5 = new MessageQueue("mockTopic", "broker-a", 5);
+
+        mqAll.add(mq0);
+        mqAll.add(mq1);
+        mqAll.add(mq2);
+        mqAll.add(mq3);
+        mqAll.add(mq4);
+        mqAll.add(mq5);
+
+        MessageQueue mq10 = new MessageQueue("mockTopic", "broker-b", 0);
+        MessageQueue mq11 = new MessageQueue("mockTopic", "broker-b", 1);
+        MessageQueue mq12 = new MessageQueue("mockTopic", "broker-b", 2);
+        mqAll.add(mq10);
+        mqAll.add(mq11);
+        mqAll.add(mq12);
+
+        TopicRouteData routeData1 = new TopicRouteData();
+
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName("broker-a");
+        queueData1.setPerm(6);
+        queueData1.setReadQueueNums(4);
+        queueData1.setWriteQueueNums(4);
+        queueData1.setTopicSysFlag(0);
+
+        List<QueueData> arrayList = new ArrayList<QueueData>();
+        arrayList.add(queueData1);
+
+        QueueData queueData2 = new QueueData();
+        queueData2.setBrokerName("broker-b");
+        queueData2.setPerm(6);
+        queueData2.setReadQueueNums(2);
+        queueData2.setWriteQueueNums(2);
+        queueData2.setTopicSysFlag(0);
+
+        arrayList.add(queueData2);
+
+        routeData1.setQueueDatas(arrayList);
+
+        List<BrokerData> brokerDataList1 = new ArrayList<BrokerData>();
+        BrokerData brokerData1 = new BrokerData();
+        brokerData1.setBrokerName("broker-a");
+        brokerData1.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs1 = new HashMap<Long, String>();
+        brokerAddrs1.put(0L, "30.250.200.103:10911");
+        brokerAddrs1.put(1L, "30.250.200.102:10911");
+        brokerData1.setBrokerAddrs(brokerAddrs1);
+
+        brokerDataList1.add(brokerData1);
+
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("broker-b");
+        brokerData2.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs2 = new HashMap<Long, String>();
+        brokerAddrs2.put(0L, "30.250.200.109:10911");
+        brokerAddrs2.put(1L, "30.250.200.108:10911");
+        brokerData2.setBrokerAddrs(brokerAddrs2);
+
+        brokerDataList1.add(brokerData2);
+
+
+        routeData1.setBrokerDatas(brokerDataList1);
+
+        topicRouteData = routeData1;
+
+
+        cidAll.add("30.250.200.103@1000");
+        cidAll.add("30.250.200.107@1000");
+        cidAll.add("30.250.200.104@1000");
+        cidAll.add("30.250.200.109@1000");
+    }
+
+    @Test
+    public void test2() {
+        init2();
+
+        List<MessageQueue> allocate1 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.103@1000", mqAll, cidAll);
+
+        System.out.println("=======30.250.200.103@1000======");
+        for (MessageQueue messageQueue : allocate1) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(2, allocate1.size());
+        Assert.assertEquals("broker-a",allocate1.get(0).getBrokerName());
+        Assert.assertEquals("broker-a",allocate1.get(1).getBrokerName());
+
+        System.out.println("======30.250.200.107@1000=======");
+        List<MessageQueue> allocate2 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.107@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate2) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(2, allocate2.size());
+
+
+        System.out.println("=======30.250.200.104@1000======");
+        List<MessageQueue> allocate3 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.104@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate3) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(2, allocate3.size());
+
+        System.out.println("======30.250.200.109@1000=======");
+        List<MessageQueue> allocate4 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.109@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate4) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(3, allocate4.size());
+        Assert.assertEquals("broker-b",allocate4.get(0).getBrokerName());
+        Assert.assertEquals("broker-b",allocate4.get(1).getBrokerName());
+        Assert.assertEquals("broker-b",allocate4.get(2).getBrokerName());
+    }
+
+    /**
+     * 4 messageQueue
+     * 3 cid
+     */
+    public void init3() {
+        MessageQueue mq0 = new MessageQueue("mockTopic", "broker-a", 0);
+        MessageQueue mq1 = new MessageQueue("mockTopic", "broker-a", 1);
+
+        mqAll.add(mq0);
+        mqAll.add(mq1);
+
+        MessageQueue mq10 = new MessageQueue("mockTopic", "broker-b", 0);
+        MessageQueue mq11 = new MessageQueue("mockTopic", "broker-b", 1);
+        mqAll.add(mq10);
+        mqAll.add(mq11);
+
+        TopicRouteData routeData1 = new TopicRouteData();
+
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName("broker-a");
+        queueData1.setPerm(6);
+        queueData1.setReadQueueNums(4);
+        queueData1.setWriteQueueNums(4);
+        queueData1.setTopicSysFlag(0);
+
+        List<QueueData> arrayList = new ArrayList<QueueData>();
+        arrayList.add(queueData1);
+
+        QueueData queueData2 = new QueueData();
+        queueData2.setBrokerName("broker-b");
+        queueData2.setPerm(6);
+        queueData2.setReadQueueNums(2);
+        queueData2.setWriteQueueNums(2);
+        queueData2.setTopicSysFlag(0);
+
+        arrayList.add(queueData2);
+
+        routeData1.setQueueDatas(arrayList);
+
+        List<BrokerData> brokerDataList1 = new ArrayList<BrokerData>();
+        BrokerData brokerData1 = new BrokerData();
+        brokerData1.setBrokerName("broker-a");
+        brokerData1.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs1 = new HashMap<Long, String>();
+        brokerAddrs1.put(0L, "30.250.200.103:10911");
+        brokerAddrs1.put(1L, "30.250.200.102:10911");
+        brokerData1.setBrokerAddrs(brokerAddrs1);
+
+        brokerDataList1.add(brokerData1);
+
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("broker-b");
+        brokerData2.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs2 = new HashMap<Long, String>();
+        brokerAddrs2.put(0L, "30.250.200.109:10911");
+        brokerAddrs2.put(1L, "30.250.200.108:10911");
+        brokerData2.setBrokerAddrs(brokerAddrs2);
+
+        brokerDataList1.add(brokerData2);
+
+
+        routeData1.setBrokerDatas(brokerDataList1);
+
+        topicRouteData = routeData1;
+
+        cidAll.add("30.250.200.103@1000");
+        cidAll.add("30.250.200.107@1000");
+        cidAll.add("30.250.200.104@1000");
+    }
+
+
+    @Test
+    public void test3(){
+        init3();
+
+        List<MessageQueue> allocate1 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.103@1000", mqAll, cidAll);
+
+        System.out.println("=======30.250.200.103@1000======");
+        for (MessageQueue messageQueue : allocate1) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(2, allocate1.size());
+        Assert.assertEquals("broker-a",allocate1.get(0).getBrokerName());
+        Assert.assertEquals("broker-a",allocate1.get(1).getBrokerName());
+
+        System.out.println("======30.250.200.107@1000=======");
+        List<MessageQueue> allocate2 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.107@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate2) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate2.size());
+
+
+        System.out.println("=======30.250.200.104@1000======");
+        List<MessageQueue> allocate3 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.104@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate3) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate3.size());
+
+    }
+
+    /**
+     * 4 messageQueue
+     * 5 cid
+     */
+    public void init4() {
+        MessageQueue mq0 = new MessageQueue("mockTopic", "broker-a", 0);
+        MessageQueue mq1 = new MessageQueue("mockTopic", "broker-a", 1);
+
+        mqAll.add(mq0);
+        mqAll.add(mq1);
+
+        MessageQueue mq10 = new MessageQueue("mockTopic", "broker-b", 0);
+        MessageQueue mq11 = new MessageQueue("mockTopic", "broker-b", 1);
+        mqAll.add(mq10);
+        mqAll.add(mq11);
+
+        TopicRouteData routeData1 = new TopicRouteData();
+
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName("broker-a");
+        queueData1.setPerm(6);
+        queueData1.setReadQueueNums(4);
+        queueData1.setWriteQueueNums(4);
+        queueData1.setTopicSysFlag(0);
+
+        List<QueueData> arrayList = new ArrayList<QueueData>();
+        arrayList.add(queueData1);
+
+        QueueData queueData2 = new QueueData();
+        queueData2.setBrokerName("broker-b");
+        queueData2.setPerm(6);
+        queueData2.setReadQueueNums(2);
+        queueData2.setWriteQueueNums(2);
+        queueData2.setTopicSysFlag(0);
+
+        arrayList.add(queueData2);
+
+        routeData1.setQueueDatas(arrayList);
+
+        List<BrokerData> brokerDataList1 = new ArrayList<BrokerData>();
+        BrokerData brokerData1 = new BrokerData();
+        brokerData1.setBrokerName("broker-a");
+        brokerData1.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs1 = new HashMap<Long, String>();
+        brokerAddrs1.put(0L, "30.250.200.103:10911");
+        brokerAddrs1.put(1L, "30.250.200.102:10911");
+        brokerData1.setBrokerAddrs(brokerAddrs1);
+
+        brokerDataList1.add(brokerData1);
+
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("broker-b");
+        brokerData2.setCluster("DefaultCluster");
+
+        HashMap<Long, String> brokerAddrs2 = new HashMap<Long, String>();
+        brokerAddrs2.put(0L, "30.250.200.109:10911");
+        brokerAddrs2.put(1L, "30.250.200.108:10911");
+        brokerData2.setBrokerAddrs(brokerAddrs2);
+
+        brokerDataList1.add(brokerData2);
+
+
+        routeData1.setBrokerDatas(brokerDataList1);
+
+        topicRouteData = routeData1;
+
+
+        cidAll.add("30.250.200.103@1000");
+        cidAll.add("30.250.200.107@1000");
+        cidAll.add("30.250.200.104@1000");
+        cidAll.add("30.250.200.109@1000");
+        cidAll.add("30.250.200.110@1000");
+    }
+
+    @Test
+    public void test4() {
+        init4();
+
+        List<MessageQueue> allocate1 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.103@1000", mqAll, cidAll);
+
+        System.out.println("=======30.250.200.103@1000======");
+        for (MessageQueue messageQueue : allocate1) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate1.size());
+        Assert.assertEquals("broker-a",allocate1.get(0).getBrokerName());
+
+        System.out.println("======30.250.200.107@1000=======");
+        List<MessageQueue> allocate2 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.107@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate2) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate2.size());
+
+
+        System.out.println("=======30.250.200.104@1000======");
+        List<MessageQueue> allocate3 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.104@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate3) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate3.size());
+
+        System.out.println("======30.250.200.109@1000=======");
+        List<MessageQueue> allocate4 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.109@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate4) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate4.size());
+        Assert.assertEquals("broker-b",allocate4.get(0).getBrokerName());
+
+        System.out.println("======30.250.200.110@1000=======");
+        List<MessageQueue> allocate5 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.110@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate5) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(0, allocate5.size());
+    }
+
+    /**
+     * 6 messageQueue
+     * 6 cid
+     */
+    public void init5() {
+        MessageQueue mq0 = new MessageQueue("mockTopic", "broker-a", 0);
+        MessageQueue mq1 = new MessageQueue("mockTopic", "broker-a", 1);
+
+        mqAll.add(mq0);
+        mqAll.add(mq1);
+
+        MessageQueue mq10 = new MessageQueue("mockTopic", "broker-b", 0);
+        MessageQueue mq11 = new MessageQueue("mockTopic", "broker-b", 1);
+        mqAll.add(mq10);
+        mqAll.add(mq11);
+
+        MessageQueue mq20 = new MessageQueue("mockTopic", "broker-c", 0);
+        MessageQueue mq21 = new MessageQueue("mockTopic", "broker-c", 1);
+        mqAll.add(mq20);
+        mqAll.add(mq21);
+
+        TopicRouteData routeData = new TopicRouteData();
+        List<QueueData> arrayList = new ArrayList<QueueData>();
+        routeData.setQueueDatas(arrayList);
+
+        List<BrokerData> brokerDataList = new ArrayList<BrokerData>();
+        routeData.setBrokerDatas(brokerDataList);
+
+
+        //1
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName("broker-a");
+        queueData1.setPerm(6);
+        queueData1.setReadQueueNums(4);
+        queueData1.setWriteQueueNums(4);
+        queueData1.setTopicSysFlag(0);
+        arrayList.add(queueData1);
+
+        BrokerData brokerData1 = new BrokerData();
+        brokerData1.setBrokerName("broker-a");
+        brokerData1.setCluster("DefaultCluster");
+        HashMap<Long, String> brokerAddrs1 = new HashMap<Long, String>();
+        brokerAddrs1.put(0L, "30.250.200.103:10911");
+        brokerAddrs1.put(1L, "30.250.200.102:10911");
+        brokerData1.setBrokerAddrs(brokerAddrs1);
+        brokerDataList.add(brokerData1);
+
+        //2
+        QueueData queueData2 = new QueueData();
+        queueData2.setBrokerName("broker-b");
+        queueData2.setPerm(6);
+        queueData2.setReadQueueNums(2);
+        queueData2.setWriteQueueNums(2);
+        queueData2.setTopicSysFlag(0);
+        arrayList.add(queueData2);
+
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("broker-b");
+        brokerData2.setCluster("DefaultCluster");
+        HashMap<Long, String> brokerAddrs2 = new HashMap<Long, String>();
+        brokerAddrs2.put(0L, "30.250.200.109:10911");
+        brokerAddrs2.put(1L, "30.250.200.108:10911");
+        brokerData2.setBrokerAddrs(brokerAddrs2);
+        brokerDataList.add(brokerData2);
+
+        //3
+        QueueData queueData3 = new QueueData();
+        queueData3.setBrokerName("broker-c");
+        queueData3.setPerm(6);
+        queueData3.setReadQueueNums(2);
+        queueData3.setWriteQueueNums(2);
+        queueData3.setTopicSysFlag(0);
+        arrayList.add(queueData3);
+
+        BrokerData brokerData3 = new BrokerData();
+        brokerData3.setBrokerName("broker-c");
+        brokerData3.setCluster("DefaultCluster");
+        HashMap<Long, String> brokerAddrs3 = new HashMap<Long, String>();
+        brokerAddrs3.put(0L, "30.250.200.120:10911");
+        brokerAddrs3.put(1L, "30.250.200.121:10911");
+        brokerData3.setBrokerAddrs(brokerAddrs3);
+        brokerDataList.add(brokerData3);
+
+
+        topicRouteData = routeData;
+
+        cidAll.add("30.250.200.103@1000");
+        cidAll.add("30.250.200.107@1000");
+        cidAll.add("30.250.200.104@1000");
+        cidAll.add("30.250.200.109@1000");
+        cidAll.add("30.250.200.105@1000");
+        cidAll.add("30.250.200.106@1000");
+
+    }
+
+    @Test
+    public void test5(){
+        init5();
+
+        List<MessageQueue> allocate1 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.103@1000", mqAll, cidAll);
+
+        System.out.println("=======30.250.200.103@1000======");
+        for (MessageQueue messageQueue : allocate1) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate1.size());
+        Assert.assertEquals("broker-a",allocate1.get(0).getBrokerName());
+
+        System.out.println("======30.250.200.107@1000=======");
+        List<MessageQueue> allocate2 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.107@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate2) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate2.size());
+
+
+        System.out.println("=======30.250.200.104@1000======");
+        List<MessageQueue> allocate3 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.104@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate3) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate3.size());
+
+        System.out.println("======30.250.200.109@1000=======");
+        List<MessageQueue> allocate4 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.109@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate4) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate4.size());
+        Assert.assertEquals("broker-b",allocate4.get(0).getBrokerName());
+
+        System.out.println("======30.250.200.105@1000=======");
+        List<MessageQueue> allocate5 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.105@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate5) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate4.size());
+
+        System.out.println("======30.250.200.106@1000=======");
+        List<MessageQueue> allocate6 = allocateByMachine.allocate(topicRouteData, "Test-C-G", "30.250.200.106@1000", mqAll, cidAll);
+        for (MessageQueue messageQueue : allocate6) {
+            System.out.println(messageQueue);
+        }
+        Assert.assertEquals(1, allocate4.size());
+    }
+}

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsitentHashTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMessageQueueConsitentHashTest.java
@@ -53,7 +53,7 @@ public class AllocateMessageQueueConsitentHashTest {
         String currentCID = String.valueOf(Integer.MAX_VALUE);
         List<String> consumerIdList = createConsumerIdList(2);
         List<MessageQueue> messageQueueList = createMessageQueueList(6);
-        List<MessageQueue> result = new AllocateMessageQueueConsistentHash().allocate("", currentCID, messageQueueList, consumerIdList);
+        List<MessageQueue> result = new AllocateMessageQueueConsistentHash().allocate(null,"", currentCID, messageQueueList, consumerIdList);
         printMessageQueue(result, "testCurrentCIDNotExists");
         Assert.assertEquals(result.size(), 0);
     }
@@ -62,21 +62,21 @@ public class AllocateMessageQueueConsitentHashTest {
     public void testCurrentCIDIllegalArgument() {
         List<String> consumerIdList = createConsumerIdList(2);
         List<MessageQueue> messageQueueList = createMessageQueueList(6);
-        new AllocateMessageQueueConsistentHash().allocate("", "", messageQueueList, consumerIdList);
+        new AllocateMessageQueueConsistentHash().allocate(null,"", "", messageQueueList, consumerIdList);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMessageQueueIllegalArgument() {
         String currentCID = "0";
         List<String> consumerIdList = createConsumerIdList(2);
-        new AllocateMessageQueueConsistentHash().allocate("", currentCID, null, consumerIdList);
+        new AllocateMessageQueueConsistentHash().allocate(null,"", currentCID, null, consumerIdList);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConsumerIdIllegalArgument() {
         String currentCID = "0";
         List<MessageQueue> messageQueueList = createMessageQueueList(6);
-        new AllocateMessageQueueConsistentHash().allocate("", currentCID, messageQueueList, null);
+        new AllocateMessageQueueConsistentHash().allocate(null,"", currentCID, messageQueueList, null);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class AllocateMessageQueueConsitentHashTest {
 
             //System.out.println("cidAll:" + cidBegin.toString());
             for (String cid : cidBegin) {
-                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate("testConsumerGroup", cid, mqAll, cidBegin);
+                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate(null,"testConsumerGroup", cid, mqAll, cidBegin);
                 for (MessageQueue mq : rs) {
                     allocateToAllOrigin.put(mq, cid);
                 }
@@ -149,7 +149,7 @@ public class AllocateMessageQueueConsitentHashTest {
             //System.out.println("cidAll:" + cidAfterRemoveOne.toString());
             List<MessageQueue> allocatedResAllAfterRemove = new ArrayList<MessageQueue>();
             for (String cid : cidAfterRemoveOne) {
-                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate("testConsumerGroup", cid, mqAll, cidAfterRemoveOne);
+                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate(null,"testConsumerGroup", cid, mqAll, cidAfterRemoveOne);
                 allocatedResAllAfterRemove.addAll(rs);
                 for (MessageQueue mq : rs) {
                     allocateToAllAfterRemoveOne.put(mq, cid);
@@ -173,7 +173,7 @@ public class AllocateMessageQueueConsitentHashTest {
             List<MessageQueue> allocatedResAllAfterAdd = new ArrayList<MessageQueue>();
             Map<MessageQueue, String> allocateToAll3 = new TreeMap<MessageQueue, String>();
             for (String cid : cidAfterAdd) {
-                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate("testConsumerGroup", cid, mqAll, cidAfterAdd);
+                List<MessageQueue> rs = allocateMessageQueueConsistentHash.allocate(null,"testConsumerGroup", cid, mqAll, cidAfterAdd);
                 allocatedResAllAfterAdd.addAll(rs);
                 for (MessageQueue mq : rs) {
                     allocateToAll3.put(mq, cid);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImplTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.client.impl.consumer;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
 import org.apache.rocketmq.client.consumer.store.OffsetStore;
@@ -30,6 +32,7 @@ import org.apache.rocketmq.common.message.MessageQueueAssignment;
 import org.apache.rocketmq.common.message.MessageRequestMode;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
+import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.junit.Before;
@@ -62,6 +65,7 @@ public class RebalancePushImplTest {
     @Before
     public void before() {
         defaultMQPushConsumer.getDefaultMQPushConsumer().setClientRebalance(false);
+        when(mqClientInstance.getTopicRouteTable()).thenReturn(new ConcurrentHashMap<String, TopicRouteData>());
     }
 
     @Test

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/topic/AllocateMQSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/topic/AllocateMQSubCommand.java
@@ -80,7 +80,7 @@ public class AllocateMQSubCommand implements SubCommand {
             RebalanceResult rr = new RebalanceResult();
 
             for (String i : ipList) {
-                final List<MessageQueue> mqResult = averagely.allocate("aa", i, new ArrayList<MessageQueue>(mqs), ipList);
+                final List<MessageQueue> mqResult = averagely.allocate(null,"aa", i, new ArrayList<MessageQueue>(mqs), ipList);
                 rr.getResult().put(i, mqResult);
             }
 


### PR DESCRIPTION
add a new allocate MessageQueue strategy: Allocated by ip, if messageQueue localed in broker has same ip with client, Allocate messageQueue to this client firstly.
