### PR TITLE
[ISSUE #4628] Fix bug in LMQ when checking multiple Dispatch Queue 

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -480,7 +480,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
             return false;
         }
         Map<String, String> prop = dispatchRequest.getPropertiesMap();
-        if (prop == null && prop.isEmpty()) {
+        if (prop == null || prop.isEmpty()) {
             return false;
         }
         String multiDispatchQueue = prop.get(MessageConst.PROPERTY_INNER_MULTI_DISPATCH);


### PR DESCRIPTION
**Bug Report**
There is bug in LMQ moudle when checking multiple dispatch queue.
if (prop == null && pro.isEmpty()) {
    .......
}
It will cause an exception.