### PR TITLE
[ISSUE #3528] fix: The value of ChannelOption.SO_BACKLOG should not be hard-coded.

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -198,7 +198,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         ServerBootstrap childHandler =
             this.serverBootstrap.group(this.eventLoopGroupBoss, this.eventLoopGroupSelector)
                 .channel(useEpoll() ? EpollServerSocketChannel.class : NioServerSocketChannel.class)
-                .option(ChannelOption.SO_BACKLOG, 1024)
+                .option(ChannelOption.SO_BACKLOG, nettyServerConfig.getServerSocketBacklog())
                 .option(ChannelOption.SO_REUSEADDR, true)
                 .option(ChannelOption.SO_KEEPALIVE, false)
                 .childOption(ChannelOption.TCP_NODELAY, true)

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
@@ -27,6 +27,7 @@ public class NettyServerConfig implements Cloneable {
 
     private int serverSocketSndBufSize = NettySystemConfig.socketSndbufSize;
     private int serverSocketRcvBufSize = NettySystemConfig.socketRcvbufSize;
+    private int serverSocketBacklog = NettySystemConfig.socketBacklog;
     private boolean serverPooledByteBufAllocatorEnable = true;
 
     /**
@@ -108,6 +109,14 @@ public class NettyServerConfig implements Cloneable {
 
     public void setServerSocketRcvBufSize(int serverSocketRcvBufSize) {
         this.serverSocketRcvBufSize = serverSocketRcvBufSize;
+    }
+
+    public int getServerSocketBacklog() {
+        return serverSocketBacklog;
+    }
+
+    public void setServerSocketBacklog(int serverSocketBacklog) {
+        this.serverSocketBacklog = serverSocketBacklog;
     }
 
     public boolean isServerPooledByteBufAllocatorEnable() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettySystemConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettySystemConfig.java
@@ -24,6 +24,8 @@ public class NettySystemConfig {
         "com.rocketmq.remoting.socket.sndbuf.size";
     public static final String COM_ROCKETMQ_REMOTING_SOCKET_RCVBUF_SIZE =
         "com.rocketmq.remoting.socket.rcvbuf.size";
+    public static final String COM_ROCKETMQ_REMOTING_SOCKET_BACKLOG =
+        "com.rocketmq.remoting.socket.backlog";
     public static final String COM_ROCKETMQ_REMOTING_CLIENT_ASYNC_SEMAPHORE_VALUE =
         "com.rocketmq.remoting.clientAsyncSemaphoreValue";
     public static final String COM_ROCKETMQ_REMOTING_CLIENT_ONEWAY_SEMAPHORE_VALUE =
@@ -47,6 +49,8 @@ public class NettySystemConfig {
         Integer.parseInt(System.getProperty(COM_ROCKETMQ_REMOTING_SOCKET_SNDBUF_SIZE, "65535"));
     public static int socketRcvbufSize =
         Integer.parseInt(System.getProperty(COM_ROCKETMQ_REMOTING_SOCKET_RCVBUF_SIZE, "65535"));
+    public static int socketBacklog =
+        Integer.parseInt(System.getProperty(COM_ROCKETMQ_REMOTING_SOCKET_BACKLOG, "1024"));
     public static int clientWorkerSize =
         Integer.parseInt(System.getProperty(COM_ROCKETMQ_REMOTING_CLIENT_WORKER_SIZE, "4"));
     public static int connectTimeoutMillis =
@@ -55,4 +59,5 @@ public class NettySystemConfig {
         Integer.parseInt(System.getProperty(COM_ROCKETMQ_REMOTING_CLIENT_CHANNEL_MAX_IDLE_SECONDS, "120"));
     public static boolean clientCloseSocketIfTimeout =
         Boolean.parseBoolean(System.getProperty(COM_ROCKETMQ_REMOTING_CLIENT_CLOSE_SOCKET_IF_TIMEOUT, "true"));
+
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyServerConfigTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyServerConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.remoting.netty;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NettyServerConfigTest {
+
+  @Test
+  public void testChangeConfigBySystemProperty() {
+    System.setProperty(NettySystemConfig.COM_ROCKETMQ_REMOTING_SOCKET_BACKLOG, "65535");
+    NettySystemConfig.socketBacklog =
+            Integer.parseInt(System.getProperty(NettySystemConfig.COM_ROCKETMQ_REMOTING_SOCKET_BACKLOG, "1024"));
+    NettyServerConfig changedConfig = new NettyServerConfig();
+    assertThat(changedConfig.getServerSocketBacklog()).isEqualTo(65535);
+  }
+}


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

for issue: https://github.com/apache/rocketmq/issues/3528  

## Brief changelog

  Make the `backlog` to be configurable, for compatibility with previous versions, it default value is 1024. 

The behavior of the `backlog` argument on TCP sockets changed with Linux 2.2.  Now it specifies the queue length for **completely established sockets** waiting to be accepted, instead of the number of **incomplete connection** requests. see: https://man7.org/linux/man-pages/man2/listen.2.html

## Verifying this change

This commit has unit tests.


