### PR TITLE
[ISSUE#3426] reduce unnecessary regex matches when namespace is null

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -39,6 +39,7 @@ public class ClientConfig {
     private String instanceName = System.getProperty("rocketmq.client.name", "DEFAULT");
     private int clientCallbackExecutorThreads = Runtime.getRuntime().availableProcessors();
     protected String namespace;
+    private boolean namespaceInitialized = false;
     protected AccessChannel accessChannel = AccessChannel.LOCAL;
 
     /**
@@ -274,20 +275,28 @@ public class ClientConfig {
     }
 
     public String getNamespace() {
+        if (namespaceInitialized) {
+            return namespace;
+        }
+
         if (StringUtils.isNotEmpty(namespace)) {
             return namespace;
         }
 
         if (StringUtils.isNotEmpty(this.namesrvAddr)) {
             if (NameServerAddressUtils.validateInstanceEndpoint(namesrvAddr)) {
-                return NameServerAddressUtils.parseInstanceIdFromEndpoint(namesrvAddr);
+                namespace = NameServerAddressUtils.parseInstanceIdFromEndpoint(namesrvAddr);
             }
         }
+        namespaceInitialized = true;
         return namespace;
     }
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+        if (StringUtils.isNotEmpty(namespace)) {
+            namespaceInitialized = true;
+        }
     }
 
     public AccessChannel getAccessChannel() {


### PR DESCRIPTION
## reduce unnecessary regex matches when namespace is null

there are too many regex matches, when default namespace is null, which used too much memory.

## Brief changelog

1. Change ClientConfig, add namespaceInitialized veriable

