### PR TITLE
[ISSUE #7786] Optimize the execution logic of tool.sh in the JRE environment

### DIFF
--- a/distribution/bin/tools.sh
+++ b/distribution/bin/tools.sh
@@ -26,12 +26,12 @@ error_exit ()
 
 find_java_home()
 {
+    if [ -n "$JAVA_HOME" ]; then
+        JAVA_HOME=$JAVA_HOME
+        return
+    fi
     case "`uname`" in
         Darwin)
-          if [ -n "$JAVA_HOME" ]; then
-              JAVA_HOME=$JAVA_HOME
-              return
-          fi
             JAVA_HOME=$(/usr/libexec/java_home)
         ;;
         *)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#7786](https://github.com/apache/rocketmq/issues/7786)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
修复了在jre环境下，mqadmin命令执行时，会报错JAVA_HOME未设置的错误！详情和复现，可以见 [#7786](https://github.com/apache/rocketmq/issues/7786)
报错信息：
```bash
readlink: missing operand
Try 'readlink --help' for more information.
dirname: missing operand
Try 'dirname --help' for more information.
dirname: missing operand
Try 'dirname --help' for more information.
ERROR: Please set the JAVA_HOME variable in your environment, We need java(x64)! !!
```

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
测试结果，可以见 [#7786](https://github.com/apache/rocketmq/issues/7786)

