### PR TITLE
[ISSUE #5740] Fix util.getIP sometimes choose localhost over LAN ip.

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
@@ -517,8 +517,10 @@ public class UtilAll {
         //10.0.0.0~10.255.255.255
         //172.16.0.0~172.31.255.255
         //192.168.0.0~192.168.255.255
+        //127.0.0.0~127.255.255.255
         if (ip[0] == (byte) 10) {
-
+            return true;
+        } else if (ip[0] == (byte) 127) {
             return true;
         } else if (ip[0] == (byte) 172) {
             if (ip[1] >= (byte) 16 && ip[1] <= (byte) 31) {
@@ -604,7 +606,7 @@ public class UtilAll {
                             if (ipCheck(ipByte)) {
                                 if (!isInternalIP(ipByte)) {
                                     return ipByte;
-                                } else if (internalIP == null) {
+                                } else if (internalIP == null || internalIP[0] == (byte) 127) {
                                     internalIP = ipByte;
                                 }
                             }


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change
fix #5740

## Brief changelog
According to RFC 1122, { 127, any } are reserved for internal host loopback address.So `isInternalIP` function return true when ip is between 127.0.0.0~127.255.255.255.
And now it prefers LAN ip to localhost(internal host loopback address).
## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
