### PR TITLE
[ISSUE #8159] Fix proxy discarding response when channel is unwritable

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivity.java
@@ -35,6 +35,7 @@ import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
 import org.apache.rocketmq.proxy.remoting.pipeline.RequestPipeline;
+import org.apache.rocketmq.remoting.netty.NettyRemotingAbstract;
 import org.apache.rocketmq.remoting.netty.NettyRequestProcessor;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
@@ -148,23 +149,15 @@ public abstract class AbstractRemotingActivity implements NettyRequestProcessor 
 
     protected void writeResponse(ChannelHandlerContext ctx, final ProxyContext context,
         final RemotingCommand request, RemotingCommand response, Throwable t) {
-        if (request.isOnewayRPC()) {
-            return;
-        }
-        if (!ctx.channel().isWritable()) {
-            return;
-        }
 
         ProxyConfig config = ConfigurationManager.getProxyConfig();
-
-        response.setOpaque(request.getOpaque());
-        response.markResponseType();
         response.addExtField(MessageConst.PROPERTY_MSG_REGION, config.getRegionId());
         response.addExtField(MessageConst.PROPERTY_TRACE_SWITCH, String.valueOf(config.isTraceOn()));
+
         if (t != null) {
             response.setRemark(t.getMessage());
         }
 
-        ctx.writeAndFlush(response);
+        NettyRemotingAbstract.writeResponse(ctx.channel(), request, response);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8159 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

1. do not check channel.isWritable when writeResponse
2. Reuse NettyRemotingAbstract.writeResponse to get better exception handling

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
