### PR TITLE
UpdateAclConfig, unable to clear groupPerms, topicPerms, and whiteRemoteAddress. Currently, at least one piece of data exists

### DIFF
--- a/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
@@ -319,7 +319,7 @@ public class PlainPermissionManager {
                     if (account.getAccessKey().equals(plainAccessConfig.getAccessKey())) {
                         // Update acl access config elements
                         accounts.remove(account);
-                        updateAccountMap = createAclAccessConfigMap(account, plainAccessConfig);
+                        updateAccountMap = createAclAccessConfigMap(null, plainAccessConfig);
                         accounts.add(updateAccountMap);
                         aclAccessConfigMap.setAccounts(accounts);
                         break;


### PR DESCRIPTION
UpdateAclConfig, unable to clear groupPerms, topicPerms, and whiteRemoteAddress. Currently, at least one piece of data exists

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

在编辑的时候，如果当前已存在account，执行updateAccountMap = createAclAccessConfigMap(account, plainAccessConfig);
该条语句时，会将原来的account重新获取，并且将新的内容set到account中，形成新的updateAccountMap 的account信息。
这就导致了，如果在编辑的时候执行的命令不填写-w，会导致plainAccessConfig为null，进而不会将原来的account中的whiteRemoteAddress设置为空，导致上述问题。
解决方案
1：将account设置为null，直接存命令行输入的内容

Fixes #7361 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
