### PR TITLE
[ISSUE #4384] Remove TimeUnit in nextDelayDuration

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/subscription/CustomizedRetryPolicy.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/CustomizedRetryPolicy.java
@@ -68,12 +68,11 @@ public class CustomizedRetryPolicy implements RetryPolicy {
      * and old index is reconsumeTime + 3
      *
      * @param reconsumeTimes Message reconsumeTimes {@link org.apache.rocketmq.common.message.MessageExt#getReconsumeTimes}
-     * @param timeUnit       {@link TimeUnit}
      * @see <a href="https://github.com/apache/rocketmq/blob/3bddd514646826253a239f95959c14840a87034a/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java#L210">org.apache.rocketmq.broker.processor.AbstractSendMessageProcessor</a>
      * @see <a href="https://github.com/apache/rocketmq/blob/3bddd514646826253a239f95959c14840a87034a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java#L242">org.apache.rocketmq.store.DefaultMessageStore</a>
      */
     @Override
-    public long nextDelayDuration(int reconsumeTimes, TimeUnit timeUnit) {
+    public long nextDelayDuration(int reconsumeTimes) {
         if (reconsumeTimes < 0) {
             reconsumeTimes = 0;
         }
@@ -81,7 +80,6 @@ public class CustomizedRetryPolicy implements RetryPolicy {
         if (index >= next.length) {
             index = next.length - 1;
         }
-        long nextDelayDurationInMillis = next[index];
-        return timeUnit.convert(nextDelayDurationInMillis, TimeUnit.MILLISECONDS);
+        return next[index];
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/ExponentialRetryPolicy.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/ExponentialRetryPolicy.java
@@ -62,14 +62,13 @@ public class ExponentialRetryPolicy implements RetryPolicy {
     }
 
     @Override
-    public long nextDelayDuration(int reconsumeTimes, TimeUnit timeUnit) {
+    public long nextDelayDuration(int reconsumeTimes) {
         if (reconsumeTimes < 0) {
             reconsumeTimes = 0;
         }
         if (reconsumeTimes > 32) {
             reconsumeTimes = 32;
         }
-        long nextDelayDurationInMillis = Math.min(max, initial * (long) Math.pow(multiplier, reconsumeTimes));
-        return timeUnit.convert(nextDelayDurationInMillis, TimeUnit.MILLISECONDS);
+        return Math.min(max, initial * (long) Math.pow(multiplier, reconsumeTimes));
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/subscription/RetryPolicy.java
+++ b/common/src/main/java/org/apache/rocketmq/common/subscription/RetryPolicy.java
@@ -17,15 +17,12 @@
 
 package org.apache.rocketmq.common.subscription;
 
-import java.util.concurrent.TimeUnit;
-
 public interface RetryPolicy {
     /**
      * Compute message's next delay duration by specify reconsumeTimes
      *
      * @param reconsumeTimes Message reconsumeTimes
-     * @param timeUnit       Given timeUnit
-     * @return Message's nextDelayDuration in given timeUnit
+     * @return Message's nextDelayDuration in milliseconds
      */
-    long nextDelayDuration(int reconsumeTimes, TimeUnit timeUnit);
+    long nextDelayDuration(int reconsumeTimes);
 }

--- a/common/src/test/java/org/apache/rocketmq/common/subscription/CustomizedRetryPolicyTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/subscription/CustomizedRetryPolicyTest.java
@@ -27,18 +27,18 @@ public class CustomizedRetryPolicyTest {
     @Test
     public void testNextDelayDuration() {
         CustomizedRetryPolicy customizedRetryPolicy = new CustomizedRetryPolicy();
-        long actual = customizedRetryPolicy.nextDelayDuration(0, TimeUnit.MILLISECONDS);
+        long actual = customizedRetryPolicy.nextDelayDuration(0);
         assertThat(actual).isEqualTo(TimeUnit.SECONDS.toMillis(10));
-        actual = customizedRetryPolicy.nextDelayDuration(10, TimeUnit.MILLISECONDS);
+        actual = customizedRetryPolicy.nextDelayDuration(10);
         assertThat(actual).isEqualTo(TimeUnit.MINUTES.toMillis(9));
     }
 
     @Test
     public void testNextDelayDurationOutOfRange() {
         CustomizedRetryPolicy customizedRetryPolicy = new CustomizedRetryPolicy();
-        long actual = customizedRetryPolicy.nextDelayDuration(-1, TimeUnit.MILLISECONDS);
+        long actual = customizedRetryPolicy.nextDelayDuration(-1);
         assertThat(actual).isEqualTo(TimeUnit.SECONDS.toMillis(10));
-        actual = customizedRetryPolicy.nextDelayDuration(100, TimeUnit.MILLISECONDS);
+        actual = customizedRetryPolicy.nextDelayDuration(100);
         assertThat(actual).isEqualTo(TimeUnit.HOURS.toMillis(2));
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/subscription/ExponentialRetryPolicyTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/subscription/ExponentialRetryPolicyTest.java
@@ -27,18 +27,18 @@ public class ExponentialRetryPolicyTest {
     @Test
     public void testNextDelayDuration() {
         ExponentialRetryPolicy exponentialRetryPolicy = new ExponentialRetryPolicy();
-        long actual = exponentialRetryPolicy.nextDelayDuration(0, TimeUnit.MILLISECONDS);
+        long actual = exponentialRetryPolicy.nextDelayDuration(0);
         assertThat(actual).isEqualTo(TimeUnit.SECONDS.toMillis(5));
-        actual = exponentialRetryPolicy.nextDelayDuration(10, TimeUnit.MILLISECONDS);
+        actual = exponentialRetryPolicy.nextDelayDuration(10);
         assertThat(actual).isEqualTo(TimeUnit.SECONDS.toMillis(1024 * 5));
     }
 
     @Test
     public void testNextDelayDurationOutOfRange() {
         ExponentialRetryPolicy exponentialRetryPolicy = new ExponentialRetryPolicy();
-        long actual = exponentialRetryPolicy.nextDelayDuration(-1, TimeUnit.MILLISECONDS);
+        long actual = exponentialRetryPolicy.nextDelayDuration(-1);
         assertThat(actual).isEqualTo(TimeUnit.SECONDS.toMillis(5));
-        actual = exponentialRetryPolicy.nextDelayDuration(100, TimeUnit.MILLISECONDS);
+        actual = exponentialRetryPolicy.nextDelayDuration(100);
         assertThat(actual).isEqualTo(TimeUnit.HOURS.toMillis(2));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Expand RocketMQ Topic/Group attributes

## Brief changelog

Remove TimeUnit in nextDelayDuration
