### PR TITLE
Update group id of rocketmq logging

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,8 +93,8 @@ maven_install(
         "io.opentelemetry:opentelemetry-api:1.19.0",
         "io.opentelemetry:opentelemetry-sdk-metrics:1.19.0",
         "io.opentelemetry:opentelemetry-sdk-common:1.19.0",
-        "io.github.aliyun-mq:rocketmq-slf4j-api:1.0.4",
-        "io.github.aliyun-mq:rocketmq-logback-classic:1.0.4",
+        "io.github.aliyunmq:rocketmq-slf4j-api:1.0.0",
+        "io.github.aliyunmq:rocketmq-logback-classic:1.0.0",
     ],
     fetch_sources = True,
     repositories = [

--- a/acl/BUILD.bazel
+++ b/acl/BUILD.bazel
@@ -35,8 +35,8 @@ java_library(
         "@maven//:org_apache_rocketmq_rocketmq_proto",
         "@maven//:org_lz4_lz4_java",
         "@maven//:org_yaml_snakeyaml",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -40,11 +40,11 @@
             <artifactId>rocketmq-srvutil</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-logback-classic</artifactId>
         </dependency>
         <dependency>

--- a/broker/BUILD.bazel
+++ b/broker/BUILD.bazel
@@ -49,8 +49,8 @@ java_library(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_lz4_lz4_java",
         "@maven//:org_slf4j_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -35,11 +35,11 @@
             <artifactId>rocketmq-store</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-logback-classic</artifactId>
         </dependency>
         <dependency>

--- a/client/BUILD.bazel
+++ b/client/BUILD.bazel
@@ -31,8 +31,8 @@ java_library(
         "@maven//:io_netty_netty_all",
         "@maven//:io_opentracing_opentracing_api",
         "@maven//:commons_collections_commons_collections",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -59,11 +59,11 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-logback-classic</artifactId>
         </dependency>
     </dependencies>

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -37,8 +37,8 @@ java_library(
         "@maven//:io_opentelemetry_opentelemetry_sdk_metrics",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_lz4_lz4_java",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -93,11 +93,11 @@
             <artifactId>annotations-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-logback-classic</artifactId>
         </dependency>
     </dependencies>

--- a/container/BUILD.bazel
+++ b/container/BUILD.bazel
@@ -41,8 +41,8 @@ java_library(
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:commons_cli_commons_cli",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -39,8 +39,8 @@ java_library(
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:commons_cli_commons_cli",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/namesrv/BUILD.bazel
+++ b/namesrv/BUILD.bazel
@@ -39,8 +39,8 @@ java_library(
         "@maven//:org_bouncycastle_bcpkix_jdk15on",
         "@maven//:commons_cli_commons_cli",
         "@maven//:com_google_guava_guava",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <openmessaging.version>0.3.1-alpha</openmessaging.version>
         <snakeyaml.version>1.32</snakeyaml.version>
         <commons-codec.version>1.13</commons-codec.version>
-        <rocketmq-logging.version>1.0.4</rocketmq-logging.version>
+        <rocketmq-logging.version>1.0.0</rocketmq-logging.version>
         <slf4j-api.version>2.0.3</slf4j-api.version>
         <logback-classic.version>1.3.4</logback-classic.version>
         <commons-validator.version>1.7</commons-validator.version>
@@ -706,12 +706,12 @@
                 <version>${logback-classic.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.aliyun-mq</groupId>
+                <groupId>io.github.aliyunmq</groupId>
                 <artifactId>rocketmq-slf4j-api</artifactId>
                 <version>${rocketmq-logging.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.aliyun-mq</groupId>
+                <groupId>io.github.aliyunmq</groupId>
                 <artifactId>rocketmq-logback-classic</artifactId>
                 <version>${rocketmq-logging.version}</version>
             </dependency>

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -58,8 +58,8 @@ java_library(
         "@maven//:org_checkerframework_checker_qual",
         "@maven//:org_lz4_lz4_java",
         "@maven//:org_slf4j_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -78,11 +78,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-logback-classic</artifactId>
         </dependency>
         <dependency>

--- a/remoting/BUILD.bazel
+++ b/remoting/BUILD.bazel
@@ -36,8 +36,8 @@ java_library(
         "@maven//:io_opentelemetry_opentelemetry_sdk_metrics",
         "@maven//:org_apache_tomcat_annotations_api",
         "@maven//:org_apache_commons_commons_lang3",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/srvutil/BUILD.bazel
+++ b/srvutil/BUILD.bazel
@@ -32,8 +32,8 @@ java_library(
         "@maven//:commons_cli_commons_cli",
         "@maven//:com_googlecode_concurrentlinkedhashmap_concurrentlinkedhashmap_lru",
         "@maven//:com_google_guava_guava",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/store/BUILD.bazel
+++ b/store/BUILD.bazel
@@ -38,8 +38,8 @@ java_library(
         "@maven//:io_opentelemetry_opentelemetry_sdk_metrics",
         "@maven//:net_java_dev_jna_jna",
         "@maven//:org_apache_commons_commons_lang3",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 
@@ -57,8 +57,8 @@ java_library(
         "@maven//:io_openmessaging_storage_dledger",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:com_google_guava_guava",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -47,8 +47,8 @@ java_library(
         "@maven//:org_lz4_lz4_java",
         "@maven//:org_reflections_reflections",
         "@maven//:org_slf4j_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -96,11 +96,11 @@
             <artifactId>reflections</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.aliyun-mq</groupId>
+            <groupId>io.github.aliyunmq</groupId>
             <artifactId>rocketmq-logback-classic</artifactId>
         </dependency>
         <dependency>

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -37,8 +37,8 @@ java_library(
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",     
         "@maven//:commons_collections_commons_collections",
-        "@maven//:io_github_aliyun_mq_rocketmq_slf4j_api",
-        "@maven//:io_github_aliyun_mq_rocketmq_logback_classic",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
     ],
 )
 


### PR DESCRIPTION
Since we have moved https://github.com/aliyun-mq/rocketmq-logging to https://github.com/aliyunmq/rocketmq-logging, the groupId of rocketmq-logging should be updated