### PR TITLE
[ISSUE#4263]Fix the issue that DeleteTopicSubCommand does't call the correct deleteTopicInNameServer method in 5.0.0-beta.

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java
@@ -48,7 +48,7 @@ public class DeleteTopicSubCommand implements SubCommand {
             nameServerSet = new HashSet(Arrays.asList(ns));
         }
 
-        adminExt.deleteTopicInNameServer(nameServerSet, topic);
+        adminExt.deleteTopicInNameServer(nameServerSet, clusterName, topic);
         System.out.printf("delete topic [%s] from NameServer success.%n", topic);
     }
 


### PR DESCRIPTION
#4263
