### PR TITLE
[ISSUE #6866] Move the judgment logic of grpc TLS mode to improve the scalability of ProtocolNegotiator

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
@@ -44,7 +44,7 @@ import org.apache.rocketmq.remoting.common.TlsMode;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 
 public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator.ProtocolNegotiator {
-    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+    protected static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
     /**
      * the length of the ssl record header (in bytes)

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
@@ -51,10 +51,10 @@ public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator
      */
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    private static SslContext SSL_CONTEXT;
+    private static SslContext sslContext;
 
     public OptionalSSLProtocolNegotiator() {
-        SSL_CONTEXT = loadSslContext();
+        sslContext = loadSslContext();
     }
 
     @Override
@@ -108,7 +108,7 @@ public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator
         private final ChannelHandler plaintext;
 
         public PortUnificationServerHandler(GrpcHttp2ConnectionHandler grpcHandler) {
-            this.ssl = InternalProtocolNegotiators.serverTls(SSL_CONTEXT)
+            this.ssl = InternalProtocolNegotiators.serverTls(sslContext)
                     .newHandler(grpcHandler);
             this.plaintext = InternalProtocolNegotiators.serverPlaintext()
                     .newHandler(grpcHandler);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.proxy.grpc;
 
 import io.grpc.netty.shaded.io.grpc.netty.GrpcHttp2ConnectionHandler;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiationEvent;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiator;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiators;
@@ -24,24 +25,33 @@ import io.grpc.netty.shaded.io.netty.buffer.ByteBuf;
 import io.grpc.netty.shaded.io.netty.channel.ChannelHandler;
 import io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext;
 import io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler;
+import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.grpc.netty.shaded.io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.grpc.netty.shaded.io.netty.util.AsciiString;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.remoting.common.TlsMode;
+import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 
 public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator.ProtocolNegotiator {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
-    private final SslContext sslContext;
+
     /**
      * the length of the ssl record header (in bytes)
      */
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    public OptionalSSLProtocolNegotiator(SslContext sslContext) {
-        this.sslContext = sslContext;
+    public OptionalSSLProtocolNegotiator() {
     }
 
     @Override
@@ -50,44 +60,82 @@ public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator
     }
 
     @Override
-    public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHttp2ConnectionHandler) {
-        ChannelHandler plaintext =
-            InternalProtocolNegotiators.serverPlaintext().newHandler(grpcHttp2ConnectionHandler);
-        ChannelHandler ssl =
-            InternalProtocolNegotiators.serverTls(sslContext).newHandler(grpcHttp2ConnectionHandler);
-        return new PortUnificationServerHandler(ssl, plaintext);
+    public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
+        return new PortUnificationServerHandler(grpcHandler);
     }
 
     @Override
     public void close() {}
 
     public static class PortUnificationServerHandler extends ByteToMessageDecoder {
+
         private final ChannelHandler ssl;
         private final ChannelHandler plaintext;
 
-        public PortUnificationServerHandler(ChannelHandler ssl, ChannelHandler plaintext) {
-            this.ssl = ssl;
-            this.plaintext = plaintext;
+        public PortUnificationServerHandler(GrpcHttp2ConnectionHandler grpcHandler) {
+            this.ssl = InternalProtocolNegotiators.serverTls(loadSslContext())
+                    .newHandler(grpcHandler);
+            this.plaintext = InternalProtocolNegotiators.serverPlaintext()
+                    .newHandler(grpcHandler);
         }
 
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out)
-            throws Exception {
+                throws Exception {
             try {
-                // in SslHandler.isEncrypted, it need at least 5 bytes to judge is encrypted or not
-                if (in.readableBytes() < SSL_RECORD_HEADER_LENGTH) {
-                    return;
-                }
-                if (SslHandler.isEncrypted(in)) {
+                TlsMode tlsMode = TlsSystemConfig.tlsMode;
+                if (TlsMode.ENFORCING.equals(tlsMode)) {
                     ctx.pipeline().addAfter(ctx.name(), null, this.ssl);
-                } else {
+                } else if (TlsMode.DISABLED.equals(tlsMode)) {
                     ctx.pipeline().addAfter(ctx.name(), null, this.plaintext);
+                } else {
+                    // in SslHandler.isEncrypted, it need at least 5 bytes to judge is encrypted or not
+                    if (in.readableBytes() < SSL_RECORD_HEADER_LENGTH) {
+                        return;
+                    }
+                    if (SslHandler.isEncrypted(in)) {
+                        ctx.pipeline().addAfter(ctx.name(), null, this.ssl);
+                    } else {
+                        ctx.pipeline().addAfter(ctx.name(), null, this.plaintext);
+                    }
                 }
                 ctx.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
                 ctx.pipeline().remove(this);
             } catch (Exception e) {
-                log.error("process protocol negotiator failed.", e);
+                log.error("process ssl protocol negotiator failed.", e);
                 throw e;
+            }
+        }
+
+        private SslContext loadSslContext() {
+            try {
+                ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+                if (proxyConfig.isTlsTestModeEnable()) {
+                    SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
+                    return GrpcSslContexts.forServer(selfSignedCertificate.certificate(),
+                                    selfSignedCertificate.privateKey())
+                            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                            .clientAuth(ClientAuth.NONE)
+                            .build();
+                } else {
+                    String tlsKeyPath = ConfigurationManager.getProxyConfig().getTlsKeyPath();
+                    String tlsCertPath = ConfigurationManager.getProxyConfig().getTlsCertPath();
+                    try (InputStream serverKeyInputStream = Files.newInputStream(
+                            Paths.get(tlsKeyPath));
+                            InputStream serverCertificateStream = Files.newInputStream(
+                                    Paths.get(tlsCertPath))) {
+                        SslContext res = GrpcSslContexts.forServer(serverCertificateStream,
+                                        serverKeyInputStream)
+                                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                .clientAuth(ClientAuth.NONE)
+                                .build();
+                        log.info("grpc load TLS configured OK");
+                        return res;
+                    }
+                }
+            } catch (Exception e) {
+                log.error("grpc tls set failed. msg: {}, e:", e.getMessage(), e);
+                throw new RuntimeException("grpc tls set failed: " + e.getMessage());
             }
         }
     }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
@@ -51,7 +51,7 @@ public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator
      */
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    private static final SslContext sslContext = loadSslContext();
+    private static final SslContext SSL_CONTEXT = loadSslContext();
 
     public OptionalSSLProtocolNegotiator() {
     }
@@ -107,7 +107,7 @@ public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator
         private final ChannelHandler plaintext;
 
         public PortUnificationServerHandler(GrpcHttp2ConnectionHandler grpcHandler) {
-            this.ssl = InternalProtocolNegotiators.serverTls(sslContext)
+            this.ssl = InternalProtocolNegotiators.serverTls(SSL_CONTEXT)
                     .newHandler(grpcHandler);
             this.plaintext = InternalProtocolNegotiators.serverPlaintext()
                     .newHandler(grpcHandler);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/OptionalSSLProtocolNegotiator.java
@@ -51,9 +51,10 @@ public class OptionalSSLProtocolNegotiator implements InternalProtocolNegotiator
      */
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    private static final SslContext SSL_CONTEXT = loadSslContext();
+    private static SslContext SSL_CONTEXT;
 
     public OptionalSSLProtocolNegotiator() {
+        SSL_CONTEXT = loadSslContext();
     }
 
     @Override


### PR DESCRIPTION
Support dynamic modification of grpc TLS mode to improve the scalability of ProtocolNegotiator

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #6866

### Brief Description

Support dynamic modification of grpc TLS mode to improve the scalability of ProtocolNegotiator

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Yes.

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
