### PR TITLE
[ISSUE #4384] Expand RocketMQ Topic/Group attributes

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/TopicAttributes.java
+++ b/common/src/main/java/org/apache/rocketmq/common/TopicAttributes.java
@@ -16,11 +16,11 @@
  */
 package org.apache.rocketmq.common;
 
-import org.apache.rocketmq.common.attribute.Attribute;
-import org.apache.rocketmq.common.attribute.EnumAttribute;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.rocketmq.common.attribute.Attribute;
+import org.apache.rocketmq.common.attribute.EnumAttribute;
+import org.apache.rocketmq.common.attribute.TopicMessageType;
 
 import static com.google.common.collect.Sets.newHashSet;
 
@@ -31,10 +31,17 @@ public class TopicAttributes {
             newHashSet("BatchCQ", "SimpleCQ"),
             "SimpleCQ"
     );
+    public static final EnumAttribute TOPIC_MESSAGE_TYPE_ATTRIBUTE = new EnumAttribute(
+        "message.type",
+        true,
+        TopicMessageType.topicMessageTypeSet(),
+        TopicMessageType.NORMAL.getValue()
+    );
     public static final Map<String, Attribute> ALL;
 
     static {
         ALL = new HashMap<>();
         ALL.put(QUEUE_TYPE_ATTRIBUTE.getName(), QUEUE_TYPE_ATTRIBUTE);
+        ALL.put(TOPIC_MESSAGE_TYPE_ATTRIBUTE.getName(), TOPIC_MESSAGE_TYPE_ATTRIBUTE);
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java
+++ b/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.attribute;
+
+import com.google.common.collect.Sets;
+import java.util.Set;
+
+public enum TopicMessageType {
+    UNSPECIFIED("UNSPECIFIED"),
+    NORMAL("NORMAL"),
+    FIFO("FIFO"),
+    DELAY("DELAY"),
+    TRANSACTION("TRANSACTION");
+
+    private final String value;
+    TopicMessageType(String value) {
+        this.value = value;
+    }
+
+    public static Set<String> topicMessageTypeSet() {
+        return Sets.newHashSet(UNSPECIFIED.value, NORMAL.value, FIFO.value, DELAY.value, TRANSACTION.value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/CustomizedRetryPolicy.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/CustomizedRetryPolicy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.subscription;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+public class CustomizedRetryPolicy {
+    // 1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h
+    private long[] next = new long[]{
+        TimeUnit.SECONDS.toMillis(1),
+        TimeUnit.SECONDS.toMillis(5),
+        TimeUnit.SECONDS.toMillis(10),
+        TimeUnit.SECONDS.toMillis(30),
+        TimeUnit.MINUTES.toMillis(1),
+        TimeUnit.MINUTES.toMillis(2),
+        TimeUnit.MINUTES.toMillis(3),
+        TimeUnit.MINUTES.toMillis(4),
+        TimeUnit.MINUTES.toMillis(5),
+        TimeUnit.MINUTES.toMillis(6),
+        TimeUnit.MINUTES.toMillis(7),
+        TimeUnit.MINUTES.toMillis(8),
+        TimeUnit.MINUTES.toMillis(9),
+        TimeUnit.MINUTES.toMillis(10),
+        TimeUnit.MINUTES.toMillis(20),
+        TimeUnit.MINUTES.toMillis(30),
+        TimeUnit.HOURS.toMillis(1),
+        TimeUnit.HOURS.toMillis(2)
+    };
+
+    public long[] getNext() {
+        return next;
+    }
+
+    public void setNext(long[] next) {
+        this.next = next;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomizedRetryPolicy{" +
+            "next=" + Arrays.toString(next) +
+            '}';
+    }
+}

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/ExponentialRetryPolicy.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/ExponentialRetryPolicy.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.subscription;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * next delay time = min(max, initial * multiplier^reconsumeTimes)
+ */
+public class ExponentialRetryPolicy {
+    private long initial = TimeUnit.SECONDS.toMillis(5);
+    private long max = TimeUnit.HOURS.toMillis(2);
+    private long multiplier = 2;
+
+    public long getInitial() {
+        return initial;
+    }
+
+    public void setInitial(long initial) {
+        this.initial = initial;
+    }
+
+    public long getMax() {
+        return max;
+    }
+
+    public void setMax(long max) {
+        this.max = max;
+    }
+
+    public long getMultiplier() {
+        return multiplier;
+    }
+
+    public void setMultiplier(long multiplier) {
+        this.multiplier = multiplier;
+    }
+
+    @Override
+    public String toString() {
+        return "ExponentialRetryPolicy{" +
+            "initial=" + initial +
+            ", max=" + max +
+            ", multiplier=" + multiplier +
+            '}';
+    }
+}

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/GroupRetryPolicy.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/GroupRetryPolicy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.subscription;
+
+public class GroupRetryPolicy {
+    private GroupRetryPolicyType type = GroupRetryPolicyType.EXPONENTIAL;
+    private ExponentialRetryPolicy exponentialRetryPolicy;
+    private CustomizedRetryPolicy customizedRetryPolicy;
+
+    public GroupRetryPolicyType getType() {
+        return type;
+    }
+
+    public void setType(GroupRetryPolicyType type) {
+        this.type = type;
+    }
+
+    public ExponentialRetryPolicy getExponentialRetryPolicy() {
+        return exponentialRetryPolicy;
+    }
+
+    public void setExponentialRetryPolicy(ExponentialRetryPolicy exponentialRetryPolicy) {
+        this.exponentialRetryPolicy = exponentialRetryPolicy;
+    }
+
+    public CustomizedRetryPolicy getCustomizedRetryPolicy() {
+        return customizedRetryPolicy;
+    }
+
+    public void setCustomizedRetryPolicy(CustomizedRetryPolicy customizedRetryPolicy) {
+        this.customizedRetryPolicy = customizedRetryPolicy;
+    }
+
+    @Override
+    public String toString() {
+        return "GroupRetryPolicy{" +
+            "type=" + type +
+            ", exponentialRetryPolicy=" + exponentialRetryPolicy +
+            ", customizedRetryPolicy=" + customizedRetryPolicy +
+            '}';
+    }
+}

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/GroupRetryPolicyType.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/GroupRetryPolicyType.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.subscription;
+
+public enum GroupRetryPolicyType {
+    EXPONENTIAL,
+    CUSTOMIZED
+}

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/SubscriptionGroupConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/SubscriptionGroupConfig.java
@@ -26,12 +26,13 @@ public class SubscriptionGroupConfig {
 
     private boolean consumeEnable = true;
     private boolean consumeFromMinEnable = true;
-
     private boolean consumeBroadcastEnable = true;
+    private boolean consumeMessageOrderly = false;
 
     private int retryQueueNums = 1;
 
     private int retryMaxTimes = 16;
+    private GroupRetryPolicy groupRetryPolicy = new GroupRetryPolicy();
 
     private long brokerId = MixAll.MASTER_ID;
 
@@ -40,6 +41,9 @@ public class SubscriptionGroupConfig {
     private boolean notifyConsumerIdsChangedEnable = true;
 
     private int groupSysFlag = 0;
+
+    // Only valid for push consumer
+    private int consumeTimeoutMinute = 15;
 
     public String getGroupName() {
         return groupName;
@@ -73,6 +77,14 @@ public class SubscriptionGroupConfig {
         this.consumeBroadcastEnable = consumeBroadcastEnable;
     }
 
+    public boolean isConsumeMessageOrderly() {
+        return consumeMessageOrderly;
+    }
+
+    public void setConsumeMessageOrderly(boolean consumeMessageOrderly) {
+        this.consumeMessageOrderly = consumeMessageOrderly;
+    }
+
     public int getRetryQueueNums() {
         return retryQueueNums;
     }
@@ -87,6 +99,14 @@ public class SubscriptionGroupConfig {
 
     public void setRetryMaxTimes(int retryMaxTimes) {
         this.retryMaxTimes = retryMaxTimes;
+    }
+
+    public GroupRetryPolicy getGroupRetryPolicy() {
+        return groupRetryPolicy;
+    }
+
+    public void setGroupRetryPolicy(GroupRetryPolicy groupRetryPolicy) {
+        this.groupRetryPolicy = groupRetryPolicy;
     }
 
     public long getBrokerId() {
@@ -119,6 +139,14 @@ public class SubscriptionGroupConfig {
 
     public void setGroupSysFlag(int groupSysFlag) {
         this.groupSysFlag = groupSysFlag;
+    }
+
+    public int getConsumeTimeoutMinute() {
+        return consumeTimeoutMinute;
+    }
+
+    public void setConsumeTimeoutMinute(int consumeTimeoutMinute) {
+        this.consumeTimeoutMinute = consumeTimeoutMinute;
     }
 
     @Override
@@ -163,11 +191,19 @@ public class SubscriptionGroupConfig {
 
     @Override
     public String toString() {
-        return "SubscriptionGroupConfig [groupName=" + groupName + ", consumeEnable=" + consumeEnable
-            + ", consumeFromMinEnable=" + consumeFromMinEnable + ", consumeBroadcastEnable="
-            + consumeBroadcastEnable + ", retryQueueNums=" + retryQueueNums + ", retryMaxTimes="
-            + retryMaxTimes + ", brokerId=" + brokerId + ", whichBrokerWhenConsumeSlowly="
-            + whichBrokerWhenConsumeSlowly + ", notifyConsumerIdsChangedEnable="
-            + notifyConsumerIdsChangedEnable + ", groupSysFlag=" + groupSysFlag + "]";
+        return "SubscriptionGroupConfig{" +
+            "groupName='" + groupName + '\'' +
+            ", consumeEnable=" + consumeEnable +
+            ", consumeFromMinEnable=" + consumeFromMinEnable +
+            ", consumeBroadcastEnable=" + consumeBroadcastEnable +
+            ", consumeMessageOrderly=" + consumeMessageOrderly +
+            ", retryQueueNums=" + retryQueueNums +
+            ", retryMaxTimes=" + retryMaxTimes +
+            ", groupRetryPolicy=" + groupRetryPolicy +
+            ", brokerId=" + brokerId +
+            ", whichBrokerWhenConsumeSlowly=" + whichBrokerWhenConsumeSlowly +
+            ", notifyConsumerIdsChangedEnable=" + notifyConsumerIdsChangedEnable +
+            ", groupSysFlag=" + groupSysFlag +
+            '}';
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/TopicConfigTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/TopicConfigTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common;
+
+import org.apache.rocketmq.common.attribute.TopicMessageType;
+import org.apache.rocketmq.common.constant.PermName;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TopicConfigTest {
+    String topicName = "topic";
+    int queueNums = 8;
+    int perm = PermName.PERM_READ | PermName.PERM_WRITE;
+    TopicFilterType topicFilterType = TopicFilterType.SINGLE_TAG;
+
+    @Test
+    public void testEncode() {
+        TopicConfig topicConfig = new TopicConfig();
+        topicConfig.setTopicName(topicName);
+        topicConfig.setReadQueueNums(queueNums);
+        topicConfig.setWriteQueueNums(queueNums);
+        topicConfig.setPerm(perm);
+        topicConfig.setTopicFilterType(topicFilterType);
+        topicConfig.setTopicMessageType(TopicMessageType.FIFO);
+
+        String encode = topicConfig.encode();
+        assertThat(encode).isEqualTo("topic 8 8 6 SINGLE_TAG {\"message.type\":\"FIFO\"}");
+    }
+
+    @Test
+    public void testDecode() {
+        String encode = "topic 8 8 6 SINGLE_TAG {\"message.type\":\"FIFO\"}";
+        TopicConfig decodeTopicConfig = new TopicConfig();
+        decodeTopicConfig.decode(encode);
+
+        TopicConfig topicConfig = new TopicConfig();
+        topicConfig.setTopicName(topicName);
+        topicConfig.setReadQueueNums(queueNums);
+        topicConfig.setWriteQueueNums(queueNums);
+        topicConfig.setPerm(perm);
+        topicConfig.setTopicFilterType(topicFilterType);
+        topicConfig.setTopicMessageType(TopicMessageType.FIFO);
+
+        assertThat(decodeTopicConfig).isEqualTo(topicConfig);
+    }
+
+    @Test
+    public void testDecodeWhenCompatible() {
+        String encode = "topic 8 8 6 SINGLE_TAG";
+        TopicConfig decodeTopicConfig = new TopicConfig();
+        decodeTopicConfig.decode(encode);
+
+        TopicConfig topicConfig = new TopicConfig();
+        topicConfig.setTopicName(topicName);
+        topicConfig.setReadQueueNums(queueNums);
+        topicConfig.setWriteQueueNums(queueNums);
+        topicConfig.setPerm(perm);
+        topicConfig.setTopicFilterType(topicFilterType);
+
+        assertThat(decodeTopicConfig).isEqualTo(topicConfig);
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/UpdateSubGroupSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/UpdateSubGroupSubCommand.java
@@ -16,10 +16,12 @@
  */
 package org.apache.rocketmq.tools.command.consumer;
 
+import com.alibaba.fastjson.JSON;
 import java.util.Set;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.rocketmq.common.subscription.GroupRetryPolicy;
 import org.apache.rocketmq.common.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.srvutil.ServerUtil;
@@ -66,11 +68,22 @@ public class UpdateSubGroupSubCommand implements SubCommand {
         opt.setRequired(false);
         options.addOption(opt);
 
+        opt = new Option("o", "consumeMessageOrderly", true, "consume message orderly");
+        opt.setRequired(false);
+        options.addOption(opt);
+
         opt = new Option("q", "retryQueueNums", true, "retry queue nums");
         opt.setRequired(false);
         options.addOption(opt);
 
         opt = new Option("r", "retryMaxTimes", true, "retry max times");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("p", "groupRetryPolicy", true,
+            "the json string of retry policy ( exp: " +
+                "{\"type\":\"EXPONENTIAL\",\"exponentialRetryPolicy\":{\"initial\":5000,\"max\":7200000,\"multiplier\":2}} " +
+                "{\"type\":\"CUSTOMIZED\",\"customizedRetryPolicy\":{\"next\":[1000,5000,10000]}} )");
         opt.setRequired(false);
         options.addOption(opt);
 
@@ -122,6 +135,12 @@ public class UpdateSubGroupSubCommand implements SubCommand {
                     .getOptionValue('d').trim()));
             }
 
+            // consumeMessageOrderly
+            if (commandLine.hasOption('o')) {
+                subscriptionGroupConfig.setConsumeMessageOrderly(Boolean.parseBoolean(commandLine
+                    .getOptionValue('o').trim()));
+            }
+
             // retryQueueNums
             if (commandLine.hasOption('q')) {
                 subscriptionGroupConfig.setRetryQueueNums(Integer.parseInt(commandLine.getOptionValue('q')
@@ -132,6 +151,13 @@ public class UpdateSubGroupSubCommand implements SubCommand {
             if (commandLine.hasOption('r')) {
                 subscriptionGroupConfig.setRetryMaxTimes(Integer.parseInt(commandLine.getOptionValue('r')
                     .trim()));
+            }
+
+            // groupRetryPolicy
+            if (commandLine.hasOption('p')) {
+                String groupRetryPolicyJson = commandLine.getOptionValue('p').trim();
+                GroupRetryPolicy groupRetryPolicy = JSON.parseObject(groupRetryPolicyJson, GroupRetryPolicy.class);
+                subscriptionGroupConfig.setGroupRetryPolicy(groupRetryPolicy);
             }
 
             // brokerId


### PR DESCRIPTION

## What is the purpose of the change

Topic and Group are important concepts in RocketMQ, but they are too simple to provide detailed information and more management ability. Therefore, there is a proposal to expand RocketMQ Topic/Group attributes.

## Brief changelog

Add attributes below:

* Topic Message Type
* Consume Timeout for PushConsumer
* Consume Retry Policy
* Max Retry Times
* Group Fifo Consume Flag
