### PR TITLE
[ISSUE #7774] Make the handle of ppv2 tlv more extendable 

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
@@ -54,7 +54,7 @@ public class BinaryUtil {
             return false;
         }
         for (byte b : subject) {
-            if ((b & 0x80) != 0) {
+            if (b < 32 || b > 126) {
                 return false;
             }
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
@@ -46,7 +46,7 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
     private final NettyServerConfig nettyServerConfig;
 
     private final RemotingProtocolHandler remotingProtocolHandler;
-    private final Http2ProtocolProxyHandler http2ProtocolProxyHandler;
+    protected Http2ProtocolProxyHandler http2ProtocolProxyHandler;
 
     public MultiProtocolRemotingServer(NettyServerConfig nettyServerConfig, ChannelEventListener channelEventListener) {
         super(nettyServerConfig, channelEventListener);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandler.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandler.java
@@ -121,15 +121,19 @@ public class Http2ProtocolProxyHandler implements ProtocolHandler {
         }
 
         final Channel outboundChannel = f.channel();
-        if (inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)) {
-            ctx.pipeline().addLast(new HAProxyMessageForwarder(outboundChannel));
-            outboundChannel.pipeline().addFirst(HAProxyMessageEncoder.INSTANCE);
-        }
+        configPipeline(inboundChannel, outboundChannel);
 
         SslHandler sslHandler = null;
         if (sslContext != null) {
             sslHandler = sslContext.newHandler(outboundChannel.alloc(), LOCAL_HOST, config.getGrpcServerPort());
         }
         ctx.pipeline().addLast(new Http2ProxyFrontendHandler(outboundChannel, sslHandler));
+    }
+
+    protected void configPipeline(Channel inboundChannel, Channel outboundChannel) {
+        if (inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)) {
+            inboundChannel.pipeline().addLast(new HAProxyMessageForwarder(outboundChannel));
+            outboundChannel.pipeline().addFirst(HAProxyMessageEncoder.INSTANCE);
+        }
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.rocketmq.proxy.grpc;
 
 import io.grpc.Attributes;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
@@ -1,0 +1,33 @@
+package org.apache.rocketmq.proxy.grpc;
+
+import io.grpc.Attributes;
+import io.grpc.netty.shaded.io.netty.buffer.ByteBuf;
+import io.grpc.netty.shaded.io.netty.buffer.Unpooled;
+import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyTLV;
+import java.nio.charset.StandardCharsets;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProxyAndTlsProtocolNegotiatorTest {
+
+    private ProxyAndTlsProtocolNegotiator negotiator;
+
+    @Before
+    public void setUp() throws Exception {
+        ConfigurationManager.intConfig();
+        ConfigurationManager.getProxyConfig().setTlsTestModeEnable(true);
+        negotiator = new ProxyAndTlsProtocolNegotiator();
+    }
+
+    @Test
+    public void handleHAProxyTLV() {
+        ByteBuf content = Unpooled.buffer();
+        content.writeBytes("xxxx".getBytes(StandardCharsets.UTF_8));
+        HAProxyTLV haProxyTLV = new HAProxyTLV((byte) 0xE1, content);
+        negotiator.handleHAProxyTLV(haProxyTLV, Attributes.newBuilder());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
@@ -1,0 +1,31 @@
+package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.haproxy.HAProxyTLV;
+import org.apache.commons.codec.DecoderException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HAProxyMessageForwarderTest {
+
+    private HAProxyMessageForwarder haProxyMessageForwarder;
+
+    @Mock
+    private Channel outboundChannel;
+
+    @Before
+    public void setUp() throws Exception {
+        haProxyMessageForwarder = new HAProxyMessageForwarder(outboundChannel);
+    }
+
+    @Test
+    public void buildHAProxyTLV() throws DecoderException {
+        HAProxyTLV haProxyTLV = haProxyMessageForwarder.buildHAProxyTLV("proxy_protocol_tlv_0xe1", "xxxx");
+        assert haProxyTLV != null;
+        assert haProxyTLV.typeByteValue() == (byte) 0xe1;
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
 
 import io.netty.channel.Channel;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
 
 import io.netty.channel.Channel;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2007 Mockito contributors
- * This program is made available under the terms of the MIT License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
@@ -1,0 +1,45 @@
+package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.haproxy.HAProxyMessageEncoder;
+import org.apache.rocketmq.remoting.netty.AttributeKeys;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Http2ProtocolProxyHandlerTest {
+
+    private Http2ProtocolProxyHandler http2ProtocolProxyHandler;
+    @Mock
+    private Channel inboundChannel;
+    @Mock
+    private ChannelPipeline inboundPipeline;
+    @Mock
+    private Channel outboundChannel;
+    @Mock
+    private ChannelPipeline outboundPipeline;
+
+    @Before
+    public void setUp() throws Exception {
+        http2ProtocolProxyHandler = new Http2ProtocolProxyHandler();
+    }
+
+    @Test
+    public void configPipeline() {
+        when(inboundChannel.hasAttr(eq(AttributeKeys.PROXY_PROTOCOL_ADDR))).thenReturn(true);
+        when(inboundChannel.pipeline()).thenReturn(inboundPipeline);
+        when(inboundPipeline.addLast(any(HAProxyMessageForwarder.class))).thenReturn(inboundPipeline);
+        when(outboundChannel.pipeline()).thenReturn(outboundPipeline);
+        when(outboundPipeline.addFirst(any(HAProxyMessageEncoder.class))).thenReturn(outboundPipeline);
+        http2ProtocolProxyHandler.configPipeline(inboundChannel, outboundChannel);
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -44,6 +44,7 @@ import io.netty.handler.codec.ProtocolDetectionState;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -55,7 +56,6 @@ import io.netty.util.TimerTask;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.List;
@@ -761,7 +761,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         }
     }
 
-    public static class HAProxyMessageHandler extends ChannelInboundHandlerAdapter {
+    public class HAProxyMessageHandler extends ChannelInboundHandlerAdapter {
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
@@ -795,19 +795,22 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                 }
                 if (CollectionUtils.isNotEmpty(msg.tlvs())) {
                     msg.tlvs().forEach(tlv -> {
-                        AttributeKey<String> key = AttributeKeys.valueOf(
-                            HAProxyConstants.PROXY_PROTOCOL_TLV_PREFIX + String.format("%02x", tlv.typeByteValue()));
-                        byte[] valueBytes = ByteBufUtil.getBytes(tlv.content());
-                        String value = StringUtils.trim(new String(valueBytes, CharsetUtil.UTF_8));
-                        if (!BinaryUtil.isAscii(value.getBytes(StandardCharsets.UTF_8))) {
-                            return;
-                        }
-                        channel.attr(key).set(value);
+                        handleHAProxyTLV(tlv, channel);
                     });
                 }
             } finally {
                 msg.release();
             }
         }
+    }
+
+    protected void handleHAProxyTLV(HAProxyTLV tlv, Channel channel) {
+        byte[] valueBytes = ByteBufUtil.getBytes(tlv.content());
+        if (!BinaryUtil.isAscii(valueBytes)) {
+            return;
+        }
+        AttributeKey<String> key = AttributeKeys.valueOf(
+            HAProxyConstants.PROXY_PROTOCOL_TLV_PREFIX + String.format("%02x", tlv.typeByteValue()));
+        channel.attr(key).set(new String(valueBytes, CharsetUtil.UTF_8));
     }
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.rocketmq.remoting.netty;
 
 import io.netty.buffer.ByteBuf;

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
@@ -1,0 +1,47 @@
+package org.apache.rocketmq.remoting.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.haproxy.HAProxyTLV;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NettyRemotingServerTest {
+
+    private NettyRemotingServer nettyRemotingServer;
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private Attribute attribute;
+
+    @Before
+    public void setUp() throws Exception {
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyRemotingServer = new NettyRemotingServer(nettyServerConfig);
+    }
+
+    @Test
+    public void handleHAProxyTLV() {
+        when(channel.attr(any(AttributeKey.class))).thenReturn(attribute);
+        doNothing().when(attribute).set(any());
+
+        ByteBuf content = Unpooled.buffer();
+        content.writeBytes("xxxx".getBytes(StandardCharsets.UTF_8));
+        HAProxyTLV haProxyTLV = new HAProxyTLV((byte) 0xE1, content);
+        nettyRemotingServer.handleHAProxyTLV(haProxyTLV, channel);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7774

### Brief Description

In the PPV2 protocol, TLV data is generally customized and needs to have the capability for extension.

### How Did You Test This Change?

customize the PPV2 TLV data, and extends the handler for data.