### PR TITLE
[ISSUE #8232] Fix the issue that proxy remoting thread pool isolation does not take effect

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
@@ -120,7 +120,6 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
         } else {
             this.defaultRemotingServer = new NettyRemotingServer(defaultServerConfig, this.clientHousekeepingService);
         }
-        this.registerRemotingServer(this.defaultRemotingServer);
 
         this.sendMessageExecutor = ThreadPoolMonitor.createAndMonitor(
             config.getRemotingSendMessageThreadPoolNums(),
@@ -186,6 +185,8 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
             new ThreadFactoryBuilder().setNameFormat("RemotingServerScheduler-%d").build()
         );
         this.timerExecutor.scheduleAtFixedRate(this::cleanExpireRequest, 10, 10, TimeUnit.SECONDS);
+
+        this.registerRemotingServer(this.defaultRemotingServer);
     }
 
     protected void registerRemotingServer(RemotingServer remotingServer) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8232 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Register processsors after thread pool initialization.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
