### PR TITLE
[ISSUE #23] solve error Algorithm HmacSHA1 not available when your java_home is not found

### DIFF
--- a/distribution/bin/tools.sh
+++ b/distribution/bin/tools.sh
@@ -24,6 +24,20 @@ error_exit ()
     exit 1
 }
 
+find_java_home()
+{
+    case "`uname`" in
+        Darwin)
+            JAVA_HOME=$(/usr/libexec/java_home)
+        ;;
+        *)
+            JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
+        ;;
+    esac
+}
+
+find_java_home
+
 [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=$HOME/jdk/java
 [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=/usr/java
 [ ! -e "$JAVA_HOME/bin/java" ] && error_exit "Please set the JAVA_HOME variable in your environment, We need java(x64)!"


### PR DESCRIPTION
add find_java_home function to avoid error: Algorithm HmacSHA1 not available


**Make sure set the target branch to `develop`**

## What is the purpose of the change

Solve error Algorithm HmacSHA1 not available when your java_home is not found by adding find_java_home function to tools.sh

## Brief changelog

Solve error Algorithm HmacSHA1 not available when your java_home is not found by adding find_java_home function to tools.sh

## Verifying this change
eg: 172.17.0.2 is you rmqnamesrv ip address

you can use this command(`docker exec -it rmqbroker ./mqadmin clusterList -n 172.17.0.2:9876`) to  verify if RocketMQ broker works now.

#23 Deploy broker with docker-compose returns NoSuchAlgorithmException