### PR TITLE
[ISSUE #7724] Fix revive incorrect message when the original message is not alive

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -525,6 +525,8 @@ public class PopReviveService extends ServiceThread {
             long msgOffset = popCheckPoint.ackOffsetByIndex((byte) j);
             CompletableFuture<Pair<Long, Boolean>> future = getBizMessage(popCheckPoint.getTopic(), msgOffset, popCheckPoint.getQueueId(), popCheckPoint.getBrokerName())
                 .thenApply(resultPair -> {
+                    // Handle getBizMessage result and revive message.
+                    // Return Pair<Long, Boolean>, the second represents the revival result, false means failure and rePutCK is needed.
                     GetMessageStatus getMessageStatus = resultPair.getObject1();
                     MessageExt message = resultPair.getObject2();
                     if (message == null) {

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -541,6 +541,12 @@ public class PopReviveService extends ServiceThread {
 
                         }
                     }
+                    // skip if message of the specified offset is not alive
+                    if (message.getQueueOffset() != msgOffset) {
+                        POP_LOGGER.warn("reviveQueueId={}, topic={}, returned msg offset is {}, required offset is {}, then continue",
+                            queueId, popCheckPoint.getTopic(), message.getQueueOffset(), msgOffset);
+                        return new Pair<>(msgOffset, true);
+                    }
                     //skip ck from last epoch
                     if (popCheckPoint.getPopTime() < message.getStoreTimestamp()) {
                         POP_LOGGER.warn("reviveQueueId={}, skip ck from last epoch {}", queueId, popCheckPoint);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7724

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Check the offset of got message before reviving it.
