### PR TITLE
[ISSUE #3720]perf: avoid multiple expansion when the number of elements in the `MessageConst` class is determined

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
@@ -55,7 +55,7 @@ public class MessageConst {
 
     public static final String KEY_SEPARATOR = " ";
 
-    public static final HashSet<String> STRING_HASH_SET = new HashSet<String>();
+    public static final HashSet<String> STRING_HASH_SET = new HashSet<>(64);
 
     static {
         STRING_HASH_SET.add(PROPERTY_TRACE_SWITCH);


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

avoid multiple expansion when the number of elements in the `org.apache.rocketmq.common.message.MessageConst` class is determined

#3720