### PR TITLE
[ISSUE #2706] FIX SEND_OK will still be returned when the storage is abnormal ，which may cause message loss

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -494,6 +494,10 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
                 break;
 
             // Failed
+            case FLUSH_DISK_FAILED:
+                response.setCode(ResponseCode.FLUSH_DISK_FAILED);
+                response.setRemark("flush disk failed, disk is broken.");
+                break;
             case CREATE_MAPEDFILE_FAILED:
                 response.setCode(ResponseCode.SYSTEM_ERROR);
                 response.setRemark("create mapped file failed, server is busy or broken.");

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -70,6 +70,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     private final Set<Integer> retryResponseCodes = new CopyOnWriteArraySet<Integer>(Arrays.asList(
             ResponseCode.TOPIC_NOT_EXIST,
             ResponseCode.SERVICE_NOT_AVAILABLE,
+            ResponseCode.FLUSH_DISK_FAILED,
             ResponseCode.SYSTEM_ERROR,
             ResponseCode.NO_PERMISSION,
             ResponseCode.NO_BUYER_ID,

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/ResponseCode.java
@@ -56,6 +56,8 @@ public class ResponseCode extends RemotingSysResponseCode {
     public static final int FILTER_DATA_NOT_EXIST = 27;
 
     public static final int FILTER_DATA_NOT_LATEST = 28;
+    
+    public static final int FLUSH_DISK_FAILED = 29;
 
     public static final int TRANSACTION_SHOULD_COMMIT = 200;
 

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1208,7 +1208,12 @@ public class CommitLog {
                         flushOK = CommitLog.this.mappedFileQueue.getFlushedWhere() >= req.getNextOffset();
                     }
 
-                    req.wakeupCustomer(flushOK ? PutMessageStatus.PUT_OK : PutMessageStatus.FLUSH_DISK_TIMEOUT);
+                    if (CommitLog.this.mappedFileQueue.isFlushError()) {
+                        req.wakeupCustomer(PutMessageStatus.FLUSH_DISK_FAILED);
+                    }
+                    else {
+                        req.wakeupCustomer(flushOK ? PutMessageStatus.PUT_OK : PutMessageStatus.FLUSH_DISK_TIMEOUT);
+                    }
                 }
 
                 long storeTimestamp = CommitLog.this.mappedFileQueue.getStoreTimestamp();

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1210,8 +1210,7 @@ public class CommitLog {
 
                     if (CommitLog.this.mappedFileQueue.isFlushError()) {
                         req.wakeupCustomer(PutMessageStatus.FLUSH_DISK_FAILED);
-                    }
-                    else {
+                    } else {
                         req.wakeupCustomer(flushOK ? PutMessageStatus.PUT_OK : PutMessageStatus.FLUSH_DISK_TIMEOUT);
                     }
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFile.java
@@ -66,7 +66,7 @@ public class MappedFile extends ReferenceResource {
     private MappedByteBuffer mappedByteBuffer;
     private volatile long storeTimestamp = 0;
     private boolean firstCreateInQueue = false;
-
+    private boolean flushError = false;
     public MappedFile() {
     }
 
@@ -295,6 +295,7 @@ public class MappedFile extends ReferenceResource {
 
                 try {
                     //We only append data to fileChannel or mappedByteBuffer, never both.
+                    this.flushError = false;
                     if (writeBuffer != null || this.fileChannel.position() != 0) {
                         this.fileChannel.force(false);
                     } else {
@@ -302,6 +303,7 @@ public class MappedFile extends ReferenceResource {
                     }
                 } catch (Throwable e) {
                     log.error("Error occurred when force data to disk.", e);
+                    this.flushError = true;
                 }
 
                 this.flushedPosition.set(value);
@@ -595,5 +597,9 @@ public class MappedFile extends ReferenceResource {
     @Override
     public String toString() {
         return this.fileName;
+    }
+    
+    public boolean getflushError() {
+        return this.flushError;
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -48,6 +48,7 @@ public class MappedFileQueue {
     private long committedWhere = 0;
 
     private volatile long storeTimestamp = 0;
+    private boolean flushError = false;
 
     public MappedFileQueue(final String storePath, int mappedFileSize,
         AllocateMappedFileService allocateMappedFileService) {
@@ -442,6 +443,9 @@ public class MappedFileQueue {
         if (mappedFile != null) {
             long tmpTimeStamp = mappedFile.getStoreTimestamp();
             int offset = mappedFile.flush(flushLeastPages);
+            if (mappedFile.getflushError()) {
+                this.flushError = true;
+            }
             long where = mappedFile.getFileFromOffset() + offset;
             result = where == this.flushedWhere;
             this.flushedWhere = where;
@@ -620,5 +624,9 @@ public class MappedFileQueue {
 
     public void setCommittedWhere(final long committedWhere) {
         this.committedWhere = committedWhere;
+    }
+    
+    public boolean isFlushError() {
+        return flushError;
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java
+++ b/store/src/main/java/org/apache/rocketmq/store/PutMessageStatus.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store;
 public enum PutMessageStatus {
     PUT_OK,
     FLUSH_DISK_TIMEOUT,
+    FLUSH_DISK_FAILED,
     FLUSH_SLAVE_TIMEOUT,
     SLAVE_NOT_AVAILABLE,
     SERVICE_NOT_AVAILABLE,


### PR DESCRIPTION
#2706  I found that the problem still exists in version 4.9.3
when the flush is abnormal ，SEND_OK will still be returned 。It will cause possible message loss .

error code show as below ：

You can see that if there is an error, a try catch will be performed .Then log.error("Error occurred when force data to disk.", e);
But there is no error code returned to the client, and the client still thinks that the send is successful.


`public int flush(final int flushLeastPages) {
        if (this.isAbleToFlush(flushLeastPages)) {
            if (this.hold()) {
                int value = getReadPosition();

                try {
                    //We only append data to fileChannel or mappedByteBuffer, never both.
                    this.flushError = false;
                    if (writeBuffer != null || this.fileChannel.position() != 0) {
                        this.fileChannel.force(false);
                    } else {
                        this.mappedByteBuffer.force();
                    }
                } **catch (Throwable e) {
                    log.error("Error occurred when force data to disk.", e);
                }**

                this.flushedPosition.set(value);
                this.release();
            } else {
                log.warn("in flush, hold failed, flush offset = " + this.flushedPosition.get());
                this.flushedPosition.set(getReadPosition());
            }
        }
        return this.getFlushedPosition();
    }`

I recommend passing the error to the client