### PR TITLE
[ISSUE #6731] Use ChannelProtocolType for ContextVariable.PROTOCOL_TYPE

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.proxy.common;
 import io.netty.channel.Channel;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.rocketmq.proxy.processor.channel.ChannelProtocolType;
 
 public class ProxyContext {
     public static final String INNER_ACTION_PREFIX = "Inner";
@@ -122,12 +123,12 @@ public class ProxyContext {
         return this.getVal(ContextVariable.ACTION);
     }
 
-    public ProxyContext setProtocolType(String protocol) {
+    public ProxyContext setProtocolType(ChannelProtocolType protocol) {
         this.withVal(ContextVariable.PROTOCOL_TYPE, protocol);
         return this;
     }
 
-    public String getProtocolType() {
+    public ChannelProtocolType getProtocolType() {
         return this.getVal(ContextVariable.PROTOCOL_TYPE);
     }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/GrpcMessagingApplication.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/GrpcMessagingApplication.java
@@ -172,7 +172,7 @@ public class GrpcMessagingApplication extends MessagingServiceGrpc.MessagingServ
             .setLocalAddress(getDefaultStringMetadataInfo(headers, InterceptorConstants.LOCAL_ADDRESS))
             .setRemoteAddress(getDefaultStringMetadataInfo(headers, InterceptorConstants.REMOTE_ADDRESS))
             .setClientID(getDefaultStringMetadataInfo(headers, InterceptorConstants.CLIENT_ID))
-            .setProtocolType(ChannelProtocolType.GRPC_V2.getName())
+            .setProtocolType(ChannelProtocolType.GRPC_V2)
             .setLanguage(getDefaultStringMetadataInfo(headers, InterceptorConstants.LANGUAGE))
             .setClientVersion(getDefaultStringMetadataInfo(headers, InterceptorConstants.CLIENT_VERSION))
             .setAction(getDefaultStringMetadataInfo(headers, InterceptorConstants.SIMPLE_RPC_NAME));

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivity.java
@@ -123,7 +123,7 @@ public abstract class AbstractRemotingActivity implements NettyRequestProcessor 
         ProxyContext context = ProxyContext.create();
         Channel channel = ctx.channel();
         context.setAction(RemotingHelper.getRequestCodeDesc(request.getCode()))
-            .setProtocolType(ChannelProtocolType.REMOTING.getName())
+            .setProtocolType(ChannelProtocolType.REMOTING)
             .setChannel(channel)
             .setLocalAddress(NetworkUtil.socketAddress2String(ctx.channel().localAddress()))
             .setRemoteAddress(NetworkUtil.socketAddress2String(ctx.channel().remoteAddress()));

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
@@ -93,7 +93,7 @@ public class AbstractRemotingActivityTest extends InitConfigTest {
         ProxyContext context = remotingActivity.createContext(ctx, request);
 
         Assert.assertEquals(context.getAction(), RemotingHelper.getRequestCodeDesc(RequestCode.PULL_MESSAGE));
-        Assert.assertEquals(context.getProtocolType(), ChannelProtocolType.REMOTING.getName());
+        Assert.assertEquals(context.getProtocolType(), ChannelProtocolType.REMOTING);
         Assert.assertEquals(context.getLanguage(), LanguageCode.JAVA.name());
         Assert.assertEquals(context.getClientID(), CLIENT_ID);
         Assert.assertEquals(context.getClientVersion(), MQVersion.getVersionDesc(MQVersion.CURRENT_VERSION));


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Fixes #6731

### Brief Description

Use ChannelProtocolType for ContextVariable.PROTOCOL_TYPE

### How Did You Test This Change?

No need
