### PR TITLE
fix:When modifying the recepteMessage pull message, if the client con…

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -60,6 +60,10 @@ public class ReceiveMessageActivity extends AbstractMessingActivity {
 
         try {
             Settings settings = this.grpcClientSettingsManager.getClientSettings(ctx);
+            if (settings == null) {
+                writer.writeAndComplete(ctx, Code.UNRECOGNIZED_CLIENT_TYPE, "cannot find client settings for this client");
+                return;
+            }
             Subscription subscription = settings.getSubscription();
             boolean fifo = subscription.getFifo();
             int maxAttempts = settings.getBackoffPolicy().getMaxAttempts();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
﻿
When modifying the recepteMessage pull message, if the client configuration fails to be obtained, the null pointer exception will not be returned, but more detailed information will be provided
﻿
Fixes #8028
﻿
### Brief Description
I want to refer to the client's heartbeat method to determine if it is empty and return Code Unrecognized_CLIENT-TYPE, "cannot find client settings for this client"
﻿
### How Did You Test This Change?
Immediately pull messages after creating consumers