### PR TITLE
[ISSUE #7142] Add command `RocksDBConfigToJson` to inspect rocksdb content

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -80,6 +80,7 @@ import org.apache.rocketmq.tools.command.message.QueryMsgByOffsetSubCommand;
 import org.apache.rocketmq.tools.command.message.QueryMsgByUniqueKeySubCommand;
 import org.apache.rocketmq.tools.command.message.QueryMsgTraceByIdSubCommand;
 import org.apache.rocketmq.tools.command.message.SendMessageCommand;
+import org.apache.rocketmq.tools.command.metadata.RocksDBConfigToJsonCommand;
 import org.apache.rocketmq.tools.command.namesrv.AddWritePermSubCommand;
 import org.apache.rocketmq.tools.command.namesrv.DeleteKvConfigCommand;
 import org.apache.rocketmq.tools.command.namesrv.GetNamesrvConfigCommand;
@@ -211,6 +212,7 @@ public class MQAdminStartup {
 
         initCommand(new ClusterListSubCommand());
         initCommand(new TopicListSubCommand());
+        initCommand(new RocksDBConfigToJsonCommand());
 
         initCommand(new UpdateKvConfigCommand());
         initCommand(new DeleteKvConfigCommand());

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java
@@ -37,7 +37,7 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
 
     @Override
     public String commandName() {
-        return "RocksDBConfigToJson";
+        return "rocksDBConfigToJson";
     }
 
     @Override
@@ -52,7 +52,8 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
         pathOption.setRequired(true);
         options.addOption(pathOption);
 
-        Option configTypeOption = new Option("t", "configType", true, "Name of kv config, e.g. topics/subscriptionGroups");
+        Option configTypeOption = new Option("t", "configType", true, "Name of kv config, e.g. " +
+                "topics/subscriptionGroups");
         configTypeOption.setRequired(true);
         options.addOption(configTypeOption);
 
@@ -82,13 +83,13 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
                     final JSONObject jsonObject = JSONObject.parseObject(topicConfig);
                     topicConfigTable.put(topic, jsonObject);
                 });
-                if (!isLoad) {
+
+                if (isLoad) {
+                    topicsJsonConfig.put("topicConfigTable", (JSONObject) JSONObject.toJSON(topicConfigTable));
+                    final String topicsJsonStr = JSONObject.toJSONString(topicsJsonConfig, true);
+                    System.out.print(topicsJsonStr + "\n");
                     return;
                 }
-                topicsJsonConfig.put("topicConfigTable", (JSONObject) JSONObject.toJSON(topicConfigTable));
-                final String topicsJsonStr = JSONObject.toJSONString(topicsJsonConfig, true);
-                System.out.print(topicsJsonStr + "\n");
-                return;
             }
             if (SUBSCRIPTION_GROUP_JSON_CONFIG.toLowerCase().equals(configType)) {
                 // for subscriptionGroup.json
@@ -100,14 +101,14 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
                     final JSONObject jsonObject = JSONObject.parseObject(subscriptionGroupConfig);
                     subscriptionGroupTable.put(subscriptionGroup, jsonObject);
                 });
