### PR TITLE
[ISSUE #7570] fix: add default value for lastPopTimestamp

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/PopProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/PopProcessQueue.java
@@ -26,7 +26,7 @@ public class PopProcessQueue {
 
     private final static long PULL_MAX_IDLE_TIME = Long.parseLong(System.getProperty("rocketmq.client.pull.pullMaxIdleTime", "120000"));
 
-    private long lastPopTimestamp;
+    private long lastPopTimestamp = System.currentTimeMillis();
     private AtomicInteger waitAckCounter = new AtomicInteger(0);
     private volatile boolean dropped = false;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7570

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Add default value as current time for lastPopTimestamp.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

Run `PopConsumer`, there are no errors in the client log.
```log
2023-11-17 10:26:42.442 INFO  [66096] [NettyClientPublicExecutor_5] [o.a.r.c.i.ClientRemotingProcessor#?:?] - receive broker's notification[x.x.x.x:10931], the consumer group: CID_JODIE_1 changed, rebalance immediately
2023-11-17 10:26:42.475 INFO  [66096] [main] [RocketmqRemoting#?:?] - createChannel: connect remote host[x.x.x.x:10911] success, AbstractBootstrap$PendingRegistrationPromise@bf1ec20(success)
2023-11-17 10:26:42.475 INFO  [66096] [NettyClientWorkerThread_3] [RocketmqRemoting#?:?] - NETTY CLIENT PIPELINE: ACTIVE, x.x.x.x:10911
2023-11-17 10:26:42.475 WARN  [66096] [NettyEventExecutor] [o.a.r.c.i.f.MQClientInstance#?:?] - sendHeartbeatToAllBrokerWithLockV2 lock heartBeat, but failed.
2023-11-17 10:26:42.509 INFO  [66096] [NettyClientPublicExecutor_8] [o.a.r.c.i.ClientRemotingProcessor#?:?] - receive broker's notification[x.x.x.x:10911], the consumer group: CID_JODIE_1 changed, rebalance immediately
2023-11-17 10:26:42.509 INFO  [66096] [main] [o.a.r.c.i.f.MQClientInstance#?:?] - send heart beat to broker[broker-a 0 x.x.x.x:10911] success
2023-11-17 10:26:42.509 INFO  [66096] [main] [o.a.r.c.i.f.MQClientInstance#?:?] - HeartbeatData [clientID=10.173.92.229@66096#2054507404466400, producerDataSet=[ProducerData [groupName=CLIENT_INNER_PRODUCER]], consumerDataSet=[ConsumerData [groupName=CID_JODIE_1, consumeType=CONSUME_PASSIVELY, messageModel=CLUSTERING, consumeFromWhere=CONSUME_FROM_FIRST_OFFSET, unitMode=false, subscriptionDataSet=[SubscriptionData [classFilterMode=false, topic=TopicTest, subString=*, tagsSet=[], codeSet=[], subVersion=1700188001236, expressionType=TAG], SubscriptionData [classFilterMode=false, topic=%RETRY%CID_JODIE_1, subString=*, tagsSet=[], codeSet=[], subVersion=1700188001243, expressionType=TAG]]]]]
2023-11-17 10:26:42.521 INFO  [66096] [RebalanceService] [o.a.r.c.c.s.RemoteBrokerOffsetStore#?:?] - remove unnecessary messageQueue offset. group=CID_JODIE_1, mq=MessageQueue [topic=%RETRY%CID_JODIE_1, brokerName=broker-b, queueId=0], offsetTableSize=0
2023-11-17 10:26:42.562 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - doRebalance, CID_JODIE_1, add a new mq, MessageQueue [topic=%RETRY%CID_JODIE_1, brokerName=broker-b, queueId=0]
2023-11-17 10:26:42.563 INFO  [66096] [RebalanceService] [o.a.r.c.c.s.RemoteBrokerOffsetStore#?:?] - remove unnecessary messageQueue offset. group=CID_JODIE_1, mq=MessageQueue [topic=%RETRY%CID_JODIE_1, brokerName=broker-a, queueId=0], offsetTableSize=1
2023-11-17 10:26:42.598 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - doRebalance, CID_JODIE_1, add a new mq, MessageQueue [topic=%RETRY%CID_JODIE_1, brokerName=broker-a, queueId=0]
2023-11-17 10:26:42.599 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - broker rebalanced result changed. allocateMessageQueueStrategyName=AVG, group=CID_JODIE_1, topic=%RETRY%CID_JODIE_1, clientId=10.173.92.229@66096#2054507404466400, assignmentSet=[MessageQueueAssignment [MessageQueue=MessageQueue [topic=%RETRY%CID_JODIE_1, brokerName=broker-a, queueId=0], Mode=PULL], MessageQueueAssignment [MessageQueue=MessageQueue [topic=%RETRY%CID_JODIE_1, brokerName=broker-b, queueId=0], Mode=PULL]]
2023-11-17 10:26:42.599 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - %RETRY%CID_JODIE_1 Rebalance changed, also update version: 1700188001243, 1700188002599
2023-11-17 10:26:42.741 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - doRebalance, CID_JODIE_1, add a new pop mq, MessageQueue [topic=TopicTest, brokerName=broker-a, queueId=-1]
2023-11-17 10:26:42.742 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - doRebalance, CID_JODIE_1, add a new pop mq, MessageQueue [topic=TopicTest, brokerName=broker-b, queueId=-1]
2023-11-17 10:26:42.742 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - broker rebalanced result changed. allocateMessageQueueStrategyName=AVG, group=CID_JODIE_1, topic=TopicTest, clientId=10.173.92.229@66096#2054507404466400, assignmentSet=[MessageQueueAssignment [MessageQueue=MessageQueue [topic=TopicTest, brokerName=broker-a, queueId=-1], Mode=POP], MessageQueueAssignment [MessageQueue=MessageQueue [topic=TopicTest, brokerName=broker-b, queueId=-1], Mode=POP]]
2023-11-17 10:26:42.742 INFO  [66096] [RebalanceService] [o.a.r.c.i.c.RebalanceImpl#?:?] - TopicTest Rebalance changed, also update version: 1700188001236, 1700188002742

```