### PR TITLE
[ISSUE #7861] Allow user can change the tls mode to avoid init ssl context

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -98,22 +98,22 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
             } else if (proxyConfig.isTlsTestModeEnable()) {
                 SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
                 return GrpcSslContexts.forServer(selfSignedCertificate.certificate(),
-                        selfSignedCertificate.privateKey())
-                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                    .clientAuth(ClientAuth.NONE)
-                    .build();
+                                selfSignedCertificate.privateKey())
+                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                        .clientAuth(ClientAuth.NONE)
+                        .build();
             } else {
                 String tlsKeyPath = ConfigurationManager.getProxyConfig().getTlsKeyPath();
                 String tlsCertPath = ConfigurationManager.getProxyConfig().getTlsCertPath();
                 try (InputStream serverKeyInputStream = Files.newInputStream(
-                    Paths.get(tlsKeyPath));
+                        Paths.get(tlsKeyPath));
                      InputStream serverCertificateStream = Files.newInputStream(
-                         Paths.get(tlsCertPath))) {
+                             Paths.get(tlsCertPath))) {
                     SslContext res = GrpcSslContexts.forServer(serverCertificateStream,
-                            serverKeyInputStream)
-                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                        .clientAuth(ClientAuth.NONE)
-                        .build();
+                                    serverKeyInputStream)
+                            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                            .clientAuth(ClientAuth.NONE)
+                            .build();
                     log.info("grpc load TLS configured OK");
                     return res;
                 }
@@ -136,14 +136,14 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
             try {
                 ProtocolDetectionResult<HAProxyProtocolVersion> ha = HAProxyMessageDecoder.detectProtocol(
-                    in);
+                        in);
                 if (ha.state() == ProtocolDetectionState.NEEDS_MORE_DATA) {
                     return;
                 }
                 if (ha.state() == ProtocolDetectionState.DETECTED) {
                     ctx.pipeline().addAfter(ctx.name(), HA_PROXY_DECODER, new HAProxyMessageDecoder())
-                        .addAfter(HA_PROXY_DECODER, HA_PROXY_HANDLER, new HAProxyMessageHandler())
-                        .addAfter(HA_PROXY_HANDLER, TLS_MODE_HANDLER, new TlsModeHandler(grpcHandler));
+                            .addAfter(HA_PROXY_DECODER, HA_PROXY_HANDLER, new HAProxyMessageHandler())
+                            .addAfter(HA_PROXY_HANDLER, TLS_MODE_HANDLER, new TlsModeHandler(grpcHandler));
                 } else {
                     ctx.pipeline().addAfter(ctx.name(), TLS_MODE_HANDLER, new TlsModeHandler(grpcHandler));
                 }
@@ -197,7 +197,7 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
                     msg.tlvs().forEach(tlv -> handleHAProxyTLV(tlv, builder));
                 }
                 pne = InternalProtocolNegotiationEvent
-                    .withAttributes(InternalProtocolNegotiationEvent.getDefault(), builder.build());
+                        .withAttributes(InternalProtocolNegotiationEvent.getDefault(), builder.build());
             } finally {
                 msg.release();
             }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7861

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Allow user can change the tls mode to avoid init ssl context

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->


