### PR TITLE
add debug log for Issue-3937. debug why cleanExpireMsgExecutors stop …

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
@@ -102,6 +102,8 @@ public class ProcessQueue {
                 }
             } catch (InterruptedException e) {
                 log.error("getExpiredMsg exception", e);
+            } catch (Throwable t) {
+                log.error("getExpiredMsg exception", t);
             }
 
             try {


### PR DESCRIPTION
…working


**Make sure set the target branch to `develop`**

## What is the purpose of the change

[For this issue](https://github.com/apache/rocketmq/issues/3937)
try to confirm the cause and avoid cleanExpireMsg thread stop working

## Brief changelog

Add log


