### PR TITLE
[ISSUE #7785] Remove the redundant code

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/common/ThreadLocalIndex.java
+++ b/client/src/main/java/org/apache/rocketmq/client/common/ThreadLocalIndex.java
@@ -35,9 +35,6 @@ public class ThreadLocalIndex {
 
     public void reset() {
         int index = Math.abs(random.nextInt(Integer.MAX_VALUE));
-        if (index < 0) {
-            index = 0;
-        }
         this.threadLocalIndex.set(index);
     }
 

--- a/client/src/test/java/org/apache/rocketmq/client/common/ThreadLocalIndexTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/common/ThreadLocalIndexTest.java
@@ -51,4 +51,11 @@ public class ThreadLocalIndexTest {
         assertThat(initialVal >= 0).isTrue();
     }
 
+    @Test
+    public void testResultOfResetIsGreaterThanOrEqualToZero() {
+        ThreadLocalIndex localIndex = new ThreadLocalIndex();
+        localIndex.reset();
+        assertThat(localIndex.incrementAndGet() > 0).isTrue();
+    }
+
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Remove the redundant code

Fixes #7785

### Brief Description

Remove the redundant code because Math.abs does not return negative numbers

### How Did You Test This Change?

```java
@Test
public void testResultOfResetIsGreaterThanOrEqualToZero() {
    ThreadLocalIndex localIndex = new ThreadLocalIndex();
    localIndex.reset();
    assertThat(localIndex.incrementAndGet() > 0).isTrue();
}
```
