### PR TITLE
[ISSUE #6897]fix: the `ArrayIndexOutOfBoundsException` exception that may occur when selecting a queue

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/latency/MQFaultStrategy.java
+++ b/client/src/main/java/org/apache/rocketmq/client/latency/MQFaultStrategy.java
@@ -61,7 +61,7 @@ public class MQFaultStrategy {
             try {
                 int index = tpInfo.getSendWhichQueue().incrementAndGet();
                 for (int i = 0; i < tpInfo.getMessageQueueList().size(); i++) {
-                    int pos = index++ % tpInfo.getMessageQueueList().size();
+                    int pos = (index++ & Integer.MAX_VALUE) % tpInfo.getMessageQueueList().size();
                     MessageQueue mq = tpInfo.getMessageQueueList().get(pos);
                     if (!StringUtils.equals(lastBrokerName, mq.getBrokerName()) && latencyFaultTolerance.isAvailable(mq.getBrokerName())) {
                         return mq;


### PR DESCRIPTION

### Which Issue(s) This PR Fixes

Fixes #6897 

### Brief Description

<img width="799" alt="image" src="https://github.com/apache/rocketmq/assets/16759505/c3507b53-c05a-4bf6-9269-435e2c533383">

* The incrementAndGet() method returns the maximum value of Integer.
* Executing the index++ inside the loop again may result in a negative number, leading to ArrayIndexOutOfBoundsException.
