### PR TITLE
[ISSUE #7493] Introduce a new event NettyEventType.ACTIVE

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ClientHousekeepingService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ClientHousekeepingService.java
@@ -87,4 +87,9 @@ public class ClientHousekeepingService implements ChannelEventListener {
         this.brokerController.getConsumerManager().doChannelCloseEvent(remoteAddr, channel);
         this.brokerController.getBrokerStatsManager().incChannelIdleNum();
     }
+
+    @Override
+    public void onChannelActive(String remoteAddr, Channel channel) {
+
+    }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -180,6 +180,10 @@ public class MQClientInstance {
                 @Override
                 public void onChannelIdle(String remoteAddr, Channel channel) {
                 }
+
+                @Override
+                public void onChannelActive(String remoteAddr, Channel channel) {
+                }
             };
         } else {
             channelEventListener = null;

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -159,14 +159,6 @@ public class MQClientInstance {
                 private final ConcurrentMap<String, HashMap<Long, String>> brokerAddrTable = MQClientInstance.this.brokerAddrTable;
                 @Override
                 public void onChannelConnect(String remoteAddr, Channel channel) {
-                    for (Map.Entry<String, HashMap<Long, String>> addressEntry : brokerAddrTable.entrySet()) {
-                        for (String address : addressEntry.getValue().values()) {
-                            if (address.equals(remoteAddr)) {
-                                sendHeartbeatToAllBrokerWithLockV2(false);
-                                break;
-                            }
-                        }
-                    }
                 }
 
                 @Override
@@ -183,6 +175,14 @@ public class MQClientInstance {
 
                 @Override
                 public void onChannelActive(String remoteAddr, Channel channel) {
+                    for (Map.Entry<String, HashMap<Long, String>> addressEntry : brokerAddrTable.entrySet()) {
+                        for (String address : addressEntry.getValue().values()) {
+                            if (address.equals(remoteAddr)) {
+                                sendHeartbeatToAllBrokerWithLockV2(false);
+                                break;
+                            }
+                        }
+                    }
                 }
             };
         } else {

--- a/container/src/main/java/org/apache/rocketmq/container/ContainerClientHouseKeepingService.java
+++ b/container/src/main/java/org/apache/rocketmq/container/ContainerClientHouseKeepingService.java
@@ -49,6 +49,11 @@ public class ContainerClientHouseKeepingService implements ChannelEventListener 
         onChannelOperation(CallbackCode.IDLE, remoteAddr, channel);
     }
 
+    @Override
+    public void onChannelActive(String remoteAddr, Channel channel) {
+        onChannelOperation(CallbackCode.ACTIVE, remoteAddr, channel);
+    }
+
     private void onChannelOperation(CallbackCode callbackCode, String remoteAddr, Channel channel) {
         Collection<InnerBrokerController> masterBrokers = this.brokerContainer.getMasterBrokers();
         Collection<InnerSalveBrokerController> slaveBrokers = this.brokerContainer.getSlaveBrokers();
@@ -103,6 +108,10 @@ public class ContainerClientHouseKeepingService implements ChannelEventListener 
         /**
          * onChannelIdle
          */
-        IDLE
+        IDLE,
+        /**
+         * onChannelActive
+         */
+        ACTIVE
     }
 }

--- a/controller/src/main/java/org/apache/rocketmq/controller/BrokerHousekeepingService.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/BrokerHousekeepingService.java
@@ -48,4 +48,9 @@ public class BrokerHousekeepingService implements ChannelEventListener {
     public void onChannelIdle(String remoteAddr, Channel channel) {
         this.controllerManager.getHeartbeatManager().onBrokerChannelClose(channel);
     }
+
+    @Override
+    public void onChannelActive(String remoteAddr, Channel channel) {
+
+    }
 }

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/BrokerHousekeepingService.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/BrokerHousekeepingService.java
@@ -46,4 +46,9 @@ public class BrokerHousekeepingService implements ChannelEventListener {
     public void onChannelIdle(String remoteAddr, Channel channel) {
         this.namesrvController.getRouteInfoManager().onChannelDestroy(channel);
     }
+
+    @Override
+    public void onChannelActive(String remoteAddr, Channel channel) {
+
+    }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/ClientHousekeepingService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/ClientHousekeepingService.java
@@ -49,5 +49,9 @@ public class ClientHousekeepingService implements ChannelEventListener {
         this.clientManagerActivity.doChannelCloseEvent(remoteAddr, channel);
     }
 
+    @Override
+    public void onChannelActive(String remoteAddr, Channel channel) {
+
+    }
 }
 

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/ChannelEventListener.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/ChannelEventListener.java
@@ -26,4 +26,6 @@ public interface ChannelEventListener {
     void onChannelException(final String remoteAddr, final Channel channel);
 
     void onChannelIdle(final String remoteAddr, final Channel channel);
+
+    void onChannelActive(final String remoteAddr, final Channel channel);
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyEventType.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyEventType.java
@@ -20,5 +20,6 @@ public enum NettyEventType {
     CONNECT,
     CLOSE,
     IDLE,
-    EXCEPTION
+    EXCEPTION,
+    ACTIVE
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -701,6 +701,9 @@ public abstract class NettyRemotingAbstract {
                             case EXCEPTION:
                                 listener.onChannelException(event.getRemoteAddr(), event.getChannel());
                                 break;
+                            case ACTIVE:
+                                listener.onChannelActive(event.getRemoteAddr(), event.getChannel());
+                                break;
                             default:
                                 break;
 

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -1107,6 +1107,17 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
         }
 
         @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            final String remoteAddress = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
+            LOGGER.info("NETTY CLIENT PIPELINE: ACTIVE, {}", remoteAddress);
+            super.channelActive(ctx);
+
+            if (NettyRemotingClient.this.channelEventListener != null) {
+                NettyRemotingClient.this.putNettyEvent(new NettyEvent(NettyEventType.ACTIVE, remoteAddress, ctx.channel()));
+            }
+        }
+
+        @Override
         public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
             final String remoteAddress = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
             LOGGER.info("NETTY CLIENT PIPELINE: DISCONNECT {}", remoteAddress);


### PR DESCRIPTION


* introduce a new event NettyEventType.ACTIVE,

* implement channelActive interface for NettyRemotingClient#NettyConnectManageHandler

* add onChannelActive for ChannelEventListener interface.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7493

### Brief Description

Introduce a new event NettyEventType.ACTIVE for ChannelEventListener

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
