### PR TITLE
[ISSUE#5039] localHostName() get stuck when constructing the BrokerIdentity object

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/BrokerIdentity.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerIdentity.java
@@ -111,7 +111,7 @@ public class BrokerIdentity {
     }
 
     private String defaultBrokerName() {
-        return localHostName == null ? "DEFAULT_BROKER" : localHostName;
+        return StringUtils.isEmpty(localHostName) ? "DEFAULT_BROKER" : localHostName;
     }
 
     public String getCanonicalName() {

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerIdentity.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerIdentity.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.common;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.rocketmq.common.annotation.ImportantField;

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerIdentity.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerIdentity.java
@@ -29,12 +29,24 @@ import org.apache.rocketmq.logging.InternalLoggerFactory;
 
 public class BrokerIdentity {
     private static final String DEFAULT_CLUSTER_NAME = "DefaultCluster";
+
     protected static final InternalLogger LOGGER = InternalLoggerFactory.getLogger(LoggerName.COMMON_LOGGER_NAME);
 
+    private static String localHostName;
+
+    static {
+        try {
+            localHostName = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            LOGGER.error("Failed to obtain the host name", e);
+        }
+    }
+
+    // load it after the localHostName is initialized
     public static final BrokerIdentity BROKER_CONTAINER_IDENTITY = new BrokerIdentity(true);
 
     @ImportantField
-    private String brokerName = localHostName();
+    private String brokerName = defaultBrokerName();
     @ImportantField
     private String brokerClusterName = DEFAULT_CLUSTER_NAME;
     @ImportantField
@@ -98,14 +110,8 @@ public class BrokerIdentity {
         isInBrokerContainer = inBrokerContainer;
     }
 
-    protected static String localHostName() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            LOGGER.error("Failed to obtain the host name", e);
-        }
-
-        return "DEFAULT_BROKER";
+    private String defaultBrokerName() {
+        return localHostName == null ? "DEFAULT_BROKER" : localHostName;
     }
 
     public String getCanonicalName() {


### PR DESCRIPTION
1. fix the issue#5039 by initializing the local host name when BrokerIdentity class loading to avoid the InetAddress#getLocalHost() to be called too many times.
issue: https://github.com/apache/rocketmq/issues/5039

**Make sure set the target branch to `develop`**

## What is the purpose of the change

XXXXX

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
