### PR TITLE
[ISSUE #4087] Make the init-method of AsyncTraceDispatcher.traceProducer more readable

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
@@ -105,7 +105,7 @@ public class AsyncTraceDispatcher implements TraceDispatcher {
                 TimeUnit.MILLISECONDS, //
                 this.appenderQueue, //
                 new ThreadFactoryImpl("MQTraceSendThread_"));
-        traceProducer = getAndCreateTraceProducer(rpcHook);
+        traceProducer = initTraceProducer(rpcHook);
     }
 
     public AccessChannel getAccessChannel() {
@@ -157,16 +157,13 @@ public class AsyncTraceDispatcher implements TraceDispatcher {
         this.registerShutDownHook();
     }
 
-    private DefaultMQProducer getAndCreateTraceProducer(RPCHook rpcHook) {
-        DefaultMQProducer traceProducerInstance = this.traceProducer;
-        if (traceProducerInstance == null) {
-            traceProducerInstance = new DefaultMQProducer(rpcHook);
-            traceProducerInstance.setProducerGroup(genGroupNameForTrace());
-            traceProducerInstance.setSendMsgTimeout(5000);
-            traceProducerInstance.setVipChannelEnabled(false);
-            // The max size of message is 128K
-            traceProducerInstance.setMaxMessageSize(maxMsgSize - 10 * 1000);
-        }
+    private DefaultMQProducer initTraceProducer(RPCHook rpcHook) {
+        DefaultMQProducer traceProducerInstance = new DefaultMQProducer(rpcHook);
+        traceProducerInstance.setProducerGroup(genGroupNameForTrace());
+        traceProducerInstance.setSendMsgTimeout(5000);
+        traceProducerInstance.setVipChannelEnabled(false);
+        // The max size of message is 128K
+        traceProducerInstance.setMaxMessageSize(maxMsgSize - 10 * 1000);
         return traceProducerInstance;
     }
 


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

[[ISSUE #4087] Make the init-method of AsyncTraceDispatcher.traceProducer more readable](https://github.com/apache/rocketmq/issues/4087)

Just found out that the issue proposer had sent out PR a month ago, but he closed it then. Don't know why, but I think it is reasonable and worth making this minor change.

## Brief changelog

Improve the readability of AsyncTraceDispatcher.traceProducer

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
