### PR TITLE
[ISSUE #7702]Fix ascii check for ppv2 tls.

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
@@ -54,7 +54,7 @@ public class BinaryUtil {
             return false;
         }
         for (byte b : subject) {
-            if ((b & 0x80) != 0) {
+            if (b < 32 || b > 126) {
                 return false;
             }
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7702

### Brief Description

When parsing the PPV2 protocol and setting the TLS contents as gRPC attributes, gRPC will log the following messages. To avoid excessive logging, filter out content that does not conform to ASCII.

### How Did You Test This Change?

1. Open the ppv2 protocol
2. Send ppv2 message with tls data [61, 12, 109]
3. Check the log
