### PR TITLE
Update mqbroker to use runbroker.sh instead of runserver.sh when enabling --enable-proxy

### DIFF
--- a/distribution/bin/mqbroker
+++ b/distribution/bin/mqbroker
@@ -68,7 +68,7 @@ if [ "$enable_proxy" = true ]; then
   if [ "$broker_config" != "" ]; then
       args_for_proxy=${args_for_proxy}" -bc "${broker_config}
   fi
-  sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.proxy.logback.xml org.apache.rocketmq.proxy.ProxyStartup ${args_for_proxy}
+  sh ${ROCKETMQ_HOME}/bin/runbroker.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.proxy.logback.xml org.apache.rocketmq.proxy.ProxyStartup ${args_for_proxy}
 else
   args_for_broker=$other_args
   if [ "$broker_config" != "" ]; then


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

no issue

### Brief Description

Update mqbroker to use runbroker.sh instead of runserver.sh when enabling `--enable-proxy` this allow JVM `heap` and `gc` configuration using broker's settings instead of other common serverices'(proxy,namenode, etc). our main purpose, like the filename `mqbroker` suggest, is to start broker (which embeds a proxy), so use broker's config is reasonable

chinese version
mqbroker的--enable-proxy选项是启动内嵌了proxy的broker，而不是内嵌broker的proxy，而且broker的工作量和重要程度大于proxy，所以使用broker的gc和heap配置更合适


### How Did You Test This Change?

after the change, started broker using configs in  runbroker.sh and work well
