### PR TITLE
[ISSUE #7491] metricsExporterType enum config support

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java
@@ -209,7 +209,7 @@ public class ControllerConfig {
         this.metricsExporterType = metricsExporterType;
     }
 
-    // support read from config file using org.apache.rocketmq.common.MixAll.properties2Object
+    // support read from config file using MixAll.properties2Object
     public void setMetricsExporterType(String metricsExporterType) {
         this.metricsExporterType = MetricsExporterType.valueOf(metricsExporterType);
     }

--- a/common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java
@@ -209,6 +209,11 @@ public class ControllerConfig {
         this.metricsExporterType = metricsExporterType;
     }
 
+    // support read from config file using org.apache.rocketmq.common.MixAll.properties2Object
+    public void setMetricsExporterType(String metricsExporterType) {
+        this.metricsExporterType = MetricsExporterType.valueOf(metricsExporterType);
+    }
+
     public String getMetricsGrpcExporterTarget() {
         return metricsGrpcExporterTarget;
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7491

### Brief Description
config file using `MixAll.properties2Object` to load not support enum type. so add a `String` arg one
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
after this change, metric port listen appear as expect
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
