### PR TITLE
[ISSUE #5443] Fix ServiceProvider report NPE misleading users when no resource file is found

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/ServiceProvider.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/ServiceProvider.java
@@ -107,15 +107,19 @@ public class ServiceProvider {
     public static <T> List<T> load(String name, Class<?> clazz) {
         LOG.info("Looking for a resource file of name [{}] ...", name);
         List<T> services = new ArrayList<>();
-        try (InputStream is = getResourceAsStream(getContextClassLoader(), name);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+        InputStream is = getResourceAsStream(getContextClassLoader(), name);
+        if (is == null) {
+            LOG.warn("No resource file with name [{}] found.", name);
+            return services;
+        }
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
 
             String serviceName = reader.readLine();
             List<String> names = new ArrayList<>();
             while (serviceName != null && !"".equals(serviceName)) {
                 LOG.info(
-                        "Creating an instance as specified by file {} which was present in the path of the context classloader.",
-                        name);
+                    "Creating an instance as specified by file {} which was present in the path of the context classloader.",
+                    name);
                 if (!names.contains(serviceName)) {
                     names.add(serviceName);
                     services.add(initService(getContextClassLoader(), serviceName, clazz));
@@ -130,8 +134,12 @@ public class ServiceProvider {
 
     public static <T> T loadClass(String name, Class<?> clazz) {
         T s = null;
-        try (InputStream is = getResourceAsStream(getContextClassLoader(), name);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+        InputStream is = getResourceAsStream(getContextClassLoader(), name);
+        if (is == null) {
+            LOG.warn("No resource file with name [{}] found.", name);
+            return null;
+        }
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
 
             String serviceName = reader.readLine();
             if (serviceName != null && !"".equals(serviceName)) {


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change

Fix ServiceProvider report NPE misleading users when no resource file is found
close #5443 

## Brief changelog

Fix ServiceProvider report NPE misleading users when no resource file is found

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
