### PR TITLE
[ISSUE #6677]Client Method RebalanceImpl#computePullFromWhere is marked with @Deprecated replace with computePullFromWhereWithException

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceImpl.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.FindBrokerResult;
@@ -521,7 +522,13 @@ public abstract class RebalanceImpl {
                 this.removeDirtyOffset(mq);
                 ProcessQueue pq = createProcessQueue(topic);
                 pq.setLocked(true);
-                long nextOffset = this.computePullFromWhere(mq);
+                long nextOffset;
+                try {
+                    nextOffset = this.computePullFromWhereWithException(mq);
+                } catch (Exception e) {
+                    log.warn("doRebalance, {}, compute offset failed, {}", consumerGroup, mq, e);
+                    continue;
+                }
                 if (nextOffset >= 0) {
                     ProcessQueue pre = this.processQueueTable.putIfAbsent(mq, pq);
                     if (pre != null) {
@@ -680,7 +687,7 @@ public abstract class RebalanceImpl {
                     try {
                         nextOffset = this.computePullFromWhereWithException(mq);
                     } catch (Exception e) {
-                        log.info("doRebalance, {}, compute offset failed, {}", consumerGroup, mq);
+                        log.warn("doRebalance, {}, compute offset failed, {}", consumerGroup, mq, e);
                         continue;
                     }
 
@@ -755,6 +762,7 @@ public abstract class RebalanceImpl {
     /**
      * When the network is unstable, using this interface may return wrong offset.
      * It is recommended to use computePullFromWhereWithException instead.
+     *
      * @param mq
      * @return offset
      */

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImpl.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumeType;
 import org.apache.rocketmq.remoting.protocol.heartbeat.MessageModel;
 
@@ -150,6 +151,11 @@ public class RebalanceLitePullImpl extends RebalanceImpl {
                 break;
             }
         }
+
+        if (result < 0) {
+            throw new MQClientException(ResponseCode.SYSTEM_ERROR, "Found unexpected result " + result);
+        }
+
         return result;
     }
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImplTest.java
@@ -16,6 +16,12 @@
  */
 package org.apache.rocketmq.client.impl.consumer;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
 import org.apache.rocketmq.client.consumer.store.OffsetStore;
 import org.apache.rocketmq.client.consumer.store.ReadOffsetType;
@@ -26,12 +32,6 @@ import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class RebalanceLitePullImplTest {
     private MessageQueue mq = new MessageQueue("topic1", "broker1", 0);
@@ -50,7 +50,7 @@ public class RebalanceLitePullImplTest {
         when(client.getMQAdminImpl()).thenReturn(admin);
     }
 
-    @Test
+    @Test(expected = MQClientException.class)
     public void testComputePullFromWhereWithException_ne_minus1() throws MQClientException {
         for (ConsumeFromWhere where : new ConsumeFromWhere[]{
             ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET,
@@ -62,7 +62,7 @@ public class RebalanceLitePullImplTest {
             assertEquals(0, rebalanceImpl.computePullFromWhereWithException(mq));
 
             when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(-2L);
-            assertEquals(-1, rebalanceImpl.computePullFromWhereWithException(mq));
+            rebalanceImpl.computePullFromWhereWithException(mq);
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #6677 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
- Client Method RebalanceImpl#computePullFromWhere is marked with @Deprecated replace with computePullFromWhereWithException
