### PR TITLE
[ISSUE #3709]Resolve export metadata errors while multiple brokers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,18 @@
                 <artifactId>commons-validator</artifactId>
                 <version>1.7</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>2.0.9</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>2.0.9</version>
+                <scope>test</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -60,5 +60,15 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java
@@ -98,7 +98,7 @@ public class ExportConfigsCommand implements SubCommand {
 
             String path = filePath + "/configs.json";
             MixAll.string2FileNotSafe(JSON.toJSONString(result, true), path);
-            System.out.printf("export %s success", path);
+            System.out.printf("export %s success\n", path);
         } catch (Exception e) {
             throw new SubCommandException(this.getClass().getSimpleName() + " command failed", e);
         } finally {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetadataCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetadataCommand.java
@@ -99,17 +99,18 @@ public class ExportMetadataCommand implements SubCommand {
                 final String brokerAddr = commandLine.getOptionValue('b').trim();
 
                 if (commandLine.hasOption('t')) {
-                    filePath = filePath + "/topic.json";
+                    String exportFilePath = filePath + "/topic.json";
                     TopicConfigSerializeWrapper topicConfigSerializeWrapper = defaultMQAdminExt.getUserTopicConfig(
                         brokerAddr, specialTopic, 10000L);
-                    MixAll.string2FileNotSafe(JSON.toJSONString(topicConfigSerializeWrapper, true), filePath);
-                    System.out.printf("export %s success", filePath);
-                } else if (commandLine.hasOption('g')) {
-                    filePath = filePath + "/subscriptionGroup.json";
+                    MixAll.string2FileNotSafe(JSON.toJSONString(topicConfigSerializeWrapper, true), exportFilePath);
+                    System.out.printf("export %s success\n", exportFilePath);
+                }
+                if (commandLine.hasOption('g')) {
+                    String exportFilePath = filePath + "/subscriptionGroup.json";
                     SubscriptionGroupWrapper subscriptionGroupWrapper = defaultMQAdminExt.getUserSubscriptionGroup(
                         brokerAddr, 10000L);
-                    MixAll.string2FileNotSafe(JSON.toJSONString(subscriptionGroupWrapper, true), filePath);
-                    System.out.printf("export %s success", filePath);
+                    MixAll.string2FileNotSafe(JSON.toJSONString(subscriptionGroupWrapper, true), exportFilePath);
+                    System.out.printf("export %s success\n", exportFilePath);
                 }
             } else if (commandLine.hasOption('c')) {
                 String clusterName = commandLine.getOptionValue('c').trim();
@@ -126,18 +127,19 @@ public class ExportMetadataCommand implements SubCommand {
 
                     SubscriptionGroupWrapper subscriptionGroupWrapper = defaultMQAdminExt.getUserSubscriptionGroup(
                         addr, 10000);
+                    String brokerName = CommandUtil.fetchBrokerNameByAddr(defaultMQAdminExt, addr);
 
                     if (commandLine.hasOption('t')) {
-                        filePath = filePath + "/topic.json";
-                        MixAll.string2FileNotSafe(JSON.toJSONString(topicConfigSerializeWrapper, true), filePath);
-                        System.out.printf("export %s success", filePath);
-                        return;
-                    } else if (commandLine.hasOption('g')) {
-                        filePath = filePath + "/subscriptionGroup.json";
-                        MixAll.string2FileNotSafe(JSON.toJSONString(subscriptionGroupWrapper, true), filePath);
-                        System.out.printf("export %s success", filePath);
-                        return;
-                    } else {
+                        String exportFilePath = filePath + "/" + brokerName + "/topic.json";
+                        MixAll.string2FileNotSafe(JSON.toJSONString(topicConfigSerializeWrapper, true), exportFilePath);
+                        System.out.printf("export %s success\n", exportFilePath);
+                    }
+                    if (commandLine.hasOption('g')) {
+                        String exportFilePath = filePath + "/" + brokerName + "/subscriptionGroup.json";
+                        MixAll.string2FileNotSafe(JSON.toJSONString(subscriptionGroupWrapper, true), exportFilePath);
+                        System.out.printf("export %s success\n", exportFilePath);
+                    }
+                    if (!commandLine.hasOption('t') && !commandLine.hasOption('g')) {
                         for (Map.Entry<String, TopicConfig> entry : topicConfigSerializeWrapper.getTopicConfigTable().entrySet()) {
                             TopicConfig topicConfig = topicConfigMap.get(entry.getKey());
                             if (null != topicConfig) {
@@ -165,11 +167,10 @@ public class ExportMetadataCommand implements SubCommand {
                         result.put("rocketmqVersion", MQVersion.getVersionDesc(MQVersion.CURRENT_VERSION));
                         result.put("exportTime", System.currentTimeMillis());
 
-                        filePath = filePath + "/metadata.json";
-                        MixAll.string2FileNotSafe(JSON.toJSONString(result, true), filePath);
-                        System.out.printf("export %s success", filePath);
+                        String exportFilePath = filePath + "/" + brokerName + "/metadata.json";
+                        MixAll.string2FileNotSafe(JSON.toJSONString(result, true), exportFilePath);
+                        System.out.printf("export %s success\n", exportFilePath);
                     }
-
                 }
             } else {
                 ServerUtil.printCommandLineHelp("mqadmin " + this.commandName(), options);

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java
@@ -136,7 +136,7 @@ public class ExportMetricsCommand implements SubCommand {
             result.put("totalData", totalData);
 
             MixAll.string2FileNotSafe(JSON.toJSONString(result, true), path);
-            System.out.printf("export %s success", path);
+            System.out.printf("export %s success\n", path);
         } catch (Exception e) {
             throw new SubCommandException(this.getClass().getSimpleName() + " command failed", e);
         } finally {

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/SubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/SubCommandTest.java
@@ -1,0 +1,22 @@
+package org.apache.rocketmq.tools.command;
+
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.Before;
+import org.powermock.api.mockito.PowerMockito;
+
+public class SubCommandTest {
+
+    public DefaultMQAdminExt defaultMQAdminExt;
+
+    public RPCHook rpcHook;
+
+    @Before
+    public void init() throws Exception {
+        rpcHook = new AclClientRPCHook(new SessionCredentials());
+        defaultMQAdminExt = PowerMockito.mock(DefaultMQAdminExt.class);
+        PowerMockito.whenNew(DefaultMQAdminExt.class).withArguments(rpcHook).thenReturn(defaultMQAdminExt);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/SubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/SubCommandTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.rocketmq.tools.command;
 
 import org.apache.rocketmq.acl.common.AclClientRPCHook;

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/export/ExportMetadataCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/export/ExportMetadataCommandTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.export;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.PosixParser;
+import org.apache.rocketmq.common.protocol.body.ClusterInfo;
+import org.apache.rocketmq.common.protocol.body.SubscriptionGroupWrapper;
+import org.apache.rocketmq.common.protocol.body.TopicConfigSerializeWrapper;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandTest;
+import org.apache.rocketmq.tools.util.MockObjectUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ExportMetadataCommand.class)
+public class ExportMetadataCommandTest extends SubCommandTest {
+    @Test
+    public void testExportMetadata() throws Exception {
+        {
+            TopicConfigSerializeWrapper topicConfigWrapper = MockObjectUtil.createTopicConfigWrapper();
+            doReturn(topicConfigWrapper).when(defaultMQAdminExt).getUserTopicConfig(anyString(), anyBoolean(), anyLong());
+            SubscriptionGroupWrapper subscriptionGroupWrapper = MockObjectUtil.createSubscriptionGroupWrapper();
+            doReturn(subscriptionGroupWrapper).when(defaultMQAdminExt).getUserSubscriptionGroup(anyString(), anyLong());
+        }
+
+        ExportMetadataCommand cmd = new ExportMetadataCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        // eg: sh mqadmin exportMetadata -b 127.0.0.1:10911 -t -g
+        String[] subargsWithBrokerAddr = new String[] {
+            "-b 127.0.0.1:10911",
+            "-t",
+            "-g"};
+        CommandLine commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargsWithBrokerAddr, cmd.buildCommandlineOptions(options), new PosixParser());
+        cmd.execute(commandLine, options, rpcHook);
+
+        {
+            ClusterInfo clusterInfo = MockObjectUtil.createClusterInfo();
+            doReturn(clusterInfo).when(defaultMQAdminExt).examineBrokerClusterInfo();
+        }
+        // eg: sh mqadmin exportMetadata -c DefaultCluster -t -g
+        String[] subargsWithClusterNameAndTopic = new String[] {
+            "-c DefaultCluster",
+            "-t",
+            "-g"};
+        commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargsWithClusterNameAndTopic, cmd.buildCommandlineOptions(options), new PosixParser());
+        cmd.execute(commandLine, options, rpcHook);
+
+        // eg: sh mqadmin exportMetadata -c DefaultCluster
+        String[] subargsWithClusterName = new String[] {"-c DefaultCluster",};
+        commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargsWithClusterName, cmd.buildCommandlineOptions(options), new PosixParser());
+        cmd.execute(commandLine, options, rpcHook);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/util/MockObjectUtil.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/util/MockObjectUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.util;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.rocketmq.common.DataVersion;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.common.protocol.body.ClusterInfo;
+import org.apache.rocketmq.common.protocol.body.SubscriptionGroupWrapper;
+import org.apache.rocketmq.common.protocol.body.TopicConfigSerializeWrapper;
+import org.apache.rocketmq.common.protocol.route.BrokerData;
+import org.apache.rocketmq.common.subscription.SubscriptionGroupConfig;
+
+public class MockObjectUtil {
+
+    public static ClusterInfo createClusterInfo() {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>(3);
+        Set<String> brokerNameSet = new HashSet<>(3);
+        brokerNameSet.add("broker-a");
+        clusterAddrTable.put("DefaultCluster", brokerNameSet);
+        clusterInfo.setClusterAddrTable(clusterAddrTable);
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>(3);
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("broker-a");
+        HashMap<Long, String> brokerAddrs = new HashMap<>(2);
+        brokerAddrs.put(MixAll.MASTER_ID, "127.0.0.1:10911");
+        brokerData.setBrokerAddrs(brokerAddrs);
+        brokerAddrTable.put("broker-a", brokerData);
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+        return clusterInfo;
+    }
+
+    public static SubscriptionGroupWrapper createSubscriptionGroupWrapper() {
+        SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
+        ConcurrentMap<String, SubscriptionGroupConfig> subscriptionGroupTable = new ConcurrentHashMap(2);
+        SubscriptionGroupConfig config = new SubscriptionGroupConfig();
+        config.setGroupName("group_test");
+        subscriptionGroupTable.put("group_test", config);
+        SubscriptionGroupConfig sysGroupConfig = new SubscriptionGroupConfig();
+        sysGroupConfig.setGroupName(MixAll.TOOLS_CONSUMER_GROUP);
+        subscriptionGroupTable.put(MixAll.TOOLS_CONSUMER_GROUP, sysGroupConfig);
+        wrapper.setSubscriptionGroupTable(subscriptionGroupTable);
+        wrapper.setDataVersion(new DataVersion());
+        return wrapper;
+    }
+
+    public static TopicConfigSerializeWrapper createTopicConfigWrapper() {
+        TopicConfigSerializeWrapper wrapper = new TopicConfigSerializeWrapper();
+        TopicConfig config = new TopicConfig();
+        config.setTopicName("topic_test");
+        ConcurrentMap<String, TopicConfig> topicConfigTable = new ConcurrentHashMap(2);
+        topicConfigTable.put("topic_test", config);
+        wrapper.setTopicConfigTable(topicConfigTable);
+        wrapper.setDataVersion(new DataVersion());
+        return wrapper;
+    }
+}


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

#3709
When there are multiple brokers in the cluster, export the metadata file using -c, prefixed with the broker name.
![image](https://user-images.githubusercontent.com/18254437/148491993-8f9472a4-524e-4ca0-bb6e-6ff19c461dec.png)



## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
