### PR TITLE
[ISSUE #3617] add a switch to control the transaction message ignore …

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -1245,6 +1245,12 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         LocalTransactionState localTransactionState = LocalTransactionState.UNKNOW;
         Throwable localException = null;
         switch (sendResult.getSendStatus()) {
+            case FLUSH_SLAVE_TIMEOUT:
+            case SLAVE_NOT_AVAILABLE:
+                if (!((TransactionMQProducer)defaultMQProducer).isTxIgnoreSlaveError()) {
+                    localTransactionState = LocalTransactionState.ROLLBACK_MESSAGE;
+                    break;
+                }
             case SEND_OK: {
                 try {
                     if (sendResult.getTransactionId() != null) {
@@ -1276,8 +1282,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             }
             break;
             case FLUSH_DISK_TIMEOUT:
-            case FLUSH_SLAVE_TIMEOUT:
-            case SLAVE_NOT_AVAILABLE:
                 localTransactionState = LocalTransactionState.ROLLBACK_MESSAGE;
                 break;
             default:

--- a/client/src/main/java/org/apache/rocketmq/client/producer/TransactionMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/TransactionMQProducer.java
@@ -32,6 +32,11 @@ public class TransactionMQProducer extends DefaultMQProducer {
 
     private TransactionListener transactionListener;
 
+    /**
+     * a switch which make the sending result of the transaction message ignore SLAVE_NOT_AVAILABLE or FLUSH_SLAVE_TIMEOUT
+     */
+    private boolean txIgnoreSlaveError = false;
+
     public TransactionMQProducer() {
     }
 
@@ -156,5 +161,13 @@ public class TransactionMQProducer extends DefaultMQProducer {
 
     public void setTransactionListener(TransactionListener transactionListener) {
         this.transactionListener = transactionListener;
+    }
+
+    public boolean isTxIgnoreSlaveError() {
+        return txIgnoreSlaveError;
+    }
+
+    public void setTxIgnoreSlaveError(boolean txIgnoreSlaveError) {
+        this.txIgnoreSlaveError = txIgnoreSlaveError;
     }
 }


### PR DESCRIPTION
It is unreasonable that transaction message will be rolled back when something wrong with slave, like SLAVE_NOT_AVAILABLE or FLUSH_SLAVE_TIMEOUT, even though the message already exists in the master