### PR TITLE
[ISSUE #8062] feat: Add virtual thread support for consumers

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java
@@ -52,6 +52,8 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 
 public class ConsumeMessagePopConcurrentlyService implements ConsumeMessageService {
     private static final Logger log = LoggerFactory.getLogger(ConsumeMessagePopConcurrentlyService.class);
+    private static final boolean PREFER_VIRTUAL = Boolean.parseBoolean(
+        System.getProperty("rocketmq.client.consumer.virtualThread", "false"));
     private final DefaultMQPushConsumerImpl defaultMQPushConsumerImpl;
     private final DefaultMQPushConsumer defaultMQPushConsumer;
     private final MessageListenerConcurrently messageListener;
@@ -76,7 +78,7 @@ public class ConsumeMessagePopConcurrentlyService implements ConsumeMessageServi
             1000 * 60,
             TimeUnit.MILLISECONDS,
             this.consumeRequestQueue,
-            new ThreadFactoryImpl("ConsumeMessageThread_"));
+            new ThreadFactoryImpl("ConsumeMessageThread_", false, null, PREFER_VIRTUAL));
 
         this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryImpl("ConsumeMessageScheduledThread_"));
     }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopOrderlyService.java
@@ -49,6 +49,8 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 
 public class ConsumeMessagePopOrderlyService implements ConsumeMessageService {
     private static final Logger log = LoggerFactory.getLogger(ConsumeMessagePopOrderlyService.class);
+    private static final boolean PREFER_VIRTUAL = Boolean.parseBoolean(
+        System.getProperty("rocketmq.client.consumer.virtualThread", "false"));
     private final DefaultMQPushConsumerImpl defaultMQPushConsumerImpl;
     private final DefaultMQPushConsumer defaultMQPushConsumer;
     private final MessageListenerOrderly messageListener;
@@ -76,7 +78,7 @@ public class ConsumeMessagePopOrderlyService implements ConsumeMessageService {
             1000 * 60,
             TimeUnit.MILLISECONDS,
             this.consumeRequestQueue,
-            new ThreadFactoryImpl("ConsumeMessageThread_"));
+            new ThreadFactoryImpl("ConsumeMessageThread_", false, null, PREFER_VIRTUAL));
 
         this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryImpl("ConsumeMessageScheduledThread_"));
     }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyServiceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyServiceTest.java
@@ -56,6 +56,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -200,6 +201,16 @@ public class ConsumeMessageOrderlyServiceTest {
 
     @Test
     public void testConsumeThreadName() throws Exception {
+        testConsumeThreadName0();
+        System.setProperty("rocketmq.client.consumer.virtualThread", "true");
+        try {
+            testConsumeThreadName0();
+        } finally {
+            System.clearProperty("rocketmq.client.consumer.virtualThread");
+        }
+    }
+
+    private void testConsumeThreadName0() throws Exception {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         final AtomicReference<String> consumeThreadName = new AtomicReference<>();
 
@@ -228,6 +239,19 @@ public class ConsumeMessageOrderlyServiceTest {
             assertThat(consumeThreadName.get()).startsWith("ConsumeMessageThread_" + consumeGroup2 + "_");
         } else {
             assertThat(consumeThreadName.get()).startsWith("ConsumeMessageThread_" + consumeGroup2.substring(0, 100) + "_");
+        }
+    }
+
+    @Test
+    public void testPreferVirtualConfig() {
+        assertFalse(Boolean.parseBoolean(
+            System.getProperty("rocketmq.client.consumer.virtualThread", "false")));
+        System.setProperty("rocketmq.client.consumer.virtualThread", "true");
+        try {
+            assertTrue(Boolean.parseBoolean(
+                System.getProperty("rocketmq.client.consumer.virtualThread", "false")));
+        } finally {
+            System.clearProperty("rocketmq.client.consumer.virtualThread");
         }
     }
 

--- a/common/src/main/java/org/apache/rocketmq/common/utils/VirtualThreadFactorySupport.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/VirtualThreadFactorySupport.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.utils;
+
+
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+
+public abstract class VirtualThreadFactorySupport {
+    private static final Logger logger = LoggerFactory.getLogger(VirtualThreadFactorySupport.class);
+
+    /**
+     * Create a virtual thread factory, returns null when failed.
+     */
+    public static final ThreadFactory create(final String prefix) {
+        try {
+            final Class<?> builderClass = ClassLoader.getSystemClassLoader()
+                .loadClass("java.lang.Thread$Builder");
+            final Class<?> ofVirtualClass = ClassLoader.getSystemClassLoader()
+                .loadClass("java.lang.Thread$Builder$OfVirtual");
+
+            final MethodHandles.Lookup lookup = MethodHandles.lookup();
+            final MethodHandle ofVirtualMethod = lookup.findStatic(
+                Thread.class, "ofVirtual", MethodType.methodType(ofVirtualClass));
+            Object builder = ofVirtualMethod.invoke();
+            final MethodHandle nameMethod = lookup.findVirtual(
+                ofVirtualClass, "name",
+                MethodType.methodType(ofVirtualClass, String.class, long.class));
+            final MethodHandle factoryMethod = lookup.findVirtual(
+                builderClass, "factory",
+                MethodType.methodType(ThreadFactory.class));
+            builder = nameMethod.invoke(builder, prefix + "-virtual-thread-", 0L);
+            final ThreadFactory threadFactory = (ThreadFactory) factoryMethod.invoke(builder);
+            return runnable -> {
+                Objects.requireNonNull(runnable, "Runnable is null");
+                final Thread thread = threadFactory.newThread(runnable);
+                thread.setUncaughtExceptionHandler((t, e) -> {
+                    logger.error("Uncaught exception in virtual thread,prefix:{}", prefix, e);
+                });
+                return thread;
+            };
+        } catch (Throwable e) {
+            logger.error("Create virtual thread factory failed", e);
+            return null;
+        }
+    }
+}

--- a/common/src/test/java/org/apache/rocketmq/common/utils/VirtualThreadFactorySupportTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/VirtualThreadFactorySupportTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.ThreadFactory;
+
+public class VirtualThreadFactorySupportTest {
+    @Test
+    public void testVirtualThreadEnabled() {
+        final ThreadFactory threadFactory = VirtualThreadFactorySupport.create("test");
+        if (getMajorJavaVersion() >= 21) {
+            Assert.assertNotNull(threadFactory);
+            final Thread thread = threadFactory.newThread(() -> {
+                //NOOP
+            });
+            Assert.assertNotNull(thread);
+            Assert.assertEquals("VirtualThread", thread.getClass().getSimpleName());
+        } else {
+            Assert.assertNull(threadFactory);
+        }
+    }
+
+    private static int getMajorJavaVersion() {
+        final String version = System.getProperty("java.specification.version");
+        if (version.indexOf('.') > 0) {
+            try {
+                final String[] parts = version.split("[._]");
+                int first = Integer.parseInt(parts[0]);
+                if (first == 1 && parts.length > 1) {
+                    return Integer.parseInt(parts[1]);
+                } else {
+                    return first;
+                }
+            } catch (Exception e) {
+                return -1;
+            }
+        }
+        return Integer.parseInt(version);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes


Fixes https://github.com/apache/rocketmq/issues/8062

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

1. Add config for preferring the virtual thread, `"rocketmq.client.consumer.virtualThread"` default to `false`
2. When config is `true` and the Virtual thread is enabled, Make use of the virtual thread.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
with unit tests