### PR TITLE
[ISSUE #3635] remove log4j dependency in client pom

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -39,11 +39,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -57,16 +52,6 @@
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
             <version>0.33.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

log4j is not used in rocketmq-client, it is better to remove it to avoid security scans.

## Brief changelog

remove log4j dependency in client pom