### PR TITLE
[ISSUE #4644] Fix mqadmin deleteTopic bug when command exec on slave broker

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java
@@ -38,8 +38,8 @@ public class DeleteTopicSubCommand implements SubCommand {
         final String topic
     ) throws InterruptedException, MQBrokerException, RemotingException, MQClientException {
 
-        Set<String> brokerAddressSet = CommandUtil.fetchMasterAndSlaveAddrByClusterName(adminExt, clusterName);
-        adminExt.deleteTopicInBroker(brokerAddressSet, topic);
+        Set<String> masterBrokerAddressSet = CommandUtil.fetchMasterAddrByClusterName(adminExt, clusterName);
+        adminExt.deleteTopicInBroker(masterBrokerAddressSet, topic);
         System.out.printf("delete topic [%s] from cluster [%s] success.%n", topic, clusterName);
 
         Set<String> nameServerSet = null;


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

mqadmin deleteTopic only request master brokers


## Brief changelog

`org.apache.rocketmq.tools.command.topic.DeleteTopicSubCommand#deleteTopic`
-- Set brokerAddressSet = CommandUtil.fetchMasterAndSlaveAddrByClusterName(adminExt, clusterName);
-- adminExt.deleteTopicInBroker(brokerAddressSet, topic);
++ Set masterBrokerAddressSet = CommandUtil.fetchMasterAddrByClusterName(adminExt, clusterName);
++ adminExt.deleteTopicInBroker(masterBrokerAddressSet, topic);

## Verifying this change
create branch `develop-deleteTopic-command-fix` based on branch `develop`
Run `mvn -Prelease-all -DskipTests clean package -U` and deploy it by old config.but it cannot run. 
```shell
Caused by: java.lang.ClassNotFoundException: com.alibaba.arthas.deps.ch.qos.logback.core.rolling.RollingFileAppender
```
So I use same code on branch `release-4.9.4` and tested on my 1m-2s-sync cluster.
here is the command exec test:
```shell
[root@master bin]# date
Thu Jul 21 12:44:57 EDT 2022
[root@master bin]# ./mqadmin topicList -n master:9876 -c
#Cluster Name         #Topic                                            #Consumer Group                                 
DefaultCluster        SCHEDULE_TOPIC_XXXX                                                                                                               
DefaultCluster        RMQ_SYS_TRANS_HALF_TOPIC                                                                                                          
DefaultCluster        DefaultCluster_REPLY_TOPIC                                                                                                        
DefaultCluster        BenchmarkTest                                                                                                                     
DefaultCluster        OFFSET_MOVED_EVENT                                                                                                                
DefaultCluster        broker-a                                                                                                                          
DefaultCluster        TBW102                                                                                                                            
DefaultCluster        SELF_TEST_TOPIC                                                                                                                   
DefaultCluster        DefaultCluster                                                                                                                    
[root@master bin]# date
Thu Jul 21 12:45:06 EDT 2022
[root@master bin]# ./mqadmin updateTopic -n master:9876 -c DefaultCluster -t test_topic
create topic to 192.168.125.201:10911 success.
TopicConfig [topicName=test_topic, readQueueNums=8, writeQueueNums=8, perm=RW-, topicFilterType=SINGLE_TAG, topicSysFlag=0, order=false][root@master bin]# 
[root@master bin]# date
Thu Jul 21 12:45:22 EDT 2022
[root@master bin]# ./mqadmin topicList -n master:9876 -c
#Cluster Name         #Topic                                            #Consumer Group                                 
DefaultCluster        SCHEDULE_TOPIC_XXXX                                                                                                               
DefaultCluster        RMQ_SYS_TRANS_HALF_TOPIC                                                                                                          
DefaultCluster        DefaultCluster_REPLY_TOPIC                                                                                                        
DefaultCluster        test_topic                                                                                                                        
DefaultCluster        BenchmarkTest                                                                                                                     
DefaultCluster        OFFSET_MOVED_EVENT                                                                                                                
DefaultCluster        broker-a                                                                                                                          
DefaultCluster        TBW102                                                                                                                            
DefaultCluster        SELF_TEST_TOPIC                                                                                                                   
DefaultCluster        DefaultCluster                                                                                                                    
[root@master bin]# date
Thu Jul 21 12:45:42 EDT 2022
[root@master bin]# ./mqadmin deleteTopic -n 'master:9876' -c DefaultCluster -t test_topic
brokerAddressSet:[192.168.125.201:10911]
org.apache.rocketmq.tools.admin.DefaultMQAdminExtImpl.deleteTopicInBroker:192.168.125.201:10911
delete topic [test_topic] from cluster [DefaultCluster] success.
delete topic [test_topic] from NameServer success.
[root@master bin]# date
Thu Jul 21 12:45:54 EDT 2022
[root@master bin]# ./mqadmin topicList -n master:9876 -c
#Cluster Name         #Topic                                            #Consumer Group                                 
DefaultCluster        SCHEDULE_TOPIC_XXXX                                                                                                               
DefaultCluster        RMQ_SYS_TRANS_HALF_TOPIC                                                                                                          
DefaultCluster        DefaultCluster_REPLY_TOPIC                                                                                                        
DefaultCluster        BenchmarkTest                                                                                                                     
DefaultCluster        OFFSET_MOVED_EVENT                                                                                                                
DefaultCluster        broker-a                                                                                                                          
DefaultCluster        TBW102                                                                                                                            
DefaultCluster        SELF_TEST_TOPIC                                                                                                                   
DefaultCluster        DefaultCluster                                                                                                                    
[root@master bin]# date
Thu Jul 21 12:46:03 EDT 2022
```

