### PR TITLE
[ISSUE #7689] In Controller mode, messages may lost due to sharing the same cq offset

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -455,7 +455,7 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
         }
 
         // Correct unSubmit consumeOffset
-        if (messageStoreConfig.isDuplicationEnable()) {
+        if (messageStoreConfig.isDuplicationEnable() || messageStore.getBrokerConfig().isEnableControllerMode()) {
             SelectMappedBufferResult lastBuffer = null;
             long startReadOffset = messageStore.getCommitLog().getConfirmOffset() == -1 ? 0 : messageStore.getCommitLog().getConfirmOffset();
             while ((lastBuffer = messageStore.selectOneMessageByOffset(startReadOffset)) != null) {

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -496,7 +496,6 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
                 String key = msg.getTopic() + "-" + msg.getQueueId();
                 cqOffsetTable.put(key, msg.getQueueOffset() + 1);
                 startReadOffset += msg.getStoreSize();
-                log.info("Correcting. Key:{}, start read Offset: {}", key, startReadOffset);
             } finally {
                 if (lastBuffer != null)
                     lastBuffer.release();

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -444,7 +444,6 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
                 String key = logic.getTopic() + "-" + logic.getQueueId();
 
                 long maxOffsetInQueue = logic.getMaxOffsetInQueue();
-                log.info("Recover offset table, key: {}, maxOffsetInQueue:{}", key, maxOffsetInQueue);
                 if (Objects.equals(CQType.BatchCQ, logic.getCQType())) {
                     bcqOffsetTable.put(key, maxOffsetInQueue);
                 } else {
@@ -496,6 +495,7 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
                 String key = msg.getTopic() + "-" + msg.getQueueId();
                 cqOffsetTable.put(key, msg.getQueueOffset() + 1);
                 startReadOffset += msg.getStoreSize();
+                log.info("Correcting. Key:{}, start read Offset: {}", key, startReadOffset);
             } finally {
                 if (lastBuffer != null)
                     lastBuffer.release();

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -16,21 +16,6 @@
  */
 package org.apache.rocketmq.store.queue;
 
-import org.apache.rocketmq.common.BoundaryType;
-import org.apache.rocketmq.common.ThreadFactoryImpl;
-import org.apache.rocketmq.common.TopicConfig;
-import org.apache.rocketmq.common.attribute.CQType;
-import org.apache.rocketmq.common.message.MessageDecoder;
-import org.apache.rocketmq.common.message.MessageExt;
-import org.apache.rocketmq.common.topic.TopicValidator;
-import org.apache.rocketmq.common.utils.QueueTypeUtils;
-import org.apache.rocketmq.common.utils.ThreadUtils;
-import org.apache.rocketmq.store.CommitLog;
-import org.apache.rocketmq.store.ConsumeQueue;
-import org.apache.rocketmq.store.DefaultMessageStore;
-import org.apache.rocketmq.store.DispatchRequest;
-import org.apache.rocketmq.store.SelectMappedBufferResult;
-
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -48,6 +33,20 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.common.BoundaryType;
+import org.apache.rocketmq.common.ThreadFactoryImpl;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.common.attribute.CQType;
+import org.apache.rocketmq.common.message.MessageDecoder;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.topic.TopicValidator;
+import org.apache.rocketmq.common.utils.QueueTypeUtils;
+import org.apache.rocketmq.common.utils.ThreadUtils;
+import org.apache.rocketmq.store.CommitLog;
+import org.apache.rocketmq.store.ConsumeQueue;
+import org.apache.rocketmq.store.DefaultMessageStore;
+import org.apache.rocketmq.store.DispatchRequest;
+import org.apache.rocketmq.store.SelectMappedBufferResult;
 
 import static java.lang.String.format;
 import static org.apache.rocketmq.store.config.StorePathConfigHelper.getStorePathBatchConsumeQueue;

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -458,49 +458,51 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
 
         // Correct unSubmit consumeOffset
         if (messageStoreConfig.isDuplicationEnable() || messageStore.getBrokerConfig().isEnableControllerMode()) {
-            SelectMappedBufferResult lastBuffer = null;
-            long startReadOffset = messageStore.getCommitLog().getConfirmOffset() == -1 ? 0 : messageStore.getCommitLog().getConfirmOffset();
-            log.info("Correct unsubmitted offset...StartReadOffset = {}", startReadOffset);
-            while ((lastBuffer = messageStore.selectOneMessageByOffset(startReadOffset)) != null) {
-                try {
-                    if (lastBuffer.getStartOffset() > startReadOffset) {
-                        startReadOffset = lastBuffer.getStartOffset();
-                        continue;
-                    }
-
-                    ByteBuffer bb = lastBuffer.getByteBuffer();
-                    int magicCode = bb.getInt(bb.position() + 4);
-                    if (magicCode == CommitLog.BLANK_MAGIC_CODE) {
-                        startReadOffset += bb.getInt(bb.position());
-                        continue;
-                    } else if (magicCode != MessageDecoder.MESSAGE_MAGIC_CODE) {
-                        throw new RuntimeException("Unknown magicCode: " + magicCode);
-                    }
-
-                    lastBuffer.getByteBuffer().mark();
-                    DispatchRequest dispatchRequest = messageStore.getCommitLog().checkMessageAndReturnSize(lastBuffer.getByteBuffer(), true, true, true);
-                    if (!dispatchRequest.isSuccess())
-                        break;
-                    lastBuffer.getByteBuffer().reset();
-
-                    MessageExt msg = MessageDecoder.decode(lastBuffer.getByteBuffer(), true, false, false, false, true);
-                    if (msg == null)
-                        break;
-
-                    String key = msg.getTopic() + "-" + msg.getQueueId();
-                    cqOffsetTable.put(key, msg.getQueueOffset() + 1);
-                    startReadOffset += msg.getStoreSize();
-                    log.info("Correcting. Key:{}, start read Offset: {}", key, startReadOffset);
-                } finally {
-                    if (lastBuffer != null)
-                        lastBuffer.release();
-                }
-
-            }
+            compensateForHA(cqOffsetTable);
         }
 
         this.setTopicQueueTable(cqOffsetTable);
         this.setBatchTopicQueueTable(bcqOffsetTable);
+    }
+    private void compensateForHA(ConcurrentMap<String, Long> cqOffsetTable) {
+        SelectMappedBufferResult lastBuffer = null;
+        long startReadOffset = messageStore.getCommitLog().getConfirmOffset() == -1 ? 0 : messageStore.getCommitLog().getConfirmOffset();
+        log.info("Correct unsubmitted offset...StartReadOffset = {}", startReadOffset);
+        while ((lastBuffer = messageStore.selectOneMessageByOffset(startReadOffset)) != null) {
+            try {
+                if (lastBuffer.getStartOffset() > startReadOffset) {
+                    startReadOffset = lastBuffer.getStartOffset();
+                    continue;
+                }
+
+                ByteBuffer bb = lastBuffer.getByteBuffer();
+                int magicCode = bb.getInt(bb.position() + 4);
+                if (magicCode == CommitLog.BLANK_MAGIC_CODE) {
+                    startReadOffset += bb.getInt(bb.position());
+                    continue;
+                } else if (magicCode != MessageDecoder.MESSAGE_MAGIC_CODE) {
+                    throw new RuntimeException("Unknown magicCode: " + magicCode);
+                }
+
+                lastBuffer.getByteBuffer().mark();
+                DispatchRequest dispatchRequest = messageStore.getCommitLog().checkMessageAndReturnSize(lastBuffer.getByteBuffer(), true, messageStoreConfig.isDuplicationEnable(), true);
+                if (!dispatchRequest.isSuccess())
+                    break;
+                lastBuffer.getByteBuffer().reset();
+
+                MessageExt msg = MessageDecoder.decode(lastBuffer.getByteBuffer(), true, false, false, false, true);
+                if (msg == null)
+                    break;
+
+                String key = msg.getTopic() + "-" + msg.getQueueId();
+                cqOffsetTable.put(key, msg.getQueueOffset() + 1);
+                startReadOffset += msg.getStoreSize();
+                log.info("Correcting. Key:{}, start read Offset: {}", key, startReadOffset);
+            } finally {
+                if (lastBuffer != null)
+                    lastBuffer.release();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7689 

Upon restart, it is necessary to compensate for messages after the confirmOffset by moving the cq offset backwards. It must be ensured that these messages remain unconsumable before the confirmOffset is reached.

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
