### PR TITLE
[ISSUE #6652] Fix reset offset fail when group is CID_RMQ_SYS_REVIVE_GROUP and enable useServerSideResetOffset

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -1725,7 +1725,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             return response;
         }
 
-        if (!brokerController.getSubscriptionGroupManager().containsSubscriptionGroup(group)) {
+        if (!brokerController.getSubscriptionGroupManager().containsSubscriptionGroup(group) && !MixAll.isSysConsumerGroup(group)) {
             response.setCode(ResponseCode.SUBSCRIPTION_GROUP_NOT_EXIST);
             response.setRemark("Group " + group + " does not exist");
             LOGGER.warn("Reset offset failed, group does not exist. topic={}, group={}", topic, group);


### PR DESCRIPTION

### Which Issue(s) This PR Fixes


Fixes #6652

### Brief Description


if REVIVE_TOPIC exists, but biz topic deleted, we can not skip , so we can reset offset , but if we want to reset the offset, now it is impossible, because no consumer online (system group),and no use for this. 

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
