### PR TITLE
[ISSUE #7478] On startup, if not check crc, not read message body. avoid startup too slow when data is large

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.store;
 
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -478,6 +479,11 @@ public class CommitLog implements Swappable {
                         }
                     }
                 } else {
+                    if(byteBuffer.remaining()<bodyLen){
+                        log.warn("bodyLen is {} but buffer remaining is {}",byteBuffer.remaining(),bodyLen);
+                        //same as try read exception
+                        throw new BufferUnderflowException();
+                    }
                     byteBuffer.position(byteBuffer.position() + bodyLen);
                 }
             }

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -479,9 +479,9 @@ public class CommitLog implements Swappable {
                         }
                     }
                 } else {
-                    if(byteBuffer.remaining()<bodyLen){
-                        log.warn("bodyLen is {} but buffer remaining is {}",byteBuffer.remaining(),bodyLen);
-                        //same as byteBuffer.get exception
+                    if(byteBuffer.remaining() < bodyLen){
+                        log.warn("bodyLen is {} but buffer remaining is {}", byteBuffer.remaining(), bodyLen);
+                        // Same as byteBuffer.get exception
                         throw new BufferUnderflowException();
                     }
                     byteBuffer.position(byteBuffer.position() + bodyLen);

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -322,6 +322,7 @@ public class CommitLog implements Swappable {
             // normal recover doesn't require dispatching
             boolean doDispatch = false;
             while (true) {
+                // if not checkcrc not need to read body, so pass checkCRCOnRecover as readBody
                 DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo, checkCRCOnRecover);
                 int size = dispatchRequest.getMsgSize();
                 // Normal data
@@ -663,6 +664,7 @@ public class CommitLog implements Swappable {
             // abnormal recover require dispatching
             boolean doDispatch = true;
             while (true) {
+                // if not checkcrc not need to read body, so pass checkCRCOnRecover as readBody
                 DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo, checkCRCOnRecover);
                 int size = dispatchRequest.getMsgSize();
 

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -480,7 +480,7 @@ public class CommitLog implements Swappable {
                     }
                 } else {
                     if (byteBuffer.remaining() < bodyLen) {
-                        log.warn("bodyLen is {} but buffer remaining is {}", byteBuffer.remaining(), bodyLen);
+                        log.warn("bodyLen is {} but buffer remaining is {}", bodyLen, byteBuffer.remaining());
                         // Same as byteBuffer.get exception
                         throw new BufferUnderflowException();
                     }

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -322,7 +322,7 @@ public class CommitLog implements Swappable {
             // normal recover doesn't require dispatching
             boolean doDispatch = false;
             while (true) {
-                DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo);
+                DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo, checkCRCOnRecover);
                 int size = dispatchRequest.getMsgSize();
                 // Normal data
                 if (dispatchRequest.isSuccess() && size > 0) {
@@ -663,7 +663,7 @@ public class CommitLog implements Swappable {
             // abnormal recover require dispatching
             boolean doDispatch = true;
             while (true) {
-                DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo);
+                DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo, checkCRCOnRecover);
                 int size = dispatchRequest.getMsgSize();
 
                 if (dispatchRequest.isSuccess()) {

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -481,7 +481,7 @@ public class CommitLog implements Swappable {
                 } else {
                     if(byteBuffer.remaining()<bodyLen){
                         log.warn("bodyLen is {} but buffer remaining is {}",byteBuffer.remaining(),bodyLen);
-                        //same as try read exception
+                        //same as byteBuffer.get exception
                         throw new BufferUnderflowException();
                     }
                     byteBuffer.position(byteBuffer.position() + bodyLen);

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -479,7 +479,7 @@ public class CommitLog implements Swappable {
                         }
                     }
                 } else {
-                    if(byteBuffer.remaining() < bodyLen){
+                    if (byteBuffer.remaining() < bodyLen) {
                         log.warn("bodyLen is {} but buffer remaining is {}", byteBuffer.remaining(), bodyLen);
                         // Same as byteBuffer.get exception
                         throw new BufferUnderflowException();

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -322,6 +322,7 @@ public class CommitLog implements Swappable {
             long lastValidMsgPhyOffset = this.getConfirmOffset();
             // normal recover doesn't require dispatching
             boolean doDispatch = false;
+            log.info("recover physics file {}", mappedFile.getFileName());
             while (true) {
                 // if not checkcrc not need to read body, so pass checkCRCOnRecover as readBody
                 DispatchRequest dispatchRequest = this.checkMessageAndReturnSize(byteBuffer, checkCRCOnRecover, checkDupInfo, checkCRCOnRecover);


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes  #7478

### Brief Description

see issue #7478 

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

tens of minuts reduced to about 1 minuts
