### PR TITLE
#3781 压测生产者内存溢出

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -122,7 +122,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                     public Thread newThread(Runnable r) {
                         return new Thread(r, "NettyClientPublicExecutor_" + this.threadIndex.incrementAndGet());
                     }
-                });
+                },new ThreadPoolExecutor.CallerRunsPolicy());
 
         this.eventLoopGroupWorker = new NioEventLoopGroup(1, new ThreadFactory() {
             private AtomicInteger threadIndex = new AtomicInteger(0);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -110,8 +110,8 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
 
         this.publicThreadPoolQueue = new LinkedBlockingQueue<Runnable>(50000);
         this.publicExecutor = new ThreadPoolExecutor(
-                Runtime.getRuntime().availableProcessors(),
-                Runtime.getRuntime().availableProcessors(),
+                publicThreadNums,
+                publicThreadNums,
                 1000 * 60,
                 TimeUnit.MILLISECONDS,
                 this.publicThreadPoolQueue,


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

#3781 When the producer sends a message successfully, the thread pool is newFixedThreadPool. The cache queue is unbounded and large concurrency causes memory overflow.

## Brief changelog

The custom thread pool sets the bounded queue length to 50000

close #3781 
