### PR TITLE
[ISSUE #4079]Replace `this` with `super` in `RebalanceService`

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceService.java
@@ -37,7 +37,7 @@ public class RebalanceService extends ServiceThread {
         log.info(this.getServiceName() + " service started");
 
         while (!this.isStopped()) {
-            this.waitForRunning(waitInterval);
+            super.waitForRunning(waitInterval);
             this.mqClientFactory.doRebalance();
         }
 


### PR DESCRIPTION
## Brief changelog

Replace `this` with `super` in `RebalanceService`, because `#run` invoked method in superclass.
