### PR TITLE
[ISSUE#4552] Add asySendBlockMode to implement BackPressure

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -42,6 +42,7 @@ public class ClientConfig {
     protected String namespace;
     private boolean namespaceInitialized = false;
     protected AccessChannel accessChannel = AccessChannel.LOCAL;
+    private boolean asySendBlockMode = true;
 
     /**
      * Pulling topic information interval from the named server
@@ -338,6 +339,12 @@ public class ClientConfig {
 
     public void setEnableStreamRequestType(boolean enableStreamRequestType) {
         this.enableStreamRequestType = enableStreamRequestType;
+    }
+
+    public boolean isAsySendBlockMode() { return  asySendBlockMode; }
+
+    public void setAsySendBlockMode(boolean asySendBlockMode) {
+        this.asySendBlockMode = asySendBlockMode;
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -42,7 +42,6 @@ public class ClientConfig {
     protected String namespace;
     private boolean namespaceInitialized = false;
     protected AccessChannel accessChannel = AccessChannel.LOCAL;
-    private boolean asySendBlockMode = true;
 
     /**
      * Pulling topic information interval from the named server
@@ -339,12 +338,6 @@ public class ClientConfig {
 
     public void setEnableStreamRequestType(boolean enableStreamRequestType) {
         this.enableStreamRequestType = enableStreamRequestType;
-    }
-
-    public boolean isAsySendBlockMode() { return  asySendBlockMode; }
-
-    public void setAsySendBlockMode(boolean asySendBlockMode) {
-        this.asySendBlockMode = asySendBlockMode;
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -509,21 +509,16 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             }
 
         };
-        try {
-            executor.submit(runnable);
-        } catch (RejectedExecutionException e) {
-            if (this.defaultMQProducer.isAsySendBlockMode() && this.asyncSenderExecutor == null) {
-                long costTime = System.currentTimeMillis() - beginStartTime;
-                if (!asyncSenderThreadPoolQueue.offer(runnable, timeout - costTime, TimeUnit.MILLISECONDS)) {
-                    sendCallback.onException(
-                            new RemotingTooMuchRequestException("DEFAULT ASYNC send call timeout"));
-                }
-            } else {
-                // custom asyncSenderExecutor not support asySendBlockMode
+
+        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()  && this.asyncSenderExecutor == null) {
+            runnable.run();
+        } else {
+            try {
+                executor.submit(runnable);
+            } catch (RejectedExecutionException e) {
                 throw new MQClientException("executor rejected ", e);
             }
         }
-
     }
 
     public MessageQueue selectOneMessageQueue(final TopicPublishInfo tpInfo, final String lastBrokerName) {
@@ -1084,16 +1079,13 @@ public class DefaultMQProducerImpl implements MQProducerInner {
 
             }
         };
-        try {
-            executor.submit(runnable);
-        } catch (RejectedExecutionException e) {
-            if (this.defaultMQProducer.isAsySendBlockMode() && this.asyncSenderExecutor == null) {
-                long costTime = System.currentTimeMillis() - beginStartTime;
-                if (!asyncSenderThreadPoolQueue.offer(runnable, timeout - costTime, TimeUnit.MILLISECONDS)) {
-                    sendCallback.onException(new RemotingTooMuchRequestException("call timeout"));
-                }
-            } else {
-                // custom asyncSenderExecutor not support asySendBlockMode
+
+        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()  && this.asyncSenderExecutor == null) {
+            runnable.run();
+        } else {
+            try {
+                executor.submit(runnable);
+            } catch (RejectedExecutionException e) {
                 throw new MQClientException("executor rejected ", e);
             }
         }
@@ -1215,18 +1207,14 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                     sendCallback.onException(new RemotingTooMuchRequestException("call timeout"));
                 }
             }
-
         };
-        try {
-            executor.submit(runnable);
-        } catch (RejectedExecutionException e) {
-            if (this.defaultMQProducer.isAsySendBlockMode() && this.asyncSenderExecutor == null) {
-                long costTime = System.currentTimeMillis() - beginStartTime;
-                if (!asyncSenderThreadPoolQueue.offer(runnable, timeout - costTime, TimeUnit.MILLISECONDS)) {
-                    sendCallback.onException(new RemotingTooMuchRequestException("call timeout"));
-                }
-            } else {
-                // custom asyncSenderExecutor not support asySendBlockMode
+
+        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()  && this.asyncSenderExecutor == null) {
+            runnable.run();
+        } else {
+            try {
+                executor.submit(runnable);
+            } catch (RejectedExecutionException e) {
                 throw new MQClientException("executor rejected ", e);
             }
         }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -510,7 +510,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
 
         };
 
-        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()  && this.asyncSenderExecutor == null) {
+        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()) {
             runnable.run();
         } else {
             try {
@@ -1080,7 +1080,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             }
         };
 
-        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()  && this.asyncSenderExecutor == null) {
+        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()) {
             runnable.run();
         } else {
             try {
@@ -1209,7 +1209,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             }
         };
 
-        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()  && this.asyncSenderExecutor == null) {
+        if (this.defaultMQProducer.isEnableBackpressureForAsyncMode()) {
             runnable.run();
         } else {
             try {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -1222,10 +1222,10 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         } catch (RejectedExecutionException e) {
             if (this.defaultMQProducer.isAsySendBlockMode() && this.asyncSenderExecutor == null) {
                 long costTime = System.currentTimeMillis() - beginStartTime;
-                if(!asyncSenderThreadPoolQueue.offer(runnable, timeout - costTime, TimeUnit.MILLISECONDS)){
+                if (!asyncSenderThreadPoolQueue.offer(runnable, timeout - costTime, TimeUnit.MILLISECONDS)) {
                     sendCallback.onException(new RemotingTooMuchRequestException("call timeout"));
                 }
-            }else {
+            } else {
                 // custom asyncSenderExecutor not support asySendBlockMode
                 throw new MQClientException("executor rejected ", e);
             }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -136,7 +136,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     /**
      * Indicate whether to block message when asynchronous sending traffic is too heavy.
      */
-    private boolean asySendBlockMode = true;
+    private boolean enableBackpressureForAsyncMode = true;
 
     /**
      * Default constructor.
@@ -1115,11 +1115,11 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
         return retryResponseCodes;
     }
 
-    public boolean isAsySendBlockMode() {
-        return  asySendBlockMode;
+    public boolean isEnableBackpressureForAsyncMode() {
+        return  enableBackpressureForAsyncMode;
     }
 
-    public void setAsySendBlockMode(boolean asySendBlockMode) {
-        this.asySendBlockMode = asySendBlockMode;
+    public void setEnableBackpressureForAsyncMode(boolean enableBackpressureForAsyncMode) {
+        this.enableBackpressureForAsyncMode = enableBackpressureForAsyncMode;
     }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -134,6 +134,11 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     private TraceDispatcher traceDispatcher = null;
 
     /**
+     * Indicate whether to block message when asynchronous sending traffic is too heavy.
+     */
+    private boolean asySendBlockMode = true;
+
+    /**
      * Default constructor.
      */
     public DefaultMQProducer() {
@@ -1108,5 +1113,13 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
 
     public Set<Integer> getRetryResponseCodes() {
         return retryResponseCodes;
+    }
+
+    public boolean isAsySendBlockMode() {
+        return  asySendBlockMode;
+    }
+
+    public void setAsySendBlockMode(boolean asySendBlockMode) {
+        this.asySendBlockMode = asySendBlockMode;
     }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -136,7 +136,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     /**
      * Indicate whether to block message when asynchronous sending traffic is too heavy.
      */
-    private boolean enableBackpressureForAsyncMode = true;
+    private boolean enableBackpressureForAsyncMode = false;
 
     /**
      * Default constructor.

--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -88,6 +88,7 @@ public class DefaultMQProducerTest {
         producer = new DefaultMQProducer(producerGroupTemp);
         producer.setNamesrvAddr("127.0.0.1:9876");
         producer.setCompressMsgBodyOverHowmuch(16);
+        producer.setAsySendBlockMode(true);
         message = new Message(topic, new byte[] {'a'});
         zeroMsg = new Message(topic, new byte[] {});
         bigMessage = new Message(topic, "This is a very huge message!".getBytes());

--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -88,7 +88,7 @@ public class DefaultMQProducerTest {
         producer = new DefaultMQProducer(producerGroupTemp);
         producer.setNamesrvAddr("127.0.0.1:9876");
         producer.setCompressMsgBodyOverHowmuch(16);
-        producer.setAsySendBlockMode(true);
+        producer.setEnableBackpressureForAsyncMode(true);
         message = new Message(topic, new byte[] {'a'});
         zeroMsg = new Message(topic, new byte[] {});
         bigMessage = new Message(topic, "This is a very huge message!".getBytes());

--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -193,7 +193,7 @@ public class DefaultMQProducerTest {
     @Test
     public void testSendMessageAsync() throws RemotingException, MQClientException, InterruptedException {
         final AtomicInteger cc = new AtomicInteger(0);
-        final CountDownLatch countDownLatch = new CountDownLatch(6);
+        final CountDownLatch countDownLatch = new CountDownLatch(12);
 
         when(mQClientAPIImpl.getTopicRouteInfoFromNameServer(anyString(), anyLong())).thenReturn(createTopicRoute());
         SendCallback sendCallback = new SendCallback() {
@@ -219,6 +219,9 @@ public class DefaultMQProducerTest {
         Message message = new Message();
         message.setTopic("test");
         message.setBody("hello world".getBytes());
+
+        // on enableBackpressureForAsyncMode
+        producer.setEnableBackpressureForAsyncMode(true);
         producer.send(new Message(), sendCallback);
         producer.send(message, new MessageQueue(), sendCallback);
         producer.send(new Message(), new MessageQueue(), sendCallback, 1000);
@@ -229,6 +232,19 @@ public class DefaultMQProducerTest {
 
         countDownLatch.await(3000L, TimeUnit.MILLISECONDS);
         assertThat(cc.get()).isEqualTo(5);
+
+        // off enableBackpressureForAsyncMode
+        producer.setEnableBackpressureForAsyncMode(false);
+        producer.send(new Message(), sendCallback);
+        producer.send(message, new MessageQueue(), sendCallback);
+        producer.send(new Message(), new MessageQueue(), sendCallback, 1000);
+        producer.send(new Message(), messageQueueSelector, null, sendCallback);
+        producer.send(message, messageQueueSelector, null, sendCallback, 1000);
+        //this message is send success
+        producer.send(message, sendCallback, 1000);
+
+        countDownLatch.await(3000L, TimeUnit.MILLISECONDS);
+        assertThat(cc.get()).isEqualTo(10);
     }
     
     @Test
@@ -265,15 +281,27 @@ public class DefaultMQProducerTest {
             message.setBody(("hello world" + i).getBytes());
             msgs.add(message);
         }
+        // on enableBackpressureForAsyncMode
+        producer.setEnableBackpressureForAsyncMode(true);
         producer.send(msgs, sendCallback);
         producer.send(msgs, sendCallback, 1000);
         MessageQueue mq = new MessageQueue("test", "BrokerA", 1);
         producer.send(msgs, mq, sendCallback);
         // this message is send failed
         producer.send(msgs, new MessageQueue(), sendCallback, 1000);
-
         countDownLatch.await(3000L, TimeUnit.MILLISECONDS);
         assertThat(cc.get()).isEqualTo(1);
+
+        // off enableBackpressureForAsyncMode
+        producer.setEnableBackpressureForAsyncMode(false);
+        producer.send(msgs, sendCallback);
+        producer.send(msgs, sendCallback, 1000);
+        producer.send(msgs, mq, sendCallback);
+        // this message is send failed
+        producer.send(msgs, new MessageQueue(), sendCallback, 1000);
+
+        countDownLatch.await(3000L, TimeUnit.MILLISECONDS);
+        assertThat(cc.get()).isEqualTo(2);
     }
 
     @Test

--- a/example/src/main/java/org/apache/rocketmq/example/quickstart/Producer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/quickstart/Producer.java
@@ -94,8 +94,6 @@ public class Producer {
                 /*
                  * if you want to get the send result in a asynchronize way, you can use this send method
                  * {@code
-                 * // suggest to on enableBackpressureForAsyncMode in heavy traffic, default is false
-                 *  producer.setEnableBackpressureForAsyncMode(true);
                  *  producer.send(msg, new SendCallback() {
                  *  @Override
                  *  public void onSuccess(SendResult sendResult) {

--- a/example/src/main/java/org/apache/rocketmq/example/quickstart/Producer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/quickstart/Producer.java
@@ -94,7 +94,8 @@ public class Producer {
                 /*
                  * if you want to get the send result in a asynchronize way, you can use this send method
                  * {@code
-                 *
+                 * // suggest to on enableBackpressureForAsyncMode in heavy traffic, default is false
+                 *  producer.setEnableBackpressureForAsyncMode(true);
                  *  producer.send(msg, new SendCallback() {
                  *  @Override
                  *  public void onSuccess(SendResult sendResult) {

--- a/example/src/main/java/org/apache/rocketmq/example/simple/AsyncProducer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/simple/AsyncProducer.java
@@ -32,6 +32,8 @@ public class AsyncProducer {
 
         DefaultMQProducer producer = new DefaultMQProducer("Jodie_Daily_test");
         producer.start();
+        // suggest to on enableBackpressureForAsyncMode in heavy traffic, default is false
+        producer.setEnableBackpressureForAsyncMode(true);
         producer.setRetryTimesWhenSendAsyncFailed(0);
 
         int messageCount = 100;


### PR DESCRIPTION
[ISSUE#4552](https://github.com/apache/rocketmq/issues/4552)

## What is the purpose of the change

When the upstream sending message traffic is too heavy, the threadpool executor will directly refuse to execute and throw  MQClientException. 

In the IO operation "Netty Remoting", backpressure is implemented by semaphoreAsync:
```java
public void invokeAsyncImpl(final Channel channel, final RemotingCommand request, final long timeoutMillis,
        final InvokeCallback invokeCallback)
        throws InterruptedException, RemotingTooMuchRequestException, RemotingTimeoutException, RemotingSendRequestException {
        long beginStartTime = System.currentTimeMillis();
        final int opaque = request.getOpaque();
        boolean acquired = this.semaphoreAsync.tryAcquire(timeoutMillis, TimeUnit.MILLISECONDS);
        if (acquired) {
            final SemaphoreReleaseOnlyOnce once = new SemaphoreReleaseOnlyOnce(this.semaphoreAsync);
            long costTime = System.currentTimeMillis() - beginStartTime;
            if (timeoutMillis < costTime) {
                once.release();
                throw new RemotingTimeoutException("invokeAsyncImpl call timeout");
            }

            final ResponseFuture responseFuture = new ResponseFuture(channel, opaque, timeoutMillis - costTime, invokeCallback, once);
            this.responseTable.put(opaque, responseFuture);
            try {
                channel.writeAndFlush(request).addListener(new ChannelFutureListener() {
                    @Override
                    public void operationComplete(ChannelFuture f) throws Exception {
                        if (f.isSuccess()) {
                            responseFuture.setSendRequestOK(true);
                            return;
                        }
                        requestFail(opaque);
                        log.warn("send a request command to channel <{}> failed.", RemotingHelper.parseChannelRemoteAddr(channel));
                    }
                });
            } catch (Exception e) {
                responseFuture.release();
                log.warn("send a request command to channel <" + RemotingHelper.parseChannelRemoteAddr(channel) + "> Exception", e);
                throw new RemotingSendRequestException(RemotingHelper.parseChannelRemoteAddr(channel), e);
            }
        } else {
            if (timeoutMillis <= 0) {
                throw new RemotingTooMuchRequestException("invokeAsyncImpl invoke too fast");
            } else {
                String info =
                    String.format("invokeAsyncImpl tryAcquire semaphore timeout, %dms, waiting thread nums: %d semaphoreAsyncValue: %d",
                        timeoutMillis,
                        this.semaphoreAsync.getQueueLength(),
                        this.semaphoreAsync.availablePermits()
                    );
                log.warn(info);
                throw new RemotingTimeoutException(info);
            }
        }
    }
```

I consider to implement backpressure mechanism  relying on BackPressure in NettyRemoting. In this situation, within the timeout allowed by the client, the SDK will block the sending operation, not reject the task. 

## Brief changelog

1. add back pressure mechanism by just run `runnable` in this thread, relying on backpressure in NettyRemoting.
2. add `asySendBlockMode` parameter in `DefaultMQProducer` to let user decide whether to enable this mode.

---

**Notice**: Through the experimental test, the time cost of asynchronous sending is mainly in the IO operation. So, whether  start `runnable` in `DefaultMQProducerImpl` through ThreadPool, there is not much difference in performace.
