### PR TITLE
[ISSUE #3593] entrySet() replace keySet()

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
@@ -18,7 +18,6 @@
 package org.apache.rocketmq.broker.filter;
 
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.BrokerPathConfigHelper;

--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.broker.filter;
 
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.BrokerPathConfigHelper;
@@ -158,8 +160,8 @@ public class ConsumerFilterManager extends ConfigManager {
     }
 
     public void unRegister(final String consumerGroup) {
-        for (String topic : filterDataByTopic.keySet()) {
-            this.filterDataByTopic.get(topic).unRegister(consumerGroup);
+        for (Entry<String, FilterDataMapByTopic> entry : filterDataByTopic.entrySet()) {
+            entry.getValue().unRegister(consumerGroup);
         }
     }
 
@@ -230,15 +232,15 @@ public class ConsumerFilterManager extends ConfigManager {
         ConsumerFilterManager load = RemotingSerializable.fromJson(jsonString, ConsumerFilterManager.class);
         if (load != null && load.filterDataByTopic != null) {
             boolean bloomChanged = false;
-            for (String topic : load.filterDataByTopic.keySet()) {
-                FilterDataMapByTopic dataMapByTopic = load.filterDataByTopic.get(topic);
+            for (Entry<String, FilterDataMapByTopic> entry : load.filterDataByTopic.entrySet()) {
+                FilterDataMapByTopic dataMapByTopic = entry.getValue();
                 if (dataMapByTopic == null) {
                     continue;
                 }
 
-                for (String group : dataMapByTopic.getGroupFilterData().keySet()) {
+                for (Entry<String, ConsumerFilterData> groupEntry : dataMapByTopic.getGroupFilterData().entrySet()) {
 
-                    ConsumerFilterData filterData = dataMapByTopic.getGroupFilterData().get(group);
+                    ConsumerFilterData filterData = groupEntry.getValue();
 
                     if (filterData == null) {
                         continue;
@@ -246,7 +248,7 @@ public class ConsumerFilterManager extends ConfigManager {
 
                     try {
                         filterData.setCompiledExpression(
-                            FilterFactory.INSTANCE.get(filterData.getExpressionType()).compile(filterData.getExpression())
+                                FilterFactory.INSTANCE.get(filterData.getExpressionType()).compile(filterData.getExpression())
                         );
                     } catch (Exception e) {
                         log.error("load filter data error, " + filterData, e);
@@ -266,7 +268,7 @@ public class ConsumerFilterManager extends ConfigManager {
                         // we think all consumers are dead when load
                         long deadTime = System.currentTimeMillis() - 30 * 1000;
                         filterData.setDeadTime(
-                            deadTime <= filterData.getBornTime() ? filterData.getBornTime() : deadTime
+                                deadTime <= filterData.getBornTime() ? filterData.getBornTime() : deadTime
                         );
                     }
                 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/MessageEvaluationContext.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/MessageEvaluationContext.java
@@ -22,7 +22,6 @@ import org.apache.rocketmq.filter.expression.EvaluationContext;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Evaluation context from message.

--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/MessageEvaluationContext.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/MessageEvaluationContext.java
@@ -21,6 +21,8 @@ import org.apache.rocketmq.filter.expression.EvaluationContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * Evaluation context from message.
@@ -49,8 +51,8 @@ public class MessageEvaluationContext implements EvaluationContext {
 
         Map<String, Object> copy = new HashMap<String, Object>(properties.size(), 1);
 
-        for (String key : properties.keySet()) {
-            copy.put(key, properties.get(key));
+        for (Entry<String, String> entry : properties.entrySet()) {
+            copy.put(entry.getKey(), entry.getValue());
         }
 
         return copy;

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumer.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.client.consumer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.QueryResult;
@@ -640,8 +641,8 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
     @Deprecated
     public void setSubscription(Map<String, String> subscription) {
         Map<String, String> subscriptionWithNamespace = new HashMap<String, String>();
-        for (String topic : subscription.keySet()) {
-            subscriptionWithNamespace.put(withNamespace(topic), subscription.get(topic));
+        for (Entry<String, String> topicEntry : subscription.entrySet()) {
+            subscriptionWithNamespace.put(withNamespace(topicEntry.getKey()), topicEntry.getValue());
         }
         this.subscription = subscriptionWithNamespace;
     }

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.client.consumer.rebalance;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
@@ -115,9 +117,9 @@ public class AllocateMachineRoomNearby implements AllocateMessageQueueStrategy {
         }
 
         //2.allocate the rest mq to each machine room if there are no consumer alive in that machine room
-        for (String machineRoom : mr2Mq.keySet()) {
-            if (!mr2c.containsKey(machineRoom)) { // no alive consumer in the corresponding machine room, so all consumers share these queues
-                allocateResults.addAll(allocateMessageQueueStrategy.allocate(consumerGroup, currentCID, mr2Mq.get(machineRoom), cidAll));
+        for (Entry<String, List<MessageQueue>> machineRoomEntry : mr2Mq.entrySet()) {
+            if (!mr2c.containsKey(machineRoomEntry.getKey())) { // no alive consumer in the corresponding machine room, so all consumers share these queues
+                allocateResults.addAll(allocateMessageQueueStrategy.allocate(consumerGroup, currentCID, machineRoomEntry.getValue(), cidAll));
             }
         }
 

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/rebalance/AllocateMachineRoomNearby.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.TreeMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/store/LocalFileOffsetStore.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/store/LocalFileOffsetStore.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -64,12 +65,12 @@ public class LocalFileOffsetStore implements OffsetStore {
         if (offsetSerializeWrapper != null && offsetSerializeWrapper.getOffsetTable() != null) {
             offsetTable.putAll(offsetSerializeWrapper.getOffsetTable());
 
-            for (MessageQueue mq : offsetSerializeWrapper.getOffsetTable().keySet()) {
-                AtomicLong offset = offsetSerializeWrapper.getOffsetTable().get(mq);
+            for (Entry<MessageQueue, AtomicLong> mqEntry : offsetSerializeWrapper.getOffsetTable().entrySet()) {
+                AtomicLong offset = mqEntry.getValue();
                 log.info("load consumer's offset, {} {} {}",
-                    this.groupName,
-                    mq,
-                    offset.get());
+                        this.groupName,
+                        mqEntry.getKey(),
+                        offset.get());
             }
         }
     }

--- a/common/src/main/java/org/apache/rocketmq/common/Configuration.java
+++ b/common/src/main/java/org/apache/rocketmq/common/Configuration.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -276,26 +277,26 @@ public class Configuration {
     }
 
     private void merge(Properties from, Properties to) {
-        for (Object key : from.keySet()) {
-            Object fromObj = from.get(key), toObj = to.get(key);
+        for (Entry<Object, Object> next : from.entrySet()) {
+            Object fromObj = next.getValue(), toObj = to.get(next.getKey());
             if (toObj != null && !toObj.equals(fromObj)) {
-                log.info("Replace, key: {}, value: {} -> {}", key, toObj, fromObj);
+                log.info("Replace, key: {}, value: {} -> {}", next.getKey(), toObj, fromObj);
             }
-            to.put(key, fromObj);
+            to.put(next.getKey(), fromObj);
         }
     }
 
     private void mergeIfExist(Properties from, Properties to) {
-        for (Object key : from.keySet()) {
-            if (!to.containsKey(key)) {
+        for (Entry<Object, Object> next : from.entrySet()) {
+            if (!to.containsKey(next.getKey())) {
                 continue;
             }
 
-            Object fromObj = from.get(key), toObj = to.get(key);
+            Object fromObj = next.getValue(), toObj = to.get(next.getKey());
             if (toObj != null && !toObj.equals(fromObj)) {
-                log.info("Replace, key: {}, value: {} -> {}", key, toObj, fromObj);
+                log.info("Replace, key: {}, value: {} -> {}", next.getKey(), toObj, fromObj);
             }
-            to.put(key, fromObj);
+            to.put(next.getKey(), fromObj);
         }
     }
 

--- a/openmessaging/src/main/java/io/openmessaging/rocketmq/utils/BeanUtils.java
+++ b/openmessaging/src/main/java/io/openmessaging/rocketmq/utils/BeanUtils.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -50,10 +51,10 @@ public final class BeanUtils {
     private static Map<Class<?>, Class<?>> wrapperMap = new HashMap<Class<?>, Class<?>>();
 
     static {
-        for (final Class<?> primitiveClass : primitiveWrapperMap.keySet()) {
-            final Class<?> wrapperClass = primitiveWrapperMap.get(primitiveClass);
-            if (!primitiveClass.equals(wrapperClass)) {
-                wrapperMap.put(wrapperClass, primitiveClass);
+        for (Entry<Class<?>, Class<?>> primitiveClass : primitiveWrapperMap.entrySet()) {
+            final Class<?> wrapperClass = primitiveClass.getValue();
+            if (!primitiveClass.getKey().equals(wrapperClass)) {
+                wrapperMap.put(wrapperClass, primitiveClass.getKey());
             }
         }
         wrapperMap.put(String.class, String.class);

--- a/test/src/main/java/org/apache/rocketmq/test/message/MessageQueueMsg.java
+++ b/test/src/main/java/org/apache/rocketmq/test/message/MessageQueueMsg.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.test.factory.MQMessageFactory;

--- a/test/src/main/java/org/apache/rocketmq/test/message/MessageQueueMsg.java
+++ b/test/src/main/java/org/apache/rocketmq/test/message/MessageQueueMsg.java
@@ -22,6 +22,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.test.factory.MQMessageFactory;
 
@@ -54,9 +57,9 @@ public class MessageQueueMsg {
     }
 
     private void init() {
-        for (MessageQueue mq : msgsWithMQ.keySet()) {
-            msgsWithMQId.put(mq.getQueueId(), msgsWithMQ.get(mq));
-            msgBodys.addAll(MQMessageFactory.getMessageBody(msgsWithMQ.get(mq)));
+        for (Entry<MessageQueue, List<Object>> mqEntry : msgsWithMQ.entrySet()) {
+            msgsWithMQId.put(mqEntry.getKey().getQueueId(), mqEntry.getValue());
+            msgBodys.addAll(MQMessageFactory.getMessageBody(mqEntry.getValue()));
         }
     }
 }

--- a/test/src/main/java/org/apache/rocketmq/test/util/FileUtil.java
+++ b/test/src/main/java/org/apache/rocketmq/test/util/FileUtil.java
@@ -22,7 +22,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 
 public class FileUtil {
     private static String lineSeperator = System.getProperty("line.separator");

--- a/test/src/main/java/org/apache/rocketmq/test/util/FileUtil.java
+++ b/test/src/main/java/org/apache/rocketmq/test/util/FileUtil.java
@@ -20,7 +20,9 @@ package org.apache.rocketmq.test.util;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 
 public class FileUtil {
     private static String lineSeperator = System.getProperty("line.separator");
@@ -68,9 +70,9 @@ public class FileUtil {
 
     private String getPropertiesAsString(Properties properties) {
         StringBuilder sb = new StringBuilder();
-        for (Object key : properties.keySet()) {
-            sb.append(key).append("=").append(properties.getProperty((String) key))
-                .append(lineSeperator);
+        for (Entry<Object, Object> keyEnty : properties.entrySet()) {
+            sb.append(keyEnty.getKey()).append("=").append((String) keyEnty.getValue())
+                    .append(lineSeperator);
         }
         return sb.toString();
     }

--- a/test/src/main/java/org/apache/rocketmq/test/util/MQAdmin.java
+++ b/test/src/main/java/org/apache/rocketmq/test/util/MQAdmin.java
@@ -124,8 +124,8 @@ public class MQAdmin {
             return false;
         } else {
             HashMap<String, BrokerData> brokers = clusterInfo.getBrokerAddrTable();
-            for (Entry<String, BrokerData> brokerNameEntry : brokers.entrySet()) {
-                HashMap<Long, String> brokerIps = brokerNameEntry.getValue().getBrokerAddrs();
+            for (Entry<String, BrokerData> brokerEntry : brokers.entrySet()) {
+                HashMap<Long, String> brokerIps = brokerEntry.getValue().getBrokerAddrs();
                 for (Entry<Long, String> brokerIdEntry : brokerIps.entrySet()) {
                     if (brokerIdEntry.getValue().contains(ip))
                         return true;

--- a/test/src/main/java/org/apache/rocketmq/test/util/MQAdmin.java
+++ b/test/src/main/java/org/apache/rocketmq/test/util/MQAdmin.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.test.util;
 
 import java.util.HashMap;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.log4j.Logger;
@@ -123,10 +124,10 @@ public class MQAdmin {
             return false;
         } else {
             HashMap<String, BrokerData> brokers = clusterInfo.getBrokerAddrTable();
-            for (String brokerName : brokers.keySet()) {
-                HashMap<Long, String> brokerIps = brokers.get(brokerName).getBrokerAddrs();
-                for (long brokerId : brokerIps.keySet()) {
-                    if (brokerIps.get(brokerId).contains(ip))
+            for (Entry<String, BrokerData> brokerNameEntry : brokers.entrySet()) {
+                HashMap<Long, String> brokerIps = brokerNameEntry.getValue().getBrokerAddrs();
+                for (Entry<Long, String> brokerIdEntry : brokerIps.entrySet()) {
+                    if (brokerIdEntry.getValue().contains(ip))
                         return true;
                 }
             }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.common.MixAll;
@@ -63,12 +64,12 @@ public class CommandUtil {
             String masterAddr = brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
             masterAndSlaveMap.put(masterAddr, new ArrayList<String>());
 
-            for (Long id : brokerData.getBrokerAddrs().keySet()) {
-                if (brokerData.getBrokerAddrs().get(id) == null || id == MixAll.MASTER_ID) {
+            for (Entry<Long, String> idEntry : brokerData.getBrokerAddrs().entrySet()) {
+                if (idEntry.getValue() == null || idEntry.getKey() == MixAll.MASTER_ID) {
                     continue;
                 }
 
-                masterAndSlaveMap.get(masterAddr).add(brokerData.getBrokerAddrs().get(id));
+                masterAndSlaveMap.get(masterAddr).add(idEntry.getValue());
             }
         }
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
@@ -64,12 +64,12 @@ public class CommandUtil {
             String masterAddr = brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
             masterAndSlaveMap.put(masterAddr, new ArrayList<String>());
 
-            for (Entry<Long, String> idEntry : brokerData.getBrokerAddrs().entrySet()) {
-                if (idEntry.getValue() == null || idEntry.getKey() == MixAll.MASTER_ID) {
+            for (Entry<Long, String> brokerAddrEntry : brokerData.getBrokerAddrs().entrySet()) {
+                if (brokerAddrEntry.getValue() == null || brokerAddrEntry.getKey() == MixAll.MASTER_ID) {
                     continue;
                 }
 
-                masterAndSlaveMap.get(masterAddr).add(idEntry.getValue());
+                masterAndSlaveMap.get(masterAddr).add(brokerAddrEntry.getValue());
             }
         }
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java
@@ -86,18 +86,18 @@ public class GetBrokerConfigCommand implements SubCommand {
                 Map<String, List<String>> masterAndSlaveMap
                     = CommandUtil.fetchMasterAndSlaveDistinguish(defaultMQAdminExt, clusterName);
 
-                for (Entry<String, List<String>> masterAddrEntry : masterAndSlaveMap.entrySet()) {
+                for (Entry<String, List<String>> masterAndSlaveEntry : masterAndSlaveMap.entrySet()) {
 
                     getAndPrint(
                             defaultMQAdminExt,
-                            String.format("============Master: %s============\n", masterAddrEntry.getKey()),
-                            masterAddrEntry.getKey()
+                            String.format("============Master: %s============\n", masterAndSlaveEntry.getKey()),
+                            masterAndSlaveEntry.getKey()
                     );
-                    for (String slaveAddr : masterAddrEntry.getValue()) {
+                    for (String slaveAddr : masterAndSlaveEntry.getValue()) {
 
                         getAndPrint(
                                 defaultMQAdminExt,
-                                String.format("============My Master: %s=====Slave: %s============\n", masterAddrEntry.getKey(), slaveAddr),
+                                String.format("============My Master: %s=====Slave: %s============\n", masterAndSlaveEntry.getKey(), slaveAddr),
                                 slaveAddr
                         );
                     }
@@ -124,8 +124,8 @@ public class GetBrokerConfigCommand implements SubCommand {
             return;
         }
 
-        for (Entry<Object, Object> keyEntry : properties.entrySet()) {
-            System.out.printf("%-50s=  %s\n", keyEntry.getKey(), keyEntry.getValue());
+        for (Entry<Object, Object> entry : properties.entrySet()) {
+            System.out.printf("%-50s=  %s\n", entry.getKey(), entry.getValue());
         }
 
         System.out.printf("%n");

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java
@@ -20,7 +20,10 @@ package org.apache.rocketmq.tools.command.broker;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -83,19 +86,19 @@ public class GetBrokerConfigCommand implements SubCommand {
                 Map<String, List<String>> masterAndSlaveMap
                     = CommandUtil.fetchMasterAndSlaveDistinguish(defaultMQAdminExt, clusterName);
 
-                for (String masterAddr : masterAndSlaveMap.keySet()) {
+                for (Entry<String, List<String>> masterAddrEntry : masterAndSlaveMap.entrySet()) {
 
                     getAndPrint(
-                        defaultMQAdminExt,
-                        String.format("============Master: %s============\n", masterAddr),
-                        masterAddr
+                            defaultMQAdminExt,
+                            String.format("============Master: %s============\n", masterAddrEntry.getKey()),
+                            masterAddrEntry.getKey()
                     );
-                    for (String slaveAddr : masterAndSlaveMap.get(masterAddr)) {
+                    for (String slaveAddr : masterAddrEntry.getValue()) {
 
                         getAndPrint(
-                            defaultMQAdminExt,
-                            String.format("============My Master: %s=====Slave: %s============\n", masterAddr, slaveAddr),
-                            slaveAddr
+                                defaultMQAdminExt,
+                                String.format("============My Master: %s=====Slave: %s============\n", masterAddrEntry.getKey(), slaveAddr),
+                                slaveAddr
                         );
                     }
                 }
@@ -121,8 +124,8 @@ public class GetBrokerConfigCommand implements SubCommand {
             return;
         }
 
-        for (Object key : properties.keySet()) {
-            System.out.printf("%-50s=  %s\n", key, properties.get(key));
+        for (Entry<Object, Object> keyEntry : properties.entrySet()) {
+            System.out.printf("%-50s=  %s\n", keyEntry.getKey(), keyEntry.getValue());
         }
 
         System.out.printf("%n");

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/GetConsumerConfigSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/GetConsumerConfigSubCommand.java
@@ -20,12 +20,14 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.rocketmq.common.protocol.body.ClusterInfo;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
 import org.apache.rocketmq.common.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -63,14 +65,14 @@ public class GetConsumerConfigSubCommand implements SubCommand {
             List<ConsumerConfigInfo> consumerConfigInfoList = new ArrayList<>();
             ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
             Map<String, Set<String>> clusterAddrTable = clusterInfo.getClusterAddrTable();
-            for (String brokerName : clusterInfo.getBrokerAddrTable().keySet()) {
-                String clusterName = this.getClusterName(brokerName, clusterAddrTable);
-                String brokerAddress = clusterInfo.getBrokerAddrTable().get(brokerName).selectBrokerAddr();
+            for (Entry<String, BrokerData> brokerNameEntry : clusterInfo.getBrokerAddrTable().entrySet()) {
+                String clusterName = this.getClusterName(brokerNameEntry.getKey(), clusterAddrTable);
+                String brokerAddress = brokerNameEntry.getValue().selectBrokerAddr();
                 SubscriptionGroupConfig subscriptionGroupConfig = adminExt.examineSubscriptionGroupConfig(brokerAddress, groupName);
                 if (subscriptionGroupConfig == null) {
                     continue;
                 }
-                consumerConfigInfoList.add(new ConsumerConfigInfo(clusterName, brokerName, subscriptionGroupConfig));
+                consumerConfigInfoList.add(new ConsumerConfigInfo(clusterName, brokerNameEntry.getKey(), subscriptionGroupConfig));
             }
             if (CollectionUtils.isEmpty(consumerConfigInfoList)) {
                 return;

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/GetConsumerConfigSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/GetConsumerConfigSubCommand.java
@@ -65,14 +65,14 @@ public class GetConsumerConfigSubCommand implements SubCommand {
             List<ConsumerConfigInfo> consumerConfigInfoList = new ArrayList<>();
             ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
             Map<String, Set<String>> clusterAddrTable = clusterInfo.getClusterAddrTable();
-            for (Entry<String, BrokerData> brokerNameEntry : clusterInfo.getBrokerAddrTable().entrySet()) {
-                String clusterName = this.getClusterName(brokerNameEntry.getKey(), clusterAddrTable);
-                String brokerAddress = brokerNameEntry.getValue().selectBrokerAddr();
+            for (Entry<String, BrokerData> brokerEntry : clusterInfo.getBrokerAddrTable().entrySet()) {
+                String clusterName = this.getClusterName(brokerEntry.getKey(), clusterAddrTable);
+                String brokerAddress = brokerEntry.getValue().selectBrokerAddr();
                 SubscriptionGroupConfig subscriptionGroupConfig = adminExt.examineSubscriptionGroupConfig(brokerAddress, groupName);
                 if (subscriptionGroupConfig == null) {
                     continue;
                 }
-                consumerConfigInfoList.add(new ConsumerConfigInfo(clusterName, brokerNameEntry.getKey(), subscriptionGroupConfig));
+                consumerConfigInfoList.add(new ConsumerConfigInfo(clusterName, brokerEntry.getKey(), subscriptionGroupConfig));
             }
             if (CollectionUtils.isEmpty(consumerConfigInfoList)) {
                 return;

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 
 import com.alibaba.fastjson.JSON;
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
@@ -19,7 +19,9 @@ package org.apache.rocketmq.tools.command.export;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 
 import com.alibaba.fastjson.JSON;
 
@@ -79,10 +81,10 @@ public class ExportConfigsCommand implements SubCommand {
             Map<String, Properties> brokerConfigs = new HashMap<>();
             Map<String, List<String>> masterAndSlaveMap
                 = CommandUtil.fetchMasterAndSlaveDistinguish(defaultMQAdminExt, clusterName);
-            for (String masterAddr : masterAndSlaveMap.keySet()) {
-                Properties masterProperties = defaultMQAdminExt.getBrokerConfig(masterAddr);
+            for (Entry<String, List<String>> masterAddrEntry : masterAndSlaveMap.entrySet()) {
+                Properties masterProperties = defaultMQAdminExt.getBrokerConfig(masterAddrEntry.getKey());
                 masterBrokerSize++;
-                slaveBrokerSize += masterAndSlaveMap.get(masterAddr).size();
+                slaveBrokerSize += masterAddrEntry.getValue().size();
 
                 brokerConfigs.put(masterProperties.getProperty("brokerName"), needBrokerProprties(masterProperties));
             }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
@@ -81,10 +81,10 @@ public class ExportConfigsCommand implements SubCommand {
             Map<String, Properties> brokerConfigs = new HashMap<>();
             Map<String, List<String>> masterAndSlaveMap
                 = CommandUtil.fetchMasterAndSlaveDistinguish(defaultMQAdminExt, clusterName);
-            for (Entry<String, List<String>> masterAddrEntry : masterAndSlaveMap.entrySet()) {
-                Properties masterProperties = defaultMQAdminExt.getBrokerConfig(masterAddrEntry.getKey());
+            for (Entry<String, List<String>> masterAndSlaveEntry : masterAndSlaveMap.entrySet()) {
+                Properties masterProperties = defaultMQAdminExt.getBrokerConfig(masterAndSlaveEntry.getKey());
                 masterBrokerSize++;
-                slaveBrokerSize += masterAddrEntry.getValue().size();
+                slaveBrokerSize += masterAndSlaveEntry.getValue().size();
 
                 brokerConfigs.put(masterProperties.getProperty("brokerName"), needBrokerProprties(masterProperties));
             }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java
@@ -20,7 +20,10 @@ package org.apache.rocketmq.tools.command.namesrv;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.rocketmq.remoting.RPCHook;
@@ -66,11 +69,11 @@ public class GetNamesrvConfigCommand implements SubCommand {
 
             Map<String, Properties> nameServerConfigs = defaultMQAdminExt.getNameServerConfig(serverList);
 
-            for (String server : nameServerConfigs.keySet()) {
+            for (Entry<String, Properties> serverEntry : nameServerConfigs.entrySet()) {
                 System.out.printf("============%s============\n",
-                    server);
-                for (Object key : nameServerConfigs.get(server).keySet()) {
-                    System.out.printf("%-50s=  %s\n", key, nameServerConfigs.get(server).get(key));
+                        serverEntry.getKey());
+                for (Entry<Object, Object> entry : serverEntry.getValue().entrySet()) {
+                    System.out.printf("%-50s=  %s\n", entry.getKey(), entry.getValue());
                 }
             }
         } catch (Exception e) {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java
@@ -69,10 +69,10 @@ public class GetNamesrvConfigCommand implements SubCommand {
 
             Map<String, Properties> nameServerConfigs = defaultMQAdminExt.getNameServerConfig(serverList);
 
-            for (Entry<String, Properties> serverEntry : nameServerConfigs.entrySet()) {
+            for (Entry<String, Properties> nameServerConfigEntry : nameServerConfigs.entrySet()) {
                 System.out.printf("============%s============\n",
-                        serverEntry.getKey());
-                for (Entry<Object, Object> entry : serverEntry.getValue().entrySet()) {
+                        nameServerConfigEntry.getKey());
+                for (Entry<Object, Object> entry : nameServerConfigEntry.getValue().entrySet()) {
                     System.out.printf("%-50s=  %s\n", entry.getKey(), entry.getValue());
                 }
             }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;


### PR DESCRIPTION
There are several inefficient iterations of Map, in such code, keySet() is retrieved from Map firstly, and values are got in each iteration by key. In my opinion, entrySet() should be used, so that keys and values can be fetched in one time.