### PR TITLE
[ISSUE #7961] use BoundaryType in binarySearchInCQByTime

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/queue/RocksDBConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/RocksDBConsumeQueueStore.java
@@ -375,7 +375,8 @@ public class RocksDBConsumeQueueStore extends AbstractConsumeQueueStore {
         if (high == null || high == -1) {
             return 0;
         }
-        return this.rocksDBConsumeQueueTable.binarySearchInCQByTime(topic, queueId, high, low, timestamp, minPhysicOffset);
+        return this.rocksDBConsumeQueueTable.binarySearchInCQByTime(topic, queueId, high, low, timestamp,
+            minPhysicOffset, boundaryType);
     }
 
     @Override


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

[Enhancement] use BoundaryType in binarySearchInCQByTime #7961

### Brief Description
use BoundaryType in binarySearchInCQByTime instead of absolute value comparison.

When performing a range query, pass BoundaryType.LOWER to get the left boundary msg offset,  pass  BoundaryType.UPPER to get the right boundary msg offset

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
I wrote a test case, the timestamp 1711351134289 does not match an exact offset, when we call mqAdminExt.searchLowerBoundaryOffset(), it returns  the offset whose storeTime is the smallest storeTime that is greater than the target storeTime. When we call mqAdminExt.searchUpperBoundaryOffset(), it returns  the offset whose storeTime is the biggest storeTime that is smaller than the target storeTime.

```java
@Test
    public void searchOffsetTest() throws MQBrokerException, RemotingException, InterruptedException, MQClientException {
        TopicRouteData routeData = mqAdminExt.examineTopicRouteInfo("TopicTest");
        TopicStatsTable topicStatsTable = mqAdminExt.examineTopicStats("TopicTest");
        Map<MessageQueue, TopicOffset> queueMap = topicStatsTable.getOffsetTable();
        for (Map.Entry<MessageQueue, TopicOffset> entry : queueMap.entrySet()) {
            MessageQueue mq = entry.getKey();
            long offset_1 = mqAdminExt.searchLowerBoundaryOffset(mq, 1711351134289L);
            long offset_2 = mqAdminExt.searchUpperBoundaryOffset(mq, 1711351134289L);
            Assert.assertTrue(offset_1 != offset_2);
            Assert.assertTrue(offset_1 == offset_2 + 1);
        }
    }
```