### PR TITLE
[ISSUE #7218] Daemon mode to start broker or other components in RocketMQ.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,9 @@ NameServer will be listening at `0.0.0.0:9876`, make sure that the port is not u
 
 For macOS and Linux users:
 ```shell
-### start Name Server
-$ nohup sh mqnamesrv &
+### start Name Server and check whether Name Server is successfully started 
+$ sh mqnamesrv -d
 
-### check whether Name Server is successfully started
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
 The Name Server boot success...
 ```
 
@@ -97,11 +95,9 @@ The Name Server boot success...
 
 For macOS and Linux users:
 ```shell
-### start Broker
-$ nohup sh bin/mqbroker -n localhost:9876 &
+### start Broker and check whether Broker is successfully started, eg: Broker's IP is 192.168.1.2, Broker's name is broker-a
+$ sh bin/mqbroker -d -n localhost:9876
 
-### check whether Broker is successfully started, eg: Broker's IP is 192.168.1.2, Broker's name is broker-a
-$ tail -f ~/logs/rocketmqlogs/broker.log
 The broker[broker-a, 192.169.1.2:10911] boot success...
 ```
 

--- a/distribution/bin/README.md
+++ b/distribution/bin/README.md
@@ -9,7 +9,7 @@ Before deploying broker servers, it's highly recommended to run **os.sh**, which
 ### Start broker
 * Unix platform
 
-  `nohup sh mqbroker &`
+  `sh mqbroker -d` or `sh mqbroker --daemon`
 
 ### Shutdown broker
   sh mqshutdown broker

--- a/distribution/bin/mqbroker
+++ b/distribution/bin/mqbroker
@@ -44,6 +44,7 @@ export ROCKETMQ_HOME
 
 other_args=" "
 enable_proxy=false
+daemon_mode=false
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -54,6 +55,10 @@ while [ $# -gt 0 ]; do
     -c|--configFile)
       broker_config="$2"
       shift
+      shift
+      ;;
+    -d|--daemon)
+      daemon_mode=true
       shift
       ;;
     *)
@@ -68,11 +73,21 @@ if [ "$enable_proxy" = true ]; then
   if [ "$broker_config" != "" ]; then
       args_for_proxy=${args_for_proxy}" -bc "${broker_config}
   fi
-  sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.proxy.logback.xml org.apache.rocketmq.proxy.ProxyStartup ${args_for_proxy}
+  start_args="sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=${ROCKETMQ_HOME}/conf/rmq.proxy.logback.xml org.apache.rocketmq.proxy.ProxyStartup ${args_for_proxy}"
 else
   args_for_broker=$other_args
   if [ "$broker_config" != "" ]; then
       args_for_broker=${args_for_broker}" -c "${broker_config}
   fi
-  sh ${ROCKETMQ_HOME}/bin/runbroker.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.broker.logback.xml org.apache.rocketmq.broker.BrokerStartup ${args_for_broker}
+  start_args="sh ${ROCKETMQ_HOME}/bin/runbroker.sh -Drmq.logback.configurationFile=${ROCKETMQ_HOME}/conf/rmq.broker.logback.xml org.apache.rocketmq.broker.BrokerStartup ${args_for_broker}"
+fi
+
+if [ "$daemon_mode" = false ]; then
+  exec ${start_args}
+else
+  nohup ${start_args} > ${logs_file} > /dev/null 2>&1 &
+  echo 'mqbroker run in daemon mode...'
+  # check broker whether success boot in daemon.
+  sleep 2
+  tail -n 20 ~/logs/rocketmqlogs/broker.log | grep 'boot success'
 fi

--- a/distribution/bin/mqcontroller
+++ b/distribution/bin/mqcontroller
@@ -42,4 +42,25 @@ fi
 
 export ROCKETMQ_HOME
 
-sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.controller.logback.xml org.apache.rocketmq.controller.ControllerStartup $@
+daemon_mode=false
+while [[ $# > 0 ]]; do
+  case $1 in
+    -d|--daemon)
+      daemon_mode=true
+      # remove daemon_mode params avoid pass it to next program.
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
+
+start_args="sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.controller.logback.xml org.apache.rocketmq.controller.ControllerStartup $@"
+if [ "$daemon_mode" = false ]; then
+  exec ${start_args}
+else
+  nohup ${start_args} > /dev/null 2>&1 &
+  echo 'mqcontroller run in daemon mode...'
+  sleep 2
+  tail -n 20 ~/logs/rocketmqlogs/controller.log | grep 'boot success'
+fi

--- a/distribution/bin/mqnamesrv
+++ b/distribution/bin/mqnamesrv
@@ -42,4 +42,27 @@ fi
 
 export ROCKETMQ_HOME
 
-sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.namesrv.logback.xml org.apache.rocketmq.namesrv.NamesrvStartup $@
+daemon_mode=false
+
+while [[ $# > 0 ]]; do
+  case $1 in
+    -d|--daemon)
+      daemon_mode=true
+      # remove daemon_mode params avoid pass it to next program.
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
+
+start_args="sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.namesrv.logback.xml org.apache.rocketmq.namesrv.NamesrvStartup $@"
+if [ "$daemon_mode" = false ]; then
+  exec ${start_args}
+else
+  nohup ${start_args} > /dev/null 2>&1 &
+  # check namesrv whether boot success in daemon mode.
+  echo 'mqnamesrv run in daemon mode...'
+  sleep 2
+  tail -n 20 ~/logs/rocketmqlogs/namesrv.log | grep 'boot success'
+fi

--- a/distribution/bin/mqproxy
+++ b/distribution/bin/mqproxy
@@ -42,4 +42,25 @@ fi
 
 export ROCKETMQ_HOME
 
-sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.proxy.logback.xml org.apache.rocketmq.proxy.ProxyStartup $@
+while [[ $# > 0 ]]; do
+  case $1 in
+    -d|--daemon)
+      daemon_mode=true
+      # remove daemon_mode params avoid pass it to next program.
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
+
+start_args="sh ${ROCKETMQ_HOME}/bin/runserver.sh -Drmq.logback.configurationFile=$ROCKETMQ_HOME/conf/rmq.proxy.logback.xml org.apache.rocketmq.proxy.ProxyStartup $@"
+if [ "$daemon_mode" = false ]; then
+  exec ${start_args}
+else
+  nohup ${start_args} > /dev/null 2>&1 &
+  echo 'mqproxy run in daemon mode...'
+  # check proxy whether boot success in daemon mode.
+  sleep 2
+  tail -n 20 ~/logs/rocketmqlogs/proxy.log | grep 'boot success'
+fi

--- a/distribution/bin/test.sh
+++ b/distribution/bin/test.sh
@@ -1,3 +1,0 @@
-if [[ $* =~ "-d" ]]; then
-  echo "true"
-fi

--- a/distribution/bin/test.sh
+++ b/distribution/bin/test.sh
@@ -1,0 +1,3 @@
+if [[ $* =~ "-d" ]]; then
+  echo "true"
+fi

--- a/docs/cn/Deployment.md
+++ b/docs/cn/Deployment.md
@@ -9,28 +9,24 @@
 **1）启动NameServer**
 
 ```shell
-### 第一步启动namesrv
-$ nohup sh mqnamesrv &
+### 第一步启动namesrv，并且验证namesrv是否启动成功
+$ sh bin/mqnamesrv -d
  
-### 验证namesrv是否启动成功
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
 The Name Server boot success...
 ```
 
-我们可以在namesrv.log 中看到'The Name Server boot success..'，表示NameServer 已成功启动。
+我们可以在控制台输出中看到'The Name Server boot success..'，表示NameServer 已成功启动。
 
 **2）启动Broker**
 
 ```shell
-### 第一步先启动broker
-$ nohup sh bin/mqbroker -n localhost:9876 &
-
-### 验证broker是否启动成功，比如，broker的ip是192.168.1.2 然后名字是broker-a
-$ tail -f ~/logs/rocketmqlogs/Broker.log 
+### 第一步先启动broker，验证broker是否启动成功，比如，broker的ip是192.168.1.2 然后名字是broker-a
+$ sh bin/mqbroker -d -n localhost:9876
+ 
 The broker[broker-a,192.169.1.2:10911] boot success...
 ```
 
-我们可以在 Broker.log 中看到“The broker[brokerName,ip:port] boot success..”，这表明 broker 已成功启动。
+我们可以在控制台输出中看到“The broker[brokerName,ip:port] boot success..”，这表明 broker 已成功启动。
 
 ### 2 多Master模式
 
@@ -49,11 +45,9 @@ The broker[broker-a,192.169.1.2:10911] boot success...
 **1）启动 NameServer**
 
 ```shell
-### 第一步先启动namesrv
-$ nohup sh mqnamesrv &
- 
-### 验证namesrv是否启动成功
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
+### 第一步先启动namesrv，并且验证namesrv是否启动成功
+$ sh mqnamesrv -d
+
 The Name Server boot success...
 ```
 
@@ -61,11 +55,10 @@ The Name Server boot success...
 
 ```shell
 ### 比如在A机器上启动第一个Master，假设配置的NameServer IP为：192.168.1.1
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-a.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-a.properties -d
  
 ### 然后在机器B上启动第二个Master，假设配置的NameServer IP是：192.168.1.1
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-b.properties &
-
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-b.properties -d
 ...
 ```
 
@@ -87,11 +80,9 @@ $ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker
 **1）启动 NameServer**
 
 ```shell
-### 第一步先启动namesrv
-$ nohup sh mqnamesrv &
- 
-### 验证namesrv是否启动成功
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
+### 第一步先启动namesrv，并且验证namesrv是否启动成功
+$ sh mqnamesrv -d
+
 The Name Server boot success...
 ```
 
@@ -99,16 +90,16 @@ The Name Server boot success...
 
 ```shell
 ### 例如在A机器上启动第一个Master，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a.properties -d
  
 ### 然后在机器B上启动第二个Master，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b.properties -d
  
 ### 然后在C机器上启动第一个Slave，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a-s.properties -d
  
 ### 最后在D机启动第二个Slave，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b-s.properties -d
 ```
 
 上图显示了 2M-2S-Async 模式的启动命令，类似于其他 nM-nS-Async 模式。
@@ -132,11 +123,9 @@ $ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broke
 **1）启动NameServer**
 
 ```shell
-### 第一步启动namesrv
-$ nohup sh mqnamesrv &
+### 第一步启动namesrv，并且验证namesrv是否启动成功
+$ sh mqnamesrv -d
  
-### 验证namesrv是否启动成功
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
 The Name Server boot success...
 ```
 
@@ -144,16 +133,16 @@ The Name Server boot success...
 
 ```shell
 ### 例如在A机器上启动第一个Master，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a.properties -d
  
 ### 然后在B机器上启动第二个Master，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b.properties -d
  
 ### 然后在C机器上启动第一个Slave，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a-s.properties -d
  
 ### 最后在D机启动第二个Slave，假设配置的NameServer IP为：192.168.1.1，端口为9876。
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b-s.properties -d
 ```
 
 上述Master和Slave是通过指定相同的config命名为“brokerName”来配对的，master节点的brokerId必须为0，slave节点的brokerId必须大于0。

--- a/docs/en/Deployment.md
+++ b/docs/en/Deployment.md
@@ -9,28 +9,24 @@ This is the simplest, but also the riskiest mode, that makes the entire service 
 **1）Start NameServer**
 
 ```shell
-### Start Name Server first
-$ nohup sh mqnamesrv &
+### Start Name Server first, then verify that the Name Server starts successfully
+$ sh mqnamesrv -d
  
-### Then verify that the Name Server starts successfully
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
 The Name Server boot success...
 ```
 
-We can see 'The Name Server boot success.. ' in namesrv.log that indicates the NameServer has been started successfully.
+We can see 'The Name Server boot success... ' in namesrv.log that indicates the NameServer has been started successfully.
 
 **2）Start Broker**
 
 ```shell
-### Also start broker first
-$ nohup sh bin/mqbroker -n localhost:9876 &
-
-### Then verify that the broker is started successfully, for example, the IP of broker is 192.168.1.2 and the name is broker-a
-$ tail -f ~/logs/rocketmqlogs/Broker.log 
+### Also start broker first, then verify that the broker is started successfully, for example, the IP of broker is 192.168.1.2 and the name is broker-a
+$ sh bin/mqbroker -n localhost:9876 -d
+ 
 The broker[broker-a,192.169.1.2:10911] boot success...
 ```
 
-We can see 'The broker[brokerName,ip:port] boot success..' in Broker.log that indicates the broker has been started successfully.
+We can see 'The broker[brokerName,ip:port] boot success...' in Broker.log that indicates the broker has been started successfully.
 
 ### 2 Multiple Master mode
 
@@ -49,11 +45,9 @@ The starting steps for multiple master mode are as follows:
 **1）Start NameServer**
 
 ```shell
-### Start Name Server first
-$ nohup sh mqnamesrv &
- 
-### Then verify that the Name Server starts successfully
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
+### Start Name Server first, then verify that the Name Server starts successfully
+$ sh mqnamesrv -d
+
 The Name Server boot success...
 ```
 
@@ -61,10 +55,10 @@ The Name Server boot success...
 
 ```shell
 ### For example, starting the first Master on machine A, assuming that the configured NameServer IP is: 192.168.1.1.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-a.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-a.properties -d
  
 ### Then starting the second Master on machine B, assuming that the configured NameServer IP is: 192.168.1.1.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-b.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-noslave/broker-b.properties -d
 
 ...
 ```
@@ -87,11 +81,9 @@ The starting steps for multiple master and multiple slave mode are as follows:
 **1）Start NameServer**
 
 ```shell
-### Start Name Server first
-$ nohup sh mqnamesrv &
+### Start Name Server first, then verify that the Name Server starts successfully
+$ sh mqnamesrv -d
  
-### Then verify that the Name Server starts successfully
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
 The Name Server boot success...
 ```
 
@@ -99,16 +91,16 @@ The Name Server boot success...
 
 ```shell
 ### For example, starting the first Master on machine A, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a.properties -d
  
 ### Then starting the second Master on machine B, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b.properties -d
  
 ### Then starting the first Slave on machine C, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-a-s.properties -d
  
 ### Last starting the second Slave on machine D, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-async/broker-b-s.properties -d
 ```
 
 The above shows a startup command for 2M-2S-Async mode, similar to other nM-nS-Async modes.
@@ -132,11 +124,9 @@ The starting steps are as follows:
 **1）Start NameServer**
 
 ```shell
-### Start Name Server first
-$ nohup sh mqnamesrv &
- 
-### Then verify that the Name Server starts successfully
-$ tail -f ~/logs/rocketmqlogs/namesrv.log
+### Start Name Server first, then verify that the Name Server starts successfully
+$ sh mqnamesrv -d
+
 The Name Server boot success...
 ```
 
@@ -144,16 +134,16 @@ The Name Server boot success...
 
 ```shell
 ### For example, starting the first Master on machine A, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a.properties -d
  
 ### Then starting the second Master on machine B, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b.properties -d
  
 ### Then starting the first Slave on machine C, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-a-s.properties -d
  
 ### Last starting the second Slave on machine D, assuming that the configured NameServer IP is: 192.168.1.1 and port is 9876.
-$ nohup sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b-s.properties &
+$ sh mqbroker -n 192.168.1.1:9876 -c $ROCKETMQ_HOME/conf/2m-2s-sync/broker-b-s.properties -d
 ```
 
 The above Master and Slave are paired by specifying the same config named "brokerName", the "brokerId" of the master node must be 0, and the "brokerId" of the slave node must be greater than 0.


### PR DESCRIPTION
…

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7218 

### Brief Description

add `-d` and `--daemon` two argument in mqbroker、mqnamesrv、mqproxy、mqcontroller shell script to make then have alibility to start in daemon.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
manual start every branch of start shell to check the component whether start successfully and in daemon mode.
