### PR TITLE
[ISSUE #8059] Fix some typos in DefaultLitePullConsumer and LitePullConsumer

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumer.java
@@ -276,8 +276,8 @@ public class DefaultLitePullConsumer extends ClientConfig implements LitePullCon
     }
 
     @Override
-    public void setSubExpressionForAssign(final String topic, final String subExpresion) {
-        defaultLitePullConsumerImpl.setSubExpressionForAssign(withNamespace(topic), subExpresion);
+    public void setSubExpressionForAssign(final String topic, final String subExpression) {
+        defaultLitePullConsumerImpl.setSubExpressionForAssign(withNamespace(topic), subExpression);
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/LitePullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/LitePullConsumer.java
@@ -223,7 +223,7 @@ public interface LitePullConsumer {
      * Manually commit consume offset saved by the system.
      *
      * @param messageQueues Message queues that need to submit consumer offset
-     * @param persist hether to persist to the broker
+     * @param persist whether to persist to the broker
      */
     void commit(final Set<MessageQueue> messageQueues, boolean persist);
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
Fixes https://github.com/apache/rocketmq/issues/8059 

### Brief Description
Fix some typos:
`subExpresion` => `subExpression`
`hether` => `whether`


