### PR TITLE
[ISSUE ##7036] rename method: getWriteQueueIdByBroker to getWriteQueu…

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
@@ -89,7 +89,7 @@ public class TopicPublishInfo {
         return this.messageQueueList.get(pos);
     }
 
-    public int getWriteQueueIdByBroker(final String brokerName) {
+    public int getWriteQueueNumsByBroker(final String brokerName) {
         for (int i = 0; i < topicRouteData.getQueueDatas().size(); i++) {
             final QueueData queueData = this.topicRouteData.getQueueDatas().get(i);
             if (queueData.getBrokerName().equals(brokerName)) {

--- a/client/src/main/java/org/apache/rocketmq/client/latency/MQFaultStrategy.java
+++ b/client/src/main/java/org/apache/rocketmq/client/latency/MQFaultStrategy.java
@@ -69,7 +69,7 @@ public class MQFaultStrategy {
                 }
 
                 final String notBestBroker = latencyFaultTolerance.pickOneAtLeast();
-                int writeQueueNums = tpInfo.getWriteQueueIdByBroker(notBestBroker);
+                int writeQueueNums = tpInfo.getWriteQueueNumsByBroker(notBestBroker);
                 if (writeQueueNums > 0) {
                     final MessageQueue mq = tpInfo.selectOneMessageQueue();
                     if (notBestBroker != null) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7036 

### Brief Description

rename method in TopicPublishInfo from  getWriteQueueIdByBroker to getWriteQueueNumsByBroker for better understand and readable. Becasue the method is to get the writequeue nums in broker instead of id.

<img width="609" alt="image" src="https://github.com/apache/rocketmq/assets/67348866/e27671a5-2987-43f6-8c52-24a82aa52b40">


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
