### PR TITLE
[ISSUE #8017] fix: fix tiered store PosixFileSegment memory leak

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
@@ -210,6 +210,14 @@ public class MessageStoreConfig {
         this.tieredStoreConsumeQueueMaxSize = tieredStoreConsumeQueueMaxSize;
     }
 
+    public int getTieredStoreOriginalIndexFileMaxSize() {
+        return 28 + 8 * tieredStoreIndexFileMaxHashSlotNum + 32 * tieredStoreIndexFileMaxIndexNum;
+    }
+
+    public int getTieredStoreCompactedIndexFileMaxSize() {
+        return 28 + 8 * tieredStoreIndexFileMaxHashSlotNum + 28 * tieredStoreIndexFileMaxIndexNum;
+    }
+
     public int getTieredStoreIndexFileMaxHashSlotNum() {
         return tieredStoreIndexFileMaxHashSlotNum;
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/FileSegmentType.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/FileSegmentType.java
@@ -24,7 +24,9 @@ public enum FileSegmentType {
 
     CONSUME_QUEUE(1),
 
-    INDEX(2);
+    INDEX(2),
+
+    INDEX_COMPACTED(3);
 
     private final int code;
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
@@ -71,7 +71,8 @@ public class FlatAppendFile {
     }
 
     public void recoverFileSize() {
-        if (fileSegmentTable.isEmpty() || FileSegmentType.INDEX.equals(fileType)) {
+        if (fileSegmentTable.isEmpty() ||
+            FileSegmentType.INDEX.equals(fileType) || FileSegmentType.INDEX_COMPACTED.equals(fileType)) {
             return;
         }
         FileSegment fileSegment = fileSegmentTable.get(fileSegmentTable.size() - 1);

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatFileFactory.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatFileFactory.java
@@ -53,4 +53,8 @@ public class FlatFileFactory {
     public FlatAppendFile createFlatFileForIndexFile(String filePath) {
         return new FlatAppendFile(this.fileSegmentFactory, FileSegmentType.INDEX, filePath);
     }
+
+    public FlatAppendFile createFlatFileForCompactedIndexFile(String filePath) {
+        return new FlatAppendFile(this.fileSegmentFactory, FileSegmentType.INDEX_COMPACTED, filePath);
+    }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -420,7 +420,7 @@ public class IndexStoreFile implements IndexFile {
         byte[] payload = new byte[IndexItem.INDEX_ITEM_SIZE];
         ByteBuffer payloadBuffer = ByteBuffer.wrap(payload);
         int writePosition = INDEX_HEADER_SIZE + (hashSlotMaxCount * HASH_SLOT_SIZE);
-        int fileMaxLength = writePosition + COMPACT_INDEX_ITEM_SIZE * indexItemCount.get();
+        int fileMaxLength = writePosition + COMPACT_INDEX_ITEM_SIZE * indexItemMaxCount;
 
         compactMappedFile = new DefaultMappedFile(this.getCompactedFilePath(), fileMaxLength);
         MappedByteBuffer newBuffer = compactMappedFile.getMappedByteBuffer();
@@ -454,6 +454,7 @@ public class IndexStoreFile implements IndexFile {
 
         this.flushNewMetadata(newBuffer, true);
         newBuffer.flip();
+        newBuffer.limit(fileMaxLength);
         return newBuffer;
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
@@ -139,7 +139,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
         this.setCompactTimestamp(this.timeStoreTable.firstKey() - 1);
 
         // recover remote
-        this.flatAppendFile = fileAllocator.createFlatFileForIndexFile(filePath);
+        this.flatAppendFile = fileAllocator.createFlatFileForCompactedIndexFile(filePath);
 
         for (FileSegment fileSegment : flatAppendFile.getFileSegmentList()) {
             IndexFile indexFile = new IndexStoreFile(storeConfig, fileSegment);

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
@@ -211,6 +211,7 @@ public class DefaultMetadataStore extends ConfigManager implements MetadataStore
             case CONSUME_QUEUE:
                 return consumeQueueFileSegmentTable;
             case INDEX:
+            case INDEX_COMPACTED:
                 return indexFileSegmentTable;
         }
         return new HashMap<>();

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
@@ -114,6 +114,9 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
             case CONSUME_QUEUE:
                 return storeConfig.getTieredStoreConsumeQueueMaxSize();
             case INDEX:
+                return storeConfig.getTieredStoreOriginalIndexFileMaxSize();
+            case INDEX_COMPACTED:
+                return storeConfig.getTieredStoreCompactedIndexFileMaxSize();
             default:
                 return Long.MAX_VALUE;
         }
@@ -250,7 +253,7 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
                 fileType, this.getCommitOffset(), bufferList, null, bufferSize);
         }
 
-        boolean append = fileType != FileSegmentType.INDEX;
+        boolean append = fileType != FileSegmentType.INDEX && fileType != FileSegmentType.INDEX_COMPACTED;
         return flightCommitRequest =
             this.commit0(fileSegmentInputStream, commitPosition, bufferSize, append)
                 .thenApply(result -> {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/stream/FileSegmentInputStreamFactory.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/stream/FileSegmentInputStreamFactory.java
@@ -36,6 +36,7 @@ public class FileSegmentInputStreamFactory {
             case CONSUME_QUEUE:
                 return new FileSegmentInputStream(fileType, bufferList, length);
             case INDEX:
+            case INDEX_COMPACTED:
                 if (bufferList.size() != 1) {
                     throw new IllegalArgumentException("buffer block size must be 1 when file type is IndexFile");
                 }

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreFileTest.java
@@ -219,7 +219,7 @@ public class IndexStoreFileTest {
 
         ByteBuffer byteBuffer = indexStoreFile.doCompaction();
         FileSegment fileSegment = new PosixFileSegment(
-            storeConfig, FileSegmentType.INDEX, filePath, 0L);
+            storeConfig, FileSegmentType.INDEX_COMPACTED, filePath, 0L);
         fileSegment.append(byteBuffer, timestamp);
         fileSegment.commitAsync().join();
         Assert.assertEquals(byteBuffer.limit(), fileSegment.getSize());
@@ -252,7 +252,7 @@ public class IndexStoreFileTest {
 
         ByteBuffer byteBuffer = indexStoreFile.doCompaction();
         FileSegment fileSegment = new PosixFileSegment(
-            storeConfig, FileSegmentType.INDEX, filePath, 0L);
+            storeConfig, FileSegmentType.INDEX_COMPACTED, filePath, 0L);
         fileSegment.append(byteBuffer, timestamp);
         fileSegment.commitAsync().join();
         Assert.assertEquals(byteBuffer.limit(), fileSegment.getSize());

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/FileSegmentTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/provider/FileSegmentTest.java
@@ -127,7 +127,12 @@ public class FileSegmentTest {
 
         fileSegment = new PosixFileSegment(
             storeConfig, FileSegmentType.INDEX, MessageStoreUtil.toFilePath(mq), 100L);
-        Assert.assertEquals(Long.MAX_VALUE, fileSegment.getMaxSize());
+        Assert.assertEquals(storeConfig.getTieredStoreOriginalIndexFileMaxSize(), fileSegment.getMaxSize());
+        fileSegment.destroyFile();
+
+        fileSegment = new PosixFileSegment(
+                storeConfig, FileSegmentType.INDEX_COMPACTED, MessageStoreUtil.toFilePath(mq), 100L);
+        Assert.assertEquals(storeConfig.getTieredStoreCompactedIndexFileMaxSize(), fileSegment.getMaxSize());
         fileSegment.destroyFile();
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8017 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
- Using `MappedByteBuffer` in `PosixFileSegment` instead of `FileChannel.write()` or `FileChannel.read()` functions; avoiding `FileChannel.transferFrom` as it has been tested to perform poorly.

### How Did You Test This Change?
See #8017 
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
