### PR TITLE
[ISSUE #5214] compatible rocketmq-mqtt save offset

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ConsumerManageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ConsumerManageProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.rocketmq.broker.processor;
 
 import io.netty.channel.ChannelHandlerContext;
-import java.util.Set;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.client.ConsumerGroupInfo;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -155,8 +154,7 @@ public class ConsumerManageProcessor implements NettyRequestProcessor {
         if (rewriteResult != null) {
             return rewriteResult;
         }
-        Set<String> topicSets = this.brokerController.getTopicConfigManager().getTopicConfigTable().keySet();
-        if (topicSets.contains(requestHeader.getTopic())) {
+        if (this.brokerController.getTopicConfigManager().containsTopic(requestHeader.getTopic())) {
             this.brokerController.getConsumerOffsetManager().commitOffset(RemotingHelper.parseChannelRemoteAddr(ctx.channel()), requestHeader.getConsumerGroup(),
                 requestHeader.getTopic(), requestHeader.getQueueId(), requestHeader.getCommitOffset());
             response.setCode(ResponseCode.SUCCESS);

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/LmqTopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/LmqTopicConfigManager.java
@@ -46,4 +46,12 @@ public class LmqTopicConfigManager extends TopicConfigManager {
         return new TopicConfig(topic, 1, 1, PermName.PERM_READ | PermName.PERM_WRITE);
     }
 
+    @Override
+    public boolean containsTopic(String topic) {
+        if (MixAll.isLmq(topic)) {
+            return true;
+        }
+        return super.containsTopic(topic);
+    }
+
 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -728,4 +728,8 @@ public class TopicConfigManager extends ConfigManager {
     private String realKey(String key) {
         return key.substring(1);
     }
+
+    public boolean containsTopic(String topic) {
+        return topicConfigTable.containsKey(topic);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
close #5200 
In RocketMQ 4.9.3，the interface updateConsumerOffset does not check whether the topic exists or not. But in RocketMQ 5.0 do the check. LMQ's topic will not register to namesv， so it will throw error when save offset in rocketmq-mqtt.

https://github.com/apache/rocketmq-mqtt/issues/150

## Brief changelog

add containsTopic interface in TopicConfigManager, when enable lmq it will use LmqTopicConfigManager#containsTopic which process LMQ Topic

