### PR TITLE
[ISSUE #7710] Handle blank string for UtilAll#split to fix the bugs of ACL

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
@@ -43,6 +43,7 @@ import java.util.function.Supplier;
 import java.util.zip.CRC32;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
+import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -679,6 +680,10 @@ public class UtilAll {
     public static List<String> split(String str, String splitter) {
         if (str == null) {
             return null;
+        }
+
+        if (StringUtils.isBlank(str)) {
+            return Collections.EMPTY_LIST;
         }
 
         String[] addrArray = str.split(splitter);

--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -142,6 +142,15 @@ public class UtilAllTest {
         assertEquals("", UtilAll.join(objects, comma));
     }
 
+    @Test
+    public void testSplit() {
+        List<String> list = Arrays.asList("groupA=DENY", "groupB=PUB|SUB", "groupC=SUB");
+        String comma = ",";
+        assertEquals(list, UtilAll.split("groupA=DENY,groupB=PUB|SUB,groupC=SUB", comma));
+        assertEquals(null, UtilAll.split(null, comma));
+        assertEquals(Collections.EMPTY_LIST, UtilAll.split("", comma));
+    }
+
     static class DemoConfig {
         private int demoWidth = 0;
         private int demoLength = 0;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7710

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

The PR is for a bug the ACL, which caused the problem of deleting the last item of the topic/group perms or the global white list.
The bug is due to the flaw of UtilAll#split func which didn't handle the blank string case properly.
So I've fixed it.
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

This change have been tested by unit test and the bug have been tested on local.
I've also searched the usages of the changed method globally.
I'm sure the bug has been fixed and has no influence on any other functions of the project.

![图片](https://github.com/apache/rocketmq/assets/29912051/814c9fbd-2979-4c50-bb42-d4330ca14fe8)
![图片](https://github.com/apache/rocketmq/assets/29912051/1ab76136-ee7b-4093-8bba-7c021fa11763)
