### PR TITLE
add getter for class Message ,fix json serialize bug

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/Message.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/Message.java
@@ -218,14 +218,36 @@ public class Message implements Serializable {
     public void setDelayTimeSec(long sec) {
         this.putProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC, String.valueOf(sec));
     }
+
+    public long getDelayTimeSec() {
+        String t = this.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC);
+        if (t != null) {
+            return Long.parseLong(t);
+        }
+        return 0;
+    }
+
     public void setDelayTimeMs(long timeMs) {
         this.putProperty(MessageConst.PROPERTY_TIMER_DELAY_MS, String.valueOf(timeMs));
     }
+
+    public long getDelayTimeMs() {
+        String t = this.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS);
+        if (t != null) {
+            return Long.parseLong(t);
+        }
+        return 0;
+    }
+
     public void setDeliverTimeMs(long timeMs) {
         this.putProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS, String.valueOf(timeMs));
     }
 
     public long getDeliverTimeMs() {
-        return Long.parseLong(this.getUserProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS));
+        String t = this.getProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS);
+        if (t != null) {
+            return Long.parseLong(t);
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
These getter and setter methods indeed cause the JSON serialization of the Message subclasses to fail.