### PR TITLE
[ISSUE #6943] fix docs typo in docs/cn/controller/design.md #6943

### DIFF
--- a/docs/cn/controller/design.md
+++ b/docs/cn/controller/design.md
@@ -125,7 +125,7 @@ nextTransferFromWhere + size > currentTransferEpochEndOffset，则将 selectMapp
 
 - Current state 代表当前的 HAConnectionState，也即 HANDSHAKE。
 
-- Two falgs 是两个状态标志位，其中，isSyncFromLastFile 代表是否要从 Master 的最后一个文件开始复制，isAsyncLearner 代表该 Slave 是否是异步复制，并以 Learner 的形式接入 Master。
+- Two flags 是两个状态标志位，其中，isSyncFromLastFile 代表是否要从 Master 的最后一个文件开始复制，isAsyncLearner 代表该 Slave 是否是异步复制，并以 Learner 的形式接入 Master。
 
 - slaveAddressLength 与 slaveAddress 代表了该 Slave 的地址，用于后续加入 SyncStateSet 。
 


### PR DESCRIPTION
The word ‘falgs’ in [docs/cn/controller/design.md] is wrong.So change it to 'falgs'.