### PR TITLE
Temporary removal of required maven-compile status check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,9 +42,6 @@ github:
         contexts:
           - misspell-check
           - check-license
-          - maven-compile (ubuntu-18.04, JDK-8)
-          - maven-compile (windows-2022, JDK-8)
-          - maven-compile (macos-11, JDK-8)
 notifications:
   commits:      commits@rocketmq.apache.org
   issues:       commits@rocketmq.apache.org

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   java_build:
     name: "maven-compile (${{ matrix.os }}, JDK-${{ matrix.jdk }})"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We will upgrade it with the latest operating system image later.

related issue: #6560 