### PR TITLE
fix violation of Sonarqube rule java:S2111

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/CLusterSendMsgRTCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/CLusterSendMsgRTCommand.java
@@ -173,7 +173,7 @@ public class CLusterSendMsgRTCommand implements SubCommand {
                         } else {
                             System.out.printf("%s", String.format("%s|%s|%s|%s|%s%n", getCurTime(),
                                 machineRoom, clusterName, brokerName,
-                                new BigDecimal(rt).setScale(0, BigDecimal.ROUND_HALF_UP)));
+                                BigDecimal.valueOf(rt).setScale(0, BigDecimal.ROUND_HALF_UP)));
                         }
 
                     }


### PR DESCRIPTION
Hello,

This PR fixes 1 violation of Sonarqube Rule java:S2111 : ['"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111).
For more details, please see [CERT, NUM10-J.](https://wiki.sei.cmu.edu/confluence/x/kzdGBQ)

The patch was automatically generated using the ViolationFixer tool.