### PR TITLE
[ISSUE #6482]style: Rename the variable "filepath" to "filePath" on line 55 of PosixFileSegment.java

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java
@@ -52,7 +52,7 @@ public class PosixFileSegment extends TieredFileSegment {
     private static final String OPERATION_POSIX_WRITE = "write";
 
     private final String basePath;
-    private final String filepath;
+    private final String filePath;
 
     private volatile File file;
     private volatile FileChannel readFileChannel;
@@ -68,7 +68,7 @@ public class PosixFileSegment extends TieredFileSegment {
         } else {
             this.basePath = basePath + File.separator;
         }
-        this.filepath = this.basePath
+        this.filePath = this.basePath
             + TieredStoreUtil.getHash(storeConfig.getBrokerClusterName()) + "_" + storeConfig.getBrokerClusterName() + File.separator
             + messageQueue.getBrokerName() + File.separator
             + messageQueue.getTopic() + File.separator
@@ -86,7 +86,7 @@ public class PosixFileSegment extends TieredFileSegment {
 
     @Override
     public String getPath() {
-        return filepath;
+        return filePath;
     }
 
     @Override
@@ -107,7 +107,7 @@ public class PosixFileSegment extends TieredFileSegment {
         if (file == null) {
             synchronized (this) {
                 if (file == null) {
-                    File file = new File(filepath);
+                    File file = new File(filePath);
                     try {
                         File dir = file.getParentFile();
                         if (!dir.exists()) {
@@ -120,7 +120,7 @@ public class PosixFileSegment extends TieredFileSegment {
                         this.writeFileChannel = new RandomAccessFile(file, "rwd").getChannel();
                         this.file = file;
                     } catch (Exception e) {
-                        logger.error("PosixFileSegment#createFile: create file {} failed: ", filepath, e);
+                        logger.error("PosixFileSegment#createFile: create file {} failed: ", filePath, e);
                     }
                 }
             }
@@ -137,7 +137,7 @@ public class PosixFileSegment extends TieredFileSegment {
                 writeFileChannel.close();
             }
         } catch (IOException e) {
-            logger.error("PosixFileSegment#destroyFile: destroy file {} failed: ", filepath, e);
+            logger.error("PosixFileSegment#destroyFile: destroy file {} failed: ", filePath, e);
         }
 
         if (file.exists()) {
@@ -174,7 +174,7 @@ public class PosixFileSegment extends TieredFileSegment {
             attributesBuilder.put(LABEL_SUCCESS, false);
             TieredStoreMetricsManager.providerRpcLatency.record(costTime, attributesBuilder.build());
             logger.error("PosixFileSegment#read0: read file {} failed: position: {}, length: {}",
-                filepath, position, length, e);
+                    filePath, position, length, e);
             future.completeExceptionally(e);
         }
         return future;
@@ -194,7 +194,7 @@ public class PosixFileSegment extends TieredFileSegment {
                     byte[] byteArray = ByteStreams.toByteArray(inputStream);
                     if (byteArray.length != length) {
                         logger.error("PosixFileSegment#commit0: append file {} failed: real data size: {}, is not equal to length: {}",
-                            filepath, byteArray.length, length);
+                                filePath, byteArray.length, length);
                         future.complete(false);
                         return;
                     }
@@ -220,7 +220,7 @@ public class PosixFileSegment extends TieredFileSegment {
                     TieredStoreMetricsManager.providerRpcLatency.record(costTime, attributesBuilder.build());
 
                     logger.error("PosixFileSegment#commit0: append file {} failed: position: {}, length: {}",
-                        filepath, position, length, e);
+                            filePath, position, length, e);
                     future.completeExceptionally(e);
                 }
             });


### PR DESCRIPTION
… file tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java


**Make sure set the target branch to `develop`**

## What is the purpose of the change

<!--
If this PR fixes a GitHub issue, please add `fixes #<XXX>` or `closes #<XXX>`. Please refer to the documentation for more information:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

In the RocketMQ project, the variable name "filepath" on line 55 of the file tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java does not comply with the naming convention and should be renamed to "filePath" to conform with the Java coding standard. <!-- <xxx> replace with issue id -->

## Brief changelog

![60dd0303544fc34353b25cc016ffdad](https://user-images.githubusercontent.com/97528982/227904786-e06d10db-6daa-4e6f-90e7-355b78dc31af.png)
