### PR TITLE
Revert "[ISSUE #7757] Use `CompositeByteBuf` to prevent memory copy."

### DIFF
--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/FileRegionEncoderTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/FileRegionEncoderTest.java
@@ -21,15 +21,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class FileRegionEncoderTest {
 


### PR DESCRIPTION
Reverts apache/rocketmq#7694

fixes #8205