### PR TITLE
changed code of REGISTER_TOPIC_IN_NAMESRV to 1217

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
@@ -130,7 +130,7 @@ public class RequestCode {
     public static final int DELETE_TOPIC_IN_BROKER = 215;
 
     public static final int DELETE_TOPIC_IN_NAMESRV = 216;
-    public static final int REGISTER_TOPIC_IN_NAMESRV = 217;
+    public static final int REGISTER_TOPIC_IN_NAMESRV = 1217;
     public static final int GET_KVLIST_BY_NAMESPACE = 219;
 
     public static final int RESET_CONSUMER_CLIENT_OFFSET = 220;


### PR DESCRIPTION

## What is the purpose of the change - #5768 

> There was described the 217 code as GET_KV_CONFIG_BY_VALUE label, see [here](https://github.com/apache/rocketmq-client-cpp/blob/master/src/protocol/MQProtos.h#L98-L100)

> But since 5.0.0-beta, the RequestCode(217) may be reusable as REGISTER_TOPIC_IN_NAMESRV

> Those two kind of RemotingCommand operations looks like incompatible, the one GET_KV_CONFIG_BY_VALUE mostly same as fetching and another REGISTER_TOPIC_IN_NAMESRV sames to pushing.