### PR TITLE
[ISSUE #5004]: Use CAS instread of ReentrantLock to set value of putMessageEntireTimeMax, getMessageEntireTimeMax.

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -522,7 +522,7 @@ public class DefaultMessageStore implements MessageStore {
                 LOGGER.warn("DefaultMessageStore#putMessage: CommitLog#putMessage cost {}ms, topic={}, bodyLength={}",
                     elapsedTime, msg.getTopic(), msg.getBody().length);
             }
-            this.storeStatsService.setPutMessageEntireTimeMax(elapsedTime);
+            this.storeStatsService.recordPutMessageLatency(elapsedTime);
 
             if (null == result || !result.isOk()) {
                 this.storeStatsService.getPutMessageFailedTimes().add(1);
@@ -550,7 +550,7 @@ public class DefaultMessageStore implements MessageStore {
             if (eclipseTime > 500) {
                 LOGGER.warn("not in lock eclipse time(ms)={}, bodyLength={}", eclipseTime, messageExtBatch.getBody().length);
             }
-            this.storeStatsService.setPutMessageEntireTimeMax(eclipseTime);
+            this.storeStatsService.recordPutMessageLatency(eclipseTime);
 
             if (null == result || !result.isOk()) {
                 this.storeStatsService.getPutMessageFailedTimes().add(1);


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

For issue #5004 

## Brief changelog

- Use `CAS `instread of `ReentrantLock `to set value of `putMessageEntireTimeMax`, `getMessageEntireTimeMax`.
- It is better to make the scope of methods(e.g: `incPutMessageEntireTime`, `findPutMessageEntireTimePX`) to be **private** instead of **public** in class `StoreStatsService`.
- Remove useless snippets.

## Verifying this change

Reference the unit tests in this PR.