### PR TITLE
[ISSUE #3533] optimize: It is better to specify the initialCapacity when initializing a HashMap as a local variable that will not add elements  in the future.

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/schedule/ScheduleMessageService.java
@@ -234,7 +234,7 @@ public class ScheduleMessageService extends ConfigManager {
     }
 
     public boolean parseDelayLevel() {
-        HashMap<String, Long> timeUnitTable = new HashMap<String, Long>();
+        HashMap<String, Long> timeUnitTable = new HashMap<String, Long>(4, 1);
         timeUnitTable.put("s", 1000L);
         timeUnitTable.put("m", 1000L * 60);
         timeUnitTable.put("h", 1000L * 60 * 60);

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
@@ -69,16 +69,17 @@ public class ExportConfigsCommand implements SubCommand {
                 .trim();
 
             defaultMQAdminExt.start();
-            Map<String, Object> result = new HashMap<>();
+            Map<String, Object> result = new HashMap<>(2, 1);
             // name servers
             List<String> nameServerAddressList = defaultMQAdminExt.getNameServerAddressList();
 
             //broker
             int masterBrokerSize = 0;
             int slaveBrokerSize = 0;
-            Map<String, Properties> brokerConfigs = new HashMap<>();
+
             Map<String, List<String>> masterAndSlaveMap
                 = CommandUtil.fetchMasterAndSlaveDistinguish(defaultMQAdminExt, clusterName);
+            Map<String, Properties> brokerConfigs = new HashMap<>(masterAndSlaveMap.size(), 1);
             for (String masterAddr : masterAndSlaveMap.keySet()) {
                 Properties masterProperties = defaultMQAdminExt.getBrokerConfig(masterAddr);
                 masterBrokerSize++;
@@ -87,7 +88,7 @@ public class ExportConfigsCommand implements SubCommand {
                 brokerConfigs.put(masterProperties.getProperty("brokerName"), needBrokerProprties(masterProperties));
             }
 
-            Map<String, Integer> clusterScaleMap = new HashMap<>();
+            Map<String, Integer> clusterScaleMap = new HashMap<>(3, 1);
             clusterScaleMap.put("namesrvSize", nameServerAddressList.size());
             clusterScaleMap.put("masterBrokerSize", masterBrokerSize);
             clusterScaleMap.put("slaveBrokerSize", slaveBrokerSize);

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java
@@ -147,7 +147,7 @@ public class ExportMetricsCommand implements SubCommand {
 
     private Map<String, Object> getRuntimeVersion(DefaultMQAdminExt defaultMQAdminExt,
         SubscriptionGroupWrapper subscriptionGroupWrapper) {
-        Map<String, Object> runtimeVersionMap = new HashMap();
+        Map<String, Object> runtimeVersionMap = new HashMap(2, 1);
 
         Set<String> clientInfoSet = new HashSet<>();
         for (Map.Entry<String, SubscriptionGroupConfig> entry : subscriptionGroupWrapper


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

for issue #3533 

## Brief changelog

Specify the initialCapacity when initializing a `HashMap` as a local variable that will not add elements  in the future, 
just like the code in class `org.apache.rocketmq.broker.filter.MessageEvaluationContext#keyValues` as shown below , it is better. 

```java
public Map<String, Object> keyValues() {
        if (properties == null) {
            return null;
        }

        Map<String, Object> copy = new HashMap<String, Object>(properties.size(), 1);

        for (String key : properties.keySet()) {
            copy.put(key, properties.get(key));
        }

        return copy;
    }
```
