### PR TITLE
[ISSUE #4109] add permission validation on broker side for ordinary topic

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
@@ -165,8 +165,7 @@ public abstract class AbstractSendMessageProcessor extends AsyncNettyRequestProc
 
     protected RemotingCommand msgCheck(final ChannelHandlerContext ctx,
         final SendMessageRequestHeader requestHeader, final RemotingCommand response) {
-        if (!PermName.isWriteable(this.brokerController.getBrokerConfig().getBrokerPermission())
-            && this.brokerController.getTopicConfigManager().isOrderTopic(requestHeader.getTopic())) {
+        if (!PermName.isWriteable(this.brokerController.getBrokerConfig().getBrokerPermission())) {
             response.setCode(ResponseCode.NO_PERMISSION);
             response.setRemark("the broker[" + this.brokerController.getBrokerConfig().getBrokerIP1()
                 + "] sending message is forbidden");


### PR DESCRIPTION
to solve the problem described in [ISSUE #4109](https://github.com/apache/rocketmq/issues/4109)

This change will cause the broker to throw a "NO_PERMISSION" exception. If the producer uses SYNC mode, it will retry sending to another broker, seeing [DefaultMQProducerImpl#sendDefaultImpl](https://github.com/apache/rocketmq/blob/develop/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java#L562-L627),  so the SYNC mode will not be affected.
