### PR TITLE
[ISSUE #8090] Optimize isSetEqual for DefaultLitePullConsumerImpl

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
@@ -181,7 +181,7 @@ public class MQAdminImpl {
                 e);
         }
 
-        throw new MQClientException("Unknow why, Can not find Message Queue for this topic, " + topic, null);
+        throw new MQClientException("Unknown why, Can not find Message Queue for this topic, " + topic, null);
     }
 
     public long searchOffset(MessageQueue mq, long timestamp) throws MQClientException {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImpl.java
@@ -1237,18 +1237,16 @@ public class DefaultLitePullConsumerImpl implements MQConsumerInner {
             return true;
         }
 
-        if (set1 == null || set2 == null || set1.size() != set2.size() || set1.size() == 0) {
+        if (set1 == null || set2 == null || set1.size() != set2.size()) {
             return false;
         }
 
-        Iterator<MessageQueue> iter = set2.iterator();
-        boolean isEqual = true;
-        while (iter.hasNext()) {
-            if (!set1.contains(iter.next())) {
-                isEqual = false;
+        for (MessageQueue messageQueue : set2) {
+            if (!set1.contains(messageQueue)) {
+                return false;
             }
         }
-        return isEqual;
+        return true;
     }
 
     public AssignedMessageQueue getAssignedMessageQueue() {

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImplTest.java
@@ -1,0 +1,85 @@
+package org.apache.rocketmq.client.impl.consumer;
+
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Willhow
+ * @since 2024/5/3
+ */
+public class DefaultLitePullConsumerImplTest {
+    private final DefaultLitePullConsumerImpl consumer = new DefaultLitePullConsumerImpl(new DefaultLitePullConsumer(), null);
+
+    private static Method isSetEqualMethod;
+
+    @BeforeClass
+    public static void initReflectionMethod() throws NoSuchMethodException {
+        Class<DefaultLitePullConsumerImpl> consumerClass = DefaultLitePullConsumerImpl.class;
+        Method testMethod = consumerClass.getDeclaredMethod("isSetEqual", Set.class, Set.class);
+        testMethod.setAccessible(true);
+        isSetEqualMethod = testMethod;
+    }
+
+
+    /**
+     * The two empty sets should be equal
+     */
+    @Test
+    public void testIsSetEqual1() throws InvocationTargetException, IllegalAccessException {
+        Set<MessageQueue> set1 = new HashSet<>();
+        Set<MessageQueue> set2 = new HashSet<>();
+        boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
+        Assert.assertTrue(equalResult);
+    }
+
+
+    /**
+     * When a set has elements and one does not, the two sets are not equal
+     */
+    @Test
+    public void testIsSetEqual2() throws InvocationTargetException, IllegalAccessException {
+        Set<MessageQueue> set1 = new HashSet<>();
+        set1.add(new MessageQueue("testTopic","testBroker",111));
+        Set<MessageQueue> set2 = new HashSet<>();
+        boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
+        Assert.assertFalse(equalResult);
+    }
+
+    /**
+     * The two null sets should be equal
+     */
+    @Test
+    public void testIsSetEqual3() throws InvocationTargetException, IllegalAccessException{
+        Set<MessageQueue> set1 = null;
+        Set<MessageQueue> set2 = null;
+        boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
+        Assert.assertTrue(equalResult);
+    }
+
+    @Test
+    public void testIsSetEqual4() throws InvocationTargetException, IllegalAccessException{
+        Set<MessageQueue> set1 = null;
+        Set<MessageQueue> set2 = new HashSet<>();
+        boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
+        Assert.assertFalse(equalResult);
+    }
+
+    @Test
+    public void testIsSetEqual5() throws InvocationTargetException, IllegalAccessException{
+        Set<MessageQueue> set1 = new HashSet<>();
+        set1.add(new MessageQueue("testTopic","testBroker",111));
+        Set<MessageQueue> set2 = new HashSet<>();
+        set2.add(new MessageQueue("testTopic","testBroker",111));
+        boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
+        Assert.assertTrue(equalResult);
+    }
+
+}

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImplTest.java
@@ -11,10 +11,7 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * @author Willhow
- * @since 2024/5/3
- */
+
 public class DefaultLitePullConsumerImplTest {
     private final DefaultLitePullConsumerImpl consumer = new DefaultLitePullConsumerImpl(new DefaultLitePullConsumer(), null);
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/DefaultLitePullConsumerImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.rocketmq.client.impl.consumer;
 
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
@@ -54,7 +70,7 @@ public class DefaultLitePullConsumerImplTest {
      * The two null sets should be equal
      */
     @Test
-    public void testIsSetEqual3() throws InvocationTargetException, IllegalAccessException{
+    public void testIsSetEqual3() throws InvocationTargetException, IllegalAccessException {
         Set<MessageQueue> set1 = null;
         Set<MessageQueue> set2 = null;
         boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
@@ -62,7 +78,7 @@ public class DefaultLitePullConsumerImplTest {
     }
 
     @Test
-    public void testIsSetEqual4() throws InvocationTargetException, IllegalAccessException{
+    public void testIsSetEqual4() throws InvocationTargetException, IllegalAccessException {
         Set<MessageQueue> set1 = null;
         Set<MessageQueue> set2 = new HashSet<>();
         boolean equalResult = (boolean) isSetEqualMethod.invoke(consumer, set1, set2);
@@ -70,7 +86,7 @@ public class DefaultLitePullConsumerImplTest {
     }
 
     @Test
-    public void testIsSetEqual5() throws InvocationTargetException, IllegalAccessException{
+    public void testIsSetEqual5() throws InvocationTargetException, IllegalAccessException {
         Set<MessageQueue> set1 = new HashSet<>();
         set1.add(new MessageQueue("testTopic","testBroker",111));
         Set<MessageQueue> set2 = new HashSet<>();


### PR DESCRIPTION
Fixes #8090 
1. 优化了DefaultLitePullConsumerImpl#isSetEqual方法，减少了循环次数和不正确的判断。并添加了isSetEqual方法的单元测试
2. 订正了一个单词拼写错误

How Did You Test This Change?
添加了单元测试验证isSetEqual方法是否符合预期