### PR TITLE
[ISSUE #4531] fix unreachable statement, redundant code and code style 

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/protocol/route/BrokerData.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/route/BrokerData.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.MixAll;
 
 public class BrokerData implements Comparable<BrokerData> {
@@ -96,12 +98,7 @@ public class BrokerData implements Comparable<BrokerData> {
                 return false;
         } else if (!brokerAddrs.equals(other.brokerAddrs))
             return false;
-        if (brokerName == null) {
-            if (other.brokerName != null)
-                return false;
-        } else if (!brokerName.equals(other.brokerName))
-            return false;
-        return true;
+        return StringUtils.equals(brokerName, other.brokerName);
     }
 
     @Override


### PR DESCRIPTION
I'm reading the sourcecode of store module and there are some cpde snippets  in class org.apache.rocketmq.store.DefaultMessageStore that I think need to be fixed.

- **code snippet 1**: redundant code  and  unreachable statement (`match`   is always true)

<img width="1177" alt="Screen Shot 2022-06-29 at 21 34 38" src="https://user-images.githubusercontent.com/16064908/176451335-51e16363-081c-4077-9c1b-e5aa39c8287c.png">

- code snippet 2 : replacing with `enhanced for` to Improve code readability
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/16064908/176458447-64fb2c6c-7570-4513-ade1-0c6174865704.png">
