### PR TITLE
Bugfix DefaultMessageStore#getEarliestMessageTime() bug in Dledger mode

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store;
 
+import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -911,7 +912,10 @@ public class DefaultMessageStore implements MessageStore {
 
     @Override
     public long getEarliestMessageTime() {
-        final long minPhyOffset = this.getMinPhyOffset();
+        long minPhyOffset = this.getMinPhyOffset();
+        if (this.getCommitLog() instanceof DLedgerCommitLog) {
+            minPhyOffset += DLedgerEntry.BODY_OFFSET;
+        }
         final int size = this.messageStoreConfig.getMaxMessageSize() * 2;
         return this.getCommitLog().pickupStoreTimestamp(minPhyOffset, size);
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix `DefaultMessageStore#getEarliestMessageTime()` bug in Dledger mode

## Brief changelog

DLedgerCommitLog's body start from position 48,

## Verifying this change

![image](https://user-images.githubusercontent.com/10664298/163421874-4823ca2c-4b6d-444c-aec8-025898828229.png)
![image](https://user-images.githubusercontent.com/10664298/163421901-ecce693a-d56f-45c7-a2b2-02816c4a932b.png)
