### PR TITLE
bump up log4j-slf4j-impl version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.7</version>
+                <version>2.15.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

fix the log4j 2 security issue
https://issues.apache.org/jira/projects/LOG4J2/issues/LOG4J2-3201?filter=allissues