### PR TITLE
[ISSUE #7109] support the mixed topic type

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java
+++ b/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java
@@ -27,7 +27,8 @@ public enum TopicMessageType {
     NORMAL("NORMAL"),
     FIFO("FIFO"),
     DELAY("DELAY"),
-    TRANSACTION("TRANSACTION");
+    TRANSACTION("TRANSACTION"),
+    MIXED("MIXED");
 
     private final String value;
     TopicMessageType(String value) {
@@ -35,7 +36,7 @@ public enum TopicMessageType {
     }
 
     public static Set<String> topicMessageTypeSet() {
-        return Sets.newHashSet(UNSPECIFIED.value, NORMAL.value, FIFO.value, DELAY.value, TRANSACTION.value);
+        return Sets.newHashSet(UNSPECIFIED.value, NORMAL.value, FIFO.value, DELAY.value, TRANSACTION.value, MIXED.value);
     }
 
     public String getValue() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -32,6 +32,8 @@ import apache.rocketmq.v2.QueryRouteResponse;
 import apache.rocketmq.v2.Resource;
 import com.google.common.net.HostAndPort;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -259,7 +261,7 @@ public class RouteActivity extends AbstractMessingActivity {
             MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
                 .setId(queueIdIndex++)
                 .setPermission(Permission.READ)
-                .addAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
                 .build();
             messageQueueList.add(messageQueue);
         }
@@ -268,7 +270,7 @@ public class RouteActivity extends AbstractMessingActivity {
             MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
                 .setId(queueIdIndex++)
                 .setPermission(Permission.WRITE)
-                .addAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
                 .build();
             messageQueueList.add(messageQueue);
         }
@@ -277,7 +279,7 @@ public class RouteActivity extends AbstractMessingActivity {
             MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
                 .setId(queueIdIndex++)
                 .setPermission(Permission.READ_WRITE)
-                .addAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
                 .build();
             messageQueueList.add(messageQueue);
         }
@@ -285,18 +287,20 @@ public class RouteActivity extends AbstractMessingActivity {
         return messageQueueList;
     }
 
-    private MessageType parseTopicMessageType(TopicMessageType topicMessageType) {
+    private List<MessageType> parseTopicMessageType(TopicMessageType topicMessageType) {
         switch (topicMessageType) {
             case NORMAL:
-                return MessageType.NORMAL;
+                return Collections.singletonList(MessageType.NORMAL);
             case FIFO:
-                return MessageType.FIFO;
+                return Collections.singletonList(MessageType.FIFO);
             case TRANSACTION:
-                return MessageType.TRANSACTION;
+                return Collections.singletonList(MessageType.TRANSACTION);
             case DELAY:
-                return MessageType.DELAY;
+                return Collections.singletonList(MessageType.DELAY);
+            case MIXED:
+                return Arrays.asList(MessageType.NORMAL, MessageType.FIFO, MessageType.DELAY, MessageType.TRANSACTION);
             default:
-                return MessageType.MESSAGE_TYPE_UNSPECIFIED;
+                return Collections.singletonList(MessageType.MESSAGE_TYPE_UNSPECIFIED);
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/DefaultTopicMessageTypeValidator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/DefaultTopicMessageTypeValidator.java
@@ -23,9 +23,10 @@ import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
 
 public class DefaultTopicMessageTypeValidator implements TopicMessageTypeValidator {
 
-    public void validate(TopicMessageType topicMessageType, TopicMessageType messageType) {
-        if (messageType.equals(TopicMessageType.UNSPECIFIED) || !messageType.equals(topicMessageType)) {
-            String errorInfo = String.format("TopicMessageType validate failed, topic type is %s, message type is %s", topicMessageType, messageType);
+    public void validate(TopicMessageType expectedType, TopicMessageType actualType) {
+        if (actualType.equals(TopicMessageType.UNSPECIFIED)
+                || (!actualType.equals(expectedType) && !expectedType.equals(TopicMessageType.MIXED))) {
+            String errorInfo = String.format("TopicMessageType validate failed, the expected type is %s, but actual type is %s", expectedType, actualType);
             throw new ProxyException(ProxyExceptionCode.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE, errorInfo);
         }
     }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/DefaultTopicMessageTypeValidator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/DefaultTopicMessageTypeValidator.java
@@ -25,7 +25,7 @@ public class DefaultTopicMessageTypeValidator implements TopicMessageTypeValidat
 
     public void validate(TopicMessageType expectedType, TopicMessageType actualType) {
         if (actualType.equals(TopicMessageType.UNSPECIFIED)
-                || (!actualType.equals(expectedType) && !expectedType.equals(TopicMessageType.MIXED))) {
+                || !actualType.equals(expectedType) && !expectedType.equals(TopicMessageType.MIXED)) {
             String errorInfo = String.format("TopicMessageType validate failed, the expected type is %s, but actual type is %s", expectedType, actualType);
             throw new ProxyException(ProxyExceptionCode.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE, errorInfo);
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/TopicMessageTypeValidator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/TopicMessageTypeValidator.java
@@ -23,8 +23,8 @@ public interface TopicMessageTypeValidator {
     /**
      * Will throw {@link org.apache.rocketmq.proxy.common.ProxyException} if validate failed.
      *
-     * @param topicMessageType Target topic
-     * @param messageType      Message's type
+     * @param expectedType Target topic
+     * @param actualType      Message's type
      */
-    void validate(TopicMessageType topicMessageType, TopicMessageType messageType);
+    void validate(TopicMessageType expectedType, TopicMessageType actualType);
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/TopicMessageTypeValidator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/validator/TopicMessageTypeValidator.java
@@ -24,7 +24,7 @@ public interface TopicMessageTypeValidator {
      * Will throw {@link org.apache.rocketmq.proxy.common.ProxyException} if validate failed.
      *
      * @param expectedType Target topic
-     * @param actualType      Message's type
+     * @param actualType   Message's type
      */
     void validate(TopicMessageType expectedType, TopicMessageType actualType);
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7109

### Brief Description

Currently, many users are using a single topic to send messages of different types. However, in the future, there is a desire to exert strict control over message types. Message type validation has already been implemented in the Proxy component. To support the transition of existing users to the Proxy architecture, a new message type called "MIXED" should be introduced to facilitate the migration process.

### How Did You Test This Change?

1. create a topic with MIXED message type.
2. send messages with different message type, and verify the result.
3. receive messages in currently and orderly mode, and verify the result.
