### PR TITLE
[ISSUE #3853]add log for interruptedException

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
@@ -849,6 +849,8 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
                             break;
                     }
                     updatePullOffset(messageQueue, pullResult.getNextBeginOffset(), processQueue);
+                } catch (InterruptedException interruptedException) {
+                    log.warn("Polling thread was interrupted.", interruptedException);
                 } catch (Throwable e) {
                     pullDelayTimeMills = pullTimeDelayMillsWhenException;
                     log.error("An error occurred in pull message process.", e);


### PR DESCRIPTION
Separate InterruptedException from others, because it will be Interrupted when seek offset in MessageQueue. 
https://github.com/apache/rocketmq/issues/3853