### PR TITLE
[ISSUE #3687] Fix wrong method comment about transaction message.

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageBridge.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageBridge.java
@@ -303,13 +303,13 @@ public class TransactionalMessageBridge {
      * Use this function while transaction msg is committed or rollback write a flag 'd' to operation queue for the
      * msg's offset
      *
-     * @param messageExt Op message
-     * @param messageQueue Op message queue
+     * @param prepareMessage Half message
+     * @param messageQueue Half message queue
      * @return This method will always return true.
      */
-    private boolean addRemoveTagInTransactionOp(MessageExt messageExt, MessageQueue messageQueue) {
+    private boolean addRemoveTagInTransactionOp(MessageExt prepareMessage, MessageQueue messageQueue) {
         Message message = new Message(TransactionalMessageUtil.buildOpTopic(), TransactionalMessageUtil.REMOVETAG,
-            String.valueOf(messageExt.getQueueOffset()).getBytes(TransactionalMessageUtil.charset));
+            String.valueOf(prepareMessage.getQueueOffset()).getBytes(TransactionalMessageUtil.charset));
         writeOp(message, messageQueue);
         return true;
     }


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

For issue #3687 

## Brief changelog

 Fix wrong method comment about transaction message.
