### PR TITLE
[ISSUE #5555] fix:build instance name with pid instead of pid+nanotime .Because tha…

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -96,7 +96,7 @@ public class ClientConfig {
 
     public void changeInstanceNameToPID() {
         if (this.instanceName.equals("DEFAULT")) {
-            this.instanceName = UtilAll.getPid() + "#" + System.nanoTime();
+            this.instanceName = String.valueOf(UtilAll.getPid());
         }
     }
 


### PR DESCRIPTION
fix that create a MQClientInstance as long as create a producer or a consumer.
That lead to clientInstance just manages one producer or producer,
but clientInstance is designed for managing many of producers and consumers;

#5555 