### PR TITLE
[ISSUE #7585] Always return duplicate buffer when filter message and fix log format

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/GetMessageResultExt.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/GetMessageResultExt.java
@@ -23,7 +23,6 @@ import org.apache.rocketmq.store.GetMessageResult;
 import org.apache.rocketmq.store.GetMessageStatus;
 import org.apache.rocketmq.store.MessageFilter;
 import org.apache.rocketmq.store.SelectMappedBufferResult;
-import org.apache.rocketmq.tieredstore.util.MessageBufferUtil;
 
 public class GetMessageResultExt extends GetMessageResult {
 
@@ -63,9 +62,9 @@ public class GetMessageResultExt extends GetMessageResult {
                 continue;
             }
 
+            long offset = this.getMessageQueueOffset().get(i);
             result.addMessage(new SelectMappedBufferResult(bufferResult.getStartOffset(),
-                    bufferResult.getByteBuffer(), bufferResult.getSize(), null),
-                MessageBufferUtil.getQueueOffset(bufferResult.getByteBuffer()));
+                bufferResult.getByteBuffer().asReadOnlyBuffer(), bufferResult.getSize(), null), offset);
         }
 
         if (result.getBufferTotalSize() == 0) {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/TieredFileSegment.java
@@ -367,7 +367,7 @@ public abstract class TieredFileSegment implements Comparable<TieredFileSegment>
             if (fileSegmentInputStream != null) {
                 long fileSize = this.getSize();
                 if (fileSize == -1L) {
-                    logger.error("Get commit position error before commit, Commit: %d, Expect: %d, Current Max: %d, FileName: %s",
+                    logger.error("Get commit position error before commit, Commit: {}, Expect: {}, Current Max: {}, FileName: {}",
                         commitPosition, commitPosition + fileSegmentInputStream.getContentLength(), appendPosition, getPath());
                     releaseCommitLock();
                     return CompletableFuture.completedFuture(false);


### PR DESCRIPTION
…format

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7585

When pull messages from the cache of tiered storage, always return a copy of the byte buffer instead of the buffer itself.

从分级存储的缓存获取消息时，将返回消息 buffer 的副本而不是 buffer 本身。

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
