### PR TITLE
Introduce Bazel Steward - a tool for keeping dependencies up to date in Bazel

### DIFF
--- a/.github/workflows/bazel-steward.yaml
+++ b/.github/workflows/bazel-steward.yaml
@@ -1,0 +1,15 @@
+name: Bazel Steward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,7 @@ http_archive(
     name = "rules_jvm_external",
     sha256 = RULES_JVM_EXTERNAL_SHA,
     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.2.zip",
 )
 
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")

--- a/bazel-steward.yaml
+++ b/bazel-steward.yaml
@@ -1,0 +1,3 @@
+pull-requests:
+  - limits:
+      max-open: 10


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

I am happy to create a Github issue if you find Bazel Steward useful.

### Brief Description

Hello everyone,

As one of developers I am submitting this pull request to introduce our new tool for Bazel repositories. [Bazel Steward](https://github.com/VirtusLab/bazel-steward) simplifies the process of checking and updating dependencies in your Bazel projects, making it more efficient to keep them up-to-date.
We hope that this tool will be useful to the Bazel community, and we look forward to your feedback.

This pull request integrates Bazel Steward through Github Actions which is currently the easiest way to do this. It will run every day at 12 and create new PRs or resolve conflicts on existing if necessary. You can preview how it looks in [a fork](https://github.com/lukaszwawrzyk/rocketmq/pulls) that I used to test it. For more details, you can check [the project readme](https://github.com/VirtusLab/bazel-steward#readme).

Bazel Steward is able to correctly update all your maven dependencies, version of Bazel itself as well as Bazel rules. 

We hope that Bazel Steward will make it easier for you to manage dependencies. If you have any questions, encounter any issues or have any feedback, please don't hesitate to reach out to me. Thank you!

Changes:

* Added GitHub Action Workflow for Bazel Steward
* Made rules_jvm_external url explicit - so that Bazel Steward can replace it reliably (as url scheme sometimes changes)
* Added config for Bazel Steward to limit concurrently open PRs to 10 to make it more manageable as I think there are 45 outdated dependencies here.

### How Did You Test This Change?

I run Bazel Steward on a fork that I mentioned earlier. I had to allow Github Actions for write access and managing PRs in repository settings. Additionally, in order to be able to have workflows triggered on Bazel Steward PRs, you'd need to follow this guide: https://github.com/VirtusLab/bazel-steward#triggering-workflows-for-pull-requests
