### PR TITLE
[ISSUE #7444] Fix testCalculateFileSizeInPath test can not rerun in same environment

### DIFF
--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -238,40 +238,42 @@ public class UtilAllTest {
          */
         String basePath = System.getProperty("java.io.tmpdir") + File.separator + "testCalculateFileSizeInPath";
         File baseFile = new File(basePath);
-        // test empty path
-        assertEquals(0, UtilAll.calculateFileSizeInPath(baseFile));
+        try {
+            // test empty path
+            assertEquals(0, UtilAll.calculateFileSizeInPath(baseFile));
 
-        // create baseDir
-        assertTrue(baseFile.mkdirs());
+            // create baseDir
+            assertTrue(baseFile.mkdirs());
 
-        File file0 = new File(baseFile, "file_0");
-        assertTrue(file0.createNewFile());
-        writeFixedBytesToFile(file0, 1313);
+            File file0 = new File(baseFile, "file_0");
+            assertTrue(file0.createNewFile());
+            writeFixedBytesToFile(file0, 1313);
 
-        assertEquals(1313, UtilAll.calculateFileSizeInPath(baseFile));
+            assertEquals(1313, UtilAll.calculateFileSizeInPath(baseFile));
 
-        // build a file tree like above
-        File dir1 = new File(baseFile, "dir_1");
-        dir1.mkdirs();
-        File file10 = new File(dir1, "file_1_0");
-        File file11 = new File(dir1, "file_1_1");
-        File dir12 = new File(dir1, "dir_1_2");
-        dir12.mkdirs();
-        File file120 = new File(dir12, "file_1_2_0");
-        File dir2 = new File(baseFile, "dir_2");
-        dir2.mkdirs();
+            // build a file tree like above
+            File dir1 = new File(baseFile, "dir_1");
+            dir1.mkdirs();
+            File file10 = new File(dir1, "file_1_0");
+            File file11 = new File(dir1, "file_1_1");
+            File dir12 = new File(dir1, "dir_1_2");
+            dir12.mkdirs();
+            File file120 = new File(dir12, "file_1_2_0");
+            File dir2 = new File(baseFile, "dir_2");
+            dir2.mkdirs();
 
-        // write all file with 1313 bytes data
-        assertTrue(file10.createNewFile());
-        writeFixedBytesToFile(file10, 1313);
-        assertTrue(file11.createNewFile());
-        writeFixedBytesToFile(file11, 1313);
-        assertTrue(file120.createNewFile());
-        writeFixedBytesToFile(file120, 1313);
+            // write all file with 1313 bytes data
+            assertTrue(file10.createNewFile());
+            writeFixedBytesToFile(file10, 1313);
+            assertTrue(file11.createNewFile());
+            writeFixedBytesToFile(file11, 1313);
+            assertTrue(file120.createNewFile());
+            writeFixedBytesToFile(file120, 1313);
 
-        assertEquals(1313 * 4, UtilAll.calculateFileSizeInPath(baseFile));
-
-        deleteFolder(baseFile);
+            assertEquals(1313 * 4, UtilAll.calculateFileSizeInPath(baseFile));
+        } finally {
+            deleteFolder(baseFile);
+        }
     }
 
     public static void deleteFolder(File folder) {

--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -271,8 +271,19 @@ public class UtilAllTest {
 
         assertEquals(1313 * 4, UtilAll.calculateFileSizeInPath(baseFile));
 
-        // clear all file
-        baseFile.deleteOnExit();
+        deleteFolder(baseFile);
+    }
+
+    public static void deleteFolder(File folder) {
+        if (folder.isDirectory()) {
+            File[] files = folder.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    deleteFolder(file);
+                }
+            }
+        }
+        folder.delete();
     }
 
     private void writeFixedBytesToFile(File file, int size) throws Exception {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7444

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Fix testCalculateFileSizeInPath test can not rerun in same environment

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
