### PR TITLE
[ISSUE #6703] Fix the incorrect of confirmOffset when recovering abnormally caused by message loss due to asynchronous flushing after restarting

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -344,7 +344,7 @@ public class CommitLog implements Swappable {
                     log.error("confirmOffset {} is less than minPhyOffset {}, correct confirmOffset to minPhyOffset", this.defaultMessageStore.getConfirmOffset(), this.defaultMessageStore.getMinPhyOffset());
                     this.defaultMessageStore.setConfirmOffset(this.defaultMessageStore.getMinPhyOffset());
                 } else if (this.defaultMessageStore.getConfirmOffset() > processOffset) {
-                    log.error("confirmOffset {} is larger than lastValidMsgPhyOffset {}, correct confirmOffset to processOffset", this.defaultMessageStore.getConfirmOffset(), processOffset);
+                    log.error("confirmOffset {} is larger than processOffset {}, correct confirmOffset to processOffset", this.defaultMessageStore.getConfirmOffset(), processOffset);
                     this.defaultMessageStore.setConfirmOffset(processOffset);
                 }
             } else {
@@ -614,7 +614,8 @@ public class CommitLog implements Swappable {
             ByteBuffer byteBuffer = mappedFile.sliceByteBuffer();
             long processOffset = mappedFile.getFileFromOffset();
             long mappedFileOffset = 0;
-            long lastValidMsgPhyOffset = this.getConfirmOffset();
+            long lastValidMsgPhyOffset = processOffset;
+            long lastConfirmValidMsgPhyOffset = processOffset;
             // abnormal recover require dispatching
             boolean doDispatch = true;
             while (true) {
@@ -628,8 +629,9 @@ public class CommitLog implements Swappable {
                         mappedFileOffset += size;
 
                         if (this.defaultMessageStore.getMessageStoreConfig().isDuplicationEnable() || this.defaultMessageStore.getBrokerConfig().isEnableControllerMode()) {
-                            if (dispatchRequest.getCommitLogOffset() < this.defaultMessageStore.getCommitLog().getConfirmOffset()) {
+                            if (dispatchRequest.getCommitLogOffset() + size <= this.defaultMessageStore.getCommitLog().getConfirmOffset()) {
                                 this.getMessageStore().onCommitLogDispatch(dispatchRequest, doDispatch, mappedFile, true, false);
+                                lastConfirmValidMsgPhyOffset = dispatchRequest.getCommitLogOffset() + size;
                             }
                         } else {
                             this.getMessageStore().onCommitLogDispatch(dispatchRequest, doDispatch, mappedFile, true, false);
@@ -670,9 +672,9 @@ public class CommitLog implements Swappable {
                 if (this.defaultMessageStore.getConfirmOffset() < this.defaultMessageStore.getMinPhyOffset()) {
                     log.error("confirmOffset {} is less than minPhyOffset {}, correct confirmOffset to minPhyOffset", this.defaultMessageStore.getConfirmOffset(), this.defaultMessageStore.getMinPhyOffset());
                     this.defaultMessageStore.setConfirmOffset(this.defaultMessageStore.getMinPhyOffset());
-                } else if (this.defaultMessageStore.getConfirmOffset() > processOffset) {
-                    log.error("confirmOffset {} is larger than lastValidMsgPhyOffset {}, correct confirmOffset to processOffset", this.defaultMessageStore.getConfirmOffset(), processOffset);
-                    this.defaultMessageStore.setConfirmOffset(processOffset);
+                } else if (this.defaultMessageStore.getConfirmOffset() > lastConfirmValidMsgPhyOffset) {
+                    log.error("confirmOffset {} is larger than lastConfirmValidMsgPhyOffset {}, correct confirmOffset to lastConfirmValidMsgPhyOffset", this.defaultMessageStore.getConfirmOffset(), lastConfirmValidMsgPhyOffset);
+                    this.defaultMessageStore.setConfirmOffset(lastConfirmValidMsgPhyOffset);
                 }
             } else {
                 this.setConfirmOffset(lastValidMsgPhyOffset);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #6703 

### Brief Description

Fix the incorrect of confirmOffset when recovering abnormally caused by message loss due to asynchronous flushing after restarting

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
