### PR TITLE
[ISSUE #8046] Fix authentication context build for no extFields

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authentication/builder/DefaultAuthenticationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authentication/builder/DefaultAuthenticationContextBuilder.java
@@ -98,12 +98,12 @@ public class DefaultAuthenticationContextBuilder implements AuthenticationContex
     @Override
     public DefaultAuthenticationContext build(ChannelHandlerContext context, RemotingCommand request) {
         HashMap<String, String> fields = request.getExtFields();
-        if (MapUtils.isEmpty(fields)) {
-            throw new AuthenticationException("authentication field is null.");
-        }
         DefaultAuthenticationContext result = new DefaultAuthenticationContext();
         result.setChannelId(context.channel().id().asLongText());
         result.setRpcCode(String.valueOf(request.getCode()));
+        if (MapUtils.isEmpty(fields)) {
+            return result;
+        }
         if (!fields.containsKey(SessionCredentials.ACCESS_KEY)) {
             return result;
         }

--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
@@ -161,8 +161,11 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
         List<DefaultAuthorizationContext> result = new ArrayList<>();
         try {
             HashMap<String, String> fields = command.getExtFields();
+            if (MapUtils.isEmpty(fields)) {
+                return result;
+            }
             Subject subject = null;
-            if (MapUtils.isNotEmpty(fields) && fields.containsKey(SessionCredentials.ACCESS_KEY)) {
+            if (fields.containsKey(SessionCredentials.ACCESS_KEY)) {
                 subject = User.of(fields.get(SessionCredentials.ACCESS_KEY));
             }
             String remoteAddr = RemotingHelper.parseChannelRemoteAddr(context.channel());

--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.acl.common.AclException;
@@ -161,7 +162,7 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
         try {
             HashMap<String, String> fields = command.getExtFields();
             Subject subject = null;
-            if (fields.containsKey(SessionCredentials.ACCESS_KEY)) {
+            if (MapUtils.isNotEmpty(fields) && fields.containsKey(SessionCredentials.ACCESS_KEY)) {
                 subject = User.of(fields.get(SessionCredentials.ACCESS_KEY));
             }
             String remoteAddr = RemotingHelper.parseChannelRemoteAddr(context.channel());


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8046

### Brief Description

Fix authentication context build for no extFields

### How Did You Test This Change?

start producer/consumer without ak/sk
