### PR TITLE
fix: write TelemetryCommand observer in writeLock

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -20,17 +20,23 @@ import apache.rocketmq.v2.PrintThreadStackTraceCommand;
 import apache.rocketmq.v2.RecoverOrphanedTransactionCommand;
 import apache.rocketmq.v2.TelemetryCommand;
 import apache.rocketmq.v2.VerifyMessageCommand;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import com.google.protobuf.TextFormat;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.netty.channel.ChannelId;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.protocol.body.ConsumeMessageDirectlyResult;
 import org.apache.rocketmq.common.protocol.body.ConsumerRunningInfo;
 import org.apache.rocketmq.common.protocol.header.CheckTransactionStateRequestHeader;
 import org.apache.rocketmq.common.protocol.header.ConsumeMessageDirectlyResultRequestHeader;
 import org.apache.rocketmq.common.protocol.header.GetConsumerRunningInfoRequestHeader;
+import org.apache.rocketmq.logging.InternalLogger;
+import org.apache.rocketmq.logging.InternalLoggerFactory;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.grpc.v2.common.GrpcConverter;
 import org.apache.rocketmq.proxy.service.relay.ProxyChannel;
@@ -40,12 +46,13 @@ import org.apache.rocketmq.proxy.service.transaction.TransactionData;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 
 public class GrpcClientChannel extends ProxyChannel {
-
+    private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
     protected static final String SEPARATOR = "@";
 
     private final GrpcChannelManager grpcChannelManager;
 
     private final AtomicReference<StreamObserver<TelemetryCommand>> telemetryCommandRef = new AtomicReference<>();
+    private final Object telemetryWriteLock = new Object();
     private final String group;
     private final String clientId;
 
@@ -101,6 +108,10 @@ public class GrpcClientChannel extends ProxyChannel {
         this.telemetryCommandRef.set(future);
     }
 
+    protected void clearClientObserver(StreamObserver<TelemetryCommand> future) {
+        this.telemetryCommandRef.compareAndSet(future, null);
+    }
+
     @Override
     public boolean isOpen() {
         return this.telemetryCommandRef.get() != null;
@@ -120,7 +131,7 @@ public class GrpcClientChannel extends ProxyChannel {
     protected CompletableFuture<Void> processOtherMessage(Object msg) {
         if (msg instanceof TelemetryCommand) {
             TelemetryCommand response = (TelemetryCommand) msg;
-            this.getTelemetryCommandStreamObserver().onNext(response);
+            this.writeTelemetryCommand(response);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -130,7 +141,7 @@ public class GrpcClientChannel extends ProxyChannel {
         MessageExt messageExt, TransactionData transactionData, CompletableFuture<ProxyRelayResult<Void>> responseFuture) {
         CompletableFuture<Void> writeFuture = new CompletableFuture<>();
         try {
-            this.getTelemetryCommandStreamObserver().onNext(TelemetryCommand.newBuilder()
+            this.writeTelemetryCommand(TelemetryCommand.newBuilder()
                 .setRecoverOrphanedTransactionCommand(RecoverOrphanedTransactionCommand.newBuilder()
                     .setTransactionId(transactionData.getTransactionId())
                     .setMessage(GrpcConverter.getInstance().buildMessage(messageExt))
@@ -152,7 +163,7 @@ public class GrpcClientChannel extends ProxyChannel {
         if (!header.isJstackEnable()) {
             return CompletableFuture.completedFuture(null);
         }
-        this.getTelemetryCommandStreamObserver().onNext(TelemetryCommand.newBuilder()
+        this.writeTelemetryCommand(TelemetryCommand.newBuilder()
             .setPrintThreadStackTraceCommand(PrintThreadStackTraceCommand.newBuilder()
                 .setNonce(this.grpcChannelManager.addResponseFuture(responseFuture))
                 .build())
@@ -164,7 +175,7 @@ public class GrpcClientChannel extends ProxyChannel {
     protected CompletableFuture<Void> processConsumeMessageDirectly(RemotingCommand command,
         ConsumeMessageDirectlyResultRequestHeader header,
         MessageExt messageExt, CompletableFuture<ProxyRelayResult<ConsumeMessageDirectlyResult>> responseFuture) {
-        this.getTelemetryCommandStreamObserver().onNext(TelemetryCommand.newBuilder()
+        this.writeTelemetryCommand(TelemetryCommand.newBuilder()
             .setVerifyMessageCommand(VerifyMessageCommand.newBuilder()
                 .setNonce(this.grpcChannelManager.addResponseFuture(responseFuture))
                 .setMessage(GrpcConverter.getInstance().buildMessage(messageExt))
@@ -189,7 +200,33 @@ public class GrpcClientChannel extends ProxyChannel {
         return localAddress;
     }
 
-    public StreamObserver<TelemetryCommand> getTelemetryCommandStreamObserver() {
-        return this.telemetryCommandRef.get();
+    public void writeTelemetryCommand(TelemetryCommand command) {
+        StreamObserver<TelemetryCommand> observer = this.telemetryCommandRef.get();
+        if (observer == null) {
+            log.warn("telemetry command observer is null when try to write data. command:{}, channel:{}", TextFormat.shortDebugString(command), this);
+            return;
+        }
+        synchronized (this.telemetryWriteLock) {
+            observer = this.telemetryCommandRef.get();
+            if (observer == null) {
+                log.warn("telemetry command observer is null when try to write data. command:{}, channel:{}", TextFormat.shortDebugString(command), this);
+                return;
+            }
+            try {
+                observer.onNext(command);
+            } catch (StatusRuntimeException | IllegalStateException statusRuntimeException) {
+                this.clearClientObserver(observer);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("group", group)
+            .add("clientId", clientId)
+            .add("remoteAddress", getRemoteAddress())
+            .add("localAddress", getLocalAddress())
+            .toString();
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -214,7 +214,8 @@ public class GrpcClientChannel extends ProxyChannel {
             }
             try {
                 observer.onNext(command);
-            } catch (StatusRuntimeException | IllegalStateException statusRuntimeException) {
+            } catch (StatusRuntimeException | IllegalStateException exception) {
+                log.warn("write telemetry failed. command:{}", command, exception);
                 this.clearClientObserver(observer);
             }
         }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/mqclient/ProxyClientRemotingProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/mqclient/ProxyClientRemotingProcessorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.mqclient;
+
+import apache.rocketmq.v2.TelemetryCommand;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.netty.channel.Channel;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.broker.client.ProducerManager;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageDecoder;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.protocol.RequestCode;
+import org.apache.rocketmq.common.protocol.header.CheckTransactionStateRequestHeader;
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
+import org.apache.rocketmq.proxy.service.channel.SimpleChannelHandlerContext;
+import org.apache.rocketmq.proxy.service.relay.ProxyRelayResult;
+import org.apache.rocketmq.proxy.service.relay.ProxyRelayService;
+import org.apache.rocketmq.proxy.service.relay.RelayData;
+import org.apache.rocketmq.proxy.service.transaction.TransactionData;
+import org.apache.rocketmq.remoting.common.RemotingUtil;
+import org.apache.rocketmq.remoting.exception.RemotingCommandException;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProxyClientRemotingProcessorTest {
+    @Mock
+    private ProducerManager producerManager;
+    @Mock
+    private ProxyRelayService proxyRelayService;
+
+    @Test
+    public void testTransactionCheck() throws Exception {
+        CompletableFuture<ProxyRelayResult<Void>> proxyRelayResultFuture = new CompletableFuture<>();
+        when(proxyRelayService.processCheckTransactionState(any(), any(), any(), any()))
+            .thenReturn(new RelayData<>(
+                new TransactionData("brokerName", 0, 0, "id", System.currentTimeMillis(), 3000),
+                proxyRelayResultFuture));
+
+        GrpcClientChannel grpcClientChannel = new GrpcClientChannel(proxyRelayService, null,
+            ProxyContext.create().setRemoteAddress("127.0.0.1:8888").setLocalAddress("127.0.0.1:10911"), "group", "clientId");
+        when(producerManager.getAvailableChannel(anyString()))
+            .thenReturn(grpcClientChannel);
+
+        ProxyClientRemotingProcessor processor = new ProxyClientRemotingProcessor(producerManager);
+        CheckTransactionStateRequestHeader requestHeader = new CheckTransactionStateRequestHeader();
+        RemotingCommand command = RemotingCommand.createRequestCommand(RequestCode.CHECK_TRANSACTION_STATE, requestHeader);
+        MessageExt message = new MessageExt();
+        message.setQueueId(0);
+        message.setFlag(12);
+        message.setQueueOffset(0L);
+        message.setCommitLogOffset(100L);
+        message.setSysFlag(0);
+        message.setBornTimestamp(System.currentTimeMillis());
+        message.setBornHost(new InetSocketAddress("127.0.0.1", 10));
+        message.setStoreTimestamp(System.currentTimeMillis());
+        message.setStoreHost(new InetSocketAddress("127.0.0.1", 11));
+        message.setBody("body".getBytes());
+        message.setTopic("topic");
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_PRODUCER_GROUP, "group");
+        command.setBody(MessageDecoder.encode(message, false));
+
+        processor.processRequest(new MockChannelHandlerContext(null), command);
+
+        ServerCallStreamObserver<TelemetryCommand> observer = mock(ServerCallStreamObserver.class);
+        grpcClientChannel.setClientObserver(observer);
+
+        processor.processRequest(new MockChannelHandlerContext(null), command);
+        verify(observer, times(1)).onNext(any());
+
+        // throw exception to test clear observer
+        doThrow(new StatusRuntimeException(Status.CANCELLED)).when(observer).onNext(any());
+
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        AtomicInteger count = new AtomicInteger();
+        for (int i = 0; i < 100; i++) {
+            executorService.submit(() -> {
+                try {
+                    processor.processRequest(new MockChannelHandlerContext(null), command);
+                    count.incrementAndGet();
+                } catch (RemotingCommandException ignored) {
+                }
+            });
+        }
+        await().atMost(Duration.ofSeconds(1)).until(() -> count.get() == 100);
+        verify(observer, times(2)).onNext(any());
+    }
+
+    protected static class MockChannelHandlerContext extends SimpleChannelHandlerContext {
+
+        public MockChannelHandlerContext(Channel channel) {
+            super(channel);
+        }
+
+        @Override
+        public Channel channel() {
+            Channel channel = mock(Channel.class);
+            when(channel.remoteAddress()).thenReturn(RemotingUtil.string2SocketAddress("127.0.0.1:10911"));
+            return channel;
+        }
+    }
+}


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

For gprc observer is not thread-safe, we need call onNext in lock

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
