### PR TITLE
Fix ppv2 tls ascii start with (byte)2

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
@@ -54,7 +54,7 @@ public class BinaryUtil {
             return false;
         }
         for (byte b : subject) {
-            if ((b & 0x80) != 0) {
+            if (b < 32 || b > 126) {
                 return false;
             }
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -41,6 +41,7 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactor
 import io.grpc.netty.shaded.io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.grpc.netty.shaded.io.netty.util.AsciiString;
 import io.grpc.netty.shaded.io.netty.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.constant.HAProxyConstants;
@@ -193,13 +194,13 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
                 }
                 if (CollectionUtils.isNotEmpty(msg.tlvs())) {
                     msg.tlvs().forEach(tlv -> {
-                        byte[] valueBytes = ByteBufUtil.getBytes(tlv.content());
-                        if (!BinaryUtil.isAscii(valueBytes)) {
-                            return;
-                        }
                         Attributes.Key<String> key = AttributeKeys.valueOf(
                                 HAProxyConstants.PROXY_PROTOCOL_TLV_PREFIX + String.format("%02x", tlv.typeByteValue()));
+                        byte[] valueBytes = ByteBufUtil.getBytes(tlv.content());
                         String value = StringUtils.trim(new String(valueBytes, CharsetUtil.UTF_8));
+                        if (!BinaryUtil.isAscii(value.getBytes(StandardCharsets.UTF_8))) {
+                            return;
+                        }
                         builder.set(key, value);
                     });
                 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -55,6 +55,7 @@ import io.netty.util.TimerTask;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.List;
@@ -794,13 +795,13 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                 }
                 if (CollectionUtils.isNotEmpty(msg.tlvs())) {
                     msg.tlvs().forEach(tlv -> {
+                        AttributeKey<String> key = AttributeKeys.valueOf(
+                            HAProxyConstants.PROXY_PROTOCOL_TLV_PREFIX + String.format("%02x", tlv.typeByteValue()));
                         byte[] valueBytes = ByteBufUtil.getBytes(tlv.content());
-                        if (!BinaryUtil.isAscii(valueBytes)) {
+                        String value = StringUtils.trim(new String(valueBytes, CharsetUtil.UTF_8));
+                        if (!BinaryUtil.isAscii(value.getBytes(StandardCharsets.UTF_8))) {
                             return;
                         }
-                        AttributeKey<String> key = AttributeKeys.valueOf(
-                                HAProxyConstants.PROXY_PROTOCOL_TLV_PREFIX + String.format("%02x", tlv.typeByteValue()));
-                        String value = StringUtils.trim(new String(valueBytes, CharsetUtil.UTF_8));
                         channel.attr(key).set(value);
                     });
                 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7752

### Brief Description
The tlvs value in ppv2 has the space character can not pass the ascii check.
So the value should be trims before the ascii check.

### How Did You Test This Change?

Send message with the byte value start with (byte)2, it will not be filtered.