### PR TITLE
[ISSUE #7958] Fix proxy always return the first broker in findOneBroker

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/metadata/ClusterMetadataService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/metadata/ClusterMetadataService.java
@@ -19,7 +19,9 @@ package org.apache.rocketmq.proxy.service.metadata;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
+import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +71,8 @@ public class ClusterMetadataService extends AbstractStartAndShutdown implements 
     protected final LoadingCache<String, Acl> aclCache;
 
     protected final static Acl EMPTY_ACL = new Acl();
+
+    protected final Random random = new Random();
 
 
     public ClusterMetadataService(TopicRouteService topicRouteService, MQClientAPIFactory mqClientAPIFactory) {
@@ -274,7 +278,9 @@ public class ClusterMetadataService extends AbstractStartAndShutdown implements 
 
     protected Optional<BrokerData> findOneBroker(String topic) throws Exception {
         try {
-            return topicRouteService.getAllMessageQueueView(ProxyContext.createForInner(this.getClass()), topic).getTopicRouteData().getBrokerDatas().stream().findAny();
+            List<BrokerData> brokerDatas = topicRouteService.getAllMessageQueueView(ProxyContext.createForInner(this.getClass()), topic).getTopicRouteData().getBrokerDatas();
+            int skipNum = random.nextInt(brokerDatas.size());
+            return brokerDatas.stream().skip(skipNum).findFirst();
         } catch (Exception e) {
             if (TopicRouteHelper.isTopicNotExistError(e)) {
                 return Optional.empty();

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/metadata/ClusterMetadataServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/metadata/ClusterMetadataServiceTest.java
@@ -18,10 +18,16 @@
 package org.apache.rocketmq.proxy.service.metadata;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.attribute.TopicMessageType;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.service.BaseServiceTest;
+import org.apache.rocketmq.proxy.service.route.MessageQueueView;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.statictopic.TopicConfigAndQueueMapping;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.junit.Before;
@@ -29,6 +35,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -37,6 +44,8 @@ import static org.mockito.Mockito.when;
 public class ClusterMetadataServiceTest extends BaseServiceTest {
 
     private ClusterMetadataService clusterMetadataService;
+
+    protected static final String BROKER2_ADDR = "127.0.0.2:10911";
 
     @Before
     public void before() throws Throwable {
@@ -51,6 +60,16 @@ public class ClusterMetadataServiceTest extends BaseServiceTest {
         when(this.mqClientAPIExt.getSubscriptionGroupConfig(anyString(), eq(GROUP), anyLong())).thenReturn(new SubscriptionGroupConfig());
 
         this.clusterMetadataService = new ClusterMetadataService(this.topicRouteService, this.mqClientAPIFactory);
+
+        BrokerData brokerData2 = new BrokerData();
+        brokerData2.setBrokerName("brokerName2");
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(MixAll.MASTER_ID, BROKER2_ADDR);
+        brokerData2.setBrokerAddrs(addrs);
+        brokerData2.setCluster(CLUSTER_NAME);
+        topicRouteData.getBrokerDatas().add(brokerData2);
+        when(this.topicRouteService.getAllMessageQueueView(any(), eq(TOPIC))).thenReturn(new MessageQueueView(CLUSTER_NAME, topicRouteData, null));
+
     }
 
     @Test
@@ -69,5 +88,23 @@ public class ClusterMetadataServiceTest extends BaseServiceTest {
         ProxyContext ctx = ProxyContext.create();
         assertNotNull(this.clusterMetadataService.getSubscriptionGroupConfig(ctx, GROUP));
         assertEquals(1, this.clusterMetadataService.subscriptionGroupConfigCache.asMap().size());
+    }
+
+    @Test
+    public void findOneBroker() {
+
+        Set<String> resultBrokerNames = new HashSet<>();
+        // run 1000 times to test the random
+        for (int i = 0; i < 1000; i++) {
+            Optional<BrokerData> brokerData = null;
+            try {
+                brokerData = this.clusterMetadataService.findOneBroker(TOPIC);
+                resultBrokerNames.add(brokerData.get().getBrokerName());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // we should choose two brokers
+        assertEquals(2, resultBrokerNames.size());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #7958

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

use test

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
