### PR TITLE
[ISSUE #6448] Fix SystemClock.now() is affected by NTP time synchronization, which can cause inaccuracies in the result of isOSPageCacheBusy()

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -106,6 +106,7 @@ import org.apache.rocketmq.common.AbstractBrokerRunnable;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.BrokerIdentity;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.SystemClock;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.UtilAll;
@@ -1107,7 +1108,7 @@ public class BrokerController {
         final Runnable peek = q.peek();
         if (peek != null) {
             RequestTask rt = BrokerFastFailure.castRunnable(peek);
-            slowTimeMills = rt == null ? 0 : this.messageStore.now() - rt.getCreateTimestamp();
+            slowTimeMills = rt == null ? 0 : SystemClock.elapsedMillis(rt.getCreateNano());
         }
 
         if (slowTimeMills < 0) {

--- a/broker/src/main/java/org/apache/rocketmq/broker/latency/BrokerFastFailure.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/latency/BrokerFastFailure.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.AbstractBrokerRunnable;
+import org.apache.rocketmq.common.SystemClock;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -87,7 +88,7 @@ public class BrokerFastFailure {
                         rt.returnResponse(RemotingSysResponseCode.SYSTEM_BUSY, String.format(
                             "[PCBUSY_CLEAN_QUEUE]broker busy, start flow control for a while, period in queue: %sms, "
                                 + "size of queue: %d",
-                            System.currentTimeMillis() - rt.getCreateTimestamp(),
+                                SystemClock.elapsedMillis(rt.getCreateNano()),
                             this.brokerController.getSendThreadPoolQueue().size()));
                     }
                 } else {
@@ -129,7 +130,7 @@ public class BrokerFastFailure {
                         break;
                     }
 
-                    final long behind = System.currentTimeMillis() - rt.getCreateTimestamp();
+                    final long behind = SystemClock.elapsedMillis(rt.getCreateNano());
                     if (behind >= maxWaitTimeMillsInQueue) {
                         if (blockingQueue.remove(runnable)) {
                             rt.setStopRun(true);

--- a/common/src/main/java/org/apache/rocketmq/common/SystemClock.java
+++ b/common/src/main/java/org/apache/rocketmq/common/SystemClock.java
@@ -20,4 +20,20 @@ public class SystemClock {
     public long now() {
         return System.currentTimeMillis();
     }
+
+    public long nano() {
+        return System.nanoTime();
+    }
+
+    private static long nanoToMillis(long nano) {
+        return nano / 1000_000L;
+    }
+
+    public static long elapsedMillis(long startNano) {
+        long diff = System.nanoTime() - startNano;
+        if (diff < 0) {
+            diff = 0;
+        }
+        return nanoToMillis(diff);
+    }
 }

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvController.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvController.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.apache.rocketmq.common.SystemClock;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.future.FutureTaskExt;
@@ -202,7 +203,7 @@ public class NamesrvController {
         if (firstRunnable instanceof FutureTaskExt) {
             final Runnable inner = ((FutureTaskExt<?>) firstRunnable).getRunnable();
             if (inner instanceof RequestTask) {
-                slowTimeMills = System.currentTimeMillis() - ((RequestTask) inner).getCreateTimestamp();
+                slowTimeMills = SystemClock.elapsedMillis(((RequestTask) inner).getCreateNano());
             }
         }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.acl.AccessValidator;
 import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.SystemClock;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.future.FutureTaskExt;
 import org.apache.rocketmq.common.thread.ThreadPoolMonitor;
@@ -293,7 +294,7 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
             final Runnable peek = q.peek();
             if (peek != null) {
                 RequestTask rt = castRunnable(peek);
-                slowTimeMills = rt == null ? 0 : System.currentTimeMillis() - rt.getCreateTimestamp();
+                slowTimeMills = rt == null ? 0 : SystemClock.elapsedMillis(rt.getCreateNano());
             }
 
             if (slowTimeMills < 0) {
@@ -332,7 +333,7 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
                         break;
                     }
 
-                    final long behind = System.currentTimeMillis() - rt.getCreateTimestamp();
+                    final long behind = SystemClock.elapsedMillis(rt.getCreateNano());
                     if (behind >= maxWaitTimeMillsInQueue) {
                         if (blockingQueue.remove(runnable)) {
                             rt.setStopRun(true);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/RequestTask.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/RequestTask.java
@@ -27,6 +27,7 @@ public class RequestTask implements Runnable {
     private final RemotingCommand request;
     private volatile boolean stopRun = false;
 
+    private final long createNano = System.nanoTime();
     public RequestTask(final Runnable runnable, final Channel channel, final RemotingCommand request) {
         this.runnable = runnable;
         this.channel = channel;
@@ -40,6 +41,7 @@ public class RequestTask implements Runnable {
         result = 31 * result + (channel != null ? channel.hashCode() : 0);
         result = 31 * result + (request != null ? request.hashCode() : 0);
         result = 31 * result + (isStopRun() ? 1 : 0);
+        result = 31 * result + (int) (getCreateNano() ^ (getCreateNano() >>> 32));
         return result;
     }
 
@@ -54,6 +56,8 @@ public class RequestTask implements Runnable {
 
         if (getCreateTimestamp() != that.getCreateTimestamp())
             return false;
+        if (getCreateNano() != that.getCreateNano())
+            return false;
         if (isStopRun() != that.isStopRun())
             return false;
         if (channel != null ? !channel.equals(that.channel) : that.channel != null)
@@ -64,6 +68,10 @@ public class RequestTask implements Runnable {
 
     public long getCreateTimestamp() {
         return createTimestamp;
+    }
+
+    public long getCreateNano() {
+        return createNano;
     }
 
     public boolean isStopRun() {

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -639,9 +639,7 @@ public class DefaultMessageStore implements MessageStore {
 
     @Override
     public boolean isOSPageCacheBusy() {
-        long begin = this.getCommitLog().getBeginTimeInLock();
-        long diff = this.systemClock.now() - begin;
-
+        long diff = this.lockTimeMills();
         return diff < 10000000
             && diff > this.messageStoreConfig.getOsPageCacheBusyTimeOutMills();
     }
@@ -1756,7 +1754,7 @@ public class DefaultMessageStore implements MessageStore {
                 if (DefaultMessageStore.this.getMessageStoreConfig().isDebugLockEnable()) {
                     try {
                         if (DefaultMessageStore.this.commitLog.getBeginTimeInLock() != 0) {
-                            long lockTime = System.currentTimeMillis() - DefaultMessageStore.this.commitLog.getBeginTimeInLock();
+                            long lockTime = SystemClock.elapsedMillis(DefaultMessageStore.this.commitLog.getBeginNanoInLock());
                             if (lockTime > 1000 && lockTime < 10000000) {
 
                                 String stack = UtilAll.jstack();


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## Fix SystemClock.now() is affected by NTP time synchronization, which can cause inaccuracies in the result of isOSPageCacheBusy()
fix #6448 

## Brief changelog

1. Replace elapsed time calculation by System.nanoTime()

## Verifying this change

