### PR TITLE
[ISSUE #5068] Fix return types  in ByteBuffer to Support JAVA9+

### DIFF
--- a/acl/src/test/java/org/apache/rocketmq/acl/plain/PlainAccessControlFlowTest.java
+++ b/acl/src/test/java/org/apache/rocketmq/acl/plain/PlainAccessControlFlowTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.acl.plain;
 
+import java.nio.Buffer;
 import org.apache.rocketmq.acl.common.AclClientRPCHook;
 import org.apache.rocketmq.acl.common.AclConstants;
 import org.apache.rocketmq.acl.common.AclException;
@@ -239,7 +240,7 @@ public class PlainAccessControlFlowTest {
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
         buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(
                 RemotingCommand.decode(buf), remoteAddr);
@@ -270,7 +271,7 @@ public class PlainAccessControlFlowTest {
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
         buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(
                 RemotingCommand.decode(buf), remoteAddr);

--- a/acl/src/test/java/org/apache/rocketmq/acl/plain/PlainAccessValidatorTest.java
+++ b/acl/src/test/java/org/apache/rocketmq/acl/plain/PlainAccessValidatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -93,8 +94,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "127.0.0.1");
             String signature = AclUtils.calSignature(accessResource.getContent(), sessionCredentials.getSecretKey());
@@ -117,8 +118,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -139,8 +140,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -160,8 +161,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -181,8 +182,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -202,8 +203,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6:9876");
             plainAccessValidator.validate(accessResource);
@@ -239,8 +240,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -260,8 +261,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -280,8 +281,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -301,8 +302,8 @@ public class PlainAccessValidatorTest {
         remotingCommand.addExtField(MixAll.UNIQUE_MSG_QUERY_FLAG, "false");
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "192.168.1.1:9876");
             plainAccessValidator.validate(accessResource);
@@ -336,8 +337,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encode();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -356,8 +357,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -376,8 +377,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -396,8 +397,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "123.4.5.6");
             plainAccessValidator.validate(accessResource);
@@ -421,8 +422,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "192.168.1.1");
             plainAccessValidator.validate(accessResource);
@@ -446,8 +447,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "192.168.1.1");
             plainAccessValidator.validate(accessResource);
@@ -465,8 +466,8 @@ public class PlainAccessValidatorTest {
 
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), whiteRemoteAddress);
             plainAccessValidator.validate(accessResource);
