### PR TITLE
[ISSUE #6537] Fix bug MessageStoreConfig.haListenPort item config not…

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -167,7 +167,6 @@ public class BrokerStartup {
             System.exit(-4);
         }
 
-        messageStoreConfig.setHaListenPort(nettyServerConfig.getListenPort() + 1);
         brokerConfig.setInBrokerContainer(false);
 
         System.setProperty("brokerLogDir", "");


### PR DESCRIPTION
[fix] [fix6537](https://github.com/apache/rocketmq/issues/6537)

**After the configuration file is loaded,  it was overwritten by the subsequent setHaListenPort**
---
After removing this line of code, the configuration takes effect