### PR TITLE
[ISSUE#4520] [Optimization] Implenment adjusting maxMessageSize dynamicly

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1488,7 +1488,7 @@ public class CommitLog {
     }
 
     public static class MessageExtEncoder {
-        private final ByteBuf byteBuf;
+        private ByteBuf byteBuf;
         // The maximum length of the message body.
         private int maxMessageBodySize;
         // The maximum length of the full message.

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1709,6 +1709,7 @@ public class CommitLog {
 
         public void updateEncoderBufferCapacity(int newMaxMessageBodySize){
             this.maxMessageBodySize = newMaxMessageBodySize;
+            //Reserve 64kb for encoding buffer outside body
             this.maxMessageSize = Integer.MAX_VALUE - newMaxMessageBodySize >= 64 * 1024 ?
                     this.maxMessageBodySize + 64 * 1024 : Integer.MAX_VALUE;
             this.byteBuf.capacity(this.maxMessageSize);

--- a/store/src/main/java/org/apache/rocketmq/store/MultiDispatch.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MultiDispatch.java
@@ -116,8 +116,17 @@ public class MultiDispatch {
         }
     }
 
+    public void updateMaxMessageSize(CommitLog.PutMessageThreadLocal putMessageThreadLocal){
+        int newMaxMessageSize = this.messageStore.getMessageStoreConfig().getMaxMessageSize();
+        if(putMessageThreadLocal.getEncoder().getMaxMessageBodySize() != newMaxMessageSize){
+            putMessageThreadLocal.getEncoder().updateEncoderBufferCapacity(newMaxMessageSize);
+        }
+    }
+
     private boolean rebuildMsgInner(MessageExtBrokerInner msgInner) {
-        MessageExtEncoder encoder = this.commitLog.getPutMessageThreadLocal().get().getEncoder();
+        CommitLog.PutMessageThreadLocal putMessageThreadLocal = this.commitLog.getPutMessageThreadLocal().get();
+        updateMaxMessageSize(putMessageThreadLocal);
+        MessageExtEncoder encoder = putMessageThreadLocal.getEncoder();
         PutMessageResult encodeResult = encoder.encode(msgInner);
         if (encodeResult != null) {
             LOGGER.error("rebuild msgInner for multiDispatch", encodeResult);

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -436,6 +436,9 @@ public class DLedgerCommitLog extends CommitLog {
         AppendMessageResult appendResult;
         AppendFuture<AppendEntryResponse> dledgerFuture;
         EncodeResult encodeResult = null;
+        this.messageSerializer.updateMaxMessageBodySize(
+                this.defaultMessageStore.getMessageStoreConfig().getMaxMessageSize()
+        );
 
         boolean isMultiDispatch = multiDispatch.isMultiDispatchMsg(msg);
         if (!isMultiDispatch) {
@@ -563,6 +566,9 @@ public class DLedgerCommitLog extends CommitLog {
         AppendMessageResult appendResult;
         BatchAppendFuture<AppendEntryResponse> dledgerFuture;
         EncodeResult encodeResult;
+        this.messageSerializer.updateMaxMessageBodySize(
+                this.defaultMessageStore.getMessageStoreConfig().getMaxMessageSize()
+        );
 
         encodeResult = this.messageSerializer.serialize(messageExtBatch);
         if (encodeResult.status != AppendMessageStatus.PUT_OK) {
@@ -781,10 +787,16 @@ public class DLedgerCommitLog extends CommitLog {
     class MessageSerializer {
 
         // The maximum length of the message body
-        private final int maxMessageBodySize;
+        private int maxMessageBodySize;
 
         MessageSerializer(final int size) {
             this.maxMessageBodySize = size;
+        }
+
+        public void updateMaxMessageBodySize(int newMaxMessageBodySize){
+            if(newMaxMessageBodySize != this.maxMessageBodySize && newMaxMessageBodySize > 0){
+                this.maxMessageBodySize = newMaxMessageBodySize;
+            }
         }
 
         public EncodeResult serialize(final MessageExtBrokerInner msgInner) {

--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
@@ -696,6 +696,28 @@ public class DefaultMessageStoreTest {
         assertTrue(encodeResult5.getPutMessageStatus() == PutMessageStatus.MESSAGE_ILLEGAL);
     }
 
+    @Test
+    public void testDynamicMaxMessageSize(){
+        MessageExtBrokerInner messageExtBrokerInner = buildMessage();
+        MessageStoreConfig messageStoreConfig = ((DefaultMessageStore) messageStore).getMessageStoreConfig();
+        int originMaxMessageSize = messageStoreConfig.getMaxMessageSize();
+
+        messageExtBrokerInner.setBody(new byte[originMaxMessageSize + 10]);
+        PutMessageResult putMessageResult = messageStore.putMessage(messageExtBrokerInner);
+        assertTrue(putMessageResult.getPutMessageStatus() == PutMessageStatus.MESSAGE_ILLEGAL);
+
+        int newMaxMessageSize = originMaxMessageSize + 10;
+        messageStoreConfig.setMaxMessageSize(newMaxMessageSize);
+        putMessageResult = messageStore.putMessage(messageExtBrokerInner);
+        assertTrue(putMessageResult.getPutMessageStatus() == PutMessageStatus.PUT_OK);
+
+        messageStoreConfig.setMaxMessageSize(10);
+        putMessageResult = messageStore.putMessage(messageExtBrokerInner);
+        assertTrue(putMessageResult.getPutMessageStatus() == PutMessageStatus.MESSAGE_ILLEGAL);
+
+        messageStoreConfig.setMaxMessageSize(originMaxMessageSize);
+    }
+
     private class MyMessageArrivingListener implements MessageArrivingListener {
         @Override
         public void arriving(String topic, int queueId, long logicOffset, long tagsCode, long msgStoreTime,


### PR DESCRIPTION
[ISSUE#4520](https://github.com/apache/rocketmq/issues/4520)

## What is the purpose of the change
In order to make maxMessageSize modification take effect after broker is started, I implenment the function of adjusting maxMessageSize dynamicly.
## Brief changelog
1. add updateEncoderBufferCapacity(int newMaxMessageBodySize), in MessageExtEncoder.
2. add updateMaxMessageSize(PutMessageThreadLocal putMessageThreadLocal), before encode buffer.
3. add junit test  "testDynamicMaxMessageSize()"