### PR TITLE
[ISSUE #7801] fix:pull message first update offset fail

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumer.java
@@ -292,6 +292,10 @@ public class DefaultMQPullConsumer extends ClientConfig implements MQPullConsume
         return this.defaultMQPullConsumerImpl.fetchSubscribeMessageQueues(withNamespace(topic));
     }
 
+    public Set<MessageQueue> fetchSubscribeMessageQueues(String topic, String subExpression) throws MQClientException, InterruptedException {
+        return this.defaultMQPullConsumerImpl.fetchSubscribeMessageQueues(withNamespace(topic), subExpression);
+    }
+
     @Override
     public void start() throws MQClientException {
         this.setConsumerGroup(NamespaceUtil.wrapNamespace(this.getNamespace(), this.consumerGroup));

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -1388,4 +1388,8 @@ public class MQClientInstance {
         }
         return data;
     }
+
+    public ConcurrentMap<String, HashMap<Long, String>> getBrokerAddrTable() {
+        return brokerAddrTable;
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #7801

### Brief Description
The client will perform a doRebalance before submitting the offset for the first time.
offsetTable will be cleared.
If a consumer only submits a position once, the submission will always fail.

### How Did You Test This Change?
Add an overloaded method to complete doRebalance when fetchSubscribeMessageQueues


