### PR TITLE
[ISSUE #7171] add misspell check in configuration during broker startup. 

### DIFF
--- a/broker/BUILD.bazel
+++ b/broker/BUILD.bazel
@@ -84,6 +84,7 @@ java_library(
         "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
         "@maven//:org_powermock_powermock_core",
         "@maven//:io_opentelemetry_opentelemetry_api",
+        "@maven//:ch_qos_logback_logback_classic",
     ],
 )
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerStartupTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerStartupTest.java
@@ -40,6 +40,12 @@ public class BrokerStartupTest {
 
     @Test
     public void testBuildBrokerController() throws Exception {
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        // using ListAppender to catch BrokerConsoleLogger's output.
+        context.getLogger(LoggerName.BROKER_CONSOLE_NAME).addAppender(listAppender);
+        listAppender.start();
+
         String invalidBrokerConf = "/tmp/invalid-broker.conf";
         Properties properties = new Properties();
         properties.put("namesrvAddr", "127.0.0.1:9876");
@@ -67,10 +73,8 @@ public class BrokerStartupTest {
         assertThat(nettyServerConfig.getServerWorkerThreads()).isEqualTo(20);
         assertThat(nettyServerConfig.getServerWorkerThreads()).isEqualTo(20);
 
-        // assert logger has warning log print.
-        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        ListAppender<ILoggingEvent> appender = (ListAppender<ILoggingEvent>) context.getLogger(LoggerName.BROKER_CONSOLE_NAME).getAppender("LIST");
-        List<ILoggingEvent> list = appender.list;
+        // assert BrokerConsoleLogger has warning log output.
+        List<ILoggingEvent> list = listAppender.list;
         list.forEach(log -> {
             assertTrue(log.toString().contains("brokerIp1"));
             assertTrue(log.toString().contains("autoCreateTopicEnabled"));

--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerStartupTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerStartupTest.java
@@ -19,14 +19,64 @@ package org.apache.rocketmq.broker;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Properties;
+import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.utils.NetworkUtil;
+import org.apache.rocketmq.logging.ch.qos.logback.classic.LoggerContext;
+import org.apache.rocketmq.logging.ch.qos.logback.classic.spi.ILoggingEvent;
+import org.apache.rocketmq.logging.ch.qos.logback.core.read.ListAppender;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.remoting.netty.NettyServerConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
 public class BrokerStartupTest {
 
-    private String storePathRootDir = ".";
+    @Test
+    public void testBuildBrokerController() throws Exception {
+        String invalidBrokerConf = "/tmp/invalid-broker.conf";
+        Properties properties = new Properties();
+        properties.put("namesrvAddr", "127.0.0.1:9876");
+        properties.put("rocketmqHome", "../distribution");
+        properties.put("brokerName", "broker-a");
+        properties.put("serverWorkerThreads", "20");
+        // invalid property
+        properties.put("autoCreateTopicEnabled", "false");
+        properties.put("brokerIp1", "127.0.0.1:10109");
+        properties.put("serverSelectorThread", "1");
+        MixAll.string2File(MixAll.properties2String(properties), invalidBrokerConf);
+
+        BrokerController controller = BrokerStartup.buildBrokerController(new String[] {"-c", invalidBrokerConf});
+
+        BrokerConfig brokerConfig = controller.getBrokerConfig();
+        NettyServerConfig nettyServerConfig = controller.getNettyServerConfig();
+        // assert equals to default value, because brokerConfig file set an incorrect property name.
+        assertThat(brokerConfig.getBrokerIP1()).isEqualTo(NetworkUtil.getLocalAddress());
+        assertThat(brokerConfig.isAutoCreateTopicEnable()).isEqualTo(true);
+        assertThat(nettyServerConfig.getServerSelectorThreads()).isEqualTo(3);
+
+        // assert equals to setting value by config file
+        assertThat(brokerConfig.getNamesrvAddr()).isEqualTo("127.0.0.1:9876");
+        assertThat(brokerConfig.getBrokerName()).isEqualTo("broker-a");
+        assertThat(nettyServerConfig.getServerWorkerThreads()).isEqualTo(20);
+        assertThat(nettyServerConfig.getServerWorkerThreads()).isEqualTo(20);
+
+        // assert logger has warning log print.
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ListAppender<ILoggingEvent> appender = (ListAppender<ILoggingEvent>) context.getLogger(LoggerName.BROKER_CONSOLE_NAME).getAppender("LIST");
+        List<ILoggingEvent> list = appender.list;
+        list.forEach(log -> {
+            assertTrue(log.toString().contains("brokerIp1"));
+            assertTrue(log.toString().contains("autoCreateTopicEnabled"));
+            assertTrue(log.toString().contains("serverSelectorThread"));
+        });
+    }
 
     @Test
     public void testProperties2SystemEnv() throws NoSuchMethodException, InvocationTargetException,

--- a/broker/src/test/resources/rmq.logback-test.xml
+++ b/broker/src/test/resources/rmq.logback-test.xml
@@ -29,12 +29,6 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
-    <!-- for test logger output -->
-    <appender name="LIST" class="org.apache.rocketmq.logging.ch.qos.logback.core.read.ListAppender"/>
-    <logger name="RocketmqConsole" level="warn" additivity="false">
-        <appender-ref ref="LIST"/>
-    </logger>
-
     <root level="error">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/broker/src/test/resources/rmq.logback-test.xml
+++ b/broker/src/test/resources/rmq.logback-test.xml
@@ -29,6 +29,12 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
+    <!-- for test logger output -->
+    <appender name="LIST" class="org.apache.rocketmq.logging.ch.qos.logback.core.read.ListAppender"/>
+    <logger name="RocketmqConsole" level="warn" additivity="false">
+        <appender-ref ref="LIST"/>
+    </logger>
+
     <root level="error">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/common/src/main/java/org/apache/rocketmq/common/MixAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MixAll.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.common;
 
+import com.google.common.collect.Sets;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -517,5 +519,26 @@ public class MixAll {
             return true;
         }
         return false;
+    }
+
+    public static Set<String> invalidProperties(Properties properties, Object... objects) {
+        if (objects == null || objects.length == 0) {
+            return null;
+        }
+        Set<String> propertyNames = properties.stringPropertyNames();
+
+        Set<String> fieldNames = new HashSet<>();
+        for (Object obj : objects) {
+            Method[] methods = obj.getClass().getMethods();
+            for (Method method : methods) {
+                String mn = method.getName();
+                if (mn.startsWith("get")) {
+                    // get getter's field name and to camel name.
+                    fieldNames.add(mn.substring(3, 4).toLowerCase() +  mn.substring(4));
+                }
+            }
+        }
+
+        return Sets.difference(propertyNames, fieldNames);
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 
@@ -90,5 +92,22 @@ public class MixAllTest {
         assertThat(MixAll.isLmq(testLmq)).isTrue();
         testLmq = "%LMQ%GID_TEST";
         assertThat(MixAll.isLmq(testLmq)).isTrue();
+    }
+
+    @Test
+    public void testInvalidProperties() {
+        Properties properties = new Properties();
+        // invalid property with incorrect property name.
+        properties.setProperty("brokerIp1", "127.0.0.1:100000");
+        // valid property with correct property name.
+        properties.setProperty("brokerIP2", "127.0.0.1:10086");
+        properties.setProperty("brokerName", "broker-a");
+
+        BrokerConfig brokerConfig = new BrokerConfig();
+
+        Set<String> invalidProperties = MixAll.invalidProperties(properties, brokerConfig);
+
+        assertThat(invalidProperties).hasSize(1);
+        assertThat(invalidProperties).element(0).isEqualTo("brokerIp1");
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7171 

### Brief Description
add misspell check during load configuration file to config instance.
when user's configuration file has incorrect or misspell properties, they will get clearly warning log in console.
such as below：
<img width="981" alt="image" src="https://github.com/apache/rocketmq/assets/67348866/11fd9f79-38ec-4c41-8945-4cd6b848a353">

<img width="1641" alt="image" src="https://github.com/apache/rocketmq/assets/67348866/df1d95fb-0eb7-44a9-b5ef-f2511a6d86df">


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

add ``testBuildBrokerController``  test case in ``BrokerStartupTest`` to assert should have warning log print when configuration file havs invalid properties (misspell occur).

add ``testInvalidProperties`` test case in ``MixAllTest`` to assert ``invalidProperties`` method work correctly