### PR TITLE
[ISSUE #8066] Tiered storage support primary/backup mode

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -2483,6 +2483,10 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         runtimeInfo.put("remainTransientStoreBufferNumbs", String.valueOf(messageStore.remainTransientStoreBufferNumbs()));
         if (this.brokerController.getMessageStore() instanceof DefaultMessageStore && ((DefaultMessageStore) this.brokerController.getMessageStore()).isTransientStorePoolEnable()) {
             runtimeInfo.put("remainHowManyDataToCommit", MixAll.humanReadableByteCount(messageStore.remainHowManyDataToCommit(), false));
+        } else if (this.brokerController.getMessageStore() instanceof TieredMessageStore &&
+            ((TieredMessageStore) this.brokerController.getMessageStore()).getDefaultStore() instanceof DefaultMessageStore &&
+            ((DefaultMessageStore) ((TieredMessageStore) this.brokerController.getMessageStore()).getDefaultStore()).isTransientStorePoolEnable()) {
+            runtimeInfo.put("remainHowManyDataToCommit", MixAll.humanReadableByteCount(messageStore.remainHowManyDataToCommit(), false));
         }
         runtimeInfo.put("remainHowManyDataToFlush", MixAll.humanReadableByteCount(messageStore.remainHowManyDataToFlush(), false));
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/tiered/SyncTieredIndexService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/tiered/SyncTieredIndexService.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.broker.tiered;
+
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.broker.out.BrokerOuterAPI;
+import org.apache.rocketmq.common.ServiceThread;
+import org.apache.rocketmq.common.ThreadFactoryImpl;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.TieredMessageStore;
+import org.apache.rocketmq.tieredstore.index.DispatchRequestExt;
+import org.apache.rocketmq.tieredstore.index.IndexStoreService;
+import org.apache.rocketmq.tieredstore.util.MessageStoreUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SyncTieredIndexService extends ServiceThread {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.BROKER_LOGGER_NAME);
+    private static final Logger TIERED_LOG = LoggerFactory.getLogger(MessageStoreUtil.TIERED_STORE_LOGGER_NAME);
+
+    private final BrokerOuterAPI brokerOuterAPI;
+    private final TieredMessageStore messageStore;
+    private final MessageStoreConfig messageStoreConfig;
+    private final org.apache.rocketmq.tieredstore.MessageStoreConfig tieredConfig;
+    private final String brokerAddr;
+    private final IndexStoreService indexStoreService;
+    private final List<String> peerAddrs;
+    private final ExecutorService syncDispatchRequestExecutor;
+    public SyncTieredIndexService(BrokerController brokerController) {
+        this.brokerOuterAPI = brokerController.getBrokerOuterAPI();
+        this.messageStore = (TieredMessageStore) brokerController.getMessageStore();
+        this.messageStoreConfig = brokerController.getMessageStoreConfig();
+        this.tieredConfig = messageStore.getStoreConfig();
+        this.brokerAddr = brokerController.getBrokerAddr();
+        this.peerAddrs = new ArrayList<>();
+        this.indexStoreService = (IndexStoreService) messageStore.getIndexService();
+        this.syncDispatchRequestExecutor = new ThreadPoolExecutor(
+            tieredConfig.getSyncDispatchRequestThreadPoolSize(),
+            tieredConfig.getSyncDispatchRequestThreadPoolSize(),
+            1000 * 60,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(tieredConfig.getSyncDispatchRequestQueueCapacity()),
+            new ThreadFactoryImpl("SyncDispatchRequestExecutor_")
+        );
+
+        String dLedgerPeers = messageStoreConfig.getdLegerPeers();
+        String[] dLedgerPeersArray = dLedgerPeers.split(";");
+        Pattern pattern = Pattern.compile("-([^:]+):");
+        for (String dLedgerPeer : dLedgerPeersArray) {
+            Matcher matcher = pattern.matcher(dLedgerPeer);
+            if (matcher.find()) {
+                String peerIp = matcher.group(1);
+                int listenPort = brokerController.getNettyServerConfig().getListenPort();
+                this.peerAddrs.add(String.format("%s:%s", peerIp, listenPort));
+            }
+        }
+    }
+
+    public void syncTieredIndex() {
+        if (MessageStoreUtil.isMaster(messageStoreConfig)) {
+            while (indexStoreService.needToSync()) {
+                if (MessageStoreUtil.isMaster(messageStoreConfig)) {
+                    List<DispatchRequestExt> requestExtList = indexStoreService.getDispatchRequestToSync();
+                    if (!requestExtList.isEmpty()) {
+                        CompletableFuture.runAsync(() -> peerAddrs.forEach(peerAddr -> {
+                            if (!peerAddr.equals(brokerAddr)) {
+                                try {
+                                    RemotingCommand response = brokerOuterAPI.syncTieredIndex(requestExtList, peerAddr);
+                                    if (response == null) {
+                                        TIERED_LOG.error("syncTieredIndex failed, no response, peer = {}", peerAddr);
+                                    } else if (response.getCode() != ResponseCode.SUCCESS) {
+                                        TIERED_LOG.error("syncTieredIndex failed, peer = {}, code = {}, remark = {}", peerAddr, response.getCode(), response.getRemark());
+                                    }
+                                } catch (Exception e) {
+                                    TIERED_LOG.error("syncTieredIndex failed, peer = {}", peerAddr, e);
+                                }
+                            }
+                        }), syncDispatchRequestExecutor);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getServiceName() {
+        return SyncTieredIndexService.class.getSimpleName();
+    }
+
+    @Override
+    public void run() {
+        TIERED_LOG.info("SyncTieredIndexService start, peerAddrs = {}", peerAddrs);
+        while (!this.isStopped()) {
+            try {
+                this.waitForRunning(50);
+                syncTieredIndex();
+            } catch (Throwable t) {
+                TIERED_LOG.error("Synchronize tiered IndexFile service failed", t);
+            }
+        }
+        TIERED_LOG.info("End synchronize tiered IndexFile service thread!");
+    }
+}

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
@@ -301,4 +301,6 @@ public class RequestCode {
     public static final int AUTH_DELETE_ACL = 3008;
     public static final int AUTH_GET_ACL = 3009;
     public static final int AUTH_LIST_ACL = 3010;
+    public static final int GET_TIERED_METADATA = 4000;
+    public static final int SYNC_TIERED_INDEX = 4001;
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
@@ -95,7 +95,7 @@ public class MessageStoreConfig {
     private int tieredStoreIndexFileRollingIdleInterval = 3 * 60 * 60 * 1000;
     private String tieredMetadataServiceProvider = "org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore";
     private String tieredBackendServiceProvider = "org.apache.rocketmq.tieredstore.provider.MemoryFileSegment";
-    private String tieredRecoverServiceProvider = "org.apache.rocketmq.tieredstore.file.DumpRecoverService";
+    private String tieredRecoverServiceProvider = "org.apache.rocketmq.tieredstore.file.MockRecoverService";
     // file reserved time, default is 72 hour
     private int tieredStoreFileReservedTime = 72;
     // time of forcing commitLog to roll to next file, default is 24 hour

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
@@ -95,6 +95,7 @@ public class MessageStoreConfig {
     private int tieredStoreIndexFileRollingIdleInterval = 3 * 60 * 60 * 1000;
     private String tieredMetadataServiceProvider = "org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore";
     private String tieredBackendServiceProvider = "org.apache.rocketmq.tieredstore.provider.MemoryFileSegment";
+    private String tieredRecoverServiceProvider = "org.apache.rocketmq.tieredstore.file.DumpRecoverService";
     // file reserved time, default is 72 hour
     private int tieredStoreFileReservedTime = 72;
     // time of forcing commitLog to roll to next file, default is 24 hour
@@ -119,6 +120,10 @@ public class MessageStoreConfig {
     private int readAheadMessageSizeThreshold = 16 * 1024 * 1024;
     private long readAheadCacheExpireDuration = 15 * 1000;
     private double readAheadCacheSizeThresholdRate = 0.3;
+    private int dispatchRequestGroupSyncCount = 10000;
+    private int syncDispatchRequestThreadPoolSize = 32;
+    private int syncDispatchRequestQueueCapacity = 50000;
+    private long slaveBuildIndexInterval = 500;
 
     private int tieredStoreMaxPendingLimit = 10000;
     private boolean tieredStoreCrcCheckEnable = false;
@@ -248,6 +253,38 @@ public class MessageStoreConfig {
 
     public void setTieredBackendServiceProvider(String tieredBackendServiceProvider) {
         this.tieredBackendServiceProvider = tieredBackendServiceProvider;
+    }
+
+    public String getTieredRecoverServiceProvider() {
+        return tieredRecoverServiceProvider;
+    }
+
+    public void setTieredRecoverServiceProvider(String tieredRecoverServiceProvider) {
+        this.tieredRecoverServiceProvider = tieredRecoverServiceProvider;
+    }
+
+    public int getSyncDispatchRequestThreadPoolSize() {
+        return syncDispatchRequestThreadPoolSize;
+    }
+
+    public void setSyncDispatchRequestThreadPoolSize(int syncDispatchRequestThreadPoolSize) {
+        this.syncDispatchRequestThreadPoolSize = syncDispatchRequestThreadPoolSize;
+    }
+
+    public int getSyncDispatchRequestQueueCapacity() {
+        return syncDispatchRequestQueueCapacity;
+    }
+
+    public void setSyncDispatchRequestQueueCapacity(int syncDispatchRequestQueueCapacity) {
+        this.syncDispatchRequestQueueCapacity = syncDispatchRequestQueueCapacity;
+    }
+
+    public long getSlaveBuildIndexInterval() {
+        return slaveBuildIndexInterval;
+    }
+
+    public void setSlaveBuildIndexInterval(long slaveBuildIndexInterval) {
+        this.slaveBuildIndexInterval = slaveBuildIndexInterval;
     }
 
     public int getTieredStoreFileReservedTime() {
@@ -424,5 +461,13 @@ public class MessageStoreConfig {
 
     public String getObjectStoreEndpoint() {
         return objectStoreEndpoint;
+    }
+
+    public int getDispatchRequestGroupSyncCount() {
+        return dispatchRequestGroupSyncCount;
+    }
+
+    public void setDispatchRequestGroupSyncCount(int dispatchRequestGroupSyncCount) {
+        this.dispatchRequestGroupSyncCount = dispatchRequestGroupSyncCount;
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
@@ -29,11 +29,13 @@ public class MessageStoreExecutor {
     public final BlockingQueue<Runnable> bufferCommitThreadPoolQueue;
     public final BlockingQueue<Runnable> bufferFetchThreadPoolQueue;
     public final BlockingQueue<Runnable> fileRecyclingThreadPoolQueue;
+    public final BlockingQueue<Runnable> indexFileThreadPoolQueue;
 
     public final ScheduledExecutorService commonExecutor;
     public final ExecutorService bufferCommitExecutor;
     public final ExecutorService bufferFetchExecutor;
     public final ExecutorService fileRecyclingExecutor;
+    public final ExecutorService indexFileExecutor;
 
     private static class SingletonHolder {
         private static final MessageStoreExecutor INSTANCE = new MessageStoreExecutor();
@@ -76,6 +78,14 @@ public class MessageStoreExecutor {
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.fileRecyclingThreadPoolQueue,
             new ThreadFactoryImpl("BufferFetchExecutor_"));
+
+        this.indexFileThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
+        this.indexFileExecutor = ThreadUtils.newThreadPoolExecutor(
+            Math.max(4, Runtime.getRuntime().availableProcessors()),
+            Math.max(4, Runtime.getRuntime().availableProcessors()),
+            TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
+            this.indexFileThreadPoolQueue,
+            new ThreadFactoryImpl("IndexFileExecutor_"));
     }
 
     private void shutdownExecutor(ExecutorService executor) {
@@ -89,5 +99,6 @@ public class MessageStoreExecutor {
         this.shutdownExecutor(this.bufferCommitExecutor);
         this.shutdownExecutor(this.bufferFetchExecutor);
         this.shutdownExecutor(this.fileRecyclingExecutor);
+        this.shutdownExecutor(this.indexFileExecutor);
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
@@ -98,6 +98,10 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
 
     @Override
     public void dispatch(DispatchRequest request) {
+        // Slave shouldn't dispatch
+        if (MessageStoreUtil.isSlave(defaultStore.getMessageStoreConfig())) {
+            return;
+        }
         if (stopped || topicFilter != null && topicFilter.filterTopic(request.getTopic())) {
             return;
         }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/DumpRecoverService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/DumpRecoverService.java
@@ -14,24 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.tieredstore.index;
+package org.apache.rocketmq.tieredstore.file;
 
-import java.nio.ByteBuffer;
-
-public interface IndexFile extends IndexInterface {
-
-    /**
-     * Enumeration for the status of the index file.
-     */
-    enum IndexStatusEnum {
-        SHUTDOWN, UNSEALED, SEALED, UPLOAD
+public class DumpRecoverService implements RecoverService {
+    @Override
+    public void recoverMetadataWhenBecomeMaster() {
     }
 
-    long getTimestamp();
+    @Override
+    public void recoverFlatFileWhenBecomeMaster() {
+    }
 
-    long getEndTimestamp();
-
-    IndexStatusEnum getFileStatus();
-
-    ByteBuffer doCompaction();
+    @Override
+    public void recoverIndexFileWhenBecomeMaster() {
+    }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
@@ -81,9 +81,10 @@ public class FlatAppendFile {
             return;
         }
         if (fileSegment.getCommitPosition() != fileSize) {
+            log.warn("FlatAppendFile last file size not correct, filePath: {}, commitPosition = {}, fileSize = {}",
+                fileSegment.getPath(), fileSegment.getCommitPosition(), fileSegment.getSize());
             fileSegment.initPosition(fileSize);
             flushFileSegmentMeta(fileSegment);
-            log.warn("FlatAppendFile last file size not correct, filePath: {}", this.filePath);
         }
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFile.java
@@ -30,7 +30,9 @@ public class FlatCommitLogFile extends FlatAppendFile {
 
     public FlatCommitLogFile(FileSegmentFactory fileSegmentFactory, String filePath) {
         super(fileSegmentFactory, FileSegmentType.COMMIT_LOG, filePath);
-        this.initOffset(0L);
+        // 1. If constructor is called on master to create a new CommitLog, there is no need to initOffset in constructor for its offset will be initialized sooner
+        // 2. If constructor is called on slave to recover an exist CommitLog when becoming a master, there should not be a initOffset(0L)
+        // this.initOffset(0L);
     }
 
     public boolean tryRollingFile(long interval) {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatMessageFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatMessageFile.java
@@ -36,6 +36,7 @@ import org.apache.rocketmq.tieredstore.common.AppendResult;
 import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
 import org.apache.rocketmq.tieredstore.metadata.entity.QueueMetadata;
 import org.apache.rocketmq.tieredstore.metadata.entity.TopicMetadata;
+import org.apache.rocketmq.tieredstore.provider.FileSegment;
 import org.apache.rocketmq.tieredstore.util.MessageFormatUtil;
 import org.apache.rocketmq.tieredstore.util.MessageStoreUtil;
 import org.slf4j.Logger;
@@ -174,6 +175,14 @@ public class FlatMessageFile implements FlatFileInterface {
 
         this.dispatchRequestList.add(request);
         return consumeQueue.append(buffer, request.getStoreTimestamp());
+    }
+
+    public void addCommitLogFileSegment(FileSegment fileSegment) {
+        this.commitLog.fileSegmentTable.add(fileSegment);
+    }
+
+    public void addConsumeQueueFileSegment(FileSegment fileSegment) {
+        this.consumeQueue.fileSegmentTable.add(fileSegment);
     }
 
     @Override

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/MockRecoverService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/MockRecoverService.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.tieredstore.file;
 
-public class DumpRecoverService implements RecoverService {
+public class MockRecoverService implements RecoverService {
     @Override
     public void recoverMetadataWhenBecomeMaster() {
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/RecoverService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/RecoverService.java
@@ -14,24 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.tieredstore.index;
+package org.apache.rocketmq.tieredstore.file;
 
-import java.nio.ByteBuffer;
+public interface RecoverService {
+    void recoverMetadataWhenBecomeMaster();
 
-public interface IndexFile extends IndexInterface {
+    void recoverFlatFileWhenBecomeMaster();
 
-    /**
-     * Enumeration for the status of the index file.
-     */
-    enum IndexStatusEnum {
-        SHUTDOWN, UNSEALED, SEALED, UPLOAD
-    }
-
-    long getTimestamp();
-
-    long getEndTimestamp();
-
-    IndexStatusEnum getFileStatus();
-
-    ByteBuffer doCompaction();
+    void recoverIndexFileWhenBecomeMaster();
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/DispatchRequestExt.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/DispatchRequestExt.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tieredstore.index;
+
+import org.apache.rocketmq.store.DispatchRequest;
+
+import java.util.Set;
+
+public class DispatchRequestExt {
+    private DispatchRequest dispatchRequest;
+    private long topicId;
+    private Set<String> keySet;
+
+    public DispatchRequestExt(DispatchRequest dispatchRequest, long topicId, Set<String> keySet) {
+        this.dispatchRequest = dispatchRequest;
+        this.topicId = topicId;
+        this.keySet = keySet;
+    }
+
+    public DispatchRequest getDispatchRequest() {
+        return dispatchRequest;
+    }
+
+    public void setDispatchRequest(DispatchRequest dispatchRequest) {
+        this.dispatchRequest = dispatchRequest;
+    }
+
+    public long getTopicId() {
+        return topicId;
+    }
+
+    public void setTopicId(long topicId) {
+        this.topicId = topicId;
+    }
+
+    public Set<String> getKeySet() {
+        return keySet;
+    }
+
+    public void setKeySet(Set<String> keySet) {
+        this.keySet = keySet;
+    }
+}

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexFileSyncService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexFileSyncService.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tieredstore.index;
+
+import org.apache.rocketmq.common.ServiceThread;
+import org.apache.rocketmq.tieredstore.TieredMessageStore;
+import org.apache.rocketmq.tieredstore.util.MessageStoreUtil;
+
+public class IndexFileSyncService extends ServiceThread {
+    private final TieredMessageStore messageStore;
+    private final IndexService indexService;
+
+    public IndexFileSyncService(TieredMessageStore messageStore, IndexService indexService) {
+        this.messageStore = messageStore;
+        this.indexService = indexService;
+    }
+
+    @Override
+    public String getServiceName() {
+        return IndexFileSyncService.class.getSimpleName();
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            if (MessageStoreUtil.isSlave(this.messageStore.getDefaultStore().getMessageStoreConfig())) {
+                this.indexService.emptySlaveDispatchRequestList();
+            }
+            this.waitForRunning(messageStore.getStoreConfig().getSlaveBuildIndexInterval());
+        }
+    }
+}

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexInterface.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexInterface.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tieredstore.index;
+
+import org.apache.rocketmq.tieredstore.common.AppendResult;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public interface IndexInterface {
+    void start();
+
+    /**
+     * Puts a key into the index.
+     *
+     * @param topic     The topic of the key.
+     * @param topicId   The ID of the topic.
+     * @param queueId   The ID of the queue.
+     * @param keySet    The set of keys to be indexed.
+     * @param offset    The offset value of the key.
+     * @param size      The size of the key.
+     * @param timestamp The timestamp of the key.
+     * @return The result of the put operation.
+     */
+    AppendResult putKey(
+            String topic, int topicId, int queueId, Set<String> keySet, long offset, int size, long timestamp);
+
+    /**
+     * Asynchronously queries the index for a specific key within a given time range.
+     *
+     * @param topic     The topic of the key.
+     * @param key       The key to be queried.
+     * @param beginTime The start time of the query range.
+     * @param endTime   The end time of the query range.
+     * @return A CompletableFuture that holds the list of IndexItems matching the query.
+     */
+    CompletableFuture<List<IndexItem>> queryAsync(String topic, String key, int maxCount, long beginTime, long endTime);
+
+    /**
+     * Shutdown the index service.
+     */
+    void shutdown();
+
+    /**
+     * Destroys the index service and releases all resources.
+     */
+    void destroy();
+}

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexService.java
@@ -18,47 +18,15 @@
 package org.apache.rocketmq.tieredstore.index;
 
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import org.apache.rocketmq.tieredstore.common.AppendResult;
 
-public interface IndexService {
+public interface IndexService extends IndexInterface {
+    void recoverWhenBecomeMaster();
 
-    void start();
+    boolean needToSync();
 
-    /**
-     * Puts a key into the index.
-     *
-     * @param topic     The topic of the key.
-     * @param topicId   The ID of the topic.
-     * @param queueId   The ID of the queue.
-     * @param keySet    The set of keys to be indexed.
-     * @param offset    The offset value of the key.
-     * @param size      The size of the key.
-     * @param timestamp The timestamp of the key.
-     * @return The result of the put operation.
-     */
-    AppendResult putKey(
-        String topic, int topicId, int queueId, Set<String> keySet, long offset, int size, long timestamp);
+    void syncDispatchRequest(List<DispatchRequestExt> requestExtList);
 
-    /**
-     * Asynchronously queries the index for a specific key within a given time range.
-     *
-     * @param topic     The topic of the key.
-     * @param key       The key to be queried.
-     * @param beginTime The start time of the query range.
-     * @param endTime   The end time of the query range.
-     * @return A CompletableFuture that holds the list of IndexItems matching the query.
-     */
-    CompletableFuture<List<IndexItem>> queryAsync(String topic, String key, int maxCount, long beginTime, long endTime);
+    List<Long> getIndexFileTimestamp();
 
-    /**
-     * Shutdown the index service.
-     */
-    void shutdown();
-
-    /**
-     * Destroys the index service and releases all resources.
-     */
-    void destroy();
+    void emptySlaveDispatchRequestList();
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -493,7 +493,7 @@ public class IndexStoreFile implements IndexFile {
                     if (this.compactMappedFile != null) {
                         this.compactMappedFile.destroy(TimeUnit.SECONDS.toMillis(10));
                     }
-                    log.debug("IndexStoreService destroy local file, timestamp: {}, status: {}", this.getTimestamp(), fileStatus.get());
+                    log.info("IndexStoreService destroy local file, timestamp: {}, status: {}", this.getTimestamp(), fileStatus.get());
                     break;
                 case UPLOAD:
                     log.warn("[BUG] IndexStoreService destroy remote file, timestamp: {}", this.getTimestamp());

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/SyncTieredIndexRequestBody.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/SyncTieredIndexRequestBody.java
@@ -16,22 +16,22 @@
  */
 package org.apache.rocketmq.tieredstore.index;
 
-import java.nio.ByteBuffer;
+import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
 
-public interface IndexFile extends IndexInterface {
+import java.util.List;
 
-    /**
-     * Enumeration for the status of the index file.
-     */
-    enum IndexStatusEnum {
-        SHUTDOWN, UNSEALED, SEALED, UPLOAD
+public class SyncTieredIndexRequestBody extends RemotingSerializable {
+    private List<DispatchRequestExt> requestExtList;
+
+    public SyncTieredIndexRequestBody(List<DispatchRequestExt> requestExtList) {
+        this.requestExtList = requestExtList;
     }
 
-    long getTimestamp();
+    public List<DispatchRequestExt> getRequestExtList() {
+        return requestExtList;
+    }
 
-    long getEndTimestamp();
-
-    IndexStatusEnum getFileStatus();
-
-    ByteBuffer doCompaction();
+    public void setRequestExtList(List<DispatchRequestExt> requestExtList) {
+        this.requestExtList = requestExtList;
+    }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/MetadataStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/MetadataStore.java
@@ -74,4 +74,6 @@ public interface MetadataStore {
     void deleteFileSegment(String basePath, FileSegmentType fileType, long baseOffset);
 
     void destroy();
+
+    void recoverWhenBecomeMaster();
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/TieredMetadataSerializeWrapper.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/TieredMetadataSerializeWrapper.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tieredstore.metadata;
+
+import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
+import org.apache.rocketmq.tieredstore.metadata.entity.FileSegmentMetadata;
+import org.apache.rocketmq.tieredstore.metadata.entity.QueueMetadata;
+import org.apache.rocketmq.tieredstore.metadata.entity.TopicMetadata;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore.DEFAULT_CAPACITY;
+
+public class TieredMetadataSerializeWrapper extends RemotingSerializable {
+    private AtomicLong topicSerialNumber = new AtomicLong(0L);
+
+    private ConcurrentMap<String /* topic */, TopicMetadata> topicMetadataTable;
+    private ConcurrentMap<String /* topic */, ConcurrentMap<Integer /* queueId */, QueueMetadata>> queueMetadataTable;
+
+    // Declare concurrent mapping tables to store file segment metadata
+    // Key: filePath -> Value: <baseOffset, metadata>
+    private ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> commitLogFileSegmentTable;
+    private ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> consumeQueueFileSegmentTable;
+    private ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> indexFileSegmentTable;
+
+    public TieredMetadataSerializeWrapper() {
+        this.topicMetadataTable = new ConcurrentHashMap<>(DEFAULT_CAPACITY);
+        this.queueMetadataTable = new ConcurrentHashMap<>(DEFAULT_CAPACITY);
+        this.commitLogFileSegmentTable = new ConcurrentHashMap<>(DEFAULT_CAPACITY);
+        this.consumeQueueFileSegmentTable = new ConcurrentHashMap<>(DEFAULT_CAPACITY);
+        this.indexFileSegmentTable = new ConcurrentHashMap<>(DEFAULT_CAPACITY);
+    }
+
+    public AtomicLong getTopicSerialNumber() {
+        return topicSerialNumber;
+    }
+
+    public void setTopicSerialNumber(AtomicLong topicSerialNumber) {
+        this.topicSerialNumber = topicSerialNumber;
+    }
+
+    public ConcurrentMap<String, TopicMetadata> getTopicMetadataTable() {
+        return topicMetadataTable;
+    }
+
+    public void setTopicMetadataTable(
+            ConcurrentMap<String, TopicMetadata> topicMetadataTable) {
+        this.topicMetadataTable = topicMetadataTable;
+    }
+
+    public ConcurrentMap<String, ConcurrentMap<Integer, QueueMetadata>> getQueueMetadataTable() {
+        return queueMetadataTable;
+    }
+
+    public void setQueueMetadataTable(
+            ConcurrentMap<String, ConcurrentMap<Integer, QueueMetadata>> queueMetadataTable) {
+        this.queueMetadataTable = queueMetadataTable;
+    }
+
+    public ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> getCommitLogFileSegmentTable() {
+        return commitLogFileSegmentTable;
+    }
+
+    public void setCommitLogFileSegmentTable(
+            ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> commitLogFileSegmentTable) {
+        this.commitLogFileSegmentTable = commitLogFileSegmentTable;
+    }
+
+    public ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> getConsumeQueueFileSegmentTable() {
+        return consumeQueueFileSegmentTable;
+    }
+
+    public void setConsumeQueueFileSegmentTable(
+            ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> consumeQueueFileSegmentTable) {
+        this.consumeQueueFileSegmentTable = consumeQueueFileSegmentTable;
+    }
+
+    public ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> getIndexFileSegmentTable() {
+        return indexFileSegmentTable;
+    }
+
+    public void setIndexFileSegmentTable(
+            ConcurrentMap<String, ConcurrentMap<Long, FileSegmentMetadata>> indexFileSegmentTable) {
+        this.indexFileSegmentTable = indexFileSegmentTable;
+    }
+}

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
@@ -23,6 +23,8 @@ import java.security.NoSuchAlgorithmException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.store.config.BrokerRole;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
 
 public class MessageStoreUtil {
 
@@ -98,5 +100,14 @@ public class MessageStoreUtil {
 
     public static long fileName2Offset(final String fileName) {
         return Long.parseLong(fileName.substring(fileName.length() - 20));
+    }
+
+    public static boolean isSlave(MessageStoreConfig storeConfig) {
+        return storeConfig.getBrokerRole().equals(BrokerRole.SLAVE) ||
+            storeConfig.isEnableDLegerCommitLog() && storeConfig.getBrokerRole().equals(BrokerRole.ASYNC_MASTER);
+    }
+
+    public static boolean isMaster(MessageStoreConfig storeConfig) {
+        return !isSlave(storeConfig);
     }
 }

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -96,6 +96,7 @@ public class TieredMessageStoreTest {
 
         defaultStore = Mockito.mock(DefaultMessageStore.class);
         Mockito.when(defaultStore.load()).thenReturn(true);
+        Mockito.when(defaultStore.getMessageStoreConfig()).thenReturn(new org.apache.rocketmq.store.config.MessageStoreConfig());
 
         currentStore = new TieredMessageStore(context, defaultStore);
         Assert.assertNotNull(currentStore.getStoreConfig());

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
@@ -79,7 +79,7 @@ public class MessageStoreDispatcherImplTest {
         mq = new MessageQueue("StoreTest", storeConfig.getBrokerName(), 1);
         metadataStore = new DefaultMetadataStore(storeConfig);
         executor = new MessageStoreExecutor();
-        fileStore = new FlatFileStore(storeConfig, metadataStore, executor);
+        fileStore = new FlatFileStore(messageStore, storeConfig, metadataStore, executor);
     }
 
     @After
@@ -95,14 +95,15 @@ public class MessageStoreDispatcherImplTest {
         MessageStore defaultStore = Mockito.mock(MessageStore.class);
         Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(100L);
         Mockito.when(defaultStore.getMaxOffsetInQueue(anyString(), anyInt())).thenReturn(200L);
+        Mockito.when(defaultStore.getMessageStoreConfig()).thenReturn(new org.apache.rocketmq.store.config.MessageStoreConfig());
 
         messageStore = Mockito.mock(TieredMessageStore.class);
-        IndexService indexService =
-            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
         Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
         Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
         Mockito.when(messageStore.getStoreExecutor()).thenReturn(executor);
         Mockito.when(messageStore.getFlatFileStore()).thenReturn(fileStore);
+        IndexService indexService =
+                new IndexStoreService(messageStore, new FlatFileFactory(metadataStore, storeConfig), storePath);
         Mockito.when(messageStore.getIndexService()).thenReturn(indexService);
 
         // mock message
@@ -160,13 +161,14 @@ public class MessageStoreDispatcherImplTest {
     public void dispatchServiceTest() {
         MessageStore defaultStore = Mockito.mock(MessageStore.class);
         messageStore = Mockito.mock(TieredMessageStore.class);
-        IndexService indexService =
-            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
         Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
         Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
         Mockito.when(messageStore.getStoreExecutor()).thenReturn(executor);
         Mockito.when(messageStore.getFlatFileStore()).thenReturn(fileStore);
+        IndexService indexService =
+                new IndexStoreService(messageStore, new FlatFileFactory(metadataStore, storeConfig), storePath);
         Mockito.when(messageStore.getIndexService()).thenReturn(indexService);
+        Mockito.when(defaultStore.getMessageStoreConfig()).thenReturn(new org.apache.rocketmq.store.config.MessageStoreConfig());
 
         // construct flat file
         ByteBuffer buffer = MessageFormatUtilTest.buildMockedMessageBuffer();

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFileTest.java
@@ -65,6 +65,7 @@ public class FlatCommitLogFileTest {
     public void constructTest() {
         String filePath = MessageStoreUtil.toFilePath(queue);
         FlatAppendFile flatFile = flatFileFactory.createFlatFileForCommitLog(filePath);
+        flatFile.initOffset(0L);
         Assert.assertEquals(1L, flatFile.fileSegmentTable.size());
     }
 
@@ -72,6 +73,7 @@ public class FlatCommitLogFileTest {
     public void tryRollingFileTest() throws InterruptedException {
         String filePath = MessageStoreUtil.toFilePath(queue);
         FlatCommitLogFile flatFile = flatFileFactory.createFlatFileForCommitLog(filePath);
+        flatFile.initOffset(0L);
         for (int i = 0; i < 3; i++) {
             ByteBuffer byteBuffer = MessageFormatUtilTest.buildMockedMessageBuffer();
             byteBuffer.putLong(MessageFormatUtil.QUEUE_OFFSET_POSITION, i);
@@ -88,6 +90,7 @@ public class FlatCommitLogFileTest {
     public void getMinOffsetFromFileAsyncTest() {
         String filePath = MessageStoreUtil.toFilePath(queue);
         FlatCommitLogFile flatFile = flatFileFactory.createFlatFileForCommitLog(filePath);
+        flatFile.initOffset(0L);
 
         // append some messages
         for (int i = 6; i < 9; i++) {

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceBenchTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceBenchTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.store.DefaultMessageStore;
+import org.apache.rocketmq.tieredstore.TieredMessageStore;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
 import org.apache.rocketmq.tieredstore.file.FlatFileFactory;
@@ -52,6 +54,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.mockito.Mockito;
 
 @Ignore
 @State(Scope.Benchmark)
@@ -78,7 +81,12 @@ public class IndexStoreServiceBenchTest {
         storeConfig.setTieredStoreIndexFileMaxIndexNum(2000 * 1000);
         MetadataStore metadataStore = new DefaultMetadataStore(storeConfig);
         FlatFileFactory flatFileFactory = new FlatFileFactory(metadataStore, storeConfig);
-        indexStoreService = new IndexStoreService(flatFileFactory, storePath);
+
+        TieredMessageStore messageStore = Mockito.mock(TieredMessageStore.class);
+        DefaultMessageStore defaultMessageStore = Mockito.mock(DefaultMessageStore.class);
+        Mockito.when(defaultMessageStore.getMessageStoreConfig()).thenReturn(new org.apache.rocketmq.store.config.MessageStoreConfig());
+        Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultMessageStore);
+        indexStoreService = new IndexStoreService(messageStore, flatFileFactory, storePath);
         indexStoreService.start();
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8066 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

1. 限制从节点分级存储行为
1.1. 修改 `MessageStoreDispatcherImpl#dispatch`：从节点不将消息分发到分级存储；
1.2. 修改 `FlatFileStore#load`：从节点不进行 recover 操作；
2. 主从节点数据同步
2.1. 在`SlaveSynchronize#syncAll` 中增加 `syncTieredMetadata`方法，定时同步分级存储元数据；
2.2. 在 `BrokerController` 中增加 `SyncTieredIndexService`，同步`DispatchRequest`以使得从节点可以构建`IndexFile`；
3. 从节点切主时执行数据恢复
3.1 在`TieredMessageStore`中增加接口`RecoverService`，负责切主时恢复`Metadata`，`FlatFile`与`IndexFile`；若冷存中文件信息与本地元数据出现不一致，以冷存为准；
4. 其他
4.1. 修改部分日志，使其更为合理；
4.2. 为防止切主时位点出现错误，`FlatCommitLogFile`构造函数中不再初始化位点，理论上不影响主节点构造`FlatMessageFile`；
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
