### PR TITLE
[ISSUE #5776] Remove duplicate empty string checks

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidator.java
@@ -100,17 +100,16 @@ public class GrpcValidator {
     }
 
     public void validateTag(String tag) {
-        if (StringUtils.isEmpty(tag)) {
-            return;
-        }
-        if (StringUtils.isBlank(tag)) {
-            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot be the char sequence of whitespace");
-        }
-        if (tag.contains("|")) {
-            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain '|'");
-        }
-        if (containControlCharacter(tag)) {
-            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain control character");
+        if (StringUtils.isNotEmpty(tag)) {
+            if (StringUtils.isBlank(tag)) {
+                throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot be the char sequence of whitespace");
+            }
+            if (tag.contains("|")) {
+                throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain '|'");
+            }
+            if (containControlCharacter(tag)) {
+                throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain control character");
+            }
         }
     }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidator.java
@@ -52,16 +52,13 @@ public class GrpcValidator {
     }
 
     public void validateTopic(String topicName) {
-        if (StringUtils.isBlank(topicName)) {
-            throw new GrpcProxyException(Code.ILLEGAL_TOPIC, "topic name cannot be empty");
-        }
-        if (TopicValidator.isSystemTopic(topicName)) {
-            throw new GrpcProxyException(Code.ILLEGAL_TOPIC, "cannot access system topic");
-        }
         try {
             Validators.checkTopic(topicName);
         } catch (MQClientException mqClientException) {
             throw new GrpcProxyException(Code.ILLEGAL_TOPIC, mqClientException.getErrorMessage());
+        }
+        if (TopicValidator.isSystemTopic(topicName)) {
+            throw new GrpcProxyException(Code.ILLEGAL_TOPIC, "cannot access system topic");
         }
     }
 
@@ -70,16 +67,13 @@ public class GrpcValidator {
     }
 
     public void validateConsumerGroup(String consumerGroupName) {
-        if (StringUtils.isBlank(consumerGroupName)) {
-            throw new GrpcProxyException(Code.ILLEGAL_CONSUMER_GROUP, "consumer group cannot be empty");
-        }
-        if (MixAll.isSysConsumerGroup(consumerGroupName)) {
-            throw new GrpcProxyException(Code.ILLEGAL_CONSUMER_GROUP, "cannot use system consumer group");
-        }
         try {
             Validators.checkGroup(consumerGroupName);
         } catch (MQClientException mqClientException) {
             throw new GrpcProxyException(Code.ILLEGAL_CONSUMER_GROUP, mqClientException.getErrorMessage());
+        }
+        if (MixAll.isSysConsumerGroup(consumerGroupName)) {
+            throw new GrpcProxyException(Code.ILLEGAL_CONSUMER_GROUP, "cannot use system consumer group");
         }
     }
 
@@ -106,16 +100,17 @@ public class GrpcValidator {
     }
 
     public void validateTag(String tag) {
-        if (StringUtils.isNotEmpty(tag)) {
-            if (StringUtils.isBlank(tag)) {
-                throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot be the char sequence of whitespace");
-            }
-            if (tag.contains("|")) {
-                throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain '|'");
-            }
-            if (containControlCharacter(tag)) {
-                throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain control character");
-            }
+        if (StringUtils.isEmpty(tag)) {
+            return;
+        }
+        if (StringUtils.isBlank(tag)) {
+            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot be the char sequence of whitespace");
+        }
+        if (tag.contains("|")) {
+            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain '|'");
+        }
+        if (containControlCharacter(tag)) {
+            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_TAG, "tag cannot contain control character");
         }
     }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidatorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidatorTest.java
@@ -44,13 +44,4 @@ public class GrpcValidatorTest {
         assertThrows(GrpcProxyException.class, () -> grpcValidator.validateConsumerGroup("CID_RMQ_SYS_xxxx"));
         grpcValidator.validateConsumerGroup("consumerGroupName");
     }
-
-    @Test
-    public void testValidateTag() {
-        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateTag("  "));
-        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateTag("tag1|tag2"));
-        grpcValidator.validateTag("tag");
-        grpcValidator.validateTag(null);
-        grpcValidator.validateTag("");
-    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidatorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcValidatorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.v2.common;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class GrpcValidatorTest {
+
+    private GrpcValidator grpcValidator;
+
+    @Before
+    public void before() {
+        this.grpcValidator = GrpcValidator.getInstance();
+    }
+
+    @Test
+    public void testValidateTopic() {
+        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateTopic(""));
+        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateTopic("rmq_sys_xxxx"));
+        grpcValidator.validateTopic("topicName");
+    }
+
+    @Test
+    public void testValidateConsumerGroup() {
+        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateConsumerGroup(""));
+        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateConsumerGroup("CID_RMQ_SYS_xxxx"));
+        grpcValidator.validateConsumerGroup("consumerGroupName");
+    }
+
+    @Test
+    public void testValidateTag() {
+        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateTag("  "));
+        assertThrows(GrpcProxyException.class, () -> grpcValidator.validateTag("tag1|tag2"));
+        grpcValidator.validateTag("tag");
+        grpcValidator.validateTag(null);
+        grpcValidator.validateTag("");
+    }
+}


### PR DESCRIPTION
For #5776 , remove repeated empty string checks for `topic` and `group`, and add unit tests.

org.apache.rocketmq.client.Validators#checkTopic：
![image](https://user-images.githubusercontent.com/12792261/209650534-7d53f3d1-1068-4b7c-af6c-0ee21a77b27c.png)
org.apache.rocketmq.client.Validators#checkGroup：
![image](https://user-images.githubusercontent.com/12792261/209650420-f3cfe34a-16ff-40e7-bb51-bcc20c3afe45.png)

