### PR TITLE
[ISSUE #5311] Add preShutdown for grace shutdown

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/ProxyStartup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/ProxyStartup.java
@@ -93,6 +93,7 @@ public class ProxyStartup {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 log.info("try to shutdown server");
                 try {
+                    PROXY_START_AND_SHUTDOWN.preShutdown();
                     PROXY_START_AND_SHUTDOWN.shutdown();
                 } catch (Exception e) {
                     log.error("err when shutdown rocketmq-proxy", e);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/AbstractStartAndShutdown.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/AbstractStartAndShutdown.java
@@ -42,6 +42,14 @@ public abstract class AbstractStartAndShutdown implements StartAndShutdown {
         }
     }
 
+    @Override
+    public void preShutdown() throws Exception {
+        int index = startAndShutdownList.size() - 1;
+        for (; index >= 0; index--) {
+            startAndShutdownList.get(index).preShutdown();
+        }
+    }
+
     public void appendStart(Start start) {
         this.appendStartAndShutdown(new StartAndShutdown() {
             @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/StartAndShutdown.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/StartAndShutdown.java
@@ -18,4 +18,5 @@
 package org.apache.rocketmq.proxy.common;
 
 public interface StartAndShutdown extends Start, Shutdown {
+    default void preShutdown() throws Exception {}
 }


### PR DESCRIPTION
## What is the purpose of the change

Add preShutdown for grace shutdown

This is to fix https://github.com/apache/rocketmq/issues/5311

## Brief changelog

Add the preShutdown to do grace shutdown work before real shutdown logic.

