### PR TITLE
[ISSUE #2516]: Fix the value of sendThreadPoolQueueHeadWaitTimeMills is 0 most of the time

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerControllerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerControllerTest.java
@@ -18,10 +18,16 @@
 package org.apache.rocketmq.broker;
 
 import java.io.File;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.rocketmq.broker.latency.FutureTaskExt;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.netty.RequestTask;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.After;
 import org.junit.Ignore;
@@ -46,5 +52,34 @@ public class BrokerControllerTest {
     @After
     public void destroy() {
         UtilAll.deleteFile(new File(new MessageStoreConfig().getStorePathRootDir()));
+    }
+
+    @Test
+    public void testHeadSlowTimeMills() throws Exception {
+        BrokerController brokerController = new BrokerController(
+                new BrokerConfig(),
+                new NettyServerConfig(),
+                new NettyClientConfig(),
+                new MessageStoreConfig());
+        brokerController.initialize();
+        BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>();
+
+        //create task is not instance of FutureTaskExt;
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+
+            }
+        };
+        queue.add(runnable);
+
+        RequestTask requestTask = new RequestTask(runnable, null, null);
+        // the requestTask is not the head of queue;
+        queue.add(new FutureTaskExt<>(requestTask, null));
+
+        long headSlowTimeMills = 100;
+        TimeUnit.MILLISECONDS.sleep(headSlowTimeMills);
+        assertThat(brokerController.headSlowTimeMills(queue)).isGreaterThanOrEqualTo(headSlowTimeMills);
+        //Attention: if we use the previous version method BrokerController#headSlowTimeMills, it will return 0;
     }
 }


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

fix bug : https://github.com/apache/rocketmq/issues/2516

## Brief changelog
1. According to the idea between the original issue author and @RongtongJin , 
optimizing the method: `BrokerController#headSlowTimeMillss(BlockingQueue<Runnable> q)`

2. Iterate over the `BrokerController#sendThreadPoolQueue` and find the first element that meets the conditions (or NULL)to cacluete the time instead of the [`sendThreadPoolQueue#peek()`] method (think about the impact of concurrency,  `BrokerController#sendThreadPoolQueue` is polled by thread in `BrokerController#sendMessageExecutor`). 

3. However, for monitoring purposes, I think it's better to count the distribution of this value over each time interval, just like `StoreStatsService#putMessageDistributeTime`,  `StoreStatsService#PUT_MESSAGE_ENTIRE_TIME_MAX_DESC` as shown below:
```
private static final String[] PUT_MESSAGE_ENTIRE_TIME_MAX_DESC = new String[] {
        "[<=0ms]", "[0~10ms]", "[10~50ms]", "[50~100ms]", "[100~200ms]", "[200~500ms]", "[500ms~1s]", "[1~2s]", "[2~3s]", "[3~4s]", "[4~5s]", "[5~10s]", "[10s~]",
    };
```
**because RocketMQ-Exporter monitor `sendThreadPoolQueueHeadWaitTimeMills` as a Prometheus `Gauge` type variable**. 

## Verifying this change
![image](https://user-images.githubusercontent.com/8653312/142388518-93330ef1-d3ce-42d0-acaa-ef35aa500501.png)





