### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml to 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <guava.version>31.1-jre</guava.version>
         <gson.version>2.9.0</gson.version>
         <openmessaging.version>0.3.1-alpha</openmessaging.version>
-        <snakeyaml.version>1.32</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <commons-codec.version>1.13</commons-codec.version>
         <rocketmq-logging.version>1.0.1</rocketmq-logging.version>
         <slf4j-api.version>2.0.3</slf4j-api.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.yaml:snakeyaml 1.32
- [CVE-2022-1471](https://www.oscs1024.com/hd/CVE-2022-1471)


### What did I do？
Upgrade org.yaml:snakeyaml from 1.32 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS