### PR TITLE
[ISSUE #6849] Fix the issue of increasing RT in three replicators

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ha/GroupTransferService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/GroupTransferService.java
@@ -86,7 +86,7 @@ public class GroupTransferService extends ServiceThread {
 
                 for (int i = 0; !transferOK && deadLine - System.nanoTime() > 0; i++) {
                     if (i > 0) {
-                        this.notifyTransferObject.waitForRunning(1000);
+                        this.notifyTransferObject.waitForRunning(1);
                     }
 
                     if (!allAckInSyncStateSet && req.getAckNums() <= 1) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fix #6849 
Solve the discussion #6839 

### Brief Description

The confirmation of the three copies may not be as timely, and there is no need to wait for 1 second when entering the second round of confirmation. 

Just wait for 1 second.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Use the checkMsgSendRT:
![image](https://github.com/apache/rocketmq/assets/21073949/02f635e1-6a57-4fb9-82ff-4eb9daf811c9)

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
