### PR TITLE
[ISSUE #6728] Compute the confirmOffset without considering new connections

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -1589,9 +1589,17 @@ public class DefaultMessageStore implements MessageStore {
         }
     }
 
+    // Fetch and compute the newest confirmOffset.
+    // Even if it is just inited.
     @Override
     public long getConfirmOffset() {
         return this.commitLog.getConfirmOffset();
+    }
+
+    // Fetch the original confirmOffset's value.
+    // Without checking and re-computing.
+    public long getConfirmOffsetDirectly() {
+        return this.commitLog.getConfirmOffsetDirectly();
     }
 
     @Override

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAService.java
@@ -435,7 +435,7 @@ public class AutoSwitchHAService extends DefaultHAService {
                     // So skip this ackOffset.
                     continue;
                 }
-                newConfirmOffset = Math.min(newConfirmOffset, connection.getSlaveAckOffset());
+                newConfirmOffset = Math.min(newConfirmOffset, slaveAckOffset);
             }
         }
         return newConfirmOffset;

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAService.java
@@ -428,14 +428,8 @@ public class AutoSwitchHAService extends DefaultHAService {
 
         for (HAConnection connection : this.connectionList) {
             final Long slaveId = ((AutoSwitchHAConnection) connection).getSlaveId();
-            if (currentSyncStateSet.contains(slaveId)) {
-                long slaveAckOffset = connection.getSlaveAckOffset();
-                if (slaveAckOffset <= 0) {
-                    // Slave's connection is just inited, the ack hasn't been calculated.
-                    // So skip this ackOffset.
-                    continue;
-                }
-                newConfirmOffset = Math.min(newConfirmOffset, slaveAckOffset);
+            if (currentSyncStateSet.contains(slaveId) && connection.getSlaveAckOffset() > 0) {
+                newConfirmOffset = Math.min(newConfirmOffset, connection.getSlaveAckOffset());
             }
         }
         return newConfirmOffset;


### PR DESCRIPTION
[ISSUE #6728] Compute the confirmOffset without considering new connections.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #6728 

### Brief Description

1. When calculate the newConfirmOffset, skip those connections with -1 ackOffset value.
2. Add a new method, getConfirmOffsetDirectly(). This method will only return the confirmOffset without checking and re-computing. Because in some cases (If set confirmOffset wrongly) endless calling will occur between the getConfirmOffset() and computeConfirmOffset().
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
