### PR TITLE
[ISSUE #7801] fix:pull message first update offset fail

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumer.java
@@ -292,6 +292,10 @@ public class DefaultMQPullConsumer extends ClientConfig implements MQPullConsume
         return this.defaultMQPullConsumerImpl.fetchSubscribeMessageQueues(withNamespace(topic));
     }
 
+    public Set<MessageQueue> fetchSubscribeMessageQueues(String topic, String subExpression) throws MQClientException, InterruptedException {
+        return this.defaultMQPullConsumerImpl.fetchSubscribeMessageQueues(withNamespace(topic), subExpression);
+    }
+
     @Override
     public void start() throws MQClientException {
         this.setConsumerGroup(NamespaceUtil.wrapNamespace(this.getNamespace(), this.consumerGroup));

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPullConsumer.java
@@ -110,7 +110,7 @@ public class DefaultMQPullConsumer extends ClientConfig implements MQPullConsume
      * Constructor specifying namespace, consumer group and RPC hook.
      *
      * @param consumerGroup Consumer group.
-     * @param rpcHook RPC hook to execute before each remoting command.
+     * @param rpcHook       RPC hook to execute before each remoting command.
      */
     public DefaultMQPullConsumer(final String namespace, final String consumerGroup, RPCHook rpcHook) {
         this.namespace = namespace;
@@ -292,7 +292,8 @@ public class DefaultMQPullConsumer extends ClientConfig implements MQPullConsume
         return this.defaultMQPullConsumerImpl.fetchSubscribeMessageQueues(withNamespace(topic));
     }
 
-    public Set<MessageQueue> fetchSubscribeMessageQueues(String topic, String subExpression) throws MQClientException, InterruptedException {
+    public Set<MessageQueue> fetchSubscribeMessageQueues(String topic,
+        String subExpression) throws MQClientException, InterruptedException {
         return this.defaultMQPullConsumerImpl.fetchSubscribeMessageQueues(withNamespace(topic), subExpression);
     }
 

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -1388,4 +1388,8 @@ public class MQClientInstance {
         }
         return data;
     }
+
+    public ConcurrentMap<String, HashMap<Long, String>> getBrokerAddrTable() {
+        return brokerAddrTable;
+    }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -157,6 +157,7 @@ public class MQClientInstance {
         if (clientConfig.isEnableHeartbeatChannelEventListener()) {
             channelEventListener = new ChannelEventListener() {
                 private final ConcurrentMap<String, HashMap<Long, String>> brokerAddrTable = MQClientInstance.this.brokerAddrTable;
+
                 @Override
                 public void onChannelConnect(String remoteAddr, Channel channel) {
                 }

--- a/example/src/main/java/org/apache/rocketmq/example/simple/PullMessageOnce.java
+++ b/example/src/main/java/org/apache/rocketmq/example/simple/PullMessageOnce.java
@@ -34,15 +34,12 @@ public class PullMessageOnce {
         Set<MessageQueue> messageQueues = consumer.fetchSubscribeMessageQueues("PullTopicTest", "*");
         for (MessageQueue messageQueue : messageQueues) {
             long offset = consumer.fetchConsumeOffset(messageQueue, true);
-            System.out.println(offset);
             if (offset < 0) {
                 continue;
             }
             PullResult result = consumer.pull(messageQueue, "*", offset, 1, 3000);
-            System.out.println(result);
             long i = result.getNextBeginOffset();
             if (result.getPullStatus() == PullStatus.FOUND) {
-                System.out.println(i);
                 consumer.updateConsumeOffset(messageQueue, i);
             }
         }

--- a/example/src/main/java/org/apache/rocketmq/example/simple/PullMessageOnce.java
+++ b/example/src/main/java/org/apache/rocketmq/example/simple/PullMessageOnce.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.example.simple;
+
+import java.util.Set;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+
+public class PullMessageOnce {
+    public static void main(String[] args) throws MQClientException, MQBrokerException, RemotingException, InterruptedException {
+        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer("pullTopicTest_consumerGroup");
+        consumer.setNamesrvAddr("127.0.0.1:9876");
+        consumer.start();
+        Set<MessageQueue> messageQueues = consumer.fetchSubscribeMessageQueues("PullTopicTest", "*");
+        for (MessageQueue messageQueue : messageQueues) {
+            long offset = consumer.fetchConsumeOffset(messageQueue, true);
+            System.out.println(offset);
+            if (offset < 0) {
+                continue;
+            }
+            PullResult result = consumer.pull(messageQueue, "*", offset, 1, 3000);
+            System.out.println(result);
+            long i = result.getNextBeginOffset();
+            if (result.getPullStatus() == PullStatus.FOUND) {
+                System.out.println(i);
+                consumer.updateConsumeOffset(messageQueue, i);
+            }
+        }
+        // wait schedule update offset to broker
+        Thread.sleep(10000);
+        consumer.shutdown();
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Fixes #7801 

### Brief Description

The client will perform a doRebalance before submitting the offset for the first time.
offsetTable will be cleared.
If a consumer only submits a position once, the submission will always fail.

### How Did You Test This Change?

Add an overloaded method to complete doRebalance when fetchSubscribeMessageQueues
