### PR TITLE
Fix unstable UtilAllTest#testCalculateFileSizeInPath on Windows

### DIFF
--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -26,7 +26,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -34,6 +37,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class UtilAllTest {
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
     @Test
     public void testCurrentStackTrace() {
@@ -236,56 +241,37 @@ public class UtilAllTest {
          *          - file_1_2_0
          *  - dir_2
          */
-        String basePath = System.getProperty("java.io.tmpdir") + File.separator + "testCalculateFileSizeInPath";
-        File baseFile = new File(basePath);
-        try {
-            // test empty path
-            assertEquals(0, UtilAll.calculateFileSizeInPath(baseFile));
+        File baseFile = tempDir.getRoot();
 
-            // create baseDir
-            assertTrue(baseFile.mkdirs());
+        // test empty path
+        assertEquals(0, UtilAll.calculateFileSizeInPath(baseFile));
 
-            File file0 = new File(baseFile, "file_0");
-            assertTrue(file0.createNewFile());
-            writeFixedBytesToFile(file0, 1313);
+        File file0 = new File(baseFile, "file_0");
+        assertTrue(file0.createNewFile());
+        writeFixedBytesToFile(file0, 1313);
 
-            assertEquals(1313, UtilAll.calculateFileSizeInPath(baseFile));
+        assertEquals(1313, UtilAll.calculateFileSizeInPath(baseFile));
 
-            // build a file tree like above
-            File dir1 = new File(baseFile, "dir_1");
-            dir1.mkdirs();
-            File file10 = new File(dir1, "file_1_0");
-            File file11 = new File(dir1, "file_1_1");
-            File dir12 = new File(dir1, "dir_1_2");
-            dir12.mkdirs();
-            File file120 = new File(dir12, "file_1_2_0");
-            File dir2 = new File(baseFile, "dir_2");
-            dir2.mkdirs();
+        // build a file tree like above
+        File dir1 = new File(baseFile, "dir_1");
+        dir1.mkdirs();
+        File file10 = new File(dir1, "file_1_0");
+        File file11 = new File(dir1, "file_1_1");
+        File dir12 = new File(dir1, "dir_1_2");
+        dir12.mkdirs();
+        File file120 = new File(dir12, "file_1_2_0");
+        File dir2 = new File(baseFile, "dir_2");
+        dir2.mkdirs();
 
-            // write all file with 1313 bytes data
-            assertTrue(file10.createNewFile());
-            writeFixedBytesToFile(file10, 1313);
-            assertTrue(file11.createNewFile());
-            writeFixedBytesToFile(file11, 1313);
-            assertTrue(file120.createNewFile());
-            writeFixedBytesToFile(file120, 1313);
+        // write all file with 1313 bytes data
+        assertTrue(file10.createNewFile());
+        writeFixedBytesToFile(file10, 1313);
+        assertTrue(file11.createNewFile());
+        writeFixedBytesToFile(file11, 1313);
+        assertTrue(file120.createNewFile());
+        writeFixedBytesToFile(file120, 1313);
 
-            assertEquals(1313 * 4, UtilAll.calculateFileSizeInPath(baseFile));
-        } finally {
-            deleteFolder(baseFile);
-        }
-    }
-
-    public static void deleteFolder(File folder) {
-        if (folder.isDirectory()) {
-            File[] files = folder.listFiles();
-            if (files != null) {
-                for (File file : files) {
-                    deleteFolder(file);
-                }
-            }
-        }
-        folder.delete();
+        assertEquals(1313 * 4, UtilAll.calculateFileSizeInPath(baseFile));
     }
 
     private void writeFixedBytesToFile(File file, int size) throws Exception {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7418

### Brief Description

This MR offers an alternative approach to #7445 (5d492c338258d07613103e6ae16df4c6fa5b3838). 
Instead of manually setting up the directory `testCalculateFileSizeInPath` needs and then recursively deleting it, it uses JUnit's `TemporaryFolder` `@Rule` to handle all of this work, and allows the code to concentrate on the business logic.


### How Did You Test This Change?

Running `mvn install` passes now, as well as running this test manually from IntelliJ