### PR TITLE
[ISSUE #7662] fix: updateAccessConfig when groupPerms is empty

### DIFF
--- a/acl/src/test/java/org/apache/rocketmq/acl/plain/PlainAccessValidatorTest.java
+++ b/acl/src/test/java/org/apache/rocketmq/acl/plain/PlainAccessValidatorTest.java
@@ -37,11 +37,13 @@ import org.apache.rocketmq.acl.common.SessionCredentials;
 import org.apache.rocketmq.common.AclConfig;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.PlainAccessConfig;
+import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.header.ConsumerSendMsgBackRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.CreateAccessConfigRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.GetConsumerListByGroupRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.PullMessageRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.QueryMessageRequestHeader;
@@ -1106,6 +1108,26 @@ public class PlainAccessValidatorTest {
         AclUtils.writeDataObject(targetFileName2, backUpAclConfigMap2);
 
         AclTestHelper.recursiveDelete(home);
+    }
+
+    @Test
+    public void testUpdateAccessConfigWhenGroupPermsIsNull() {
+        List<String> groupPerms = new ArrayList<>();
+        CreateAccessConfigRequestHeader requestHeader = new CreateAccessConfigRequestHeader();
+        requestHeader.setAccessKey("admin-user");
+        requestHeader.setSecretKey("123456789");
+        requestHeader.setAdmin(true);
+        requestHeader.setGroupPerms(UtilAll.join(groupPerms, ","));
+
+        PlainAccessValidator plainAccessValidator = new PlainAccessValidator();
+        PlainAccessConfig plainAccessConfig = new PlainAccessConfig();
+        plainAccessConfig.setAccessKey(requestHeader.getAccessKey());
+        plainAccessConfig.setSecretKey(requestHeader.getSecretKey());
+        plainAccessConfig.setAdmin(requestHeader.isAdmin());
+        plainAccessConfig.setGroupPerms(UtilAll.split(requestHeader.getGroupPerms(), ","));
+
+        // update
+        plainAccessValidator.updateAccessConfig(plainAccessConfig);
     }
 
 

--- a/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
@@ -661,7 +661,7 @@ public class UtilAll {
     }
 
     public static String join(List<String> list, String splitter) {
-        if (list == null) {
+        if (list == null || list.isEmpty()) {
             return null;
         }
 

--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -139,7 +139,7 @@ public class UtilAllTest {
         assertEquals("groupA=DENY,groupB=PUB|SUB,groupC=SUB", UtilAll.join(list, comma));
         assertEquals(null, UtilAll.join(null, comma));
         List<String> objects = Collections.emptyList();
-        assertEquals("", UtilAll.join(objects, comma));
+        assertEquals(null, UtilAll.join(objects, comma));
     }
 
     static class DemoConfig {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #7662 

### Brief Description

org.apache.rocketmq.common.UtilAll#join return "" when list is empty, 
When I updateAccessConfig,  the method UtilAll.split(requestHeader.getGroupPerms(), ",")
Returns a collection of empty strings.
The method  org.apache.rocketmq.acl.common.Permission#checkResourcePerms will not running well.

### How Did You Test This Change?
yes, I updateAccessConfig successfully.