### PR TITLE
Unnecessary boxing of primitives

### DIFF
--- a/acl/src/main/java/org/apache/rocketmq/acl/common/AclUtils.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/common/AclUtils.java
@@ -163,7 +163,7 @@ public class AclUtils {
     }
 
     public static boolean isScope(String num) {
-        return isScope(Integer.valueOf(num.trim()));
+        return isScope(Integer.parseInt(num.trim()));
     }
 
     public static boolean isScope(int num) {

--- a/acl/src/main/java/org/apache/rocketmq/acl/plain/RemoteAddressStrategyFactory.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/plain/RemoteAddressStrategyFactory.java
@@ -187,8 +187,8 @@ public class RemoteAddressStrategyFactory {
 
                 }
                 String[] valueArray = StringUtils.split(value, "-");
-                this.start = Integer.valueOf(valueArray[0]);
-                this.end = Integer.valueOf(valueArray[1]);
+                this.start = Integer.parseInt(valueArray[0]);
+                this.end = Integer.parseInt(valueArray[1]);
                 if (!(AclUtils.isScope(end) && AclUtils.isScope(start) && start <= end)) {
                     throw new AclException(String.format("RangeRemoteAddressStrategy netaddress examine scope Exception start is %s , end is %s", start, end));
                 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -393,7 +393,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
     private Long getLong(String s) {
         long v = -1;
         try {
-            v = Long.valueOf(s);
+            v = Long.parseLong(s);
         } catch (Exception e) {
             log.error("GetLong error", e);
         }
@@ -404,7 +404,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
     private Integer getInt(String s) {
         int v = -1;
         try {
-            v = Integer.valueOf(s);
+            v = Integer.parseInt(s);
         } catch (Exception e) {
             log.error("GetInt error", e);
         }

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -94,7 +94,7 @@ public class DLedgerCommitLog extends CommitLog {
         dLedgerConfig.setPreferredLeaderId(defaultMessageStore.getMessageStoreConfig().getPreferredLeaderId());
         dLedgerConfig.setEnableBatchPush(defaultMessageStore.getMessageStoreConfig().isEnableBatchPush());
 
-        id = Integer.valueOf(dLedgerConfig.getSelfId().substring(1)) + 1;
+        id = Integer.parseInt(dLedgerConfig.getSelfId().substring(1)) + 1;
         dLedgerServer = new DLedgerServer(dLedgerConfig);
         dLedgerFileStore = (DLedgerMmapFileStore) dLedgerServer.getdLedgerStore();
         DLedgerMmapFileStore.AppendHook appendHook = (entry, buffer, bodyOffset) -> {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/queue/QueryConsumeQueueCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/queue/QueryConsumeQueueCommand.java
@@ -92,9 +92,9 @@ public class QueryConsumeQueueCommand implements SubCommand {
             defaultMQAdminExt.start();
 
             String topic = commandLine.getOptionValue("t").trim();
-            int queueId = Integer.valueOf(commandLine.getOptionValue("q").trim());
-            long index = Long.valueOf(commandLine.getOptionValue("i").trim());
-            int count = Integer.valueOf(commandLine.getOptionValue("c", "10").trim());
+            int queueId = Integer.parseInt(commandLine.getOptionValue("q").trim());
+            long index = Long.parseLong(commandLine.getOptionValue("i").trim());
+            int count = Integer.parseInt(commandLine.getOptionValue("c", "10").trim());
             String broker = null;
             if (commandLine.hasOption("b")) {
                 broker = commandLine.getOptionValue("b").trim();


### PR DESCRIPTION
In method private Long getLong(String s) and private Integer getInt(String s) of org.apache.rocketmq.broker.transaction.queue.TransactionalMessageServiceImpl, a boxed numeric primitive is created from String, and then unboxed.

For example, v = Integer.valueOf(s) (v is of type int), it would be more efficient to use Integer.parseInt(), which returns a primitive value directly.