### PR TITLE
[ISSUE #5493] fix : npe caused by get item by logic offset if the target logicQueueMappingItem was out of date

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/statictopic/TopicQueueMappingUtils.java
+++ b/common/src/main/java/org/apache/rocketmq/common/statictopic/TopicQueueMappingUtils.java
@@ -651,6 +651,8 @@ public class TopicQueueMappingUtils {
             LogicQueueMappingItem item =  mappingItems.get(i);
             if (ignoreNegative && item.getLogicOffset() < 0) {
                 continue;
+            } else {
+                return item;
             }
         }
         return null;


### PR DESCRIPTION
closes https://github.com/apache/rocketmq/issues/5493