### PR TITLE
[ISSUE #7042] TlsTest's serverRejectsSSLClient test case will throw TooLongFrameException

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -502,7 +502,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                     case DISABLED:
                         ctx.close();
                         log.warn("Clients intend to establish an SSL connection while this server is running in SSL disabled mode");
-                        break;
+                        throw new UnsupportedOperationException("The NettyRemotingServer in SSL disabled mode doesn't support ssl client");
                     case PERMISSIVE:
                     case ENFORCING:
                         if (null != sslContext) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
@@ -144,8 +144,13 @@ public class TlsTest {
             tlsClientKeyPath = "";
             tlsClientCertPath = "";
             clientConfig.setUseTLS(false);
-        } else if ("serverRejectsSSLClient".equals(name.getMethodName())) {
+        } else if ("disabledServerRejectsSSLClient".equals(name.getMethodName())) {
             tlsMode = TlsMode.DISABLED;
+        } else if ("disabledServerAcceptUnAuthClient".equals(name.getMethodName())) {
+            tlsMode = TlsMode.DISABLED;
+            tlsClientKeyPath = "";
+            tlsClientCertPath = "";
+            clientConfig.setUseTLS(false);
         } else if ("reloadSslContextForServer".equals(name.getMethodName())) {
             tlsClientAuthServer = false;
             tlsServerNeedClientAuth = "none";
@@ -211,12 +216,17 @@ public class TlsTest {
     }
 
     @Test
-    public void serverRejectsSSLClient() throws Exception {
+    public void disabledServerRejectsSSLClient() throws Exception {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 5);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
         } catch (RemotingSendRequestException ignore) {
         }
+    }
+
+    @Test
+    public void disabledServerAcceptUnAuthClient() throws Exception {
+        requestThenAssertResponse();
     }
 
     /**


### PR DESCRIPTION
…tsSSLClient test case will throw TooLongFrameException

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Fixes #7042 

### Brief Description

In the disabled TLS mode Server, it will not reject the request directly and then request contain SSL cert will cause TooLongFrameException in the NettyDecoder.

more detail see #7042 

### How Did You Test This Change?

To conform to the semantics of the disable mode, I test the change in two case:
1. when server in disabled mode, then client send ssl request to server. and then server will reject the request.
2. when server in disabled mode, then client send no auth  request to server. and then server will accept the request.
 
