### PR TITLE
[ISSUE #5243] Add acl support to TimerProducer/TimerConsumer

### DIFF
--- a/distribution/benchmark/shutdown.sh
+++ b/distribution/benchmark/shutdown.sh
@@ -72,6 +72,35 @@ case $1 in
 
     echo "Send shutdown request to benchmark batch producer(${pid}) OK"
     ;;
+      timerproducer)
+
+      pid=`ps ax | grep -i 'org.apache.rocketmq.example.benchmark.timer.TimerProducer' |grep java | grep -v grep | awk '{print $1}'`
+      if [ -z "$pid" ] ; then
+              echo "No benchmark timerProducer running."
+              exit -1;
+      fi
+
+      echo "The benchmark timerProducer(${pid}) is running..."
+
+      kill ${pid}
+
+      echo "Send shutdown request to benchmark timerProducer(${pid}) OK"
+      ;;
+      timerconsumer)
+
+      pid=`ps ax | grep -i 'org.apache.rocketmq.example.benchmark.timer.TimerConsumer' |grep java | grep -v grep | awk '{print $1}'`
+      if [ -z "$pid" ] ; then
+              echo "No benchmark timerConsumer running."
+              exit -1;
+      fi
+
+      echo "The benchmark timerConsumer(${pid}) is running..."
+
+      kill ${pid}
+
+      echo "Send shutdown request to benchmark timerConsumer(${pid}) OK"
+      ;;
+
     *)
-    echo "Usage: shutdown producer | consumer | tproducer | bproducer"
+    echo "Usage: shutdown producer | consumer | tproducer | bproducer | timerProducer | timerConsumer"
 esac

--- a/distribution/benchmark/timerConsumer.sh
+++ b/distribution/benchmark/timerConsumer.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sh ./runclass.sh org.apache.rocketmq.example.benchmark.timer.TimerConsumer $@ &

--- a/distribution/benchmark/timerProducer.sh
+++ b/distribution/benchmark/timerProducer.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sh ./runclass.sh org.apache.rocketmq.example.benchmark.timer.TimerProducer $@ &


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

close #5243 

## Brief changelog

1. fix wrong option name of namesrv
2. add acl support to TimerProducer/Consumer benchmark
3. add new options



