### PR TITLE
[ISSUE #8007]fix abnormally recover index file

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
@@ -59,6 +59,8 @@ public class IndexService {
         File dir = new File(this.storePath);
         File[] files = dir.listFiles();
         if (files != null) {
+            //retain the first file that need deleted
+            boolean isNeedDeleteFirst = false;
             // ascending order
             Arrays.sort(files);
             for (File file : files) {
@@ -68,9 +70,19 @@ public class IndexService {
 
                     if (!lastExitOK) {
                         if (f.getEndTimestamp() > this.defaultMessageStore.getStoreCheckpoint()
-                            .getIndexMsgTimestamp()) {
-                            f.destroy(0);
-                            continue;
+                                .getIndexMsgTimestamp()) {
+
+                            if (isNeedDeleteFirst) {
+                                f.destroy(0);
+                                continue;
+                            } else {
+                                if (!f.putKey()) {
+                                    f.destroy(0);
+                                    continue;
+                                }
+                                isNeedDeleteFirst = true;
+                            }
+
                         }
                     }
 


### PR DESCRIPTION
Avoid crashes and retain the last file and switch new file to putkey.
Add a linked list correct scan check to prevent endless loops caused by file corruption, when an error is checked, messages before this message will be discarded, and set the preIndexNo of this message to -1