### PR TITLE
Re-enable testing on ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ matrix:
   # On Linux we install latest OpenJDK 1.8 from Ubuntu repositories
   - name: Linux x86_64
     arch: amd64
-#  - name: Linux aarch64
-#    arch: arm64
+  - name: Linux aarch64
+    dist: focal
+    arch: arm64-graviton2
+    group: edge
+    virt: vm
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - ulimit -c unlimited
 
 script:
-  - mvn -B -ntp verify -DskipTests
+  - mvn -B verify -DskipTests
   - travis_retry mvn -B clean apache-rat:check
   - travis_retry mvn -B install jacoco:report coveralls:report
   - travis_retry mvn -B clean install -pl test -Pit-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - ulimit -c unlimited
 
 script:
-  - mvn verify -DskipTests
+  - mvn -B -ntp verify -DskipTests
   - travis_retry mvn -B clean apache-rat:check
   - travis_retry mvn -B install jacoco:report coveralls:report
   - travis_retry mvn -B clean install -pl test -Pit-test


### PR DESCRIPTION

## What is the purpose of the change

Some time ago I have enabled testing on Linux ARM64 with https://github.com/apache/rocketmq/commit/98aca7ffcbf282b2885ad4b9c433927a5ac0e78b
I see that it has been disabled with https://github.com/apache/rocketmq/commit/360b616b6fc2e137f30340c87314b4c65a1750b2 because the builds were unstable (timing out).

With this PR I suggest to re-enable it but this time using AWS Graviton2 nodes at TravisCI because they are more stable than Equinix Metal ones (`arch: arm64`) and run it on Ubuntu 20.04 instead of 18.04.

## Brief changelog

Re-enable testing on Linux ARM64 at TravisCI

## Verifying this change

TravisCI build should pass!

- [ ] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
