### PR TITLE
fix UtilAllTest.java Can't create a empty path

### DIFF
--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -236,7 +237,8 @@ public class UtilAllTest {
          *          - file_1_2_0
          *  - dir_2
          */
-        String basePath = System.getProperty("java.io.tmpdir") + File.separator + "testCalculateFileSizeInPath";
+        String uniqueDirName = UUID.randomUUID().toString();
+        String basePath = System.getProperty("java.io.tmpdir") + File.separator + uniqueDirName;
         File baseFile = new File(basePath);
         // test empty path
         assertEquals(0, UtilAll.calculateFileSizeInPath(baseFile));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

<!--fix-->

Fixes #7484

### Brief Description

When using this line of code to test UtilAllTest#testCalculateFileSizeInPath:
`mvn -pl common test -Dtest=org.apache.rocketmq.common.UtilAllTest#testCalculateFileSizeInPath
`
An error would occur. 
Part of the error message: 
```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.785 sec <<< FAILURE! - in org.apache.rocketmq.common.UtilAllTest
testCalculateFileSizeInPath(org.apache.rocketmq.common.UtilAllTest)  Time elapsed: 0.641 sec  <<< FAILURE!
java.lang.AssertionError: expected:<0> but was:<5252>
	at org.apache.rocketmq.common.UtilAllTest.testCalculateFileSizeInPath(UtilAllTest.java:242)

Results :

Failed tests: 
  UtilAllTest.testCalculateFileSizeInPath:242 expected:<0> but was:<5252>
```
The related original code: 
```
String basePath = System.getProperty("java.io.tmpdir") + File.separator + "testCalculateFileSizeInPath";
File baseFile = new File(basePath);
// test empty path
assertEquals(0, UtilAll.calculateFileSizeInPath(baseFile));
```
The error message shows the size of the "empty" path that the code creates is not zero, which means the path is not empty. After careful examination of the code, I have found that the occurrence of this issue is certain and persistent. When we run the code for the first time, nothing happens, and the build succeeds. However, after that, because the path names in the code remain unchanged, this path becomes non-empty every time we build. As a result, an error occurs every time it is run.
So we need to change part of the code to make sure the temporary path we created is empty everytime.

So I import `java.util.UUID`, and used `String uniqueDirName = UUID.randomUUID().toString();` to create a unique and random id, and add this id to the end of the path: `String basePath = System.getProperty("java.io.tmpdir") + File.separator + uniqueDirName;` This makes every temp path the function creates is unique. 

### How Did You Test This Change?

After the modification, the test will not fail anymore. I used the same test: 
`mvn -pl common test -Dtest=org.apache.rocketmq.common.UtilAllTest#testCalculateFileSizeInPath`
to test the UtilAllTest.java, and it builds success. 