@@ -1043,8 +1044,8 @@ public class PlainAccessValidatorTest {
         aclClient.doBeforeRequest("", remotingCommand);
         ByteBuffer buf = remotingCommand.encodeHeader();
         buf.getInt();
-        buf = ByteBuffer.allocate(buf.limit() - buf.position()).put(buf);
-        buf.position(0);
+        buf = ByteBuffer.allocate(buf.limit() - ((Buffer)buf).position()).put(buf);
+        ((Buffer)buf).position(0);
         try {
             PlainAccessResource accessResource = (PlainAccessResource) plainAccessValidator.parse(RemotingCommand.decode(buf), "1.1.1.1:9876");
             plainAccessValidator.validate(accessResource);

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageClientIDSetter.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageClientIDSetter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.common.message;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Calendar;
 import java.util.Date;
@@ -69,7 +70,7 @@ public class MessageClientIDSetter {
         buf.put((byte) 0);
         buf.put((byte) 0);
         buf.put(bytes, ipLength + 2 + 4, 4);
-        buf.position(0);
+        ((Buffer)buf).position(0);
         long spanMS = buf.getLong();
         Calendar cal = Calendar.getInstance();
         long now = cal.getTimeInMillis();
@@ -143,7 +144,7 @@ public class MessageClientIDSetter {
     public static byte[] createFakeIP() {
         ByteBuffer bb = ByteBuffer.allocate(8);
         bb.putLong(System.currentTimeMillis());
-        bb.position(4);
+        ((Buffer)bb).position(4);
         byte[] fakeIP = new byte[4];
         bb.get(fakeIP);
         return fakeIP;

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -136,13 +136,13 @@ public class MessageDecoder {
             + 8; // 14 Prepared Transaction Offset
 
         int topicLengthPosition = bodySizePosition + 4 + byteBuffer.getInt(bodySizePosition);
-        byteBuffer.position(topicLengthPosition);
+        ((Buffer)byteBuffer).position(topicLengthPosition);
         int topicLengthSize = version.getTopicLengthSize();
         int topicLength = version.getTopicLength(byteBuffer);
 
         int propertiesPosition = topicLengthPosition + topicLengthSize + topicLength;
         short propertiesLength = byteBuffer.getShort(propertiesPosition);
-        byteBuffer.position(propertiesPosition + 2);
+        ((Buffer)byteBuffer).position(propertiesPosition + 2);
 
         if (propertiesLength > 0) {
             byte[] properties = new byte[propertiesLength];
@@ -496,7 +496,7 @@ public class MessageDecoder {
 
                     msgExt.setBody(body);
                 } else {
-                    byteBuffer.position(byteBuffer.position() + bodyLen);
+                    ((Buffer)byteBuffer).position(((Buffer)byteBuffer).position() + bodyLen);
                 }
             }
 
@@ -533,7 +533,7 @@ public class MessageDecoder {
 
             return msgExt;
         } catch (Exception e) {
-            byteBuffer.position(byteBuffer.limit());
+            ((Buffer)byteBuffer).position(byteBuffer.limit());
         }
 
         return null;
@@ -760,7 +760,7 @@ public class MessageDecoder {
             count++;
             int currPos = buffer.position();
             int size = buffer.getInt();
-            buffer.position(currPos + size);
+            ((Buffer)buffer).position(currPos + size);
         }
         return count;
     }

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -70,7 +71,7 @@ public class MessageDecoder {
 //        + 8; // 14 Prepared Transaction Offset
 
     public static String createMessageId(final ByteBuffer input, final ByteBuffer addr, final long offset) {
-        input.flip();
+        ((Buffer)input).flip();
         int msgIDLength = addr.limit() == 8 ? 16 : 28;
         input.limit(msgIDLength);
 
@@ -87,7 +88,7 @@ public class MessageDecoder {
         byteBuffer.put(inetSocketAddress.getAddress().getAddress());
         byteBuffer.putInt(inetSocketAddress.getPort());
         byteBuffer.putLong(transactionIdhashCode);
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         return UtilAll.bytes2string(byteBuffer.array());
     }
 

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -73,7 +73,7 @@ public class MessageDecoder {
     public static String createMessageId(final ByteBuffer input, final ByteBuffer addr, final long offset) {
         ((Buffer)input).flip();
         int msgIDLength = addr.limit() == 8 ? 16 : 28;
-        input.limit(msgIDLength);
+        ((Buffer)input).limit(msgIDLength);
 
         input.put(addr);
         input.putLong(offset);

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageExt.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageExt.java
@@ -20,6 +20,7 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.common.TopicFilterType;
 import org.apache.rocketmq.common.sysflag.MessageSysFlag;
@@ -77,7 +78,7 @@ public class MessageExt extends Message {
             byteBuffer.put(inetSocketAddress.getAddress().getAddress(), 0, 16);
         }
         byteBuffer.putInt(inetSocketAddress.getPort());
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         return byteBuffer;
     }
 

--- a/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.common;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +37,7 @@ public class MessageEncodeDecodeTest {
         byte[] bytes = MessageDecoder.encodeMessage(message);
         ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
         buffer.put(bytes);
-        buffer.flip();
+        ((Buffer)buffer).flip();
         Message newMessage = MessageDecoder.decodeMessage(buffer);
 
         assertTrue(message.getFlag() == newMessage.getFlag());
@@ -57,7 +58,7 @@ public class MessageEncodeDecodeTest {
 
         ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
         buffer.put(bytes);
-        buffer.flip();
+        ((Buffer)buffer).flip();
 
         List<Message> newMsgs = MessageDecoder.decodeMessages(buffer);
 

--- a/common/src/test/java/org/apache/rocketmq/common/message/MessageDecoderTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/message/MessageDecoderTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.common.message;
 
+import java.nio.Buffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.sysflag.MessageSysFlag;
 import org.junit.Test;
@@ -200,7 +201,7 @@ public class MessageDecoderTest {
         ByteBuffer byteBuffer = ByteBuffer.allocate(msgBytes.length);
         byteBuffer.put(msgBytes);
 
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         MessageExt decodedMsg = MessageDecoder.decode(byteBuffer);
 
         assertThat(decodedMsg).isNotNull();
@@ -261,7 +262,7 @@ public class MessageDecoderTest {
         ByteBuffer byteBuffer = ByteBuffer.allocate(msgBytes.length);
         byteBuffer.put(msgBytes);
 
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         MessageExt decodedMsg = MessageDecoder.decode(byteBuffer);
 
         assertThat(decodedMsg).isNotNull();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import java.nio.Buffer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.utils.NetworkUtil;
@@ -172,7 +173,7 @@ public class RemotingHelper {
                     Thread.sleep(1);
                 }
 
-                byteBufferBody.flip();
+                ((Buffer)byteBufferBody).flip();
                 return RemotingCommand.decode(byteBufferBody);
             } catch (IOException e) {
                 log.error("invokeSync failure", e);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
@@ -399,7 +399,7 @@ public class RemotingCommand {
             result.put(this.body);
         }
 
-        result.flip();
+        ((Buffer)result).flip();
 
         return result;
     }

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.store;
 
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -473,7 +474,7 @@ public class CommitLog implements Swappable {
                         }
                     }
                 } else {
-                    byteBuffer.position(byteBuffer.position() + bodyLen);
+                    ((Buffer)byteBuffer).position(((Buffer)byteBuffer).position() + bodyLen);
                 }
             }
 
@@ -700,7 +701,7 @@ public class CommitLog implements Swappable {
                         log.warn("found a half message at {}, it will be truncated.", processOffset + mappedFileOffset);
                     }
 
-                    log.info("recover physics file end, " + mappedFile.getFileName() + " pos=" + byteBuffer.position());
+                    log.info("recover physics file end, " + mappedFile.getFileName() + " pos=" + ((Buffer)byteBuffer).position());
                     break;
                 }
             }
@@ -1759,7 +1760,7 @@ public class CommitLog implements Swappable {
                 int msgIdLen = (sysflag & MessageSysFlag.STOREHOSTADDRESS_V6_FLAG) == 0 ? 4 + 4 + 8 : 16 + 4 + 8;
                 ByteBuffer msgIdBuffer = ByteBuffer.allocate(msgIdLen);
                 MessageExt.socketAddress2ByteBuffer(msgInner.getStoreHost(), msgIdBuffer);
-                msgIdBuffer.clear();//because socketAddress2ByteBuffer flip the buffer
+                ((Buffer)msgIdBuffer).clear();//because socketAddress2ByteBuffer flip the buffer
                 msgIdBuffer.putLong(msgIdLen - 8, wroteOffset);
                 return UtilAll.bytes2string(msgIdBuffer.array());
             };
@@ -1789,7 +1790,7 @@ public class CommitLog implements Swappable {
 
             // Determines whether there is sufficient free space
             if ((msgLen + END_FILE_MIN_BLANK_LENGTH) > maxBlank) {
-                this.msgStoreItemMemory.clear();
+                ((Buffer)this.msgStoreItemMemory).clear();
                 // 1 TOTALSIZE
                 this.msgStoreItemMemory.putInt(maxBlank);
                 // 2 MAGICCODE
@@ -1849,7 +1850,7 @@ public class CommitLog implements Swappable {
                 long[] phyPosArray = putMessageContext.getPhyPos();
                 ByteBuffer msgIdBuffer = ByteBuffer.allocate(msgIdLen);
                 MessageExt.socketAddress2ByteBuffer(messageExtBatch.getStoreHost(), msgIdBuffer);
-                msgIdBuffer.clear();//because socketAddress2ByteBuffer flip the buffer
+                ((Buffer)msgIdBuffer).clear();//because socketAddress2ByteBuffer flip the buffer
 
                 StringBuilder buffer = new StringBuilder(batchCount * msgIdLen * 2 + batchCount - 1);
                 for (int i = 0; i < phyPosArray.length; i++) {
@@ -1873,7 +1874,7 @@ public class CommitLog implements Swappable {
                 totalMsgLen += msgLen;
                 // Determines whether there is sufficient free space
                 if ((totalMsgLen + END_FILE_MIN_BLANK_LENGTH) > maxBlank) {
-                    this.msgStoreItemMemory.clear();
+                    ((Buffer)this.msgStoreItemMemory).clear();
                     // 1 TOTALSIZE
                     this.msgStoreItemMemory.putInt(maxBlank);
                     // 2 MAGICCODE
@@ -1900,11 +1901,11 @@ public class CommitLog implements Swappable {
                 putMessageContext.getPhyPos()[index++] = wroteOffset + totalMsgLen - msgLen;
                 queueOffset++;
                 msgNum++;
-                messagesByteBuff.position(msgPos + msgLen);
+                ((Buffer)messagesByteBuff).position(msgPos + msgLen);
             }
 
-            messagesByteBuff.position(0);
-            messagesByteBuff.limit(totalMsgLen);
+            ((Buffer)messagesByteBuff).position(0);
+            ((Buffer)messagesByteBuff).limit(totalMsgLen);
             byteBuffer.put(messagesByteBuff);
             messageExtBatch.setEncodedBuff(null);
             AppendMessageResult result = new AppendMessageResult(AppendMessageStatus.PUT_OK, wroteOffset, totalMsgLen, msgIdSupplier,

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.store;
 
 import java.io.File;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
@@ -884,7 +885,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
             return true;
         }
 
-        this.byteBufferIndex.flip();
+        ((Buffer)this.byteBufferIndex).flip();
         this.byteBufferIndex.limit(CQ_STORE_UNIT_SIZE);
         this.byteBufferIndex.putLong(offset);
         this.byteBufferIndex.putInt(size);

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -886,7 +886,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
         }
 
         ((Buffer)this.byteBufferIndex).flip();
-        this.byteBufferIndex.limit(CQ_STORE_UNIT_SIZE);
+        ((Buffer)this.byteBufferIndex).limit(CQ_STORE_UNIT_SIZE);
         this.byteBufferIndex.putLong(offset);
         this.byteBufferIndex.putInt(size);
         this.byteBufferIndex.putLong(tagsCode);

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -245,7 +245,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                     long phyOffset;
                     int size;
                     // Handle case 1
-                    byteBuffer.position(ceiling);
+                    ((Buffer)byteBuffer).position(ceiling);
                     phyOffset = byteBuffer.getLong();
                     size = byteBuffer.getInt();
                     storeTime = messageStore.getCommitLog().pickupStoreTimestamp(phyOffset, size);
@@ -262,7 +262,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                     }
 
                     // Handle case 2
-                    byteBuffer.position(floor);
+                    ((Buffer)byteBuffer).position(floor);
                     phyOffset = byteBuffer.getLong();
                     size = byteBuffer.getInt();
                     storeTime = messageStore.getCommitLog().pickupStoreTimestamp(phyOffset, size);
@@ -281,7 +281,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                     // Perform binary search
                     while (high >= low) {
                         midOffset = (low + high) / (2 * CQ_STORE_UNIT_SIZE) * CQ_STORE_UNIT_SIZE;
-                        byteBuffer.position(midOffset);
+                        ((Buffer)byteBuffer).position(midOffset);
                         phyOffset = byteBuffer.getLong();
                         size = byteBuffer.getInt();
                         if (phyOffset < minPhysicOffset) {
@@ -317,7 +317,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                                     if (attempt < floor) {
                                         break;
                                     }
-                                    byteBuffer.position(attempt);
+                                    ((Buffer)byteBuffer).position(attempt);
                                     long physicalOffset = byteBuffer.getLong();
                                     int messageSize = byteBuffer.getInt();
                                     long messageStoreTimestamp = messageStore.getCommitLog()
@@ -338,7 +338,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                                     if (attempt > ceiling) {
                                         break;
                                     }
-                                    byteBuffer.position(attempt);
+                                    ((Buffer)byteBuffer).position(attempt);
                                     long physicalOffset = byteBuffer.getLong();
                                     int messageSize = byteBuffer.getInt();
                                     long messageStoreTimestamp = messageStore.getCommitLog()
@@ -498,7 +498,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                 position = 0;
 
             ByteBuffer byteBuffer = mappedFile.sliceByteBuffer();
-            byteBuffer.position(position);
+            ((Buffer)byteBuffer).position(position);
             for (int i = 0; i < logicFileSize; i += CQ_STORE_UNIT_SIZE) {
                 long offset = byteBuffer.getLong();
                 int size = byteBuffer.getInt();
@@ -626,7 +626,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                         break;
                     }
                     int mid = (low + high) / 2 / ConsumeQueue.CQ_STORE_UNIT_SIZE * ConsumeQueue.CQ_STORE_UNIT_SIZE;
-                    buffer.position(mid);
+                    ((Buffer)buffer).position(mid);
                     commitLogOffset = buffer.getLong();
                     if (commitLogOffset > minCommitLogOffset) {
                         high = mid;
@@ -641,9 +641,9 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
 
                 // Examine the last one or two entries
                 for (int i = low; i <= high; i += ConsumeQueue.CQ_STORE_UNIT_SIZE) {
-                    buffer.position(i);
+                    ((Buffer)buffer).position(i);
                     long offsetPy = buffer.getLong();
-                    buffer.position(i + 12);
+                    ((Buffer)buffer).position(i + 12);
                     long tagsCode = buffer.getLong();
 
                     if (offsetPy >= minCommitLogOffset) {
@@ -1223,7 +1223,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                     int current = 0;
                     while (current < len) {
                         // skip physicalOffset and message length fields.
-                        buffer.position(current + MSG_TAG_OFFSET_INDEX);
+                        ((Buffer)buffer).position(current + MSG_TAG_OFFSET_INDEX);
                         long tagCode = buffer.getLong();
                         ConsumeQueueExt.CqExtUnit ext = null;
                         if (isExtWriteEnable()) {

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
@@ -244,7 +244,7 @@ public class ConsumeQueueExt {
 
     protected void fullFillToEnd(final MappedFile mappedFile, final int wrotePosition) {
         ByteBuffer mappedFileBuffer = mappedFile.sliceByteBuffer();
-        mappedFileBuffer.position(wrotePosition);
+        ((Buffer)mappedFileBuffer).position(wrotePosition);
 
         // ending.
         mappedFileBuffer.putShort((short) -1);
@@ -499,7 +499,7 @@ public class ConsumeQueueExt {
             this.size = tempSize;
 
             if (tempSize > 0) {
-                buffer.position(buffer.position() + this.size);
+                ((Buffer)buffer).position(((Buffer)buffer).position() + this.size);
             }
         }
 

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
@@ -521,7 +521,7 @@ public class ConsumeQueueExt {
             }
 
             ((Buffer)temp).flip();
-            temp.limit(this.size);
+            ((Buffer)temp).limit(this.size);
 
             temp.putShort(this.size);
             temp.putLong(this.tagsCode);

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.store;
 
+import java.nio.Buffer;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
@@ -519,7 +520,7 @@ public class ConsumeQueueExt {
                 temp = ByteBuffer.allocate(this.size);
             }
 
-            temp.flip();
+            ((Buffer)temp).flip();
             temp.limit(this.size);
 
             temp.putShort(this.size);

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -29,6 +29,7 @@ import java.io.RandomAccessFile;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
@@ -1268,7 +1269,7 @@ public class DefaultMessageStore implements MessageStore {
                     SelectMappedBufferResult result = this.commitLog.getData(offset, false);
                     if (result != null) {
                         int size = result.getByteBuffer().getInt(0);
-                        result.getByteBuffer().limit(size);
+                        ((Buffer)result.getByteBuffer()).limit(size);
                         result.setSize(size);
                         queryMessageResult.addMessage(result);
                     }
@@ -2924,8 +2925,8 @@ public class DefaultMessageStore implements MessageStore {
                     batchDispatchRequestExecutor.execute(() -> {
                         try {
                             ByteBuffer tmpByteBuffer = task.byteBuffer;
-                            tmpByteBuffer.position(task.position);
-                            tmpByteBuffer.limit(task.position + task.size);
+                            ((Buffer)tmpByteBuffer).position(task.position);
+                            ((Buffer)tmpByteBuffer).limit(task.position + task.size);
                             List<DispatchRequest> dispatchRequestList = new ArrayList<>();
                             while (tmpByteBuffer.hasRemaining()) {
                                 DispatchRequest dispatchRequest = DefaultMessageStore.this.commitLog.checkMessageAndReturnSize(tmpByteBuffer, false, false, false);
@@ -3103,7 +3104,7 @@ public class DefaultMessageStore implements MessageStore {
                                 batchDispatchRequestStart = -1;
                                 batchDispatchRequestSize = -1;
                             }
-                            byteBuffer.position(byteBuffer.position() + totalSize);
+                            ((Buffer)byteBuffer).position(byteBuffer.position() + totalSize);
                             this.reputFromOffset += totalSize;
                             readSize += totalSize;
                         } else {

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -576,7 +577,7 @@ public class MappedFileQueue implements Swappable {
                         result.getByteBuffer().getLong(); //prev pos
                         int magic = result.getByteBuffer().getInt();
                         if (size == unitSize && (magic | 0xF) == 0xF) {
-                            result.getByteBuffer().position(position + MixAll.UNIT_PRE_SIZE_FOR_MSG);
+                            ((Buffer)result.getByteBuffer()).position(position + MixAll.UNIT_PRE_SIZE_FOR_MSG);
                             long maxOffsetPy = result.getByteBuffer().getLong();
                             destroy = maxOffsetPy < offset;
                             if (destroy) {

--- a/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import java.nio.Buffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.message.MessageDecoder;
@@ -202,11 +203,11 @@ public class MessageExtEncoder {
             int bodyLen = messagesByteBuff.getInt();
             int bodyPos = messagesByteBuff.position();
             int bodyCrc = UtilAll.crc32(messagesByteBuff.array(), bodyPos, bodyLen);
-            messagesByteBuff.position(bodyPos + bodyLen);
+            ((Buffer)messagesByteBuff).position(bodyPos + bodyLen);
             // 6 properties
             short propertiesLen = messagesByteBuff.getShort();
             int propertiesPos = messagesByteBuff.position();
-            messagesByteBuff.position(propertiesPos + propertiesLen);
+            ((Buffer)messagesByteBuff).position(propertiesPos + propertiesLen);
             boolean needAppendLastPropertySeparator = propertiesLen > 0 && batchPropLen > 0
                 && messagesByteBuff.get(messagesByteBuff.position() - 1) != MessageDecoder.PROPERTY_SEPARATOR;
 

--- a/store/src/main/java/org/apache/rocketmq/store/SelectMappedBufferResult.java
+++ b/store/src/main/java/org/apache/rocketmq/store/SelectMappedBufferResult.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.store.logfile.MappedFile;
 
@@ -48,7 +49,7 @@ public class SelectMappedBufferResult {
 
     public void setSize(final int s) {
         this.size = s;
-        this.byteBuffer.limit(this.size);
+        ((Buffer)this.byteBuffer).limit(this.size);
     }
 
     public MappedFile getMappedFile() {

--- a/store/src/main/java/org/apache/rocketmq/store/TransientStorePool.java
+++ b/store/src/main/java/org/apache/rocketmq/store/TransientStorePool.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.store;
 
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -67,8 +68,8 @@ public class TransientStorePool {
     }
 
     public void returnBuffer(ByteBuffer byteBuffer) {
-        byteBuffer.position(0);
-        byteBuffer.limit(fileSize);
+        ((Buffer)byteBuffer).position(0);
+        ((Buffer)byteBuffer).limit(fileSize);
         this.availableBuffers.offerFirst(byteBuffer);
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -32,6 +32,7 @@ import io.openmessaging.storage.dledger.store.file.SelectMmapBufferResult;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
@@ -970,7 +971,7 @@ public class DLedgerCommitLog extends CommitLog {
         }
 
         private void resetByteBuffer(final ByteBuffer byteBuffer, final int limit) {
-            byteBuffer.flip();
+            ((Buffer)byteBuffer).flip();
             byteBuffer.limit(limit);
         }
     }

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -106,7 +106,7 @@ public class DLedgerCommitLog extends CommitLog {
         dLedgerFileStore = (DLedgerMmapFileStore) dLedgerServer.getdLedgerStore();
         DLedgerMmapFileStore.AppendHook appendHook = (entry, buffer, bodyOffset) -> {
             assert bodyOffset == DLedgerEntry.BODY_OFFSET;
-            buffer.position(buffer.position() + bodyOffset + MessageDecoder.PHY_POS_POSITION);
+            ((Buffer)buffer).position(((Buffer)buffer).position() + bodyOffset + MessageDecoder.PHY_POS_POSITION);
             buffer.putLong(entry.getPos() + bodyOffset);
         };
         dLedgerFileStore.addAppendHook(appendHook);
@@ -310,7 +310,7 @@ public class DLedgerCommitLog extends CommitLog {
             return;
         }
         ByteBuffer byteBuffer = mappedFile.sliceByteBuffer();
-        byteBuffer.position(mappedFile.getWrotePosition());
+        ((Buffer)byteBuffer).position(mappedFile.getWrotePosition());
         boolean needWriteMagicCode = true;
         // 1 TOTAL SIZE
         byteBuffer.getInt(); //size
@@ -324,7 +324,7 @@ public class DLedgerCommitLog extends CommitLog {
         dividedCommitlogOffset = mappedFile.getFileFromOffset() + mappedFile.getFileSize();
         log.info("Recover old commitlog needWriteMagicCode={} pos={} file={} dividedCommitlogOffset={}", needWriteMagicCode, mappedFile.getFileFromOffset() + mappedFile.getWrotePosition(), mappedFile.getFileName(), dividedCommitlogOffset);
         if (needWriteMagicCode) {
-            byteBuffer.position(mappedFile.getWrotePosition());
+            ((Buffer)byteBuffer).position(mappedFile.getWrotePosition());
             byteBuffer.putInt(mappedFile.getFileSize() - mappedFile.getWrotePosition());
             byteBuffer.putInt(BLANK_MAGIC_CODE);
             mappedFile.flush(0);
@@ -361,13 +361,13 @@ public class DLedgerCommitLog extends CommitLog {
             if (magicOld == CommitLog.BLANK_MAGIC_CODE
                 || magicOld == MessageDecoder.MESSAGE_MAGIC_CODE
                 || magicOld == MessageDecoder.MESSAGE_MAGIC_CODE_V2) {
-                byteBuffer.position(pos);
+                ((Buffer)byteBuffer).position(pos);
                 return super.checkMessageAndReturnSize(byteBuffer, checkCRC, checkDupInfo, readBody);
             }
             if (magic == MmapFileList.BLANK_MAGIC_CODE) {
                 return new DispatchRequest(0, true);
             }
-            byteBuffer.position(pos + bodyOffset);
+            ((Buffer)byteBuffer).position(pos + bodyOffset);
             DispatchRequest dispatchRequest = super.checkMessageAndReturnSize(byteBuffer, checkCRC, checkDupInfo, readBody);
             if (dispatchRequest.isSuccess()) {
                 dispatchRequest.setBufferSize(dispatchRequest.getMsgSize() + bodyOffset);
@@ -901,11 +901,11 @@ public class DLedgerCommitLog extends CommitLog {
                 int bodyLen = messagesByteBuff.getInt();
                 int bodyPos = messagesByteBuff.position();
                 int bodyCrc = UtilAll.crc32(messagesByteBuff.array(), bodyPos, bodyLen);
-                messagesByteBuff.position(bodyPos + bodyLen);
+                ((Buffer)messagesByteBuff).position(bodyPos + bodyLen);
                 // 6 properties
                 short propertiesLen = messagesByteBuff.getShort();
                 int propertiesPos = messagesByteBuff.position();
-                messagesByteBuff.position(propertiesPos + propertiesLen);
+                ((Buffer)messagesByteBuff).position(propertiesPos + propertiesLen);
 
                 final byte[] topicData = messageExtBatch.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
 

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -962,7 +962,7 @@ public class DLedgerCommitLog extends CommitLog {
                     msgStoreItemMemory.put(messagesByteBuff.array(), propertiesPos, propertiesLen);
                 }
                 byte[] data = new byte[msgLen];
-                msgStoreItemMemory.clear();
+                ((Buffer)msgStoreItemMemory).clear();
                 msgStoreItemMemory.get(data);
                 batchBody.add(data);
             }
@@ -972,7 +972,7 @@ public class DLedgerCommitLog extends CommitLog {
 
         private void resetByteBuffer(final ByteBuffer byteBuffer, final int limit) {
             ((Buffer)byteBuffer).flip();
-            byteBuffer.limit(limit);
+            ((Buffer)byteBuffer).limit(limit);
         }
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAClient.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAClient.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store.ha;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
@@ -108,11 +109,11 @@ public class DefaultHAClient extends ServiceThread implements HAClient {
     }
 
     private boolean reportSlaveMaxOffset(final long maxOffset) {
-        this.reportOffset.position(0);
-        this.reportOffset.limit(REPORT_HEADER_SIZE);
+        ((Buffer)this.reportOffset).position(0);
+        ((Buffer)this.reportOffset).limit(REPORT_HEADER_SIZE);
         this.reportOffset.putLong(maxOffset);
-        this.reportOffset.position(0);
-        this.reportOffset.limit(REPORT_HEADER_SIZE);
+        ((Buffer)this.reportOffset).position(0);
+        ((Buffer)this.reportOffset).limit(REPORT_HEADER_SIZE);
 
         for (int i = 0; i < 3 && this.reportOffset.hasRemaining(); i++) {
             try {
@@ -130,17 +131,17 @@ public class DefaultHAClient extends ServiceThread implements HAClient {
     private void reallocateByteBuffer() {
         int remain = READ_MAX_BUFFER_SIZE - this.dispatchPosition;
         if (remain > 0) {
-            this.byteBufferRead.position(this.dispatchPosition);
+            ((Buffer)this.byteBufferRead).position(this.dispatchPosition);
 
-            this.byteBufferBackup.position(0);
-            this.byteBufferBackup.limit(READ_MAX_BUFFER_SIZE);
+            ((Buffer)this.byteBufferBackup).position(0);
+            ((Buffer)this.byteBufferBackup).limit(READ_MAX_BUFFER_SIZE);
             this.byteBufferBackup.put(this.byteBufferRead);
         }
 
         this.swapByteBuffer();
 
-        this.byteBufferRead.position(remain);
-        this.byteBufferRead.limit(READ_MAX_BUFFER_SIZE);
+        ((Buffer)this.byteBufferRead).position(remain);
+        ((Buffer)this.byteBufferRead).limit(READ_MAX_BUFFER_SIZE);
         this.dispatchPosition = 0;
     }
 
@@ -207,7 +208,7 @@ public class DefaultHAClient extends ServiceThread implements HAClient {
                     this.defaultMessageStore.appendToCommitLog(
                         masterPhyOffset, bodyData, dataStart, bodySize);
 
-                    this.byteBufferRead.position(readSocketPos);
+                    ((Buffer)this.byteBufferRead).position(readSocketPos);
                     this.dispatchPosition += DefaultHAConnection.TRANSFER_HEADER_SIZE + bodySize;
 
                     if (!reportSlaveMaxOffsetPlus()) {
@@ -291,11 +292,11 @@ public class DefaultHAClient extends ServiceThread implements HAClient {
             this.lastReadTimestamp = 0;
             this.dispatchPosition = 0;
 
-            this.byteBufferBackup.position(0);
-            this.byteBufferBackup.limit(READ_MAX_BUFFER_SIZE);
+            ((Buffer)this.byteBufferBackup).position(0);
+            ((Buffer)this.byteBufferBackup).limit(READ_MAX_BUFFER_SIZE);
 
-            this.byteBufferRead.position(0);
-            this.byteBufferRead.limit(READ_MAX_BUFFER_SIZE);
+            ((Buffer)this.byteBufferRead).position(0);
+            ((Buffer)this.byteBufferRead).limit(READ_MAX_BUFFER_SIZE);
         }
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
@@ -315,7 +315,7 @@ public class DefaultHAConnection implements HAConnection {
                             .getHaSendHeartbeatInterval()) {
 
                             // Build Header
-                            this.byteBufferHeader.position(0);
+                            ((Buffer)this.byteBufferHeader).position(0);
                             this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
                             this.byteBufferHeader.putLong(this.nextTransferFromWhere);
                             this.byteBufferHeader.putInt(0);
@@ -357,7 +357,7 @@ public class DefaultHAConnection implements HAConnection {
                         this.selectMappedBufferResult = selectResult;
 
                         // Build Header
-                        this.byteBufferHeader.position(0);
+                        ((Buffer)this.byteBufferHeader).position(0);
                         this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
                         this.byteBufferHeader.putLong(thisOffset);
                         this.byteBufferHeader.putInt(size);

--- a/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
@@ -316,7 +316,7 @@ public class DefaultHAConnection implements HAConnection {
 
                             // Build Header
                             ((Buffer)this.byteBufferHeader).position(0);
-                            this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
+                            ((Buffer)this.byteBufferHeader).limit(TRANSFER_HEADER_SIZE);
                             this.byteBufferHeader.putLong(this.nextTransferFromWhere);
                             this.byteBufferHeader.putInt(0);
                             ((Buffer)this.byteBufferHeader).flip();
@@ -353,12 +353,12 @@ public class DefaultHAConnection implements HAConnection {
                         long thisOffset = this.nextTransferFromWhere;
                         this.nextTransferFromWhere += size;
 
-                        selectResult.getByteBuffer().limit(size);
+                        ((Buffer)selectResult.getByteBuffer()).limit(size);
                         this.selectMappedBufferResult = selectResult;
 
                         // Build Header
                         ((Buffer)this.byteBufferHeader).position(0);
-                        this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
+                        ((Buffer)this.byteBufferHeader).limit(TRANSFER_HEADER_SIZE);
                         this.byteBufferHeader.putLong(thisOffset);
                         this.byteBufferHeader.putInt(size);
                         ((Buffer)this.byteBufferHeader).flip();

--- a/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.store.ha;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -212,7 +213,7 @@ public class DefaultHAConnection implements HAConnection {
             int readSizeZeroTimes = 0;
 
             if (!this.byteBufferRead.hasRemaining()) {
-                this.byteBufferRead.flip();
+                ((Buffer)this.byteBufferRead).flip();
                 this.processPosition = 0;
             }
 
@@ -318,7 +319,7 @@ public class DefaultHAConnection implements HAConnection {
                             this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
                             this.byteBufferHeader.putLong(this.nextTransferFromWhere);
                             this.byteBufferHeader.putInt(0);
-                            this.byteBufferHeader.flip();
+                            ((Buffer)this.byteBufferHeader).flip();
 
                             this.lastWriteOver = this.transferData();
                             if (!this.lastWriteOver)
@@ -360,7 +361,7 @@ public class DefaultHAConnection implements HAConnection {
                         this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
                         this.byteBufferHeader.putLong(thisOffset);
                         this.byteBufferHeader.putInt(size);
-                        this.byteBufferHeader.flip();
+                        ((Buffer)this.byteBufferHeader).flip();
 
                         this.lastWriteOver = this.transferData();
                     } else {

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAClient.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAClient.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store.ha.autoswitch;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -301,7 +302,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
         // Slave brokerId
         this.handshakeHeaderBuffer.putLong(this.brokerId);
 
-        this.handshakeHeaderBuffer.flip();
+        ((Buffer)this.handshakeHeaderBuffer).flip();
         return this.haWriter.write(this.socketChannel, this.handshakeHeaderBuffer);
     }
 
@@ -324,7 +325,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
         this.transferHeaderBuffer.limit(TRANSFER_HEADER_SIZE);
         this.transferHeaderBuffer.putInt(currentState.ordinal());
         this.transferHeaderBuffer.putLong(offsetToReport);
-        this.transferHeaderBuffer.flip();
+        ((Buffer)this.transferHeaderBuffer).flip();
         return this.haWriter.write(this.socketChannel, this.transferHeaderBuffer);
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAClient.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAClient.java
@@ -259,7 +259,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
             this.processPosition = 0;
 
             ((Buffer)this.byteBufferRead).position(0);
-            this.byteBufferRead.limit(READ_MAX_BUFFER_SIZE);
+            ((Buffer)this.byteBufferRead).limit(READ_MAX_BUFFER_SIZE);
         }
     }
 
@@ -290,7 +290,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
 
     private boolean sendHandshakeHeader() throws IOException {
         ((Buffer)this.handshakeHeaderBuffer).position(0);
-        this.handshakeHeaderBuffer.limit(HANDSHAKE_HEADER_SIZE);
+        ((Buffer)this.handshakeHeaderBuffer).limit(HANDSHAKE_HEADER_SIZE);
         // Original state
         this.handshakeHeaderBuffer.putInt(HAConnectionState.HANDSHAKE.ordinal());
         // IsSyncFromLastFile
@@ -322,7 +322,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
 
     private boolean reportSlaveOffset(HAConnectionState currentState, final long offsetToReport) throws IOException {
         ((Buffer)this.transferHeaderBuffer).position(0);
-        this.transferHeaderBuffer.limit(TRANSFER_HEADER_SIZE);
+        ((Buffer)this.transferHeaderBuffer).limit(TRANSFER_HEADER_SIZE);
         this.transferHeaderBuffer.putInt(currentState.ordinal());
         this.transferHeaderBuffer.putLong(offsetToReport);
         ((Buffer)this.transferHeaderBuffer).flip();

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAClient.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAClient.java
@@ -258,7 +258,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
             this.lastReadTimestamp = 0;
             this.processPosition = 0;
 
-            this.byteBufferRead.position(0);
+            ((Buffer)this.byteBufferRead).position(0);
             this.byteBufferRead.limit(READ_MAX_BUFFER_SIZE);
         }
     }
@@ -289,7 +289,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
     }
 
     private boolean sendHandshakeHeader() throws IOException {
-        this.handshakeHeaderBuffer.position(0);
+        ((Buffer)this.handshakeHeaderBuffer).position(0);
         this.handshakeHeaderBuffer.limit(HANDSHAKE_HEADER_SIZE);
         // Original state
         this.handshakeHeaderBuffer.putInt(HAConnectionState.HANDSHAKE.ordinal());
@@ -321,7 +321,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
     }
 
     private boolean reportSlaveOffset(HAConnectionState currentState, final long offsetToReport) throws IOException {
-        this.transferHeaderBuffer.position(0);
+        ((Buffer)this.transferHeaderBuffer).position(0);
         this.transferHeaderBuffer.limit(TRANSFER_HEADER_SIZE);
         this.transferHeaderBuffer.putInt(currentState.ordinal());
         this.transferHeaderBuffer.putLong(offsetToReport);
@@ -525,7 +525,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
                                     long startOffset = byteBufferRead.getLong(AutoSwitchHAClient.this.processPosition + i * entrySize + 4);
                                     epochEntries.add(new EpochEntry(epoch, startOffset));
                                 }
-                                byteBufferRead.position(readSocketPos);
+                                ((Buffer)byteBufferRead).position(readSocketPos);
                                 AutoSwitchHAClient.this.processPosition += bodySize;
                                 LOGGER.info("Receive handshake, masterMaxPosition {}, masterEpochEntries:{}, try truncate log", masterOffset, epochEntries);
                                 if (!doTruncate(epochEntries, masterOffset)) {
@@ -542,9 +542,9 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
                                     break;
                                 }
                                 byte[] bodyData = new byte[bodySize];
-                                byteBufferRead.position(AutoSwitchHAClient.this.processPosition + AutoSwitchHAConnection.TRANSFER_HEADER_SIZE);
+                                ((Buffer)byteBufferRead).position(AutoSwitchHAClient.this.processPosition + AutoSwitchHAConnection.TRANSFER_HEADER_SIZE);
                                 byteBufferRead.get(bodyData);
-                                byteBufferRead.position(readSocketPos);
+                                ((Buffer)byteBufferRead).position(readSocketPos);
                                 AutoSwitchHAClient.this.processPosition += AutoSwitchHAConnection.TRANSFER_HEADER_SIZE + bodySize;
                                 long slavePhyOffset = AutoSwitchHAClient.this.messageStore.getMaxPhyOffset();
                                 if (slavePhyOffset != 0) {
@@ -583,7 +583,7 @@ public class AutoSwitchHAClient extends ServiceThread implements HAClient {
                     }
 
                     if (!byteBufferRead.hasRemaining()) {
-                        byteBufferRead.position(AutoSwitchHAClient.this.processPosition);
+                        ((Buffer)byteBufferRead).position(AutoSwitchHAClient.this.processPosition);
                         byteBufferRead.compact();
                         AutoSwitchHAClient.this.processPosition = 0;
                     }

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
@@ -402,7 +402,7 @@ public class AutoSwitchHAConnection implements HAConnection {
         protected boolean transferData(int maxTransferSize) throws Exception {
 
             if (null != this.selectMappedBufferResult && maxTransferSize >= 0) {
-                this.selectMappedBufferResult.getByteBuffer().limit(maxTransferSize);
+                ((Buffer)this.selectMappedBufferResult.getByteBuffer()).limit(maxTransferSize);
             }
 
             // Write Header
@@ -479,7 +479,7 @@ public class AutoSwitchHAConnection implements HAConnection {
             final int lastEpoch = AutoSwitchHAConnection.this.epochCache.lastEpoch();
             final long maxPhyOffset = AutoSwitchHAConnection.this.haService.getDefaultMessageStore().getMaxPhyOffset();
             ((Buffer)this.byteBufferHeader).position(0);
-            this.byteBufferHeader.limit(HANDSHAKE_HEADER_SIZE);
+            ((Buffer)this.byteBufferHeader).limit(HANDSHAKE_HEADER_SIZE);
             // State
             this.byteBufferHeader.putInt(currentState.ordinal());
             // Body size
@@ -492,7 +492,7 @@ public class AutoSwitchHAConnection implements HAConnection {
 
             // EpochEntries
             ((Buffer)this.handShakeBuffer).position(0);
-            this.handShakeBuffer.limit(EPOCH_ENTRY_SIZE * epochEntries.size());
+            ((Buffer)this.handShakeBuffer).limit(EPOCH_ENTRY_SIZE * epochEntries.size());
             for (final EpochEntry entry : epochEntries) {
                 if (entry != null) {
                     this.handShakeBuffer.putInt(entry.getEpoch());
@@ -536,7 +536,7 @@ public class AutoSwitchHAConnection implements HAConnection {
             }
             // Build Header
             ((Buffer)this.byteBufferHeader).position(0);
-            this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
+            ((Buffer)this.byteBufferHeader).limit(TRANSFER_HEADER_SIZE);
             // State
             this.byteBufferHeader.putInt(currentState.ordinal());
             // Body size

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.store.ha.autoswitch;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -487,7 +488,7 @@ public class AutoSwitchHAConnection implements HAConnection {
             this.byteBufferHeader.putLong(maxPhyOffset);
             // Epoch
             this.byteBufferHeader.putInt(lastEpoch);
-            this.byteBufferHeader.flip();
+            ((Buffer)this.byteBufferHeader).flip();
 
             // EpochEntries
             this.handShakeBuffer.position(0);
@@ -498,7 +499,7 @@ public class AutoSwitchHAConnection implements HAConnection {
                     this.handShakeBuffer.putLong(entry.getStartOffset());
                 }
             }
-            this.handShakeBuffer.flip();
+            ((Buffer)this.handShakeBuffer).flip();
             LOGGER.info("Master build handshake header: maxEpoch:{}, maxOffset:{}, epochEntries:{}", lastEpoch, maxPhyOffset, epochEntries);
             return true;
         }
@@ -549,7 +550,7 @@ public class AutoSwitchHAConnection implements HAConnection {
             // Additional info(confirm offset)
             final long confirmOffset = AutoSwitchHAConnection.this.haService.getDefaultMessageStore().getConfirmOffset();
             this.byteBufferHeader.putLong(confirmOffset);
-            this.byteBufferHeader.flip();
+            ((Buffer)this.byteBufferHeader).flip();
         }
 
         private boolean sendHeartbeatIfNeeded() throws Exception {

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
@@ -330,7 +330,7 @@ public class AutoSwitchHAConnection implements HAConnection {
                                 }
 
                                 isSlaveSendHandshake = true;
-                                byteBufferRead.position(readSocketPos);
+                                ((Buffer)byteBufferRead).position(readSocketPos);
                                 ReadSocketService.this.processPosition += AutoSwitchHAClient.HANDSHAKE_HEADER_SIZE;
                                 LOGGER.info("Receive slave handshake, slaveBrokerId:{}, isSyncFromLastFile:{}, isAsyncLearner:{}",
                                     AutoSwitchHAConnection.this.slaveId, AutoSwitchHAConnection.this.isSyncFromLastFile, AutoSwitchHAConnection.this.isAsyncLearner);
@@ -343,7 +343,7 @@ public class AutoSwitchHAConnection implements HAConnection {
                                 if (slaveRequestOffset < 0) {
                                     slaveRequestOffset = slaveMaxOffset;
                                 }
-                                byteBufferRead.position(readSocketPos);
+                                ((Buffer)byteBufferRead).position(readSocketPos);
                                 maybeExpandInSyncStateSet(slaveMaxOffset);
                                 AutoSwitchHAConnection.this.haService.updateConfirmOffsetWhenSlaveAck(AutoSwitchHAConnection.this.slaveId);
                                 AutoSwitchHAConnection.this.haService.notifyTransferSome(AutoSwitchHAConnection.this.slaveAckOffset);
@@ -363,7 +363,7 @@ public class AutoSwitchHAConnection implements HAConnection {
                     }
 
                     if (!byteBufferRead.hasRemaining()) {
-                        byteBufferRead.position(ReadSocketService.this.processPosition);
+                        ((Buffer)byteBufferRead).position(ReadSocketService.this.processPosition);
                         byteBufferRead.compact();
                         ReadSocketService.this.processPosition = 0;
                     }
@@ -478,7 +478,7 @@ public class AutoSwitchHAConnection implements HAConnection {
             final List<EpochEntry> epochEntries = AutoSwitchHAConnection.this.epochCache.getAllEntries();
             final int lastEpoch = AutoSwitchHAConnection.this.epochCache.lastEpoch();
             final long maxPhyOffset = AutoSwitchHAConnection.this.haService.getDefaultMessageStore().getMaxPhyOffset();
-            this.byteBufferHeader.position(0);
+            ((Buffer)this.byteBufferHeader).position(0);
             this.byteBufferHeader.limit(HANDSHAKE_HEADER_SIZE);
             // State
             this.byteBufferHeader.putInt(currentState.ordinal());
@@ -491,7 +491,7 @@ public class AutoSwitchHAConnection implements HAConnection {
             ((Buffer)this.byteBufferHeader).flip();
 
             // EpochEntries
-            this.handShakeBuffer.position(0);
+            ((Buffer)this.handShakeBuffer).position(0);
             this.handShakeBuffer.limit(EPOCH_ENTRY_SIZE * epochEntries.size());
             for (final EpochEntry entry : epochEntries) {
                 if (entry != null) {
@@ -535,7 +535,7 @@ public class AutoSwitchHAConnection implements HAConnection {
                 entry = AutoSwitchHAConnection.this.epochCache.firstEntry();
             }
             // Build Header
-            this.byteBufferHeader.position(0);
+            ((Buffer)this.byteBufferHeader).position(0);
             this.byteBufferHeader.limit(TRANSFER_HEADER_SIZE);
             // State
             this.byteBufferHeader.putInt(currentState.ordinal());

--- a/store/src/main/java/org/apache/rocketmq/store/kv/CompactionLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/kv/CompactionLog.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.store.kv;
 
 import com.google.common.collect.Lists;
+import java.nio.Buffer;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -164,7 +165,7 @@ public class CompactionLog {
             if (size < 0 || size > byteBuffer.capacity()) {
                 break;
             } else {
-                bb.limit(size);
+                ((Buffer)bb).limit(size);
                 bb.rewind();
             }
 
@@ -179,7 +180,7 @@ public class CompactionLog {
                 return false;
             }
 
-            byteBuffer.position(mark + size);
+            ((Buffer)byteBuffer).position(mark + size);
         }
 
         return true;
@@ -868,7 +869,7 @@ public class CompactionLog {
             int destPos = bbDest.position();
             long physicalOffset = fileFromOffset + bbDest.position();
             bbSrc.rewind();
-            bbSrc.limit(msgLen);
+            ((Buffer)bbSrc).limit(msgLen);
             bbDest.put(bbSrc);
             bbDest.putLong(destPos + logicOffsetPos + 8, physicalOffset);       //replace physical offset
 
@@ -915,7 +916,7 @@ public class CompactionLog {
             int tryNum = 0;
             int index = indexOf(hash1, tryNum);
             while (!isEmpty(index)) {
-                dataBytes.position(index);
+                ((Buffer)dataBytes).position(index);
                 dataBytes.get(hash2);
                 if (Arrays.equals(hash1, hash2)) {
                     dataBytes.putLong(offset);
@@ -926,7 +927,7 @@ public class CompactionLog {
                 index = indexOf(hash1, tryNum);
             }
 
-            dataBytes.position(index);
+            ((Buffer)dataBytes).position(index);
             dataBytes.put(hash1);
             dataBytes.putLong(offset);
             lastOffset = offset;
@@ -943,7 +944,7 @@ public class CompactionLog {
                     return -1L;
                 }
                 index = indexOf(hash1, tryNum);
-                dataBytes.position(index);
+                ((Buffer)dataBytes).position(index);
                 if (isEmpty(index)) {
                     return -1L;
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -554,7 +554,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
         }
 
         ((Buffer)this.byteBufferItem).flip();
-        this.byteBufferItem.limit(CQ_STORE_UNIT_SIZE);
+        ((Buffer)this.byteBufferItem).limit(CQ_STORE_UNIT_SIZE);
         this.byteBufferItem.putLong(offset);
         this.byteBufferItem.putInt(size);
         this.byteBufferItem.putLong(tagsCode);
@@ -916,7 +916,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
             ByteBuffer tmpBuffer = sbr.getByteBuffer().slice();
             ((Buffer)tmpBuffer).position(MSG_COMPACT_OFFSET_INDEX);
             ByteBuffer compactOffsetStoreBuffer = tmpBuffer.slice();
-            compactOffsetStoreBuffer.limit(MSG_COMPACT_OFFSET_LENGTH);
+            ((Buffer)compactOffsetStoreBuffer).limit(MSG_COMPACT_OFFSET_LENGTH);
 
             int relativePos = sbr.getByteBuffer().position();
             long offsetPy = sbr.getByteBuffer().getLong();

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -221,7 +221,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
             long mappedFileOffset = 0;
             while (true) {
                 for (int i = 0; i < mappedFileSizeLogics; i += CQ_STORE_UNIT_SIZE) {
-                    byteBuffer.position(i);
+                    ((Buffer)byteBuffer).position(i);
                     long offset = byteBuffer.getLong();
                     int size = byteBuffer.getInt();
                     byteBuffer.getLong();//tagscode
@@ -371,7 +371,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
                 mappedFile.setFlushedPosition(0);
 
                 for (int i = 0; i < logicFileSize; i += CQ_STORE_UNIT_SIZE) {
-                    byteBuffer.position(i);
+                    ((Buffer)byteBuffer).position(i);
                     long offset = byteBuffer.getLong();
                     int size = byteBuffer.getInt();
                     byteBuffer.getLong();//tagscode
@@ -446,7 +446,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
                 try {
                     int startPos = result.getByteBuffer().position();
                     for (int i = 0; i < result.getSize(); i += BatchConsumeQueue.CQ_STORE_UNIT_SIZE) {
-                        result.getByteBuffer().position(startPos + i);
+                        ((Buffer)result.getByteBuffer()).position(startPos + i);
                         long offsetPy = result.getByteBuffer().getLong();
                         result.getByteBuffer().getInt(); //size
                         result.getByteBuffer().getLong();//tagscode
@@ -914,7 +914,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
                 return null;
             }
             ByteBuffer tmpBuffer = sbr.getByteBuffer().slice();
-            tmpBuffer.position(MSG_COMPACT_OFFSET_INDEX);
+            ((Buffer)tmpBuffer).position(MSG_COMPACT_OFFSET_INDEX);
             ByteBuffer compactOffsetStoreBuffer = tmpBuffer.slice();
             compactOffsetStoreBuffer.limit(MSG_COMPACT_OFFSET_LENGTH);
 
@@ -926,7 +926,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
             long msgBaseOffset = sbr.getByteBuffer().getLong();
             short batchSize = sbr.getByteBuffer().getShort();
             int compactedOffset = sbr.getByteBuffer().getInt();
-            sbr.getByteBuffer().position(relativePos + CQ_STORE_UNIT_SIZE);
+            ((Buffer)sbr.getByteBuffer()).position(relativePos + CQ_STORE_UNIT_SIZE);
 
             return new CqUnit(msgBaseOffset, offsetPy, sizePy, tagsCode, batchSize, compactedOffset, compactOffsetStoreBuffer);
         }
@@ -1087,9 +1087,9 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
                     int current = 0;
                     while (current < len) {
                         // skip physicalOffset and message length fields.
-                        buffer.position(current + MSG_TAG_OFFSET_INDEX);
+                        ((Buffer)buffer).position(current + MSG_TAG_OFFSET_INDEX);
                         long tagCode = buffer.getLong();
-                        buffer.position(current + MSG_BATCH_SIZE_INDEX);
+                        ((Buffer)buffer).position(current + MSG_BATCH_SIZE_INDEX);
                         long batchSize = buffer.getShort();
                         if (filter.isMatchedByConsumeQueue(tagCode, null)) {
                             match += batchSize;

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.store.queue;
 
 import java.io.File;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -552,7 +553,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
             log.warn("Reput behind {} topic:{} queue:{} offset:{} behind:{}", flag, topic, queueId, offset, behind);
         }
 
-        this.byteBufferItem.flip();
+        ((Buffer)this.byteBufferItem).flip();
         this.byteBufferItem.limit(CQ_STORE_UNIT_SIZE);
         this.byteBufferItem.putLong(offset);
         this.byteBufferItem.putInt(size);

--- a/store/src/main/java/org/apache/rocketmq/store/queue/SparseConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/SparseConsumeQueue.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store.queue;
 
+import java.nio.Buffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.store.MessageStore;
 import org.apache.rocketmq.store.SelectMappedBufferResult;
@@ -251,7 +252,7 @@ public class SparseConsumeQueue extends BatchConsumeQueue {
     public void putEndPositionInfo(MappedFile mappedFile) {
         // cache max offset
         if (!mappedFile.isFull()) {
-            this.byteBufferItem.flip();
+            ((Buffer)this.byteBufferItem).flip();
             this.byteBufferItem.limit(CQ_STORE_UNIT_SIZE);
             this.byteBufferItem.putLong(-1);
             this.byteBufferItem.putInt(0);

--- a/store/src/main/java/org/apache/rocketmq/store/queue/SparseConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/SparseConsumeQueue.java
@@ -253,7 +253,7 @@ public class SparseConsumeQueue extends BatchConsumeQueue {
         // cache max offset
         if (!mappedFile.isFull()) {
             ((Buffer)this.byteBufferItem).flip();
-            this.byteBufferItem.limit(CQ_STORE_UNIT_SIZE);
+            ((Buffer)this.byteBufferItem).limit(CQ_STORE_UNIT_SIZE);
             this.byteBufferItem.putLong(-1);
             this.byteBufferItem.putInt(0);
             this.byteBufferItem.putLong(0);

--- a/store/src/main/java/org/apache/rocketmq/store/queue/SparseConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/SparseConsumeQueue.java
@@ -65,7 +65,7 @@ public class SparseConsumeQueue extends BatchConsumeQueue {
             long processOffset = mappedFile.getFileFromOffset();
             while (true) {
                 for (int i = 0; i < mappedFileSize; i += CQ_STORE_UNIT_SIZE) {
-                    byteBuffer.position(i);
+                    ((Buffer)byteBuffer).position(i);
                     long offset = byteBuffer.getLong();
                     int size = byteBuffer.getInt();
                     byteBuffer.getLong();   //tagscode
@@ -322,7 +322,7 @@ public class SparseConsumeQueue extends BatchConsumeQueue {
 
         ByteBuffer byteBuffer = mappedFile.sliceByteBuffer();
         for (int i = mappedFile.getReadPosition() - CQ_STORE_UNIT_SIZE; i >= 0; i -= CQ_STORE_UNIT_SIZE) {
-            byteBuffer.position(i);
+            ((Buffer)byteBuffer).position(i);
             long offset = byteBuffer.getLong();
             int size = byteBuffer.getInt();
             long tagsCode = byteBuffer.getLong();   //tagscode
@@ -330,7 +330,7 @@ public class SparseConsumeQueue extends BatchConsumeQueue {
             long msgBaseOffset = byteBuffer.getLong();
             short batchSize = byteBuffer.getShort();
             if (offset >= 0 && size > 0 && msgBaseOffset >= 0 && batchSize > 0) {
-                byteBuffer.position(i);     //reset position
+                ((Buffer)byteBuffer).position(i);     //reset position
                 return function.apply(byteBuffer.slice());
             }
         }
@@ -346,7 +346,7 @@ public class SparseConsumeQueue extends BatchConsumeQueue {
 
         ByteBuffer byteBuffer = mappedFile.sliceByteBuffer();
         for (int i = mappedFile.getReadPosition() - CQ_STORE_UNIT_SIZE; i >= 0; i -= CQ_STORE_UNIT_SIZE) {
-            byteBuffer.position(i);
+            ((Buffer)byteBuffer).position(i);
             long offset = byteBuffer.getLong();
             int size = byteBuffer.getInt();
             byteBuffer.getLong();   //tagscode

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerCheckpoint.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerCheckpoint.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store.timer;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -129,7 +130,7 @@ public class TimerCheckpoint {
         byteBuffer.putLong(another.getDataVersion().getStateVersion());
         byteBuffer.putLong(another.getDataVersion().getTimestamp());
         byteBuffer.putLong(another.getDataVersion().getCounter().get());
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         return byteBuffer;
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store.timer;
 import com.conversantmedia.util.concurrent.DisruptorBlockingQueue;
 import java.io.File;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -1013,7 +1014,7 @@ public class TimerMessageStore {
             bufferLocal.get().limit(sizePy);
             boolean res = messageStore.getData(offsetPy, sizePy, bufferLocal.get());
             if (res) {
-                bufferLocal.get().flip();
+                ((Buffer)bufferLocal.get()).flip();
                 msgExt = MessageDecoder.decode(bufferLocal.get(), true, false, false);
             }
             if (null == msgExt) {

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -716,7 +716,7 @@ public class TimerMessageStore {
         String realTopic = messageExt.getProperty(MessageConst.PROPERTY_REAL_TOPIC);
         Slot slot = timerWheel.getSlot(delayedTime);
         ByteBuffer tmpBuffer = timerLogBuffer;
-        tmpBuffer.clear();
+        ((Buffer)tmpBuffer).clear();
         tmpBuffer.putInt(TimerLog.UNIT_SIZE); //size
         tmpBuffer.putLong(slot.lastPos); //prev pos
         tmpBuffer.putInt(magic); //magic
@@ -1011,7 +1011,7 @@ public class TimerMessageStore {
         for (int i = 0; i < 3; i++) {
             MessageExt msgExt = null;
             ((Buffer)bufferLocal.get()).position(0);
-            bufferLocal.get().limit(sizePy);
+            ((Buffer)bufferLocal.get()).limit(sizePy);
             boolean res = messageStore.getData(offsetPy, sizePy, bufferLocal.get());
             if (res) {
                 ((Buffer)bufferLocal.get()).flip();

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -404,7 +404,7 @@ public class TimerMessageStore {
             boolean stopCheck = false;
             for (; position < sbr.getSize(); position += TimerLog.UNIT_SIZE) {
                 try {
-                    bf.position(position);
+                    ((Buffer)bf).position(position);
                     int size = bf.getInt();//size
                     bf.getLong();//prev pos
                     int magic = bf.getInt();
@@ -782,10 +782,10 @@ public class TimerMessageStore {
                 long prevPos = -1;
                 try {
                     int position = (int) (currOffsetPy % timerLogFileSize);
-                    timeSbr.getByteBuffer().position(position);
+                    ((Buffer)timeSbr.getByteBuffer()).position(position);
                     timeSbr.getByteBuffer().getInt(); //size
                     prevPos = timeSbr.getByteBuffer().getLong();
-                    timeSbr.getByteBuffer().position(position + TimerLog.UNIT_PRE_SIZE_FOR_MSG);
+                    ((Buffer)timeSbr.getByteBuffer()).position(position + TimerLog.UNIT_PRE_SIZE_FOR_MSG);
                     long offsetPy = timeSbr.getByteBuffer().getLong();
                     int sizePy = timeSbr.getByteBuffer().getInt();
                     if (null == msgSbr || msgSbr.getStartOffset() > offsetPy) {
@@ -798,7 +798,7 @@ public class TimerMessageStore {
                         ByteBuffer bf = msgSbr.getByteBuffer();
                         int firstPos = (int) (offsetPy % commitLogFileSize);
                         for (int pos = firstPos; pos < firstPos + sizePy; pos += 4096) {
-                            bf.position(pos);
+                            ((Buffer)bf).position(pos);
                             bf.get();
                         }
                     }
@@ -904,7 +904,7 @@ public class TimerMessageStore {
                 long prevPos = -1;
                 try {
                     int position = (int) (currOffsetPy % timerLogFileSize);
-                    timeSbr.getByteBuffer().position(position);
+                    ((Buffer)timeSbr.getByteBuffer()).position(position);
                     timeSbr.getByteBuffer().getInt(); //size
                     prevPos = timeSbr.getByteBuffer().getLong();
                     int magic = timeSbr.getByteBuffer().getInt();
@@ -1010,7 +1010,7 @@ public class TimerMessageStore {
     private MessageExt getMessageByCommitOffset(long offsetPy, int sizePy) {
         for (int i = 0; i < 3; i++) {
             MessageExt msgExt = null;
-            bufferLocal.get().position(0);
+            ((Buffer)bufferLocal.get()).position(0);
             bufferLocal.get().limit(sizePy);
             boolean res = messageStore.getData(offsetPy, sizePy, bufferLocal.get());
             if (res) {
@@ -1197,7 +1197,7 @@ public class TimerMessageStore {
                 }
                 ByteBuffer bf = timeSbr.getByteBuffer();
                 for (int position = 0; position < timeSbr.getSize(); position += TimerLog.UNIT_SIZE) {
-                    bf.position(position);
+                    ((Buffer)bf).position(position);
                     bf.getInt();//size
                     bf.getLong();//prev pos
                     int magic = bf.getInt(); //magic

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store.timer;
 
+import java.nio.Buffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
@@ -100,10 +101,10 @@ public class TimerWheel {
 
     public void flush() {
         ByteBuffer bf = localBuffer.get();
-        bf.position(0);
-        bf.limit(wheelLength);
-        mappedByteBuffer.position(0);
-        mappedByteBuffer.limit(wheelLength);
+        ((Buffer)bf).position(0);
+        ((Buffer)bf).limit(wheelLength);
+        ((Buffer)mappedByteBuffer).position(0);
+        ((Buffer)mappedByteBuffer).limit(wheelLength);
         for (int i = 0; i < wheelLength; i++) {
             if (bf.get(i) != mappedByteBuffer.get(i)) {
                 mappedByteBuffer.put(i, bf.get(i));
@@ -122,7 +123,7 @@ public class TimerWheel {
 
     //testable
     public Slot getRawSlot(long timeMs) {
-        localBuffer.get().position(getSlotIndex(timeMs) * Slot.SIZE);
+        ((Buffer)localBuffer.get()).position(getSlotIndex(timeMs) * Slot.SIZE);
         return new Slot(localBuffer.get().getLong() * precisionMs,
             localBuffer.get().getLong(), localBuffer.get().getLong(), localBuffer.get().getInt(), localBuffer.get().getInt());
     }
@@ -132,7 +133,7 @@ public class TimerWheel {
     }
 
     public void putSlot(long timeMs, long firstPos, long lastPos) {
-        localBuffer.get().position(getSlotIndex(timeMs) * Slot.SIZE);
+        ((Buffer)localBuffer.get()).position(getSlotIndex(timeMs) * Slot.SIZE);
         // To be compatible with previous version.
         // The previous version's precision is fixed at 1000ms and it store timeMs / 1000 in slot.
         localBuffer.get().putLong(timeMs / precisionMs);
@@ -140,7 +141,7 @@ public class TimerWheel {
         localBuffer.get().putLong(lastPos);
     }
     public void putSlot(long timeMs, long firstPos, long lastPos, int num, int magic) {
-        localBuffer.get().position(getSlotIndex(timeMs) * Slot.SIZE);
+        ((Buffer)localBuffer.get()).position(getSlotIndex(timeMs) * Slot.SIZE);
         localBuffer.get().putLong(timeMs / precisionMs);
         localBuffer.get().putLong(firstPos);
         localBuffer.get().putLong(lastPos);
@@ -149,7 +150,7 @@ public class TimerWheel {
     }
 
     public void reviseSlot(long timeMs, long firstPos, long lastPos, boolean force) {
-        localBuffer.get().position(getSlotIndex(timeMs) * Slot.SIZE);
+        ((Buffer)localBuffer.get()).position(getSlotIndex(timeMs) * Slot.SIZE);
 
         if (timeMs / precisionMs != localBuffer.get().getLong()) {
             if (force) {
@@ -173,7 +174,7 @@ public class TimerWheel {
         int firstSlotIndex = getSlotIndex(timeStartMs);
         for (int i = 0; i < slotsTotal * 2; i++) {
             int slotIndex = (firstSlotIndex + i) % (slotsTotal * 2);
-            localBuffer.get().position(slotIndex * Slot.SIZE);
+            ((Buffer)localBuffer.get()).position(slotIndex * Slot.SIZE);
             if ((timeStartMs + i * precisionMs) / precisionMs != localBuffer.get().getLong()) {
                 continue;
             }
@@ -197,7 +198,7 @@ public class TimerWheel {
         int firstSlotIndex = getSlotIndex(timeStartMs);
         for (int i = 0; i < slotsTotal * 2; i++) {
             int slotIndex = (firstSlotIndex + i) % (slotsTotal * 2);
-            localBuffer.get().position(slotIndex * Slot.SIZE);
+            ((Buffer)localBuffer.get()).position(slotIndex * Slot.SIZE);
             if ((timeStartMs + i * precisionMs) / precisionMs == localBuffer.get().getLong()) {
                 localBuffer.get().getLong(); //first pos
                 localBuffer.get().getLong(); //last pos

--- a/store/src/test/java/org/apache/rocketmq/store/AppendCallbackTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/AppendCallbackTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.store;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -179,8 +180,8 @@ public class AppendCallbackTest {
             msgIds.add(msgId);
         }
         assertEquals(messages.size(), msgIds.size());
-
-        List<MessageExt> decodeMsgs = MessageDecoder.decodes((ByteBuffer) buff.flip());
+        ((Buffer) buff).flip();
+        List<MessageExt> decodeMsgs = MessageDecoder.decodes(buff);
         assertEquals(decodeMsgs.size(), decodeMsgs.size());
         long queueOffset = decodeMsgs.get(0).getQueueOffset();
         long storeTimeStamp = decodeMsgs.get(0).getStoreTimestamp();
@@ -241,8 +242,8 @@ public class AppendCallbackTest {
             msgIds.add(msgId);
         }
         assertEquals(messages.size(), msgIds.size());
-
-        List<MessageExt> decodeMsgs = MessageDecoder.decodes((ByteBuffer) buff.flip());
+        ((Buffer) buff).flip();
+        List<MessageExt> decodeMsgs = MessageDecoder.decodes(buff);
         assertEquals(decodeMsgs.size(), decodeMsgs.size());
         long queueOffset = decodeMsgs.get(0).getQueueOffset();
         long storeTimeStamp = decodeMsgs.get(0).getStoreTimestamp();

--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.Buffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
@@ -745,7 +746,7 @@ public class DefaultMessageStoreTest {
             MappedByteBuffer mappedByteBuffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, 1024 * 1024 * 10);
             int bodyLen = mappedByteBuffer.getInt((int) offset + 84);
             int topicLenIndex = (int) offset + 84 + bodyLen + 4;
-            mappedByteBuffer.position(topicLenIndex);
+            ((Buffer)mappedByteBuffer).position(topicLenIndex);
             mappedByteBuffer.putInt(0);
             mappedByteBuffer.putInt(0);
             mappedByteBuffer.putInt(0);

--- a/store/src/test/java/org/apache/rocketmq/store/MappedFileQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/MappedFileQueueTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.store;
 
+import java.nio.Buffer;
 import java.util.concurrent.CountDownLatch;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.rocketmq.common.MixAll;
@@ -204,7 +205,7 @@ public class MappedFileQueueTest {
             byte[] padding = new byte[12];
             Arrays.fill(padding, (byte) '0');
             byteBuffer.put(padding);
-            byteBuffer.flip();
+            ((Buffer)byteBuffer).flip();
 
             assertThat(mappedFile.appendMessage(byteBuffer.array())).isTrue();
         }

--- a/store/src/test/java/org/apache/rocketmq/store/queue/SparseConsumeQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/queue/SparseConsumeQueueTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store.queue;
 
+import java.nio.Buffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.store.CommitLog;
 import org.apache.rocketmq.store.DefaultMessageStore;
@@ -89,7 +90,7 @@ public class SparseConsumeQueueTest {
         Files.createDirectories(Paths.get(path, topic, String.valueOf(queueId)));
         Files.write(Paths.get(path, topic, String.valueOf(queueId), file1), bb.array(),
             StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        bb.clear();
+        ((Buffer)bb).clear();
         fillByteBuf(bb, phyOffset + 1, queueOffset + 1);
         Files.write(Paths.get(path, topic, String.valueOf(queueId), file2), bb.array(),
             StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
@@ -132,7 +133,7 @@ public class SparseConsumeQueueTest {
                 StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
             basePhyOffset = i * 100 + 1;
             baseQueueOffset = i * 100 + 1;
-            bb.clear();
+            ((Buffer)bb).clear();
         }
 
         scq.load();

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/TieredConsumeQueue.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/TieredConsumeQueue.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.tieredstore.file;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.tuple.Pair;
@@ -81,7 +82,7 @@ public class TieredConsumeQueue {
         cqItem.putLong(offset);
         cqItem.putInt(size);
         cqItem.putLong(tagsCode);
-        cqItem.flip();
+        ((Buffer)cqItem).flip();
         return flatFile.append(cqItem, timeStamp, commit);
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/TieredFlatFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/TieredFlatFile.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.tieredstore.file;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -568,7 +569,7 @@ public class TieredFlatFile {
             .thenCombine(fileSegment2.readAsync(0, length - segment1Length), (buffer1, buffer2) -> {
                 ByteBuffer compositeBuffer = ByteBuffer.allocate(buffer1.remaining() + buffer2.remaining());
                 compositeBuffer.put(buffer1).put(buffer2);
-                compositeBuffer.flip();
+                ((Buffer)compositeBuffer).flip();
                 return compositeBuffer;
             });
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/TieredIndexFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/TieredIndexFile.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.tieredstore.file;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.file.Paths;
@@ -436,7 +437,7 @@ public class TieredIndexFile {
             }
             compactMappedByteBuffer.putInt(INDEX_FILE_HEADER_MAGIC_CODE_POSITION, INDEX_FILE_END_MAGIC_CODE);
             compactMappedByteBuffer.putInt(rePutSlotValue, INDEX_FILE_BEGIN_MAGIC_CODE);
-            compactMappedByteBuffer.limit(rePutSlotValue + 4);
+            ((Buffer)compactMappedByteBuffer).limit(rePutSlotValue + 4);
         }
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegment.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.tieredstore.provider;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -281,7 +282,7 @@ public abstract class TieredFileSegment implements Comparable<TieredFileSegment>
         codaBuffer.putInt(TieredCommitLog.CODA_SIZE);
         codaBuffer.putInt(TieredCommitLog.BLANK_MAGIC_CODE);
         codaBuffer.putLong(maxTimestamp);
-        codaBuffer.flip();
+        ((Buffer)codaBuffer).flip();
         appendPosition += TieredCommitLog.CODA_SIZE;
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/inputstream/TieredCommitLogInputStream.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/inputstream/TieredCommitLogInputStream.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.tieredstore.provider.inputstream;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.rocketmq.tieredstore.common.FileSegmentType;
@@ -125,9 +126,9 @@ public class TieredCommitLogInputStream extends TieredFileSegmentInputStream {
                 // read from coda buffer
                 remaining = codaBuffer.remaining() - posInCurBuffer;
                 readLen = Math.min(remaining, needRead);
-                codaBuffer.position(posInCurBuffer);
+                ((Buffer)codaBuffer).position(posInCurBuffer);
                 codaBuffer.get(b, off, readLen);
-                codaBuffer.position(0);
+                ((Buffer)codaBuffer).position(0);
                 // update flags
                 off += readLen;
                 needRead -= readLen;
@@ -141,9 +142,9 @@ public class TieredCommitLogInputStream extends TieredFileSegmentInputStream {
             if (posInCurBuffer < MessageBufferUtil.PHYSICAL_OFFSET_POSITION) {
                 realReadLen = Math.min(MessageBufferUtil.PHYSICAL_OFFSET_POSITION - posInCurBuffer, readLen);
                 // read from commitLog buffer
-                curBuf.position(posInCurBuffer);
+                ((Buffer)curBuf).position(posInCurBuffer);
                 curBuf.get(b, off, realReadLen);
-                curBuf.position(0);
+                ((Buffer)curBuf).position(0);
             } else if (posInCurBuffer < MessageBufferUtil.SYS_FLAG_OFFSET_POSITION) {
                 realReadLen = Math.min(MessageBufferUtil.SYS_FLAG_OFFSET_POSITION - posInCurBuffer, readLen);
                 // read from converted PHYSICAL_OFFSET_POSITION
@@ -155,9 +156,9 @@ public class TieredCommitLogInputStream extends TieredFileSegmentInputStream {
             } else {
                 realReadLen = readLen;
                 // read from commitLog buffer
-                curBuf.position(posInCurBuffer);
+                ((Buffer)curBuf).position(posInCurBuffer);
                 curBuf.get(b, off, readLen);
-                curBuf.position(0);
+                ((Buffer)curBuf).position(0);
             }
             // update flags
             off += realReadLen;

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/inputstream/TieredFileSegmentInputStream.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/inputstream/TieredFileSegmentInputStream.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.tieredstore.provider.inputstream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.rocketmq.tieredstore.common.FileSegmentType;
@@ -158,9 +159,9 @@ public class TieredFileSegmentInputStream extends InputStream {
             int remaining = curBuf.remaining() - posInCurBuffer;
             int readLen = Math.min(remaining, needRead);
             // read from curBuf
-            curBuf.position(posInCurBuffer);
+            ((Buffer)curBuf).position(posInCurBuffer);
             curBuf.get(b, off, readLen);
-            curBuf.position(0);
+            ((Buffer)curBuf).position(0);
             // update flags
             off += readLen;
             needRead -= readLen;

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Paths;
@@ -156,7 +157,7 @@ public class PosixFileSegment extends TieredFileSegment {
         try {
             readFileChannel.position(position);
             readFileChannel.read(byteBuffer);
-            byteBuffer.flip();
+            ((Buffer)byteBuffer).flip();
 
             attributesBuilder.put(LABEL_SUCCESS, true);
             long costTime = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtil.java
@@ -127,20 +127,20 @@ public class MessageBufferUtil {
         try {
             long startCommitLogOffset = CQItemBufferUtil.getCommitLogOffset(cqBuffer);
             for (int pos = cqBuffer.position(); pos < cqBuffer.limit(); pos += TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE) {
-                cqBuffer.position(pos);
+                ((Buffer)cqBuffer).position(pos);
                 int diff = (int) (CQItemBufferUtil.getCommitLogOffset(cqBuffer) - startCommitLogOffset);
                 int size = CQItemBufferUtil.getSize(cqBuffer);
                 if (diff + size > msgBuffer.limit()) {
                     logger.error("MessageBufferUtil#splitMessage: message buffer size is incorrect: record in consume queue: {}, actual: {}", diff + size, msgBuffer.remaining());
                     return messageList;
                 }
-                msgBuffer.position(diff);
+                ((Buffer)msgBuffer).position(diff);
 
                 int magicCode = getMagicCode(msgBuffer);
                 if (magicCode == TieredCommitLog.BLANK_MAGIC_CODE) {
                     logger.warn("MessageBufferUtil#splitMessage: message decode error: blank magic code, this message may be coda, try to fix offset");
                     diff = diff + TieredCommitLog.CODA_SIZE;
-                    msgBuffer.position(diff);
+                    ((Buffer)msgBuffer).position(diff);
                     magicCode = getMagicCode(msgBuffer);
                 }
                 if (magicCode != MessageDecoder.MESSAGE_MAGIC_CODE && magicCode != MessageDecoder.MESSAGE_MAGIC_CODE_V2) {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.tieredstore.util;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,7 +101,7 @@ public class MessageBufferUtil {
         idBuffer.limit(TieredStoreUtil.MSG_ID_LENGTH);
         idBuffer.putLong(message.getLong(message.position() + STORE_HOST_POSITION));
         idBuffer.putLong(getCommitLogOffset(message));
-        idBuffer.flip();
+        ((Buffer)idBuffer).flip();
         return idBuffer;
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtil.java
@@ -98,7 +98,7 @@ public class MessageBufferUtil {
 
     public static ByteBuffer getOffsetIdBuffer(ByteBuffer message) {
         ByteBuffer idBuffer = ByteBuffer.allocate(TieredStoreUtil.MSG_ID_LENGTH);
-        idBuffer.limit(TieredStoreUtil.MSG_ID_LENGTH);
+        ((Buffer)idBuffer).limit(TieredStoreUtil.MSG_ID_LENGTH);
         idBuffer.putLong(message.getLong(message.position() + STORE_HOST_POSITION));
         idBuffer.putLong(getCommitLogOffset(message));
         ((Buffer)idBuffer).flip();

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredDispatcherTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredDispatcherTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.tieredstore;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import org.apache.rocketmq.common.message.MessageQueue;
@@ -146,7 +147,7 @@ public class TieredDispatcherTest {
         cqItem.putLong(7);
         cqItem.putInt(MessageBufferUtilTest.MSG_LEN);
         cqItem.putLong(1);
-        cqItem.flip();
+        ((Buffer)cqItem).flip();
         SelectMappedBufferResult mockResult = new SelectMappedBufferResult(0, cqItem, ConsumeQueue.CQ_STORE_UNIT_SIZE, null);
         Mockito.when(((ConsumeQueue) defaultStore.getConsumeQueue(mq.getTopic(), mq.getQueueId())).getIndexBuffer(6)).thenReturn(mockResult);
 
@@ -154,7 +155,7 @@ public class TieredDispatcherTest {
         cqItem.putLong(8);
         cqItem.putInt(MessageBufferUtilTest.MSG_LEN);
         cqItem.putLong(1);
-        cqItem.flip();
+        ((Buffer)cqItem).flip();
         mockResult = new SelectMappedBufferResult(0, cqItem, ConsumeQueue.CQ_STORE_UNIT_SIZE, null);
 
         Mockito.when(((ConsumeQueue) defaultStore.getConsumeQueue(mq.getTopic(), mq.getQueueId())).getIndexBuffer(7)).thenReturn(mockResult);

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegmentInputStreamTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegmentInputStreamTest.java
@@ -231,7 +231,7 @@ public class TieredFileSegmentInputStreamTest {
     private void verifyInputStream(InputStream inputStream, ByteBuffer expectedBuffer, int expectedBufferReadPos,
         int expectedMarkCalledPos) {
         try {
-            expectedBuffer.position(expectedBufferReadPos);
+            ((Buffer)expectedBuffer).position(expectedBufferReadPos);
             while (true) {
                 if (expectedMarkCalledPos == expectedBuffer.position()) {
                     inputStream.mark(0);
@@ -259,7 +259,7 @@ public class TieredFileSegmentInputStreamTest {
     private void verifyInputStreamViaBatchRead(InputStream inputStream, ByteBuffer expectedBuffer,
         int expectedBufferReadPos, int expectedMarkCalledPos, int readBatchSize) {
         try {
-            expectedBuffer.position(expectedBufferReadPos);
+            ((Buffer)expectedBuffer).position(expectedBufferReadPos);
             byte[] buf = new byte[readBatchSize];
             while (true) {
                 if (expectedMarkCalledPos == expectedBuffer.position()) {

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegmentInputStreamTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegmentInputStreamTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.tieredstore.provider;
 import com.google.common.base.Supplier;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,7 +95,7 @@ public class TieredFileSegmentInputStreamTest {
         codaBuffer.putInt(TieredCommitLog.BLANK_MAGIC_CODE);
         long timeMillis = System.currentTimeMillis();
         codaBuffer.putLong(timeMillis);
-        codaBuffer.flip();
+        ((Buffer)codaBuffer).flip();
         int codaBufferSize = codaBuffer.remaining();
         bufferSize += codaBufferSize;
 
@@ -153,7 +154,7 @@ public class TieredFileSegmentInputStreamTest {
         byteBuffer.putLong(1);
         byteBuffer.putLong(2);
         byteBuffer.putLong(3);
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         List<ByteBuffer> uploadBufferList = Arrays.asList(byteBuffer);
 
         // build expected byte buffer for verifying the TieredFileSegmentInputStream

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegmentTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegmentTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.tieredstore.provider;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.apache.rocketmq.common.message.MessageQueue;
@@ -84,7 +85,7 @@ public class TieredFileSegmentTest {
         cqItem.putLong(commitLogOffset);
         cqItem.putInt(2);
         cqItem.putLong(3);
-        cqItem.flip();
+        ((Buffer)cqItem).flip();
         return cqItem;
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/memory/MemoryFileSegment.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/memory/MemoryFileSegment.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.tieredstore.provider.memory;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -53,7 +54,7 @@ public class MemoryFileSegment extends TieredFileSegment {
                 memStore = null;
                 break;
         }
-        memStore.position((int) getSize());
+        ((Buffer)memStore).position((int) getSize());
     }
 
     @Override
@@ -77,9 +78,9 @@ public class MemoryFileSegment extends TieredFileSegment {
     @Override
     public CompletableFuture<ByteBuffer> read0(long position, int length) {
         ByteBuffer buffer = memStore.duplicate();
-        buffer.position((int) position);
+        ((Buffer)buffer).position((int) position);
         ByteBuffer slice = buffer.slice();
-        slice.limit(length);
+        ((Buffer)slice).limit(length);
         return CompletableFuture.completedFuture(slice);
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/util/CQItemBufferUtilTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/util/CQItemBufferUtilTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.tieredstore.util;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.store.ConsumeQueue;
 import org.junit.Assert;
@@ -31,7 +32,7 @@ public class CQItemBufferUtilTest {
         cqItem.putLong(1);
         cqItem.putInt(2);
         cqItem.putLong(3);
-        cqItem.flip();
+        ((Buffer)cqItem).flip();
     }
 
     @Test

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtilTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/util/MessageBufferUtilTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.tieredstore.util;
 
 import java.net.InetSocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -93,7 +94,7 @@ public class MessageBufferUtilTest {
         byte[] propertiesBytes = properties.getBytes(StandardCharsets.UTF_8);
         buffer.putShort((short) propertiesBytes.length);
         buffer.put(propertiesBytes);
-        buffer.flip();
+        ((Buffer)buffer).flip();
 
         Assert.assertEquals(MSG_LEN, buffer.remaining());
         return buffer;
@@ -107,7 +108,7 @@ public class MessageBufferUtilTest {
         byteBuffer.putInt(2);
         // 3 TAG_HASH_CODE
         byteBuffer.putLong(3);
-        byteBuffer.flip();
+        ((Buffer)byteBuffer).flip();
         return byteBuffer;
     }
 
@@ -159,7 +160,7 @@ public class MessageBufferUtilTest {
         msgBuffer2.putInt(TieredCommitLog.CODA_SIZE);
         msgBuffer2.putInt(TieredCommitLog.BLANK_MAGIC_CODE);
         msgBuffer2.putLong(System.currentTimeMillis());
-        msgBuffer2.flip();
+        ((Buffer)msgBuffer2).flip();
 
         ByteBuffer msgBuffer3 = buildMockedMessageBuffer();
         msgBuffer3.putLong(MessageBufferUtil.QUEUE_OFFSET_POSITION, 11);
@@ -169,42 +170,42 @@ public class MessageBufferUtilTest {
         msgBuffer.put(msgBuffer1);
         msgBuffer.put(msgBuffer2);
         msgBuffer.put(msgBuffer3);
-        msgBuffer.flip();
+        ((Buffer)msgBuffer).flip();
 
         ByteBuffer cqBuffer1 = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE);
         cqBuffer1.putLong(1000);
         cqBuffer1.putInt(MSG_LEN);
         cqBuffer1.putLong(0);
-        cqBuffer1.flip();
+        ((Buffer)cqBuffer1).flip();
 
         ByteBuffer cqBuffer2 = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE);
         cqBuffer2.putLong(1000 + TieredCommitLog.CODA_SIZE + MSG_LEN);
         cqBuffer2.putInt(MSG_LEN);
         cqBuffer2.putLong(0);
-        cqBuffer2.flip();
+        ((Buffer)cqBuffer2).flip();
 
         ByteBuffer cqBuffer3 = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE);
         cqBuffer3.putLong(1000 + MSG_LEN);
         cqBuffer3.putInt(MSG_LEN);
         cqBuffer3.putLong(0);
-        cqBuffer3.flip();
+        ((Buffer)cqBuffer3).flip();
 
         ByteBuffer cqBuffer4 = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE);
         cqBuffer4.putLong(1000 + TieredCommitLog.CODA_SIZE + MSG_LEN);
         cqBuffer4.putInt(MSG_LEN - 10);
         cqBuffer4.putLong(0);
-        cqBuffer4.flip();
+        ((Buffer)cqBuffer4).flip();
 
         ByteBuffer cqBuffer5 = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE);
         cqBuffer5.putLong(1000 + TieredCommitLog.CODA_SIZE + MSG_LEN);
         cqBuffer5.putInt(MSG_LEN * 10);
         cqBuffer5.putLong(0);
-        cqBuffer5.flip();
+        ((Buffer)cqBuffer5).flip();
 
         ByteBuffer cqBuffer = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE * 2);
         cqBuffer.put(cqBuffer1);
         cqBuffer.put(cqBuffer2);
-        cqBuffer.flip();
+        ((Buffer)cqBuffer).flip();
         cqBuffer1.rewind();
         cqBuffer2.rewind();
         List<Pair<Integer, Integer>> msgList = MessageBufferUtil.splitMessageBuffer(cqBuffer, msgBuffer);
@@ -215,7 +216,7 @@ public class MessageBufferUtilTest {
         cqBuffer = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE * 2);
         cqBuffer.put(cqBuffer1);
         cqBuffer.put(cqBuffer4);
-        cqBuffer.flip();
+        ((Buffer)cqBuffer).flip();
         cqBuffer1.rewind();
         cqBuffer4.rewind();
         msgList = MessageBufferUtil.splitMessageBuffer(cqBuffer, msgBuffer);
@@ -225,7 +226,7 @@ public class MessageBufferUtilTest {
         cqBuffer = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE * 3);
         cqBuffer.put(cqBuffer1);
         cqBuffer.put(cqBuffer3);
-        cqBuffer.flip();
+        ((Buffer)cqBuffer).flip();
         msgList = MessageBufferUtil.splitMessageBuffer(cqBuffer, msgBuffer);
         Assert.assertEquals(2, msgList.size());
         Assert.assertEquals(Pair.of(0, MSG_LEN), msgList.get(0));
@@ -233,7 +234,7 @@ public class MessageBufferUtilTest {
 
         cqBuffer = ByteBuffer.allocate(TieredConsumeQueue.CONSUME_QUEUE_STORE_UNIT_SIZE);
         cqBuffer.put(cqBuffer5);
-        cqBuffer.flip();
+        ((Buffer)cqBuffer).flip();
         msgList = MessageBufferUtil.splitMessageBuffer(cqBuffer, msgBuffer);
         Assert.assertEquals(0, msgList.size());
     }
@@ -259,7 +260,7 @@ public class MessageBufferUtilTest {
         ByteBuffer addr = ByteBuffer.allocate(Long.BYTES);
         addr.put(inetSocketAddress.getAddress().getAddress(), 0, 4);
         addr.putInt(inetSocketAddress.getPort());
-        addr.flip();
+        ((Buffer)addr).flip();
         for (int i = 0; i < addr.remaining(); i++) {
             buffer.put(MessageBufferUtil.STORE_HOST_POSITION + i, addr.get(i));
         }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.tools.command.message;
 
+import java.nio.Buffer;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -76,13 +77,13 @@ public class DumpCompactionLogCommand implements SubCommand {
 
                 int current = 0;
                 while (current < fileSize) {
-                    buf.position(current);
+                    ((Buffer)buf).position(current);
                     ByteBuffer bb = buf.slice();
                     int size = bb.getInt();
                     if (size > buf.capacity() || size < 0) {
                         break;
                     } else {
-                        bb.limit(size);
+                        ((Buffer)bb).limit(size);
                         bb.rewind();
                     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id
https://github.com/apache/rocketmq/issues/5068

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Java 9 introduces overridden methods with covariant return types for the following methods in java.nio.ByteBuffer:

- position
- limit
- flip
- clear

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

After compiling in the Java11 environment, it can run in the Java8 environment and send and receive messages normally