### PR TITLE
ISSUE #6398

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
@@ -66,28 +66,54 @@ public class TopicPublishInfo {
         this.haveTopicRouterInfo = haveTopicRouterInfo;
     }
 
+//    public MessageQueue selectOneMessageQueue(final String lastBrokerName) {
+//        if (lastBrokerName == null) {
+//            return selectOneMessageQueue();
+//        } else {
+//            for (int i = 0; i < this.messageQueueList.size(); i++) {
+//                int index = this.sendWhichQueue.incrementAndGet();
+//                int pos = index % this.messageQueueList.size();
+//                MessageQueue mq = this.messageQueueList.get(pos);
+//                if (!mq.getBrokerName().equals(lastBrokerName)) {
+//                    return mq;
+//                }
+//            }
+//            return selectOneMessageQueue();
+//        }
+//    }
+//
+//    public MessageQueue selectOneMessageQueue() {
+//        int index = this.sendWhichQueue.incrementAndGet();
+//        int pos = index % this.messageQueueList.size();
+//
+//        return this.messageQueueList.get(pos);
+//    }
+
     public MessageQueue selectOneMessageQueue(final String lastBrokerName) {
         if (lastBrokerName == null) {
             return selectOneMessageQueue();
         } else {
-            for (int i = 0; i < this.messageQueueList.size(); i++) {
-                int index = this.sendWhichQueue.incrementAndGet();
-                int pos = index % this.messageQueueList.size();
-                MessageQueue mq = this.messageQueueList.get(pos);
-                if (!mq.getBrokerName().equals(lastBrokerName)) {
-                    return mq;
-                }
-            }
-            return selectOneMessageQueue();
+            return selectOneMessageQueueHelper(lastBrokerName);
         }
     }
 
     public MessageQueue selectOneMessageQueue() {
-        int index = this.sendWhichQueue.incrementAndGet();
-        int pos = index % this.messageQueueList.size();
-
-        return this.messageQueueList.get(pos);
+        return selectOneMessageQueueHelper(null);
     }
+
+    private MessageQueue selectOneMessageQueueHelper(final String lastBrokerName) {
+        for (int i = 0; i < this.messageQueueList.size(); i++) {
+            int index = this.sendWhichQueue.incrementAndGet();
+            int pos = index % this.messageQueueList.size();
+            MessageQueue mq = this.messageQueueList.get(pos);
+            if (lastBrokerName == null || !mq.getBrokerName().equals(lastBrokerName)) {
+                return mq;
+            }
+        }
+        // If we haven't found a suitable message queue yet, just return the first one
+        return this.messageQueueList.get(0);
+    }
+
 
     public int getWriteQueueIdByBroker(final String brokerName) {
         for (int i = 0; i < topicRouteData.getQueueDatas().size(); i++) {


### PR DESCRIPTION
To clarify, while there is indeed some duplicated code between the two selectOneMessageQueue methods, there are some differences as well, particularly in the handling of the lastBrokerName argument. Therefore, simply merging the two methods into one may not be the best solution in this case.

However, there are still some opportunities to refactor the code to reduce duplication. One option could be to extract the common code into a private helper method, which both selectOneMessageQueue methods can call as needed.
In this refactored version, the selectOneMessageQueue methods now simply call a private helper method, passing in null or the lastBrokerName argument as appropriate. The helper method contains the common code for selecting a message queue, including the loop, incrementing the queue index, and checking whether the broker name matches the given parameter.

Note that in the refactored version, I also added a fallback option.