### PR TITLE
[ISSUE #7813] setStartDetectorEnable Not effective

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -1810,4 +1810,8 @@ public class DefaultMQProducerImpl implements MQProducerInner {
     public DefaultMQProducer getDefaultMQProducer() {
         return defaultMQProducer;
     }
+
+    public MQFaultStrategy getMqFaultStrategy() {
+        return mqFaultStrategy;
+    }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -1366,4 +1366,10 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     public void setTopics(List<String> topics) {
         this.topics = topics;
     }
+
+    @Override
+    public void setStartDetectorEnable(boolean startDetectorEnable) {
+        super.setStartDetectorEnable(startDetectorEnable);
+        this.defaultMQProducerImpl.getMqFaultStrategy().setStartDetectorEnable(startDetectorEnable);
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7813

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

由于StartDetectorEnable 在构造函数里面只初始化了一次，所以后续再set的时候， 已经不会生效了。


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
