### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -78,7 +78,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <skipAfterFailureCount>1</skipAfterFailureCount>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>true</reuseForks>
                     <excludes>
                         <exclude>**/IT*.java</exclude>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
