### PR TITLE
[ISSUE #5536] fix:new version name server should be compatible with old version broker

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
@@ -286,7 +286,8 @@ public class DefaultRequestProcessor implements NettyRequestProcessor {
 
         if (request.getBody() != null) {
             try {
-                registerBrokerBody = RegisterBrokerBody.decode(request.getBody(), requestHeader.isCompressed());
+                Version brokerVersion = MQVersion.value2Version(request.getVersion());
+                registerBrokerBody = RegisterBrokerBody.decode(request.getBody(), requestHeader.isCompressed(), brokerVersion);
             } catch (Exception e) {
                 throw new RemotingCommandException("Failed to decode RegisterBrokerBody", e);
             }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RegisterBrokerBodyTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RegisterBrokerBodyTest.java
@@ -20,6 +20,8 @@ package org.apache.rocketmq.remoting.protocol;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import org.apache.rocketmq.common.MQVersion;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.remoting.protocol.body.RegisterBrokerBody;
 import org.apache.rocketmq.remoting.protocol.body.TopicConfigAndMappingSerializeWrapper;
@@ -43,7 +45,7 @@ public class RegisterBrokerBodyTest {
 
         byte[] compareEncode = registerBrokerBody.encode(true);
         byte[] encode2 = registerBrokerBody.encode(false);
-        RegisterBrokerBody decodeRegisterBrokerBody = RegisterBrokerBody.decode(compareEncode, true);
+        RegisterBrokerBody decodeRegisterBrokerBody = RegisterBrokerBody.decode(compareEncode, true, MQVersion.Version.V5_0_0);
 
         assertEquals(registerBrokerBody.getTopicConfigSerializeWrapper().getTopicConfigTable().size(), decodeRegisterBrokerBody.getTopicConfigSerializeWrapper().getTopicConfigTable().size());
 


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change
fixes https://github.com/apache/rocketmq/issues/5536
Make the new name srv compatible with the old broker.
While broker configure compressedRegister=true，if we update the cluster by rolling, upgrading broker after upgrading name server or vice versa, would cause exception as follows:
![image](https://user-images.githubusercontent.com/50660789/202614146-fe8b4c94-b333-41e5-a23f-842164bc55d7.png)

So, we should consider the broker version to decode the register broker body



