### PR TITLE
[ISSUE #8092] Fixed non-idempotent test

### DIFF
--- a/filter/src/test/java/org/apache/rocketmq/filter/FilterSpiTest.java
+++ b/filter/src/test/java/org/apache/rocketmq/filter/FilterSpiTest.java
@@ -68,6 +68,7 @@ public class FilterSpiTest {
             e.printStackTrace();
             assertThat(Boolean.FALSE).isTrue();
         }
+        FilterFactory.INSTANCE.unRegister("Nothing");
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #8092 

### Brief Description

The test `org.apache.rocketmq.filter.FilterSpiTest#testRegister` is non-idempotent, as it passes in the first run but fails in the second run in the same JVM. The test fails in subsequent runs in the same environment because it registers a `NothingFilter` without unregistering it. The repeated run will then throw a `Filter already exist` error. A fix is recommended as unit tests shall be idempotent, and state pollution shall be mitigated so that newly introduced tests do not fail in the future due to polluted shared states.

### Failure Message in the 2nd Run:
```
java.lang.IllegalArgumentException: Filter spi type(Nothing) already exist!
	at org.apache.rocketmq.filter.FilterFactory.register(FilterFactory.java:44)
	at org.apache.rocketmq.filter.FilterSpiTest.testRegister(FilterSpiTest.java:53)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```

### How Did You Test This Change?
Unset `NothingFilter` before exiting the test. All tests pass and are idempotent after the fix.