-                if (!isLoad) {
+
+                if (isLoad) {
+                    subscriptionGroupJsonConfig.put("subscriptionGroupTable",
+                            (JSONObject) JSONObject.toJSON(subscriptionGroupTable));
+                    final String subscriptionGroupJsonStr = JSONObject.toJSONString(subscriptionGroupJsonConfig, true);
+                    System.out.print(subscriptionGroupJsonStr + "\n");
                     return;
                 }
-                subscriptionGroupJsonConfig.put("subscriptionGroupTable",
-                        (JSONObject) JSONObject.toJSON(subscriptionGroupTable));
-                final String subscriptionGroupJsonStr = JSONObject.toJSONString(subscriptionGroupJsonConfig, true);
-                System.out.print(subscriptionGroupJsonStr + "\n");
-                return;
             }
             System.out.print("Config type was not recognized, configType=" + configType + "\n");
         } finally {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.metadata;
+
+import com.alibaba.fastjson.JSONObject;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.common.config.RocksDBConfigManager;
+import org.apache.rocketmq.common.utils.DataConverter;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.command.SubCommand;
+import org.apache.rocketmq.tools.command.SubCommandException;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RocksDBConfigToJsonCommand implements SubCommand {
+    private static final String TOPICS_JSON_CONFIG = "topics";
+    private static final String SUBSCRIPTION_GROUP_JSON_CONFIG = "subscriptionGroups";
+
+    @Override
+    public String commandName() {
+        return "RocksDBConfigToJson";
+    }
+
+    @Override
+    public String commandDesc() {
+        return "Convert RocksDB kv config (topics/subscriptionGroups) to json";
+    }
+
+    @Override
+    public Options buildCommandlineOptions(Options options) {
+        Option pathOption = new Option("p", "path", true,
+                "Absolute path to the metadata directory");
+        pathOption.setRequired(true);
+        options.addOption(pathOption);
+
+        Option configTypeOption = new Option("t", "configType", true, "Name of kv config, e.g. topics/subscriptionGroups");
+        configTypeOption.setRequired(true);
+        options.addOption(configTypeOption);
+
+        return options;
+    }
+
+    @Override
+    public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) throws SubCommandException {
+        String path = commandLine.getOptionValue("path").trim();
+        if (StringUtils.isEmpty(path) || !new File(path).exists()) {
+            System.out.print("Rocksdb path is invalid.\n");
+            return;
+        }
+
+        String configType = commandLine.getOptionValue("configType").trim().toLowerCase();
+
+        final long memTableFlushInterval = 60 * 60 * 1000L;
+        RocksDBConfigManager kvConfigManager = new RocksDBConfigManager(memTableFlushInterval);
+        try {
+            if (TOPICS_JSON_CONFIG.toLowerCase().equals(configType)) {
+                // for topics.json
+                final Map<String, JSONObject> topicsJsonConfig = new HashMap<>();
+                final Map<String, JSONObject> topicConfigTable = new HashMap<>();
+                boolean isLoad = kvConfigManager.load(path, (key, value) -> {
+                    final String topic = new String(key, DataConverter.charset);
+                    final String topicConfig = new String(value, DataConverter.charset);
+                    final JSONObject jsonObject = JSONObject.parseObject(topicConfig);
+                    topicConfigTable.put(topic, jsonObject);
+                });
+                if (!isLoad) {
+                    return;
+                }
+                topicsJsonConfig.put("topicConfigTable", (JSONObject) JSONObject.toJSON(topicConfigTable));
+                final String topicsJsonStr = JSONObject.toJSONString(topicsJsonConfig, true);
+                System.out.print(topicsJsonStr + "\n");
+                return;
+            }
+            if (SUBSCRIPTION_GROUP_JSON_CONFIG.toLowerCase().equals(configType)) {
+                // for subscriptionGroup.json
+                final Map<String, JSONObject> subscriptionGroupJsonConfig = new HashMap<>();
+                final Map<String, JSONObject> subscriptionGroupTable = new HashMap<>();
+                boolean isLoad = kvConfigManager.load(path, (key, value) -> {
+                    final String subscriptionGroup = new String(key, DataConverter.charset);
+                    final String subscriptionGroupConfig = new String(value, DataConverter.charset);
+                    final JSONObject jsonObject = JSONObject.parseObject(subscriptionGroupConfig);
+                    subscriptionGroupTable.put(subscriptionGroup, jsonObject);
+                });
+                if (!isLoad) {
+                    return;
+                }
+                subscriptionGroupJsonConfig.put("subscriptionGroupTable",
+                        (JSONObject) JSONObject.toJSON(subscriptionGroupTable));
+                final String subscriptionGroupJsonStr = JSONObject.toJSONString(subscriptionGroupJsonConfig, true);
+                System.out.print(subscriptionGroupJsonStr + "\n");
+                return;
+            }
+            System.out.print("Config type was not recognized, configType=" + configType + "\n");
+        } finally {
+            kvConfigManager.stop();
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/metadata/KvConfigToJsonCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/metadata/KvConfigToJsonCommandTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.metadata;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KvConfigToJsonCommandTest {
+    private static final String BASE_PATH = System.getProperty("user.home") + File.separator + "store/config/";
+
+    @Test
+    public void testExecute() throws SubCommandException {
+        {
+            String[] cases = new String[] { "topics", "subscriptionGroups" };
+            for (String c : cases) {
+                RocksDBConfigToJsonCommand cmd = new RocksDBConfigToJsonCommand();
+                Options options = ServerUtil.buildCommandlineOptions(new Options());
+                String[] subargs = new String[] { "-p " + BASE_PATH + c, "-t " + c };
+                final CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
+                        cmd.buildCommandlineOptions(options), new DefaultParser());
+                cmd.execute(commandLine, options, null);
+                assertThat(commandLine.getOptionValue("p").trim()).isEqualTo(BASE_PATH + c);
+                assertThat(commandLine.getOptionValue("t").trim()).isEqualTo(c);
+            }
+        }
+        // invalid cases
+        {
+            String[][] cases = new String[][] {
+                    { "-p " + BASE_PATH + "tmpPath", "-t topics" },
+                    { "-p  ", "-t topics" },
+                    { "-p " + BASE_PATH + "topics", "-t invalid_type" }
+            };
+
+            for (String[] c : cases) {
+                RocksDBConfigToJsonCommand cmd = new RocksDBConfigToJsonCommand();
+                Options options = ServerUtil.buildCommandlineOptions(new Options());
+                final CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), c,
+                        cmd.buildCommandlineOptions(options), new DefaultParser());
+                cmd.execute(commandLine, options, null);
+            }
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/metadata/KvConfigToJsonCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/metadata/KvConfigToJsonCommandTest.java
@@ -33,11 +33,11 @@ public class KvConfigToJsonCommandTest {
     @Test
     public void testExecute() throws SubCommandException {
         {
-            String[] cases = new String[] { "topics", "subscriptionGroups" };
+            String[] cases = new String[]{"topics", "subscriptionGroups"};
             for (String c : cases) {
                 RocksDBConfigToJsonCommand cmd = new RocksDBConfigToJsonCommand();
                 Options options = ServerUtil.buildCommandlineOptions(new Options());
-                String[] subargs = new String[] { "-p " + BASE_PATH + c, "-t " + c };
+                String[] subargs = new String[]{"-p " + BASE_PATH + c, "-t " + c};
                 final CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
                         cmd.buildCommandlineOptions(options), new DefaultParser());
                 cmd.execute(commandLine, options, null);
@@ -47,10 +47,10 @@ public class KvConfigToJsonCommandTest {
         }
         // invalid cases
         {
-            String[][] cases = new String[][] {
-                    { "-p " + BASE_PATH + "tmpPath", "-t topics" },
-                    { "-p  ", "-t topics" },
-                    { "-p " + BASE_PATH + "topics", "-t invalid_type" }
+            String[][] cases = new String[][]{
+                    {"-p " + BASE_PATH + "tmpPath", "-t topics"},
+                    {"-p  ", "-t topics"},
+                    {"-p " + BASE_PATH + "topics", "-t invalid_type"}
             };
 
             for (String[] c : cases) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Fixes https://github.com/apache/rocketmq/issues/7142

### Brief Description

- case get topic config
`mqadmin RocksDBConfigToJson -p /home/xxx/store/config/topics -t topics`
```
	"topicConfigTable":{
		"SCHEDULE_TOPIC_XXXX":{
			"readQueueNums":18,
			"perm":6,
			"writeQueueNums":18,
			"topicFilterType":"SINGLE_TAG",
			"topicName":"SCHEDULE_TOPIC_XXXX",
			"attributes":{},
			"order":false,
			"topicSysFlag":0
		},
		"RMQ_SYS_TRANS_HALF_TOPIC":{
			"readQueueNums":1,
			"perm":6,
			"writeQueueNums":1,
			"topicFilterType":"SINGLE_TAG",
			"topicName":"RMQ_SYS_TRANS_HALF_TOPIC",
			"attributes":{},
			"order":false,
			"topicSysFlag":0
		},
// ...
}
```
- case get subscription config
`mqadmin RocksDBConfigToJson -p /home/xxx/store/config/subscriptionGroups -t subscriptionGroups`
```
{
	"subscriptionGroupTable":{
		"CID_ONSAPI_OWNER":{
			"retryMaxTimes":16,
			"whichBrokerWhenConsumeSlowly":1,
			"brokerId":0,
			"groupRetryPolicy":{
				"type":"CUSTOMIZED"
			},
			"consumeFromMinEnable":true,
			"consumeTimeoutMinute":15,
			"groupName":"CID_ONSAPI_OWNER",
			"groupSysFlag":0,
			"consumeEnable":true,
			"consumeBroadcastEnable":true,
			"retryQueueNums":1,
			"notifyConsumerIdsChangedEnable":true,
			"consumeMessageOrderly":false,
			"attributes":{}
		},
//...
}
```

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

### TBD
- [ ] allow append to file