### PR TITLE
[ISSUE #4099]Optimized the performance of sending traceMessage in `AsyncTraceDispatcher`

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
@@ -322,7 +322,7 @@ public class AsyncTraceDispatcher implements TraceDispatcher {
             initFirstBeanAddTime();
             this.traceTransferBeanList.add(traceTransferBean);
             this.currentMsgSize += traceTransferBean.getTransData().length();
-            if (currentMsgSize >= maxMsgSize) {
+            if (currentMsgSize >= traceProducer.getMaxMessageSize()) {
                 List<TraceTransferBean> dataToSend = new ArrayList(traceTransferBeanList);
                 AsyncDataSendTask asyncDataSendTask = new AsyncDataSendTask(regionId, dataToSend);
                 traceExecutor.submit(asyncDataSendTask);


### PR DESCRIPTION
## What is the purpose of the change

Details in https://github.com/apache/rocketmq/pull/4099#issuecomment-1099351837. Given the details for convenience.

# Describe in Chinese
该 PR 目的是优化轨迹消息发送模块性能，详情讨论见 https://github.com/apache/rocketmq/pull/4099#issuecomment-1099351837 。为 review 方便此处给出设计详情和背景。

##  当前逻辑

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/18216266/163427423-99836b88-8ada-46a1-8981-bd90fbe14d2e.png">

1. 业务线程调用`AsyncTraceDispatcher#append`向任务元数据队列`traceContextQueue`添加`TraceContext`；
2.  `worker`线程循环从`traceContextQueue`中获取`TraceContext`、并包装为任务`AsyncAppenderRequest`，由线程池`traceExecutor`执行；
3. `AsyncAppenderRequest#sendTraceData`中将`TraceContext`转换为可计量大小的`TraceTransferBean`，并按照按照**topic+regionId**对`TraceTransferBean`进行分组、获取结构为`Map<String, List<TraceTransferBean>>`的数据；
4. 将`TraceTransferBean`按照`maxMsgSize`进行分批次的发送，根据`AsyncTraceDispatcher#accessChannel`决定发送到`rmq_sys_TRACE_DATA_${regionId}`还是轨迹消息队列(默认为`RMQ_SYS_TRACE_TOPIC`) 。

当前逻辑的问题是`worker`通过`AsyncAppenderRequest`对数据进行了不必要的分割`List<TraceTransferBean>`，在`AsyncAppenderRequest#sendTraceData`中对数据也进行了不必要的分组。

## 优化思路
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/18216266/163450807-6aa00276-b544-4768-9f64-ba23bfcfcdd0.png">

1. `work`线程将数据按照topic分组、保存到`HashMap<String, TraceDataSegment>`中，`TraceDataSegment`中保存了TraceTransferBean列表、数据大小和当前列表第一个TraceTransferBean的保存时间；
2. 将数据保存到`TraceDataSegment`中时会判断TraceTransferBean列表是否已经达到 maxMsgSize，是则发送数据、并恢复`TraceDataSegment`的初始值；
3. `work`线程每`pollingTimeMil`毫秒会遍历所有的`TraceDataSegment`，检查其数据保存超过是否`waitTimeThresholdMil`毫秒，是则发送所有数据、以此避免时间保存过久不发送。

该算法的总体思路是在数据达到大小阈值`maxMsgSize`或者时间阈值时发送数据。可避免之前因为数据不恰当的分组导致过多的请求。