### PR TITLE
Remove redundant variables

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/consumer/store/RemoteBrokerOffsetStore.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/store/RemoteBrokerOffsetStore.java
@@ -90,8 +90,7 @@ public class RemoteBrokerOffsetStore implements OffsetStore {
                 case READ_FROM_STORE: {
                     try {
                         long brokerOffset = this.fetchConsumeOffsetFromBroker(mq);
-                        AtomicLong offset = new AtomicLong(brokerOffset);
-                        this.updateOffset(mq, offset.get(), false);
+                        this.updateOffset(mq, brokerOffset, false);
                         return brokerOffset;
                     }
                     // No offset in broker


### PR DESCRIPTION
This AtomicInteger variable is meaningless, there is no thread safety issue here, and the variable does not return