### PR TITLE
 Enhancement MQClientInstance #7402

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -257,6 +257,7 @@ public class MQClientInstance {
         return mqList;
     }
 
+    @SuppressWarnings("checkstyle:UnnecessaryParentheses")
     public void start() throws MQClientException {
 
         synchronized (this) {
@@ -276,7 +277,7 @@ public class MQClientInstance {
                     if (!consumerTable.isEmpty()
                             || clientConfig instanceof LitePullConsumer
                             || clientConfig instanceof MQPushConsumer) {
-                        startConsumerService();
+                        tryStartConsumerService();
                     }
 
                     log.info("the client factory [{}] start OK", this.clientId);
@@ -284,8 +285,8 @@ public class MQClientInstance {
                     break;
                 case RUNNING:
                     // If a Consumer is added later, make sure to start the Consumer-related services
-                    if (!consumerTable.isEmpty() && !pullMessageService.isStopped()) {
-                        startConsumerService();
+                    if (!consumerTable.isEmpty()) {
+                        tryStartConsumerService();
                     }
                     break;
                 case START_FAILED:
@@ -296,7 +297,7 @@ public class MQClientInstance {
         }
     }
 
-    private void startConsumerService() throws MQClientException {
+    private void tryStartConsumerService() throws MQClientException {
         // Start pull service
         this.pullMessageService.start();
         // Start rebalance service

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -38,6 +38,8 @@ import com.alibaba.fastjson.JSON;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.admin.MQAdminExtInner;
+import org.apache.rocketmq.client.consumer.LitePullConsumer;
+import org.apache.rocketmq.client.consumer.MQPushConsumer;
 import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.ClientRemotingProcessor;
@@ -269,14 +271,22 @@ public class MQClientInstance {
                     this.mQClientAPIImpl.start();
                     // Start various schedule tasks
                     this.startScheduledTask();
-                    // Start pull service
-                    this.pullMessageService.start();
-                    // Start rebalance service
-                    this.rebalanceService.start();
-                    // Start push service
-                    this.defaultMQProducer.getDefaultMQProducerImpl().start(false);
+
+                    // only for consumer
+                    if (!consumerTable.isEmpty()
+                            || clientConfig instanceof LitePullConsumer
+                            || clientConfig instanceof MQPushConsumer) {
+                        start4ConsumerService();
+                    }
+
                     log.info("the client factory [{}] start OK", this.clientId);
                     this.serviceState = ServiceState.RUNNING;
+                    break;
+                case RUNNING:
+                    // If a Consumer is added later, make sure to start the Consumer-related services
+                    if (!consumerTable.isEmpty() && !pullMessageService.isStopped()) {
+                        start4ConsumerService();
+                    }
                     break;
                 case START_FAILED:
                     throw new MQClientException("The Factory object[" + this.getClientId() + "] has been created before, and failed.", null);
@@ -285,6 +295,17 @@ public class MQClientInstance {
             }
         }
     }
+
+    private void start4ConsumerService() throws MQClientException {
+        // Start pull service
+        this.pullMessageService.start();
+        // Start rebalance service
+        this.rebalanceService.start();
+        // Start push service ;
+        // When the consumer fails to consume and needs to retry, use this internal producer to send a retry message back to the Broker.
+        this.defaultMQProducer.getDefaultMQProducerImpl().start(false);
+    }
+
 
     private void startScheduledTask() {
         if (null == this.clientConfig.getNamesrvAddr()) {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -276,7 +276,7 @@ public class MQClientInstance {
                     if (!consumerTable.isEmpty()
                             || clientConfig instanceof LitePullConsumer
                             || clientConfig instanceof MQPushConsumer) {
-                        start4ConsumerService();
+                        startConsumerService();
                     }
 
                     log.info("the client factory [{}] start OK", this.clientId);
@@ -285,7 +285,7 @@ public class MQClientInstance {
                 case RUNNING:
                     // If a Consumer is added later, make sure to start the Consumer-related services
                     if (!consumerTable.isEmpty() && !pullMessageService.isStopped()) {
-                        start4ConsumerService();
+                        startConsumerService();
                     }
                     break;
                 case START_FAILED:
@@ -296,7 +296,7 @@ public class MQClientInstance {
         }
     }
 
-    private void start4ConsumerService() throws MQClientException {
+    private void startConsumerService() throws MQClientException {
         // Start pull service
         this.pullMessageService.start();
         // Start rebalance service

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -302,6 +302,10 @@ public class DefaultMQProducerImpl implements MQProducerInner {
     public void shutdown(final boolean shutdownFactory) {
         switch (this.serviceState) {
             case CREATE_JUST:
+                // If the instance is created but not started
+                this.defaultAsyncSenderExecutor.shutdown();
+                this.mqFaultStrategy.shutdown();
+                this.serviceState = ServiceState.SHUTDOWN_ALREADY;
                 break;
             case RUNNING:
                 this.mQClientFactory.unregisterProducer(this.defaultMQProducer.getProducerGroup());

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -269,13 +269,13 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                     this.defaultMQProducer.isSendMessageWithVIPChannel());
                 this.serviceState = ServiceState.RUNNING;
                 break;
-            case RUNNING:
             case START_FAILED:
             case SHUTDOWN_ALREADY:
                 throw new MQClientException("The producer service state not OK, maybe started once, "
                     + this.serviceState
                     + FAQUrl.suggestTodo(FAQUrl.CLIENT_SERVICE_NOT_OK),
                     null);
+            case RUNNING:
             default:
                 break;
         }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
@@ -48,6 +48,7 @@ import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.ByteArrayOutputStream;
@@ -71,6 +72,10 @@ public class MQClientInstanceTest {
     private String group = "FooBarGroup";
     private ConcurrentMap<String, HashMap<Long, String>> brokerAddrTable = new ConcurrentHashMap<>();
 
+
+
+    @Mock
+    private  MQClientAPIImpl mQClientAPIImpl ;
 
 
 
@@ -218,7 +223,9 @@ public class MQClientInstanceTest {
 
         DefaultMQProducer producer = new DefaultMQProducer("szz_producer");
         producer.setInstanceName("szz_producer_instanceName");
+        producer.setNamesrvAddr("127.0.0.1:9876");
         producer.start();
+
 
 
         ConcurrentMap<String, MQClientInstance> factoryTable = (ConcurrentMap<String, MQClientInstance>) FieldUtils.readDeclaredField(MQClientManager.getInstance(), "factoryTable", true);
@@ -228,6 +235,12 @@ public class MQClientInstanceTest {
         // alread created
         MQClientInstance mqClientInstance = MQClientManager.getInstance().getOrCreateMQClientInstance(producer);
         assertThat(instance1).isEqualTo(mqClientInstance);
+
+
+        MQClientInstance mQClientFactorySpy = spy(mqClientInstance);
+
+        lenient().doReturn(false).when(mQClientFactorySpy).updateTopicRouteInfoFromNameServer(anyString());
+
 
         // only producer shouldn't start inner DefaultMQProducer and pullRequest
         ServiceState serviceState = mqClientInstance.getDefaultMQProducer().getDefaultMQProducerImpl().getServiceState();
@@ -263,8 +276,6 @@ public class MQClientInstanceTest {
 
     @Test
     public void testOnlyRegisterConsumer() throws MQClientException, IllegalAccessException, MQBrokerException, RemotingException, InterruptedException, NoSuchFieldException {
-
-        MQClientAPIImpl mQClientAPIImpl = mock(MQClientAPIImpl.class);
 
         DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("szz_consumer");
         consumer.setInstanceName("szz_consumer_instanceName");
@@ -336,8 +347,6 @@ public class MQClientInstanceTest {
 
     @Test
     public void testBothProducerAndConsumer() throws MQClientException, IllegalAccessException, NoSuchFieldException {
-        MQClientAPIImpl mQClientAPIImpl = mock(MQClientAPIImpl.class);
-
 
         DefaultMQProducer producer = new DefaultMQProducer("szz_producer");
         producer.setInstanceName("szz_producerAndConsumer_instanceName");


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->



Fixes #7402 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

通过判断consumerTable的数量判断是否有消费者存在

1. 在初次启动的时候，如果是注册的消费者，则直接将那几个服务启动，否则不启动
2. 如果初次启动不是消费者，但是后续有加入新的消费者，则判断那几个服务是否已经启动，如果没有则启动

Determine whether there are consumers by judging the number of consumerTables

1. At the initial startup, if it is a registered consumer, directly start those services, otherwise it will not start.
2. If the initial startup is not a consumer, but new consumers are added later, determine whether those services have been started, and if not, start them


<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
