### PR TITLE
[ISSUE #3742] BUG: Make mqClientApiTimeout param cloneable and resettable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ notifications:
   email:
     recipients:
       - dev@rocketmq.apache.org
+    if: branch = develop OR branch = master
   on_success: change
   on_failure: always
+  
 
 language: java
 

--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -158,6 +158,7 @@ public class ClientConfig {
         this.useTLS = cc.useTLS;
         this.namespace = cc.namespace;
         this.language = cc.language;
+        this.mqClientApiTimeout = cc.mqClientApiTimeout;
     }
 
     public ClientConfig cloneClientConfig() {
@@ -176,6 +177,7 @@ public class ClientConfig {
         cc.useTLS = useTLS;
         cc.namespace = namespace;
         cc.language = language;
+        cc.mqClientApiTimeout = mqClientApiTimeout;
         return cc;
     }
 


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change
For issue #3742

## Brief changelog
Set the value of mqClientApiTimeout in cloneClientConfig() and resetClientConfig()

