### PR TITLE
[ISSUE #4644] Fix mqadmin deleteTopic bug when command exec on slave broker

### DIFF
--- a/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
@@ -344,7 +344,7 @@ public class PlainPermissionManager {
                 accountMap.put(plainAccessConfig.getAccessKey(), buildPlainAccessResource(plainAccessConfig));
             } else {
                 for (Map.Entry<String, PlainAccessResource> entry : accountMap.entrySet()) {
-                    if (entry.getValue().equals(plainAccessConfig.getAccessKey())) {
+                    if (entry.getValue().getAccessKey().equals(plainAccessConfig.getAccessKey())) {
                         PlainAccessResource plainAccessResource = buildPlainAccessResource(plainAccessConfig);
                         accountMap.put(entry.getKey(), plainAccessResource);
                         break;

--- a/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
@@ -86,7 +86,7 @@ public class BrokerOuterAPI {
     public String fetchNameServerAddr() {
         try {
             String addrs = this.topAddressing.fetchNSAddr();
-            if (addrs != null) {
+            if (addrs != null && !UtilAll.isBlank(addrs)) {
                 if (!addrs.equals(this.nameSrvAddr)) {
                     log.info("name server address changed, old: {} new: {}", this.nameSrvAddr, addrs);
                     this.updateNameServerAddressList(addrs);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -227,7 +227,7 @@ public class MQClientAPIImpl {
     public String fetchNameServerAddr() {
         try {
             String addrs = this.topAddressing.fetchNSAddr();
-            if (addrs != null) {
+            if (addrs != null && !UtilAll.isBlank(addrs)) {
                 if (!addrs.equals(this.nameSrvAddr)) {
                     log.info("name server address changed, old=" + this.nameSrvAddr + ", new=" + addrs);
                     this.updateNameServerAddressList(addrs);

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <opentracing.version>0.33.0</opentracing.version>
         <jaeger.version>1.6.0</jaeger.version>
-        <dleger.version>0.2.6</dleger.version>
+        <dleger.version>0.2.7</dleger.version>
         <annotations-api.version>6.0.53</annotations-api.version>
         <extra-enforcer-rules.version>1.0-beta-4</extra-enforcer-rules.version>
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java
@@ -38,8 +38,8 @@ public class DeleteTopicSubCommand implements SubCommand {
         final String topic
     ) throws InterruptedException, MQBrokerException, RemotingException, MQClientException {
 
-        Set<String> brokerAddressSet = CommandUtil.fetchMasterAndSlaveAddrByClusterName(adminExt, clusterName);
-        adminExt.deleteTopicInBroker(brokerAddressSet, topic);
+        Set<String> masterBrokerAddressSet = CommandUtil.fetchMasterAddrByClusterName(adminExt, clusterName);
+        adminExt.deleteTopicInBroker(masterBrokerAddressSet, topic);
         System.out.printf("delete topic [%s] from cluster [%s] success.%n", topic, clusterName);
 
         Set<String> nameServerSet = null;


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

mqadmin deleteTopic only request master brokers

## Brief changelog
`org.apache.rocketmq.tools.command.topic.DeleteTopicSubCommand#deleteTopic`
--        Set<String> brokerAddressSet = CommandUtil.fetchMasterAndSlaveAddrByClusterName(adminExt, clusterName);
--        adminExt.deleteTopicInBroker(brokerAddressSet, topic);
++       Set<String> masterBrokerAddressSet = CommandUtil.fetchMasterAddrByClusterName(adminExt, clusterName);
++       adminExt.deleteTopicInBroker(masterBrokerAddressSet, topic);

## Verifying this change
I cannot exec `mvn clean package -DskipTests` on branch `4.9.x`,so I did same change on branch `release-4.9.4`(didn't commit).
And tested on my 1m-2s-sync cluster.
```shell
[root@master bin]# ./mqadmin topicList -n master:9876 -c
#Cluster Name         #Topic                                            #Consumer Group                                 
DefaultCluster        SCHEDULE_TOPIC_XXXX                                                                                                               
DefaultCluster        RMQ_SYS_TRANS_HALF_TOPIC                                                                                                          
DefaultCluster        DefaultCluster_REPLY_TOPIC                                                                                                        
DefaultCluster        BenchmarkTest                                                                                                                     
DefaultCluster        OFFSET_MOVED_EVENT                                                                                                                
DefaultCluster        broker-a                                                                                                                          
DefaultCluster        TBW102                                                                                                                            
DefaultCluster        SELF_TEST_TOPIC                                                                                                                   
DefaultCluster        DefaultCluster                                                                                                                    

[root@master bin]# date
Thu Jul 21 07:11:08 EDT 2022
[root@master bin]# ./mqadmin updateTopic -n master:9876 -c DefaultCluster -t test_topic
create topic to 192.168.125.201:10911 success.
TopicConfig [topicName=test_topic, readQueueNums=8, writeQueueNums=8, perm=RW-, topicFilterType=SINGLE_TAG, topicSysFlag=0, order=false]
[root@master bin]# date
Thu Jul 21 07:11:17 EDT 2022
[root@master bin]# ./mqadmin topicList -n master:9876 -c
#Cluster Name         #Topic                                            #Consumer Group                                 
DefaultCluster        SCHEDULE_TOPIC_XXXX                                                                                                               
DefaultCluster        RMQ_SYS_TRANS_HALF_TOPIC                                                                                                          
DefaultCluster        DefaultCluster_REPLY_TOPIC                                                                                                        
DefaultCluster        test_topic                                                                                                                        
DefaultCluster        BenchmarkTest                                                                                                                     
DefaultCluster        OFFSET_MOVED_EVENT                                                                                                                
DefaultCluster        broker-a                                                                                                                          
DefaultCluster        TBW102                                                                                                                            
DefaultCluster        SELF_TEST_TOPIC                                                                                                                   
DefaultCluster        DefaultCluster                                                                                                                    
[root@master bin]# ./mqadmin deleteTopic -n 'master:9876' -c DefaultCluster -t test_topic
brokerAddressSet:[192.168.125.201:10911]
org.apache.rocketmq.tools.admin.DefaultMQAdminExtImpl.deleteTopicInBroker:192.168.125.201:10911
delete topic [test_topic] from cluster [DefaultCluster] success.
delete topic [test_topic] from NameServer success.
[root@master bin]# date
Thu Jul 21 07:11:33 EDT 2022
[root@master bin]# ./mqadmin topicList -n master:9876 -c
#Cluster Name         #Topic                                            #Consumer Group                                 
DefaultCluster        SCHEDULE_TOPIC_XXXX                                                                                                               
DefaultCluster        RMQ_SYS_TRANS_HALF_TOPIC                                                                                                          
DefaultCluster        DefaultCluster_REPLY_TOPIC                                                                                                        
DefaultCluster        BenchmarkTest                                                                                                                     
DefaultCluster        OFFSET_MOVED_EVENT                                                                                                                
DefaultCluster        broker-a                                                                                                                          
DefaultCluster        TBW102                                                                                                                            
DefaultCluster        SELF_TEST_TOPIC                                                                                                                   
DefaultCluster        DefaultCluster                                                                                                                    

```