### PR TITLE
To config the cardinalityLimit for openTelemetry metrics exporting an…

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
@@ -34,8 +34,10 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -361,22 +363,45 @@ public class BrokerMetricsManager {
             .setType(InstrumentType.HISTOGRAM)
             .setName(HISTOGRAM_MESSAGE_SIZE)
             .build();
-        View messageSizeView = View.builder()
-            .setAggregation(Aggregation.explicitBucketHistogram(messageSizeBuckets))
+        ViewBuilder messageSizeViewBuilder = View.builder()
+            .setAggregation(Aggregation.explicitBucketHistogram(messageSizeBuckets));
+        // To config the cardinalityLimit for openTelemetry metrics exporting.
+        SdkMeterProviderUtil.setCardinalityLimit(messageSizeViewBuilder, brokerConfig.getMetricsOtelCardinalityLimit());
+        providerBuilder.registerView(messageSizeSelector, messageSizeViewBuilder.build());
+
+        for (Pair<InstrumentSelector, ViewBuilder> selectorViewPair : RemotingMetricsManager.getMetricsView()) {
+            ViewBuilder viewBuilder = selectorViewPair.getObject2();
+            SdkMeterProviderUtil.setCardinalityLimit(viewBuilder, brokerConfig.getMetricsOtelCardinalityLimit());
+            providerBuilder.registerView(selectorViewPair.getObject1(), viewBuilder.build());
+        }
+
+        for (Pair<InstrumentSelector, ViewBuilder> selectorViewPair : messageStore.getMetricsView()) {
+            ViewBuilder viewBuilder = selectorViewPair.getObject2();
+            SdkMeterProviderUtil.setCardinalityLimit(viewBuilder, brokerConfig.getMetricsOtelCardinalityLimit());
+            providerBuilder.registerView(selectorViewPair.getObject1(), viewBuilder.build());
+        }
+
+        for (Pair<InstrumentSelector, ViewBuilder> selectorViewPair : PopMetricsManager.getMetricsView()) {
+            ViewBuilder viewBuilder = selectorViewPair.getObject2();
+            SdkMeterProviderUtil.setCardinalityLimit(viewBuilder, brokerConfig.getMetricsOtelCardinalityLimit());
+            providerBuilder.registerView(selectorViewPair.getObject1(), viewBuilder.build());
+        }
+
+        // default view builder for all counter.
+        InstrumentSelector defaultCounterSelector = InstrumentSelector.builder()
+            .setType(InstrumentType.COUNTER)
             .build();
-        providerBuilder.registerView(messageSizeSelector, messageSizeView);
+        ViewBuilder defaultCounterViewBuilder = View.builder().setDescription("default view for counter.");
+        SdkMeterProviderUtil.setCardinalityLimit(defaultCounterViewBuilder, brokerConfig.getMetricsOtelCardinalityLimit());
+        providerBuilder.registerView(defaultCounterSelector, defaultCounterViewBuilder.build());
 
-        for (Pair<InstrumentSelector, View> selectorViewPair : RemotingMetricsManager.getMetricsView()) {
-            providerBuilder.registerView(selectorViewPair.getObject1(), selectorViewPair.getObject2());
-        }
-
-        for (Pair<InstrumentSelector, View> selectorViewPair : messageStore.getMetricsView()) {
-            providerBuilder.registerView(selectorViewPair.getObject1(), selectorViewPair.getObject2());
-        }
-
-        for (Pair<InstrumentSelector, View> selectorViewPair : PopMetricsManager.getMetricsView()) {
-            providerBuilder.registerView(selectorViewPair.getObject1(), selectorViewPair.getObject2());
-        }
+        //default view builder for all observable gauge.
+        InstrumentSelector defaultGaugeSelector = InstrumentSelector.builder()
+            .setType(InstrumentType.OBSERVABLE_GAUGE)
+            .build();
+        ViewBuilder defaultGaugeViewBuilder = View.builder().setDescription("default view for gauge.");
+        SdkMeterProviderUtil.setCardinalityLimit(defaultGaugeViewBuilder, brokerConfig.getMetricsOtelCardinalityLimit());
+        providerBuilder.registerView(defaultGaugeSelector, defaultGaugeViewBuilder.build());
     }
 
     private void initStatsMetrics() {

--- a/broker/src/main/java/org/apache/rocketmq/broker/metrics/PopMetricsManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/metrics/PopMetricsManager.java
@@ -27,6 +27,7 @@ import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -63,7 +64,7 @@ public class PopMetricsManager {
     private static LongCounter popReviveGetTotal = new NopLongCounter();
     private static LongCounter popReviveRetryMessageTotal = new NopLongCounter();
 
-    public static List<Pair<InstrumentSelector, View>> getMetricsView() {
+    public static List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
         List<Double> rpcCostTimeBuckets = Arrays.asList(
             (double) Duration.ofMillis(1).toMillis(),
             (double) Duration.ofMillis(10).toMillis(),
@@ -76,10 +77,10 @@ public class PopMetricsManager {
             .setType(InstrumentType.HISTOGRAM)
             .setName(HISTOGRAM_POP_BUFFER_SCAN_TIME_CONSUME)
             .build();
-        View popBufferScanTimeConsumeView = View.builder()
-            .setAggregation(Aggregation.explicitBucketHistogram(rpcCostTimeBuckets))
-            .build();
-        return Lists.newArrayList(new Pair<>(popBufferScanTimeConsumeSelector, popBufferScanTimeConsumeView));
+        ViewBuilder popBufferScanTimeConsumeViewBuilder = View.builder()
+            .setAggregation(Aggregation.explicitBucketHistogram(rpcCostTimeBuckets));
+
+        return Lists.newArrayList(new Pair<>(popBufferScanTimeConsumeSelector, popBufferScanTimeConsumeViewBuilder));
     }
 
     public static void initMetrics(Meter meter, BrokerController brokerController,

--- a/broker/src/main/resources/rmq.broker.logback.xml
+++ b/broker/src/main/resources/rmq.broker.logback.xml
@@ -559,27 +559,27 @@
         </sift>
     </appender>
 
-    <appender name="RocketmqBrokerMetricsAppender" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <appender name="RocketmqBrokerMetricsSiftingAppender_inner" class="ch.qos.logback.classic.sift.SiftingAppender">
         <discriminator>
             <key>brokerContainerLogDir</key>
             <defaultValue>${file.separator}</defaultValue>
         </discriminator>
         <sift>
-            <appender name="RocketmqCommercialAppender"
+            <appender name="RocketmqBrokerMetricsAppender"
                       class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <file>
-                    ${user.home}${file.separator}logs${file.separator}rocketmqlogs${brokerLogDir:-${file.separator}}${brokerContainerLogDir}${file.separator}broker_metric.log
+                    ${user.home}${file.separator}logs${file.separator}rocketmqlogs${brokerLogDir:-${file.separator}}${brokerContainerLogDir}${file.separator}broker_metrics.log
                 </file>
                 <append>true</append>
                 <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
                     <fileNamePattern>
-                        ${user.home}${file.separator}logs${file.separator}rocketmqlogs${brokerLogDir:-${file.separator}}${brokerContainerLogDir}${file.separator}otherdays${file.separator}broker_metric.%i.log.gz
+                        ${user.home}${file.separator}logs${file.separator}rocketmqlogs${brokerLogDir:-${file.separator}}${brokerContainerLogDir}${file.separator}otherdays${file.separator}broker_metrics.%i.log.gz
                     </fileNamePattern>
                     <minIndex>1</minIndex>
-                    <maxIndex>10</maxIndex>
+                    <maxIndex>3</maxIndex>
                 </rollingPolicy>
                 <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-                    <maxFileSize>500MB</maxFileSize>
+                    <maxFileSize>512MB</maxFileSize>
                 </triggeringPolicy>
                 <encoder>
                     <pattern>%d{yyy-MM-dd HH:mm:ss,GMT+8} %p %t - %m%n</pattern>
@@ -587,6 +587,9 @@
                 </encoder>
             </appender>
         </sift>
+    </appender>
+    <appender name="RocketmqBrokerMetricsSiftingAppender" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="RocketmqBrokerMetricsSiftingAppender_inner"/>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -670,7 +673,7 @@
     </logger>
 
     <logger name="io.opentelemetry.exporter.logging.LoggingMetricExporter" additivity="false" level="INFO">
-        <appender-ref ref="RocketmqBrokerMetricsAppender"/>
+        <appender-ref ref="RocketmqBrokerMetricsSiftingAppender"/>
     </logger>
 
     <root level="INFO">

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -350,6 +350,7 @@ public class BrokerConfig extends BrokerIdentity {
 
     private MetricsExporterType metricsExporterType = MetricsExporterType.DISABLE;
 
+    private int metricsOtelCardinalityLimit = 50 * 1000;
     private String metricsGrpcExporterTarget = "";
     private String metricsGrpcExporterHeader = "";
     private long metricGrpcExporterTimeOutInMills = 3 * 1000;
@@ -1529,6 +1530,14 @@ public class BrokerConfig extends BrokerIdentity {
 
     public void setMetricsExporterType(String metricsExporterType) {
         this.metricsExporterType = MetricsExporterType.valueOf(metricsExporterType);
+    }
+
+    public int getMetricsOtelCardinalityLimit() {
+        return metricsOtelCardinalityLimit;
+    }
+
+    public void setMetricsOtelCardinalityLimit(int metricsOtelCardinalityLimit) {
+        this.metricsOtelCardinalityLimit = metricsOtelCardinalityLimit;
     }
 
     public String getMetricsGrpcExporterTarget() {

--- a/controller/src/main/java/org/apache/rocketmq/controller/metrics/ControllerMetricsManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/metrics/ControllerMetricsManager.java
@@ -203,7 +203,7 @@ public class ControllerMetricsManager {
             10 * s
         );
 
-        View latecyView = View.builder()
+        View latencyView = View.builder()
             .setAggregation(Aggregation.explicitBucketHistogram(latencyBuckets))
             .build();
 
@@ -217,8 +217,8 @@ public class ControllerMetricsManager {
             .setName(HISTOGRAM_DLEDGER_OP_LATENCY)
             .build();
 
-        providerBuilder.registerView(requestLatencySelector, latecyView);
-        providerBuilder.registerView(dLedgerOpLatencySelector, latecyView);
+        providerBuilder.registerView(requestLatencySelector, latencyView);
+        providerBuilder.registerView(dLedgerOpLatencySelector, latencyView);
     }
 
     private void initMetric(Meter meter) {

--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@
         <caffeine.version>2.9.3</caffeine.version>
         <spring.version>5.3.27</spring.version>
         <okio-jvm.version>3.0.0</okio-jvm.version>
-        <opentelemetry.version>1.26.0</opentelemetry.version>
-        <opentelemetry-exporter-prometheus.version>1.26.0-alpha</opentelemetry-exporter-prometheus.version>
+        <opentelemetry.version>1.29.0</opentelemetry.version>
+        <opentelemetry-exporter-prometheus.version>1.29.0-alpha</opentelemetry-exporter-prometheus.version>
         <jul-to-slf4j.version>2.0.6</jul-to-slf4j.version>
         <s3.version>2.20.29</s3.version>
         <rocksdb.version>1.0.3</rocksdb.version>

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/metrics/RemotingMetricsManager.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/metrics/RemotingMetricsManager.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -61,7 +62,7 @@ public class RemotingMetricsManager {
             .build();
     }
 
-    public static List<Pair<InstrumentSelector, View>> getMetricsView() {
+    public static List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
         List<Double> rpcCostTimeBuckets = Arrays.asList(
             (double) Duration.ofMillis(1).toMillis(),
             (double) Duration.ofMillis(3).toMillis(),
@@ -77,10 +78,9 @@ public class RemotingMetricsManager {
             .setType(InstrumentType.HISTOGRAM)
             .setName(HISTOGRAM_RPC_LATENCY)
             .build();
-        View view = View.builder()
-            .setAggregation(Aggregation.explicitBucketHistogram(rpcCostTimeBuckets))
-            .build();
-        return Lists.newArrayList(new Pair<>(selector, view));
+        ViewBuilder viewBuilder = View.builder()
+            .setAggregation(Aggregation.explicitBucketHistogram(rpcCostTimeBuckets));
+        return Lists.newArrayList(new Pair<>(selector, viewBuilder));
     }
 
     public static String getWriteAndFlushResult(Future<?> future) {

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -22,7 +22,7 @@ import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
-import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -42,23 +42,24 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.AbstractBrokerRunnable;
+import org.apache.rocketmq.common.BoundaryType;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.BrokerIdentity;
 import org.apache.rocketmq.common.MixAll;
@@ -82,7 +83,6 @@ import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.common.utils.CleanupPolicyUtils;
 import org.apache.rocketmq.common.utils.QueueTypeUtils;
 import org.apache.rocketmq.common.utils.ServiceProvider;
-import org.apache.rocketmq.common.BoundaryType;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.remoting.protocol.body.HARuntimeInfo;
@@ -3268,7 +3268,7 @@ public class DefaultMessageStore implements MessageStore {
     }
 
     @Override
-    public List<Pair<InstrumentSelector, View>> getMetricsView() {
+    public List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
         return DefaultStoreMetricsManager.getMetricsView();
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/MessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageStore.java
@@ -19,8 +19,7 @@ package org.apache.rocketmq.store;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
-import io.opentelemetry.sdk.metrics.View;
-
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -28,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-
 import org.apache.rocketmq.common.BoundaryType;
 import org.apache.rocketmq.common.Pair;
 import org.apache.rocketmq.common.SystemClock;
@@ -964,7 +962,7 @@ public interface MessageStore {
      *
      * @return List of metrics selector and view pair
      */
-    List<Pair<InstrumentSelector, View>> getMetricsView();
+    List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView();
 
     /**
      * Init store metrics

--- a/store/src/main/java/org/apache/rocketmq/store/metrics/DefaultStoreMetricsManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/metrics/DefaultStoreMetricsManager.java
@@ -23,7 +23,7 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
-import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.io.File;
 import java.util.List;
 import java.util.function.Supplier;
@@ -69,7 +69,7 @@ public class DefaultStoreMetricsManager {
     public static LongCounter timerDequeueTotal = new NopLongCounter();
     public static LongCounter timerEnqueueTotal = new NopLongCounter();
 
-    public static List<Pair<InstrumentSelector, View>> getMetricsView() {
+    public static List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
         return Lists.newArrayList();
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/plugin/AbstractPluginMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/plugin/AbstractPluginMessageStore.java
@@ -20,8 +20,7 @@ package org.apache.rocketmq.store.plugin;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
-import io.opentelemetry.sdk.metrics.View;
-
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-
 import org.apache.rocketmq.common.Pair;
 import org.apache.rocketmq.common.SystemClock;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -643,7 +641,7 @@ public abstract class AbstractPluginMessageStore implements MessageStore {
     }
 
     @Override
-    public List<Pair<InstrumentSelector, View>> getMetricsView() {
+    public List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
         return next.getMetricsView();
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -21,7 +21,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
-import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -352,8 +352,8 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
     }
 
     @Override
-    public List<Pair<InstrumentSelector, View>> getMetricsView() {
-        List<Pair<InstrumentSelector, View>> res = super.getMetricsView();
+    public List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
+        List<Pair<InstrumentSelector, ViewBuilder>> res = super.getMetricsView();
         res.addAll(TieredStoreMetricsManager.getMetricsView());
         return res;
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metrics/TieredStoreMetricsManager.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metrics/TieredStoreMetricsManager.java
@@ -27,6 +27,7 @@ import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -101,8 +102,8 @@ public class TieredStoreMetricsManager {
     public static ObservableLongGauge storageSize = new NopObservableLongGauge();
     public static ObservableLongGauge storageMessageReserveTime = new NopObservableLongGauge();
 
-    public static List<Pair<InstrumentSelector, View>> getMetricsView() {
-        ArrayList<Pair<InstrumentSelector, View>> res = new ArrayList<>();
+    public static List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView() {
+        ArrayList<Pair<InstrumentSelector, ViewBuilder>> res = new ArrayList<>();
 
         InstrumentSelector providerRpcLatencySelector = InstrumentSelector.builder()
             .setType(InstrumentType.HISTOGRAM)
@@ -114,10 +115,9 @@ public class TieredStoreMetricsManager {
             .setName(HISTOGRAM_API_LATENCY)
             .build();
 
-        View rpcLatencyView = View.builder()
+        ViewBuilder rpcLatencyViewBuilder = View.builder()
             .setAggregation(Aggregation.explicitBucketHistogram(Arrays.asList(1d, 3d, 5d, 7d, 10d, 100d, 200d, 400d, 600d, 800d, 1d * 1000, 1d * 1500, 1d * 3000)))
-            .setDescription("tiered_store_rpc_latency_view")
-            .build();
+            .setDescription("tiered_store_rpc_latency_view");
 
         InstrumentSelector uploadBufferSizeSelector = InstrumentSelector.builder()
             .setType(InstrumentType.HISTOGRAM)
@@ -129,15 +129,14 @@ public class TieredStoreMetricsManager {
             .setName(HISTOGRAM_DOWNLOAD_BYTES)
             .build();
 
-        View bufferSizeView = View.builder()
+        ViewBuilder bufferSizeViewBuilder = View.builder()
             .setAggregation(Aggregation.explicitBucketHistogram(Arrays.asList(1d * TieredStoreUtil.KB, 10d * TieredStoreUtil.KB, 100d * TieredStoreUtil.KB, 1d * TieredStoreUtil.MB, 10d * TieredStoreUtil.MB, 32d * TieredStoreUtil.MB, 50d * TieredStoreUtil.MB, 100d * TieredStoreUtil.MB)))
-            .setDescription("tiered_store_buffer_size_view")
-            .build();
+            .setDescription("tiered_store_buffer_size_view");
 
-        res.add(new Pair<>(rpcLatencySelector, rpcLatencyView));
-        res.add(new Pair<>(providerRpcLatencySelector, rpcLatencyView));
-        res.add(new Pair<>(uploadBufferSizeSelector, bufferSizeView));
-        res.add(new Pair<>(downloadBufferSizeSelector, bufferSizeView));
+        res.add(new Pair<>(rpcLatencySelector, rpcLatencyViewBuilder));
+        res.add(new Pair<>(providerRpcLatencySelector, rpcLatencyViewBuilder));
+        res.add(new Pair<>(uploadBufferSizeSelector, bufferSizeViewBuilder));
+        res.add(new Pair<>(downloadBufferSizeSelector, bufferSizeViewBuilder));
         return res;
     }
 


### PR DESCRIPTION
## To config the cardinalityLimit for openTelemetry metrics exporting.

### Which Issue(s) This PR Fixes

(1) To config the cardinalityLimit for openTelemetry metrics exporting, or we may encounter warning like this:

WARNING: Instrument rocketmq_storage_size has exceeded the maximum allowed accumulations (2000).


### Brief Description

(1) Introduce a higher version of opentelemetry.
(2) allow user to config metricsOtelCardinalityLimit in brokerconfig.

### How Did You Test This Change?

