### PR TITLE
[ISSUE #5013] allow broker to bind specified network interface

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -138,12 +138,6 @@ public class BrokerStartup {
                 System.exit(-2);
             }
 
-            if (!nettyServerConfig.getBindIP().equals("0.0.0.0") &&
-                !nettyServerConfig.getBindIP().equals(brokerConfig.getBrokerIP1())) {
-                System.out.printf("Broker bind ip: %s should be 0.0.0.0 or equal to broker ip1: %s", nettyServerConfig.getBindIP(), brokerConfig.getBrokerIP1());
-                System.exit(-2);
-            }
-
             String namesrvAddr = brokerConfig.getNamesrvAddr();
             if (null != namesrvAddr) {
                 try {

--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -18,6 +18,11 @@ package org.apache.rocketmq.broker;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -39,12 +44,6 @@ import org.apache.rocketmq.store.config.BrokerRole;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.rocketmq.remoting.netty.TlsSystemConfig.TLS_ENABLE;
 
@@ -136,6 +135,12 @@ public class BrokerStartup {
 
             if (null == brokerConfig.getRocketmqHome()) {
                 System.out.printf("Please set the %s variable in your environment to match the location of the RocketMQ installation", MixAll.ROCKETMQ_HOME_ENV);
+                System.exit(-2);
+            }
+
+            if (!nettyServerConfig.getBindIP().equals("0.0.0.0") &&
+                !nettyServerConfig.getBindIP().equals(brokerConfig.getBrokerIP1())) {
+                System.out.printf("Broker bind ip: %s should be 0.0.0.0 or equal to broker ip1: %s", nettyServerConfig.getBindIP(), brokerConfig.getBrokerIP1());
                 System.exit(-2);
             }
 

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -245,9 +245,9 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             InetSocketAddress addr = (InetSocketAddress) sync.channel().localAddress();
             if (0 == nettyServerConfig.getListenPort()) {
                 this.nettyServerConfig.setListenPort(addr.getPort());
-                log.info("Server is listening {}:{}", this.nettyServerConfig.getBindAddress(),
-                    this.nettyServerConfig.getListenPort());
             }
+            log.info("RemotingServer started, listening {}:{}", this.nettyServerConfig.getBindAddress(),
+                this.nettyServerConfig.getListenPort());
             this.remotingServerTable.put(this.nettyServerConfig.getListenPort(), this);
         } catch (Exception e) {
             throw new IllegalStateException(String.format("Failed to bind to %s:%d", nettyServerConfig.getBindAddress(),

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -243,7 +243,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             InetSocketAddress addr = (InetSocketAddress) sync.channel().localAddress();
             if (0 == nettyServerConfig.getListenPort()) {
                 this.nettyServerConfig.setListenPort(addr.getPort());
-                log.debug("Server is listening {}:{}", this.nettyServerConfig.getBindIP(), this.nettyServerConfig.getListenPort());
+                log.info("Server is listening {}:{}", this.nettyServerConfig.getBindIP(), this.nettyServerConfig.getListenPort());
             }
             this.remotingServerTable.put(this.nettyServerConfig.getListenPort(), this);
         } catch (Exception e) {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
@@ -17,7 +17,12 @@
 package org.apache.rocketmq.remoting.netty;
 
 public class NettyServerConfig implements Cloneable {
-    private String bindIP = "0.0.0.0";
+
+    /**
+     * Bind address may be hostname, IPv4 or IPv6.
+     * By default, it's wildcard address, listening all network interfaces.
+     */
+    private String bindAddress = "0.0.0.0";
     private int listenPort = 0;
     private int serverWorkerThreads = 8;
     private int serverCallbackExecutorThreads = 0;
@@ -42,12 +47,12 @@ public class NettyServerConfig implements Cloneable {
      */
     private boolean useEpollNativeSelector = false;
 
-    public String getBindIP() {
-        return bindIP;
+    public String getBindAddress() {
+        return bindAddress;
     }
 
-    public void setBindIP(String bindIP) {
-        this.bindIP = bindIP;
+    public void setBindAddress(String bindAddress) {
+        this.bindAddress = bindAddress;
     }
 
     public int getListenPort() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.remoting.netty;
 
 public class NettyServerConfig implements Cloneable {
+    private String bindIP = "0.0.0.0";
     private int listenPort = 0;
     private int serverWorkerThreads = 8;
     private int serverCallbackExecutorThreads = 0;
@@ -40,6 +41,14 @@ public class NettyServerConfig implements Cloneable {
      * --host=x86_64-linux-gnu \ --build=x86_64-pc-linux-gnu \ --without-gd
      */
     private boolean useEpollNativeSelector = false;
+
+    public String getBindIP() {
+        return bindIP;
+    }
+
+    public void setBindIP(String bindIP) {
+        this.bindIP = bindIP;
+    }
 
     public int getListenPort() {
         return listenPort;


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

close #5013 

## Brief changelog

Add a new configuration item "bindIP" to make rocketmq only bind to a specific IP.

## Verifying this change

Does this pr affect the original behavior?
No. The default value of the new config is 0.0.0.0, which means binding all network interfaces.

What are the limitations of the new configuration items?
It must be "0.0.0.0" or any IP assigned to a network interface. And if it's not 0.0.0.0, it needs to be the same as brokerIP1 to avoid potential network problems.