### PR TITLE
 [ISSUE #3905] Remove unused header fields

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ReplyMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ReplyMessageProcessor.java
@@ -173,7 +173,6 @@ public class ReplyMessageProcessor extends AbstractSendMessageProcessor {
         replyMessageRequestHeader.setProperties(requestHeader.getProperties());
         replyMessageRequestHeader.setReconsumeTimes(requestHeader.getReconsumeTimes());
         replyMessageRequestHeader.setUnitMode(requestHeader.isUnitMode());
-        replyMessageRequestHeader.setBname(requestHeader.getBname());
 
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.PUSH_REPLY_MESSAGE_TO_CLIENT, replyMessageRequestHeader);
         request.setBody(msg.getBody());

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -351,7 +351,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                 thisHeader.setTranStateTableOffset(checkRequestHeader.getTranStateTableOffset());
                 thisHeader.setFromTransactionCheck(true);
                 thisHeader.setBname(checkRequestHeader.getBname());
-                thisHeader.setQueueId(checkRequestHeader.getQueueId());
 
                 String uniqueKey = message.getProperties().get(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX);
                 if (uniqueKey == null) {
@@ -1327,7 +1326,6 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         requestHeader.setTransactionId(transactionId);
         requestHeader.setCommitLogOffset(id.getOffset());
         requestHeader.setBname(sendResult.getMessageQueue().getBrokerName());
-        requestHeader.setQueueId(sendResult.getMessageQueue().getQueueId());
         switch (localTransactionState) {
             case COMMIT_MESSAGE:
                 requestHeader.setCommitOrRollback(MessageSysFlag.TRANSACTION_COMMIT_TYPE);

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/header/CheckTransactionStateRequestHeader.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/header/CheckTransactionStateRequestHeader.java
@@ -32,7 +32,6 @@ public class CheckTransactionStateRequestHeader extends RpcRequestHeader {
     private String msgId;
     private String transactionId;
     private String offsetMsgId;
-    private int queueId;
 
     @Override
     public void checkFields() throws RemotingCommandException {
@@ -76,13 +75,5 @@ public class CheckTransactionStateRequestHeader extends RpcRequestHeader {
 
     public void setOffsetMsgId(String offsetMsgId) {
         this.offsetMsgId = offsetMsgId;
-    }
-
-    public int getQueueId() {
-        return queueId;
-    }
-
-    public void setQueueId(int queueId) {
-        this.queueId = queueId;
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/header/EndTransactionRequestHeader.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/header/EndTransactionRequestHeader.java
@@ -43,8 +43,6 @@ public class EndTransactionRequestHeader extends RpcRequestHeader {
 
     private String transactionId;
 
-    private int queueId;
-
     @Override
     public void checkFields() throws RemotingCommandException {
         if (MessageSysFlag.TRANSACTION_NOT_TYPE == this.commitOrRollback) {
@@ -128,16 +126,7 @@ public class EndTransactionRequestHeader extends RpcRequestHeader {
             ", fromTransactionCheck=" + fromTransactionCheck +
             ", msgId='" + msgId + '\'' +
             ", transactionId='" + transactionId + '\'' +
-            ", queueId=" + queueId +
             ", bname='" + bname + '\'' +
             '}';
-    }
-
-    public int getQueueId() {
-        return queueId;
-    }
-
-    public void setQueueId(int queueId) {
-        this.queueId = queueId;
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/protocol/header/ReplyMessageRequestHeader.java
+++ b/common/src/main/java/org/apache/rocketmq/common/protocol/header/ReplyMessageRequestHeader.java
@@ -17,12 +17,12 @@
 
 package org.apache.rocketmq.common.protocol.header;
 
-import org.apache.rocketmq.common.rpc.RpcRequestHeader;
+import org.apache.rocketmq.remoting.CommandCustomHeader;
 import org.apache.rocketmq.remoting.annotation.CFNotNull;
 import org.apache.rocketmq.remoting.annotation.CFNullable;
 import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 
-public class ReplyMessageRequestHeader extends RpcRequestHeader {
+public class ReplyMessageRequestHeader implements CommandCustomHeader {
     @CFNotNull
     private String producerGroup;
     @CFNotNull


### PR DESCRIPTION
## What is the purpose of the change

Remove unused header fields to keep compatible with develop

## Brief changelog

 * including `CheckTransactionStateRequestHeader`, `EndTransactionRequestHeader`, `ReplyMessageRequestHeader`
