### PR TITLE
[ISSUE#3983] Duplicated warn log in class DefaultMQProducerImpl is unnecessary.

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -630,9 +630,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                         this.updateFaultItem(mq.getBrokerName(), endTimestamp - beginTimestampPrev, false);
                         log.warn(String.format("sendKernelImpl exception, throw exception, InvokeID: %s, RT: %sms, Broker: %s", invokeID, endTimestamp - beginTimestampPrev, mq), e);
                         log.warn(msg.toString());
-
-                        log.warn("sendKernelImpl exception", e);
-                        log.warn(msg.toString());
                         throw e;
                     }
                 } else {


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

For #3983 

## Brief changelog

Remove duplicated warn log in class DefaultMQProducerImpl.

## Verifying this change

XXXX
