### PR TITLE
[ISSUE #6525]Make ConsumeQueueInterface extends from FileQueueLifeCycle

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -41,7 +41,7 @@ import org.apache.rocketmq.store.SelectMappedBufferResult;
 import org.apache.rocketmq.store.config.BrokerRole;
 import org.apache.rocketmq.store.logfile.MappedFile;
 
-public class BatchConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
+public class BatchConsumeQueue implements ConsumeQueueInterface {
     protected static final Logger log = LoggerFactory.getLogger(LoggerName.STORE_LOGGER_NAME);
 
     /**

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueInterface.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueInterface.java
@@ -22,7 +22,7 @@ import org.apache.rocketmq.common.message.MessageExtBrokerInner;
 import org.apache.rocketmq.store.DispatchRequest;
 import org.apache.rocketmq.store.MessageFilter;
 
-public interface ConsumeQueueInterface {
+public interface ConsumeQueueInterface extends FileQueueLifeCycle {
     /**
      * Get the topic name
      * @return the topic this cq belongs to.

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -79,7 +79,7 @@ public class ConsumeQueueStore {
     }
 
     private FileQueueLifeCycle getLifeCycle(String topic, int queueId) {
-        return (FileQueueLifeCycle) findOrCreateConsumeQueue(topic, queueId);
+        return findOrCreateConsumeQueue(topic, queueId);
     }
 
     public long rollNextFile(ConsumeQueueInterface consumeQueue, final long offset) {

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -220,7 +220,7 @@ public class ConsumeQueueStore {
                     FutureTask<Boolean> futureTask = new FutureTask<>(() -> {
                         boolean ret = true;
                         try {
-                            ((FileQueueLifeCycle) logic).recover();
+                            logic.recover();
                         } catch (Throwable e) {
                             ret = false;
                             log.error("Exception occurs while recover consume queue concurrently, " +


### PR DESCRIPTION
**Make sure set the target branch to `develop`**

## What is the purpose of the change
close #6525
we are typecasting here
```
 private FileQueueLifeCycle getLifeCycle(String topic, int queueId) {
        return (FileQueueLifeCycle) findOrCreateConsumeQueue(topic, queueId);
    }
```
but interface is not extending FileQueueLifeCycle.
So it will throw typecast error.