### PR TITLE
[ISSUE #7979]Fix timerWheel message metric

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -760,6 +760,7 @@ public class TimerMessageStore {
             timerWheel.putSlot(delayedTime, slot.firstPos == -1 ? ret : slot.firstPos, ret,
                 isDelete ? slot.num - 1 : slot.num + 1, slot.magic);
             if(isDelete){
+                //Reduce the time range affected by the deletion failure
                 if(!needRoll) {
                     addMetric(messageExt, -1);
                 }
@@ -1562,6 +1563,7 @@ public class TimerMessageStore {
                             if (null != msgExt) {
                                 if (needDelete(tr.getMagic()) && !needRoll(tr.getMagic())) {
                                     if (msgExt.getProperty(MessageConst.PROPERTY_TIMER_DEL_UNIQKEY) != null && tr.getDeleteList() != null) {
+                                        //Execute metric plus one for messages that fail to be deleted
                                         addMetric(msgExt, 1);
                                         tr.getDeleteList().add(msgExt.getProperty(MessageConst.PROPERTY_TIMER_DEL_UNIQKEY));
                                     }
@@ -1573,6 +1575,7 @@ public class TimerMessageStore {
                                         LOGGER.warn("No uniqueKey for msg:{}", msgExt);
                                     }
                                     if (null != uniqueKey && tr.getDeleteList() != null && tr.getDeleteList().size() > 0 && tr.getDeleteList().contains(uniqueKey)) {
+                                        //Normally, it cancels out with the +1 above
                                         addMetric(msgExt, -1);
                                         doRes = true;
                                         tr.idempotentRelease();

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -759,7 +759,13 @@ public class TimerMessageStore {
             // TODO: check if the delete msg is in the same slot with "the msg to be deleted".
             timerWheel.putSlot(delayedTime, slot.firstPos == -1 ? ret : slot.firstPos, ret,
                 isDelete ? slot.num - 1 : slot.num + 1, slot.magic);
-            addMetric(messageExt, isDelete ? -1 : 1);
+            if(isDelete){
+                if(!needRoll) {
+                    addMetric(messageExt, -1);
+                }
+            }else {
+                addMetric(messageExt, 1);
+            }
         }
         return -1 != ret;
     }
@@ -1556,6 +1562,7 @@ public class TimerMessageStore {
                             if (null != msgExt) {
                                 if (needDelete(tr.getMagic()) && !needRoll(tr.getMagic())) {
                                     if (msgExt.getProperty(MessageConst.PROPERTY_TIMER_DEL_UNIQKEY) != null && tr.getDeleteList() != null) {
+                                        addMetric(msgExt,1);
                                         tr.getDeleteList().add(msgExt.getProperty(MessageConst.PROPERTY_TIMER_DEL_UNIQKEY));
                                     }
                                     tr.idempotentRelease();
@@ -1566,6 +1573,7 @@ public class TimerMessageStore {
                                         LOGGER.warn("No uniqueKey for msg:{}", msgExt);
                                     }
                                     if (null != uniqueKey && tr.getDeleteList() != null && tr.getDeleteList().size() > 0 && tr.getDeleteList().contains(uniqueKey)) {
+                                        addMetric(msgExt,-1);
                                         doRes = true;
                                         tr.idempotentRelease();
                                         perfCounterTicks.getCounter("dequeue_delete").flow(1);

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -1562,7 +1562,7 @@ public class TimerMessageStore {
                             if (null != msgExt) {
                                 if (needDelete(tr.getMagic()) && !needRoll(tr.getMagic())) {
                                     if (msgExt.getProperty(MessageConst.PROPERTY_TIMER_DEL_UNIQKEY) != null && tr.getDeleteList() != null) {
-                                        addMetric(msgExt,1);
+                                        addMetric(msgExt, 1);
                                         tr.getDeleteList().add(msgExt.getProperty(MessageConst.PROPERTY_TIMER_DEL_UNIQKEY));
                                     }
                                     tr.idempotentRelease();
@@ -1573,7 +1573,7 @@ public class TimerMessageStore {
                                         LOGGER.warn("No uniqueKey for msg:{}", msgExt);
                                     }
                                     if (null != uniqueKey && tr.getDeleteList() != null && tr.getDeleteList().size() > 0 && tr.getDeleteList().contains(uniqueKey)) {
-                                        addMetric(msgExt,-1);
+                                        addMetric(msgExt, -1);
                                         doRes = true;
                                         tr.idempotentRelease();
                                         perfCounterTicks.getCounter("dequeue_delete").flow(1);

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -759,14 +759,7 @@ public class TimerMessageStore {
             // TODO: check if the delete msg is in the same slot with "the msg to be deleted".
             timerWheel.putSlot(delayedTime, slot.firstPos == -1 ? ret : slot.firstPos, ret,
                 isDelete ? slot.num - 1 : slot.num + 1, slot.magic);
-            if(isDelete){
-                //Reduce the time range affected by the deletion failure
-                if(!needRoll) {
-                    addMetric(messageExt, -1);
-                }
-            }else {
-                addMetric(messageExt, 1);
-            }
+            addMetric(messageExt, isDelete ? -1 : 1);
         }
         return -1 != ret;
     }


### PR DESCRIPTION
In normal cases, the number of messages of the deletion type is equal to the number of messages that should be deleted. When out of queue, add one for the deletion type and subtract one for the message that should be deleted. This ensures that the metric is accurate when deletion fails