### PR TITLE
[ISSUE #3782] docs: Fix the default value of parameter 'sendMsgTimeout'.

### DIFF
--- a/docs/cn/best_practice.md
+++ b/docs/cn/best_practice.md
@@ -264,7 +264,7 @@ DefaultMQProducer、TransactionMQProducer、DefaultMQPushConsumer、DefaultMQPul
 | producerGroup                    | DEFAULT_PRODUCER | Producer组名，多个Producer如果属于一个应用，发送同样的消息，则应该将它们归为同一组 |
 | createTopicKey                   | TBW102           | 在发送消息时，自动创建服务器不存在的topic，需要指定Key，该Key可用于配置发送消息所在topic的默认路由。 |
 | defaultTopicQueueNums            | 4                | 在发送消息，自动创建服务器不存在的topic时，默认创建的队列数  |
-| sendMsgTimeout                   | 10000            | 发送消息超时时间，单位毫秒                                   |
+| sendMsgTimeout                   | 3000             | 发送消息超时时间，单位毫秒                                   |
 | compressMsgBodyOverHowmuch       | 4096             | 消息Body超过多大开始压缩（Consumer收到消息会自动解压缩），单位字节 |
 | retryAnotherBrokerWhenNotStoreOK | FALSE            | 如果发送消息返回sendResult，但是sendStatus!=SEND_OK，是否重试发送 |
 | retryTimesWhenSendFailed         | 2                | 如果消息发送失败，最大重试次数，该参数只对同步发送模式起作用 |

--- a/docs/en/Configuration_Client.md
+++ b/docs/en/Configuration_Client.md
@@ -59,7 +59,7 @@ HTTP static server addressing is recommended, because it is simple client deploy
 | producerGroup                    | DEFAULT_PRODUCER | The name of the Producer group. If multiple producers belong to one application and send the same message, they should be grouped into the same group |
 | createTopicKey                   | TBW102           | When a message is sent, topics that do not exist on the server are automatically created and a Key is specified that can be used to configure the default route to the topic where the message is sent.|
 | defaultTopicQueueNums            | 4                | The number of default queue when sending messages and auto created topic which not exists the server|
-| sendMsgTimeout                   | 10000            | Timeout time of sending message in milliseconds                           |
+| sendMsgTimeout                   | 3000             | Timeout time of sending message in milliseconds                           |
 | compressMsgBodyOverHowmuch       | 4096             | The message Body begins to compress beyond the size(the Consumer gets the message automatically unzipped.), unit of byte|
 | retryAnotherBrokerWhenNotStoreOK | FALSE            | If send message and return sendResult but sendStatus!=SEND_OK, Whether to resend |
 | retryTimesWhenSendFailed         | 2                | If send message failed, maximum number of retries, this parameter only works for synchronous send mode|


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

For issue #3782 

## Brief changelog

Fix the default value of parameter '**sendMsgTimeout**' in documents.


