### PR TITLE
Feature/3676

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -1530,7 +1530,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         RequestResponseFuture responseFuture = RequestFutureHolder.getInstance().getRequestFutureTable().remove(correlationId);
         if (responseFuture != null) {
             responseFuture.setSendRequestOk(isSuccess);
-            responseFuture.putResponseMessage(null);
             try {
                 responseFuture.executeRequestCallback();
             } catch (Exception e) {

--- a/client/src/main/java/org/apache/rocketmq/client/producer/RequestResponseFuture.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/RequestResponseFuture.java
@@ -29,7 +29,7 @@ public class RequestResponseFuture {
     private long timeoutMillis;
     private CountDownLatch countDownLatch = new CountDownLatch(1);
     private volatile Message responseMsg = null;
-    private volatile boolean sendRequestOk = true;
+    private volatile boolean sendRequestOk = false;
     private volatile Throwable cause = null;
 
     public RequestResponseFuture(String correlationId, long timeoutMillis, RequestCallback requestCallback) {
@@ -53,9 +53,8 @@ public class RequestResponseFuture {
         return diff > this.timeoutMillis;
     }
 
-    public Message waitResponseMessage(final long timeout) throws InterruptedException {
-        this.countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
-        return this.responseMsg;
+    public boolean waitResponseMessage(final long timeout) throws InterruptedException {
+        return this.countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
     }
 
     public void putResponseMessage(final Message responseMsg) {
@@ -105,6 +104,7 @@ public class RequestResponseFuture {
 
     public void setSendRequestOk(boolean sendRequestOk) {
         this.sendRequestOk = sendRequestOk;
+        this.countDownLatch.countDown();
     }
 
     public Message getRequestMsg() {


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

Issues #3676: handle the hook after the request () is sent

1. Use countdownlatch When await (), only onException () will countDown (), which will lead to timeout exceptions after successful transmission.

2. Solve the problem that the onsuccess () method of the incoming requestcallback is not called after sending successfully

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
