### PR TITLE
[#2870] delete useless shuffle before sort in pickOneAtLeast()

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImpl.java
@@ -72,8 +72,6 @@ public class LatencyFaultToleranceImpl implements LatencyFaultTolerance<String> 
         }
 
         if (!tmpList.isEmpty()) {
-            Collections.shuffle(tmpList);
-
             Collections.sort(tmpList);
 
             final int half = tmpList.size() / 2;


### PR DESCRIPTION
It seem have not fix in 4.9.3. #2870