### PR TITLE
[ISSUE #3567] fix: The default value of configuration item (PushConsumer#consumeThreadMin) in document and code is different.

### DIFF
--- a/docs/cn/best_practice.md
+++ b/docs/cn/best_practice.md
@@ -287,7 +287,7 @@ DefaultMQProducer、TransactionMQProducer、DefaultMQPushConsumer、DefaultMQPul
 | subscription                 |                               | 订阅关系                                                     |
 | messageListener              |                               | 消息监听器                                                   |
 | offsetStore                  |                               | 消费进度存储                                                 |
-| consumeThreadMin             | 10                            | 消费线程池最小线程数                                               |
+| consumeThreadMin             | 20                            | 消费线程池最小线程数                                               |
 | consumeThreadMax             | 20                            | 消费线程池最大线程数                                               |
 | consumeConcurrentlyMaxSpan   | 2000                          | 单队列并行消费允许的最大跨度                                 |
 | pullThresholdForQueue        | 1000                          | 拉消息本地队列缓存消息最大数                                 |

--- a/docs/en/Configuration_Client.md
+++ b/docs/en/Configuration_Client.md
@@ -82,7 +82,7 @@ HTTP static server addressing is recommended, because it is simple client deploy
 | subscription                 |                               | subscription relation                                                    |
 | messageListener              |                               | message listener                                                  |
 | offsetStore                  |                               | Consumption progress store                                                 |
-| consumeThreadMin             | 10                            | Minimum of thread in consumption thread pool                                               |
+| consumeThreadMin             | 20                            | Minimum of thread in consumption thread pool                                               |
 | consumeThreadMax             | 20                            | Maximum of thread in consumption thread pool                                               |
 |                              |                               |                                                              |
 | consumeConcurrentlyMaxSpan   | 2000                          | Maximum span allowed for single queue parallel consumption                                 |


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

For issue #3567 

## Brief changelog

Keep the value of configuration item (PushConsumer#consumeThreadMin) in document and code is same.

## Verifying this change

XXXX
