### PR TITLE
Change PullMessageRequestHeader maxMsgNums to CFNullable

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/protocol/header/PullMessageRequestHeader.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/header/PullMessageRequestHeader.java
@@ -35,8 +35,6 @@ public class PullMessageRequestHeader extends TopicQueueRequestHeader {
     @CFNotNull
     private Long queueOffset;
     @CFNotNull
-    private Integer maxMsgBytes;
-    @CFNotNull
     private Integer maxMsgNums;
     @CFNotNull
     private Integer sysFlag;
@@ -49,6 +47,9 @@ public class PullMessageRequestHeader extends TopicQueueRequestHeader {
     @CFNotNull
     private Long subVersion;
     private String expressionType;
+
+    @CFNullable
+    private Integer maxMsgBytes;
 
     @Override
     public void checkFields() throws RemotingCommandException {


### PR DESCRIPTION
## What is the purpose of the change

Change PullMessageRequestHeader maxMsgNums to CFNullable to ensure protocol compatibility.

## Brief changelog

See https://github.com/apache/rocketmq/blob/82a48be00a6d9def14abb871a40cb68cf8a041e9/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java#L277