### PR TITLE
[ISSUE #3929] wake up client’s waiting when server crashed

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -527,6 +527,16 @@ public abstract class NettyRemotingAbstract {
             }
         }
     }
+    
+    protected void wakeup(final Channel channel) {
+        Iterator<Entry<Integer, ResponseFuture>> it = responseTable.entrySet().iterator();
+        while (it.hasNext()) {
+            Entry<Integer, ResponseFuture> entry = it.next();
+            if (entry.getValue().getProcessChannel() == channel) {
+                entry.getValue().wakeupResponse();
+            }
+        }
+    }    
 
     public void invokeOnewayImpl(final Channel channel, final RemotingCommand request, final long timeoutMillis)
         throws InterruptedException, RemotingTooMuchRequestException, RemotingTimeoutException, RemotingSendRequestException {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -38,12 +38,7 @@ import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.security.cert.CertificateException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
@@ -161,7 +156,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                     return new Thread(r, "NettyClientWorkerThread_" + this.threadIndex.incrementAndGet());
                 }
             });
-
+        final ConcurrentMap<Integer, ResponseFuture> responseTable = super.responseTable;
         Bootstrap handler = this.bootstrap.group(this.eventLoopGroupWorker).channel(NioSocketChannel.class)
             .option(ChannelOption.TCP_NODELAY, true)
             .option(ChannelOption.SO_KEEPALIVE, false)
@@ -183,7 +178,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                         new NettyEncoder(),
                         new NettyDecoder(),
                         new IdleStateHandler(0, 0, nettyClientConfig.getClientChannelMaxIdleTimeSeconds()),
-                        new NettyConnectManageHandler(),
+                        new NettyConnectManageHandler(responseTable),
                         new NettyClientHandler());
                 }
             });
@@ -641,6 +636,15 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
     }
 
     class NettyConnectManageHandler extends ChannelDuplexHandler {
+        private ConcurrentMap<Integer /* opaque */, ResponseFuture> responseTable;
+
+        public NettyConnectManageHandler() {
+        }
+
+        public NettyConnectManageHandler(ConcurrentMap<Integer, ResponseFuture> responseTable) {
+            this.responseTable = responseTable;
+        }
+
         @Override
         public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
             ChannelPromise promise) throws Exception {
@@ -706,6 +710,26 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
             if (NettyRemotingClient.this.channelEventListener != null) {
                 NettyRemotingClient.this.putNettyEvent(new NettyEvent(NettyEventType.EXCEPTION, remoteAddress, ctx.channel()));
             }
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            Channel channel = ctx.channel();
+            if (null == channel) {
+                return;
+            }
+            if (responseTable != null) {
+                Iterator<Map.Entry<Integer, ResponseFuture>> it = responseTable.entrySet().iterator();
+                while (it.hasNext()) {
+                    Map.Entry<Integer, ResponseFuture> entry = it.next();
+                    if (channel == entry.getValue().getProcessChannel()) {
+                        final String remoteAddress = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
+                        log.warn("NETTY CLIENT PIPELINE: channelInactive, so wakeup response, the channel[{}]", remoteAddress);
+                        entry.getValue().wakeupResponse();
+                    }
+                }
+            }
+            super.channelInactive(ctx);
         }
     }
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/ResponseFuture.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/ResponseFuture.java
@@ -72,6 +72,10 @@ public class ResponseFuture {
         return this.responseCommand;
     }
 
+    public void wakeupResponse() {
+        this.countDownLatch.countDown();
+    }
+
     public void putResponse(final RemotingCommand responseCommand) {
         this.responseCommand = responseCommand;
         this.countDownLatch.countDown();


### PR DESCRIPTION
This PR is aimed to  wake up client’s waiting when server crashed. 
When producer has send message to broker successfully and wait for response，but broker crashed at this time，the produer would  blocked until timeout and wouldn't retry. This PR can detect broker crashed and wake up producer's waiting state, then producer will resend message to other broker.



