### PR TITLE
[ISSUE #5923] Revert "Fix tiered store README.md error about Configuration (#7436)"

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/TieredMessageStoreConfig.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/TieredMessageStoreConfig.java
@@ -115,7 +115,7 @@ public class TieredMessageStoreConfig {
     private long readAheadCacheExpireDuration = 10 * 1000;
     private double readAheadCacheSizeThresholdRate = 0.3;
 
-    private String tieredStoreFilepath = "";
+    private String tieredStoreFilePath = "";
 
     private String objectStoreEndpoint = "";
 
@@ -350,12 +350,12 @@ public class TieredMessageStoreConfig {
         this.readAheadCacheSizeThresholdRate = rate;
     }
 
-    public String getTieredStoreFilepath() {
-        return tieredStoreFilepath;
+    public String getTieredStoreFilePath() {
+        return tieredStoreFilePath;
     }
 
-    public void setTieredStoreFilepath(String tieredStoreFilepath) {
-        this.tieredStoreFilepath = tieredStoreFilepath;
+    public void setTieredStoreFilePath(String tieredStoreFilePath) {
+        this.tieredStoreFilePath = tieredStoreFilePath;
     }
 
     public void setObjectStoreEndpoint(String objectStoreEndpoint) {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegment.java
@@ -66,8 +66,8 @@ public class PosixFileSegment extends TieredFileSegment {
         super(storeConfig, fileType, filePath, baseOffset);
 
         // basePath
-        String basePath = StringUtils.defaultString(storeConfig.getTieredStoreFilepath(),
-            StringUtils.appendIfMissing(storeConfig.getTieredStoreFilepath(), File.separator));
+        String basePath = StringUtils.defaultString(storeConfig.getTieredStoreFilePath(),
+            StringUtils.appendIfMissing(storeConfig.getTieredStoreFilePath(), File.separator));
 
         // fullPath: basePath/hash_cluster/broker/topic/queueId/fileType/baseOffset
         String brokerClusterName = storeConfig.getBrokerClusterName();

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/TieredCommitLogTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/TieredCommitLogTest.java
@@ -49,7 +49,7 @@ public class TieredCommitLogTest {
         TieredMessageStoreConfig storeConfig = new TieredMessageStoreConfig();
         storeConfig.setBrokerName("brokerName");
         storeConfig.setStorePathRootDir(storePath);
-        storeConfig.setTieredStoreFilepath(storePath + File.separator);
+        storeConfig.setTieredStoreFilePath(storePath + File.separator);
         storeConfig.setTieredBackendServiceProvider("org.apache.rocketmq.tieredstore.provider.posix.PosixFileSegment");
         storeConfig.setCommitLogRollingInterval(0);
         storeConfig.setTieredStoreCommitLogMaxSize(1000);

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegmentTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/posix/PosixFileSegmentTest.java
@@ -42,7 +42,7 @@ public class PosixFileSegmentTest {
     @Before
     public void setUp() {
         storeConfig = new TieredMessageStoreConfig();
-        storeConfig.setTieredStoreFilepath(storePath);
+        storeConfig.setTieredStoreFilePath(storePath);
         mq = new MessageQueue("OSSFileSegmentTest", "broker", 0);
         TieredStoreExecutor.init();
     }


### PR DESCRIPTION
[ISSUE #5923] Revert "Fix tiered store README.md error about Configuration (#7436)"

This reverts commit 70dc93abbcb9bf161378d66fcaca55bedc78b905.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

for issue #5923

There is a widely use of filePath in the rocketmq project. The rename operation which not only brings compatibility issues but also conflicts with the naming style of the rocketmq project. It is recommended to revert this change.

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
