### PR TITLE
[ISSUE #8055]remove unnecessary math.abs() method

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
@@ -83,7 +83,7 @@ public class TopicPublishInfo {
 
         if (filter != null && filter.length != 0) {
             for (int i = 0; i < messageQueueList.size(); i++) {
-                int index = Math.abs(sendQueue.incrementAndGet() % messageQueueList.size());
+                int index = sendQueue.incrementAndGet() % messageQueueList.size();
                 MessageQueue mq = messageQueueList.get(index);
                 boolean filterResult = true;
                 for (QueueFilter f: filter) {
@@ -98,7 +98,7 @@ public class TopicPublishInfo {
             return null;
         }
 
-        int index = Math.abs(sendQueue.incrementAndGet() % messageQueueList.size());
+        int index = sendQueue.incrementAndGet() % messageQueueList.size();
         return messageQueueList.get(index);
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### remove unnecessary math.abs() method in TopicPublishInfo#selectOneMessageQueue

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8055

### remove unnecessary math.abs() method in TopicPublishInfo#selectOneMessageQueue

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
In the ThreadLocalIndexTest class, there are already some test that the return value of the incrementAndGet method must be a positive number.
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
