### PR TITLE
[ISSUE #8077] Optimize message queue write selector used by proxy

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueView.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueView.java
@@ -24,14 +24,14 @@ public class MessageQueueView {
     public static final MessageQueueView WRAPPED_EMPTY_QUEUE = new MessageQueueView("", new TopicRouteData(), null);
 
     private final MessageQueueSelector readSelector;
-    private final MessageQueueSelector writeSelector;
+    private final MessageQueueWriteSelector writeSelector;
     private final TopicRouteWrapper topicRouteWrapper;
 
     public MessageQueueView(String topic, TopicRouteData topicRouteData, MQFaultStrategy mqFaultStrategy) {
         this.topicRouteWrapper = new TopicRouteWrapper(topicRouteData, topic);
 
         this.readSelector = new MessageQueueSelector(topicRouteWrapper, mqFaultStrategy, true);
-        this.writeSelector = new MessageQueueSelector(topicRouteWrapper, mqFaultStrategy, false);
+        this.writeSelector = new MessageQueueWriteSelector(topicRouteWrapper, mqFaultStrategy);
     }
 
     public TopicRouteData getTopicRouteData() {
@@ -54,7 +54,7 @@ public class MessageQueueView {
         return readSelector;
     }
 
-    public MessageQueueSelector getWriteSelector() {
+    public MessageQueueWriteSelector getWriteSelector() {
         return writeSelector;
     }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueWriteSelector.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueWriteSelector.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.route;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.math.IntMath;
+import java.util.List;
+import org.apache.rocketmq.client.common.ThreadLocalIndex;
+import org.apache.rocketmq.client.impl.producer.TopicPublishInfo;
+import org.apache.rocketmq.client.latency.MQFaultStrategy;
+
+public class MessageQueueWriteSelector extends MessageQueueSelector {
+    private final ThreadLocalIndex brokerIndex;
+    private final ThreadLocalIndex queueIndex;
+
+    public MessageQueueWriteSelector(TopicRouteWrapper topicRouteWrapper, MQFaultStrategy mqFaultStrategy) {
+        super(topicRouteWrapper, mqFaultStrategy, false);
+        brokerIndex = new ThreadLocalIndex();
+        queueIndex = new ThreadLocalIndex();
+    }
+
+    @Override
+    public AddressableMessageQueue selectOne(boolean onlyBroker) {
+        int nextIndex = onlyBroker ? brokerIndex.incrementAndGet() : queueIndex.incrementAndGet();
+        return selectOneByIndex(nextIndex, onlyBroker);
+    }
+
+    public AddressableMessageQueue selectOneByPipeline(boolean onlyBroker) {
+        if (mqFaultStrategy != null && mqFaultStrategy.isSendLatencyFaultEnable()) {
+            List<AddressableMessageQueue> addressableMessageQueueList = onlyBroker ? brokerActingQueues : queues;
+            ThreadLocalIndex index = onlyBroker ? brokerIndex : queueIndex;
+
+            AddressableMessageQueue addressableMessageQueue;
+
+            // use available and reachable filters.
+            addressableMessageQueue = selectOneMessageQueue(addressableMessageQueueList, index,
+                mqFaultStrategy.getAvailableFilter(), mqFaultStrategy.getReachableFilter());
+            if (addressableMessageQueue != null) {
+                return addressableMessageQueue;
+            }
+
+            // use available filter.
+            addressableMessageQueue = selectOneMessageQueue(addressableMessageQueueList, index,
+                mqFaultStrategy.getAvailableFilter());
+            if (addressableMessageQueue != null) {
+                return addressableMessageQueue;
+            }
+
+            // no available filter, then use reachable filter.
+            addressableMessageQueue = selectOneMessageQueue(addressableMessageQueueList, index,
+                mqFaultStrategy.getReachableFilter());
+            if (addressableMessageQueue != null) {
+                return addressableMessageQueue;
+            }
+        }
+
+        // SendLatency is not enabled, or no queue is selected, then select by index.
+        return selectOne(onlyBroker);
+    }
+
+    private AddressableMessageQueue selectOneMessageQueue(List<AddressableMessageQueue> addressableMessageQueueList,
+        ThreadLocalIndex index, TopicPublishInfo.QueueFilter... filter) {
+        if (addressableMessageQueueList == null || addressableMessageQueueList.isEmpty()) {
+            return null;
+        }
+        if (filter != null) {
+            // pre-check
+            for (TopicPublishInfo.QueueFilter f : filter) {
+                Preconditions.checkNotNull(f);
+            }
+            int size = addressableMessageQueueList.size();
+            for (int i = 0; i < size; i++) {
+                AddressableMessageQueue amq = addressableMessageQueueList.get(IntMath.mod(index.incrementAndGet(), size));
+                boolean filterResult = true;
+                for (TopicPublishInfo.QueueFilter f : filter) {
+                    filterResult = f.filter(amq.getMessageQueue());
+                    if (!filterResult) {
+                        break;
+                    }
+                }
+                if (filterResult) {
+                    return amq;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("queues", queues)
+            .add("brokerActingQueues", brokerActingQueues)
+            .add("brokerNameQueueMap", brokerNameQueueMap)
+            .add("queueIndex", queueIndex)
+            .add("brokerIndex", brokerIndex)
+            .toString();
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelectorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelectorTest.java
@@ -17,14 +17,41 @@
 
 package org.apache.rocketmq.proxy.service.route;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.client.impl.producer.TopicPublishInfo;
+import org.apache.rocketmq.client.latency.MQFaultStrategy;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.constant.PermName;
+import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.proxy.service.BaseServiceTest;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class MessageQueueSelectorTest extends BaseServiceTest {
+
+    private static final String BROKER_NAME_0 = "broker-0";
+    private static final String BROKER_NAME_1 = "broker-1";
+    private static final String BROKER_ADDR_0 = "127.0.0.1:10911";
+    private static final String BROKER_ADDR_1 = "127.0.0.1:10912";
+
+    private MQFaultStrategy mqFaultStrategy;
+
+    @Override
+    public void before() throws Throwable {
+        super.before();
+        mqFaultStrategy = mock(MQFaultStrategy.class);
+    }
 
     @Test
     public void testReadMessageQueue() {
@@ -58,12 +85,12 @@ public class MessageQueueSelectorTest extends BaseServiceTest {
     public void testWriteMessageQueue() {
         queueData.setPerm(PermName.PERM_WRITE);
         queueData.setReadQueueNums(0);
-        MessageQueueSelector messageQueueSelector = new MessageQueueSelector(new TopicRouteWrapper(topicRouteData, TOPIC), null, false);
+        MessageQueueWriteSelector messageQueueSelector = new MessageQueueWriteSelector(new TopicRouteWrapper(topicRouteData, TOPIC), null);
         assertTrue(messageQueueSelector.getQueues().isEmpty());
 
         queueData.setPerm(PermName.PERM_WRITE);
         queueData.setWriteQueueNums(3);
-        messageQueueSelector = new MessageQueueSelector(new TopicRouteWrapper(topicRouteData, TOPIC), null, false);
+        messageQueueSelector = new MessageQueueWriteSelector(new TopicRouteWrapper(topicRouteData, TOPIC), null);
         assertEquals(3, messageQueueSelector.getQueues().size());
         assertEquals(1, messageQueueSelector.getBrokerActingQueues().size());
         for (int i = 0; i < messageQueueSelector.getQueues().size(); i++) {
@@ -80,5 +107,90 @@ public class MessageQueueSelectorTest extends BaseServiceTest {
         messageQueueSelector.selectOne(false);
         messageQueueSelector.selectOne(false);
         assertEquals(queue, messageQueueSelector.selectOne(false));
+    }
+
+    @Test
+    public void testWriteSelectOneByPipeline() throws Exception {
+        HashMap<Long, String> brokerAddrs0 = new HashMap<>();
+        brokerAddrs0.put(MixAll.MASTER_ID, BROKER_ADDR_0);
+        BrokerData brokerData0 = new BrokerData(CLUSTER_NAME, BROKER_NAME_0, brokerAddrs0);
+        HashMap<Long, String> brokerAddrs1 = new HashMap<>();
+        brokerAddrs1.put(MixAll.MASTER_ID, BROKER_ADDR_1);
+        BrokerData brokerData1 = new BrokerData(CLUSTER_NAME, BROKER_NAME_1, brokerAddrs1);
+        topicRouteData.setBrokerDatas(Arrays.asList(brokerData0, brokerData1));
+
+        QueueData queueData0 = new QueueData();
+        queueData0.setBrokerName(BROKER_NAME_0);
+        queueData0.setPerm(PermName.PERM_WRITE);
+        queueData0.setWriteQueueNums(3);
+        QueueData queueData1 = new QueueData();
+        queueData1.setBrokerName(BROKER_NAME_1);
+        queueData1.setPerm(PermName.PERM_WRITE);
+        queueData1.setWriteQueueNums(3);
+        topicRouteData.setQueueDatas(Arrays.asList(queueData0, queueData1));
+
+        MessageQueueWriteSelector messageQueueWriteSelector = new MessageQueueWriteSelector(new TopicRouteWrapper(topicRouteData, TOPIC), mqFaultStrategy);
+
+        // broker-0 is not available, expected to select broker-1
+        TopicPublishInfo.QueueFilter availableFilter = mq -> !BROKER_NAME_0.equals(mq.getBrokerName());
+        TopicPublishInfo.QueueFilter reachableFilter = mq -> true;
+
+        when(mqFaultStrategy.isSendLatencyFaultEnable()).thenReturn(true);
+        when(mqFaultStrategy.getAvailableFilter()).thenReturn(availableFilter);
+        when(mqFaultStrategy.getReachableFilter()).thenReturn(reachableFilter);
+
+        for (int i = 0; i < 6; i++) {
+            AddressableMessageQueue messageQueue = messageQueueWriteSelector.selectOneByPipeline(false);
+            assertEquals(BROKER_NAME_1, messageQueue.getBrokerName());
+        }
+
+        for (int i = 0; i < 6; i++) {
+            AddressableMessageQueue messageQueue = messageQueueWriteSelector.selectOneByPipeline(true);
+            assertEquals(BROKER_NAME_1, messageQueue.getBrokerName());
+        }
+
+        // both are not available, broker-1 is not reachable, expected to select broker-0
+        availableFilter = mq -> false;
+        reachableFilter = mq -> !BROKER_NAME_1.equals(mq.getBrokerName());
+
+        when(mqFaultStrategy.getAvailableFilter()).thenReturn(availableFilter);
+        when(mqFaultStrategy.getReachableFilter()).thenReturn(reachableFilter);
+
+        for (int i = 0; i < 6; i++) {
+            AddressableMessageQueue messageQueue = messageQueueWriteSelector.selectOneByPipeline(false);
+            assertEquals(BROKER_NAME_0, messageQueue.getBrokerName());
+        }
+
+        for (int i = 0; i < 6; i++) {
+            AddressableMessageQueue messageQueue = messageQueueWriteSelector.selectOneByPipeline(true);
+            assertEquals(BROKER_NAME_0, messageQueue.getBrokerName());
+        }
+
+        // both are not available and reachable, expected to select by RR
+        availableFilter = mq -> false;
+        reachableFilter = mq -> false;
+
+        when(mqFaultStrategy.getAvailableFilter()).thenReturn(availableFilter);
+        when(mqFaultStrategy.getReachableFilter()).thenReturn(reachableFilter);
+
+        HashMap<MessageQueue, AtomicInteger> resultMap = new HashMap<>();
+        for (int i = 0; i < 6; i++) {
+            AddressableMessageQueue messageQueue = messageQueueWriteSelector.selectOneByPipeline(false);
+            resultMap.computeIfAbsent(messageQueue.getMessageQueue(), k -> new AtomicInteger()).incrementAndGet();
+        }
+        assertEquals(1, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_0, 0)).get());
+        assertEquals(1, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_0, 1)).get());
+        assertEquals(1, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_0, 2)).get());
+        assertEquals(1, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_1, 0)).get());
+        assertEquals(1, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_1, 1)).get());
+        assertEquals(1, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_1, 2)).get());
+
+        resultMap.clear();
+        for (int i = 0; i < 6; i++) {
+            AddressableMessageQueue messageQueue = messageQueueWriteSelector.selectOneByPipeline(true);
+            resultMap.computeIfAbsent(messageQueue.getMessageQueue(), k -> new AtomicInteger()).incrementAndGet();
+        }
+        assertEquals(3, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_0, -1)).get());
+        assertEquals(3, resultMap.get(new MessageQueue(TOPIC, BROKER_NAME_1, -1)).get());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8077 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

1. Add new MessageQueueReadSelector to extend MessageQueueSelector, using ThreadLocalIndex as write selector index.
2. Remove unnecessary transferring between MessageQueue and AddressableMessageQueue.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

UT
