### PR TITLE
[ISSUE #4349] fix negative index when index reach Integer.MAX_VALUE

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/common/ThreadLocalIndex.java
+++ b/client/src/main/java/org/apache/rocketmq/client/common/ThreadLocalIndex.java
@@ -22,6 +22,7 @@ import java.util.Random;
 public class ThreadLocalIndex {
     private final ThreadLocal<Integer> threadLocalIndex = new ThreadLocal<Integer>();
     private final Random random = new Random();
+    private final static int POSITIVE_MASK = 0x7FFFFFFF;
 
     public int incrementAndGet() {
         Integer index = this.threadLocalIndex.get();
@@ -31,7 +32,7 @@ public class ThreadLocalIndex {
         }
 
         this.threadLocalIndex.set(++index);
-        return Math.abs(index);
+        return Math.abs(index & POSITIVE_MASK);
     }
 
     @Override

--- a/client/src/test/java/org/apache/rocketmq/client/common/ThreadLocalIndexTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/common/ThreadLocalIndexTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.client.common;
 
+import java.lang.reflect.Field;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +33,20 @@ public class ThreadLocalIndexTest {
     @Test
     public void testIncrementAndGet2() throws Exception {
         ThreadLocalIndex localIndex = new ThreadLocalIndex();
+        int initialVal = localIndex.incrementAndGet();
+        assertThat(initialVal >= 0).isTrue();
+    }
+
+    @Test
+    public void testIncrementAndGet3() throws Exception {
+        ThreadLocalIndex localIndex = new ThreadLocalIndex();
+        Field threadLocalIndexField = ThreadLocalIndex.class.getDeclaredField("threadLocalIndex");
+        ThreadLocal<Integer> mockThreadLocal = new ThreadLocal<Integer>();
+        mockThreadLocal.set(Integer.MAX_VALUE);
+
+        threadLocalIndexField.setAccessible(true);
+        threadLocalIndexField.set(localIndex, mockThreadLocal);
+
         int initialVal = localIndex.incrementAndGet();
         assertThat(initialVal >= 0).isTrue();
     }


### PR DESCRIPTION
## What is the purpose of the change
See https://github.com/apache/rocketmq/issues/4349

In ThreadLocalIndex.java, when the random index increase to Integer.MAX_VALUE(2147483647), the next increment value is Integer.MIN_VALUE(-2147483648). And the code `Math.abs(index)` will also return the same negatice value Integer.MIN_VALUE(-2147483648)

```java
    /**
     * Returns the absolute value of an {@code int} value.
     * If the argument is not negative, the argument is returned.
     * If the argument is negative, the negation of the argument is returned.
     *
     * <p>Note that if the argument is equal to the value of
     * {@link Integer#MIN_VALUE}, the most negative representable
     * {@code int} value, the result is that same value, which is
     * negative.
     *
     * @param   a   the argument whose absolute value is to be determined
     * @return  the absolute value of the argument.
     */
    public static int abs(int a) {
        return (a < 0) ? -a : a;
    }
```

## Brief changelog
[ISSUE #4349] Fix negative ThreadLocalIndex
