### PR TITLE
ISSUE#2706  FIX

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -486,6 +486,10 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
                 break;
 
             // Failed
+            case FLUSH_DISK_FAILED:
+                response.setCode(ResponseCode.FLUSH_DISK_FAILED);
+                response.setRemark("flush disk failed, disk is broken.");
+                break;
             case CREATE_MAPEDFILE_FAILED:
                 response.setCode(ResponseCode.SYSTEM_ERROR);
                 response.setRemark("create mapped file failed, server is busy or broken.");

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -70,6 +70,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     private final Set<Integer> retryResponseCodes = new CopyOnWriteArraySet<Integer>(Arrays.asList(
             ResponseCode.TOPIC_NOT_EXIST,
             ResponseCode.SERVICE_NOT_AVAILABLE,
+            ResponseCode.FLUSH_DISK_FAILED,
             ResponseCode.SYSTEM_ERROR,
             ResponseCode.NO_PERMISSION,
             ResponseCode.NO_BUYER_ID,

--- a/client/src/main/java/org/apache/rocketmq/client/producer/SendStatus.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/SendStatus.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.client.producer;
 public enum SendStatus {
     SEND_OK,
     FLUSH_DISK_TIMEOUT,
+    FLUSH_DISK_FAILED,
     FLUSH_SLAVE_TIMEOUT,
     SLAVE_NOT_AVAILABLE,
 }

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
@@ -20,7 +20,9 @@ package org.apache.rocketmq.common.protocol;
 import org.apache.rocketmq.remoting.protocol.RemotingSysResponseCode;
 
 public class ResponseCode extends RemotingSysResponseCode {
-
+	
+    public static final int FLUSH_DISK_FAILED = 9;
+    
     public static final int FLUSH_DISK_TIMEOUT = 10;
 
     public static final int SLAVE_NOT_AVAILABLE = 11;

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1161,7 +1161,7 @@ public class CommitLog {
         public CompletableFuture<PutMessageStatus> future() {
             return flushOKFuture;
         }
-
+     
     }
 
     /**
@@ -1204,7 +1204,12 @@ public class CommitLog {
                         flushOK = CommitLog.this.mappedFileQueue.getFlushedWhere() >= req.getNextOffset();
                     }
 
-                    req.wakeupCustomer(flushOK ? PutMessageStatus.PUT_OK : PutMessageStatus.FLUSH_DISK_TIMEOUT);
+                    if (CommitLog.this.mappedFileQueue.isFlushError()) {
+                      req.wakeupCustomer(PutMessageStatus.FLUSH_DISK_FAILED);
+                    }
+                    else {
+                       req.wakeupCustomer(flushOK ? PutMessageStatus.PUT_OK : PutMessageStatus.FLUSH_DISK_TIMEOUT);
+                    }
                 }
 
                 long storeTimestamp = CommitLog.this.mappedFileQueue.getStoreTimestamp();

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFile.java
@@ -65,7 +65,8 @@ public class MappedFile extends ReferenceResource {
     private MappedByteBuffer mappedByteBuffer;
     private volatile long storeTimestamp = 0;
     private boolean firstCreateInQueue = false;
-
+    private boolean flushError = false;
+    
     public MappedFile() {
     }
 
@@ -288,6 +289,7 @@ public class MappedFile extends ReferenceResource {
                     }
                 } catch (Throwable e) {
                     log.error("Error occurred when force data to disk.", e);
+                    this.flushError = true;
                 }
 
                 this.flushedPosition.set(value);
@@ -582,4 +584,8 @@ public class MappedFile extends ReferenceResource {
     public String toString() {
         return this.fileName;
     }
+    public boolean getflushError() {
+        return this.flushError;
+    }
+
 }

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -48,6 +48,7 @@ public class MappedFileQueue {
     private long committedWhere = 0;
 
     private volatile long storeTimestamp = 0;
+    private boolean flushError = false ;
 
     public MappedFileQueue(final String storePath, int mappedFileSize,
         AllocateMappedFileService allocateMappedFileService) {
@@ -442,6 +443,9 @@ public class MappedFileQueue {
         if (mappedFile != null) {
             long tmpTimeStamp = mappedFile.getStoreTimestamp();
             int offset = mappedFile.flush(flushLeastPages);
+            if (mappedFile.getflushError()) {
+              this.flushError =true;
+            }
             long where = mappedFile.getFileFromOffset() + offset;
             result = where == this.flushedWhere;
             this.flushedWhere = where;
@@ -620,5 +624,9 @@ public class MappedFileQueue {
 
     public void setCommittedWhere(final long committedWhere) {
         this.committedWhere = committedWhere;
+    }
+    
+    public boolean isFlushError() {
+        return flushError;
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java
+++ b/store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store;
 public enum PutMessageStatus {
     PUT_OK,
     FLUSH_DISK_TIMEOUT,
+    FLUSH_DISK_FAILED,
     FLUSH_SLAVE_TIMEOUT,
     SLAVE_NOT_AVAILABLE,
     SERVICE_NOT_AVAILABLE,


### PR DESCRIPTION
ISSUE #2706 

The original pull request was #2707。 

You can see from the code below. When flush fails, only an error is reported, but the client is not notified 。
If there is an error, a try catch will be performed .Then log.error("Error occurred when force data to disk.", e);
But there is no error code returned to the client, and the client still thinks that the send is successful.

public int flush(final int flushLeastPages) {
    if (this.isAbleToFlush(flushLeastPages)) {
      if (this.hold()) {
      int value = getReadPosition();
            try {
                //We only append data to fileChannel or mappedByteBuffer, never both.
                if (writeBuffer != null || this.fileChannel.position() != 0) {
                    this.fileChannel.force(false);
                } else {
                    this.mappedByteBuffer.force();
                }
            } **catch (Throwable e) {
                log.error("Error occurred when force data to disk.", e);
            }**

            this.flushedPosition.set(value);
            this.release();
        } else {
            log.warn("in flush, hold failed, flush offset = " + this.flushedPosition.get());
            this.flushedPosition.set(getReadPosition());
        }
    }
    return this.getFlushedPosition();
}
