### PR TITLE
[ISSUE #6712]Remove useless method BrokerOuterAPI#pullMessageFromSpecificBroker

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
@@ -1272,31 +1272,6 @@ public class BrokerOuterAPI {
         });
     }
 
-    public PullResult pullMessageFromSpecificBroker(String brokerName, String brokerAddr,
-        String consumerGroup, String topic, int queueId, long offset,
-        int maxNums, long timeoutMillis) throws MQBrokerException, RemotingException, InterruptedException {
-        PullMessageRequestHeader requestHeader = new PullMessageRequestHeader();
-        requestHeader.setConsumerGroup(consumerGroup);
-        requestHeader.setTopic(topic);
-        requestHeader.setQueueId(queueId);
-        requestHeader.setQueueOffset(offset);
-        requestHeader.setMaxMsgNums(maxNums);
-        requestHeader.setSysFlag(PullSysFlag.buildSysFlag(false, false, true, false));
-        requestHeader.setCommitOffset(0L);
-        requestHeader.setSuspendTimeoutMillis(0L);
-        requestHeader.setSubscription(SubscriptionData.SUB_ALL);
-        requestHeader.setSubVersion(System.currentTimeMillis());
-        requestHeader.setMaxMsgBytes(Integer.MAX_VALUE);
-        requestHeader.setExpressionType(ExpressionType.TAG);
-        requestHeader.setBname(brokerName);
-
-        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.PULL_MESSAGE, requestHeader);
-        RemotingCommand response = this.remotingClient.invokeSync(brokerAddr, request, timeoutMillis);
-        PullResultExt pullResultExt = this.processPullResponse(response, brokerAddr);
-        this.processPullResult(pullResultExt, brokerName, queueId);
-        return pullResultExt;
-    }
-
     public CompletableFuture<PullResult> pullMessageFromSpecificBrokerAsync(String brokerName, String brokerAddr,
         String consumerGroup, String topic, int queueId, long offset,
         int maxNums, long timeoutMillis) throws RemotingException, InterruptedException {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #6712 

### Brief Description

-Remove useless method BrokerOuterAPI#pullMessageFromSpecificBroker

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
