### PR TITLE
[ISSUE #8239] Fix the issue of potential message loss after a crash under synchronous disk flushing configuration.

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -651,7 +651,7 @@ public class CommitLog implements Swappable {
         } else if (this.defaultMessageStore.getMessageStoreConfig().isDuplicationEnable()) {
             return this.confirmOffset;
         } else {
-            return getMaxOffset();
+            return this.defaultMessageStore.isSyncDiskFlush() ? getFlushedWhere() : getMaxOffset();
         }
     }
 
@@ -1483,7 +1483,7 @@ public class CommitLog implements Swappable {
         }
     }
 
-    class FlushRealTimeService extends FlushCommitLogService {
+    public class FlushRealTimeService extends FlushCommitLogService {
         private long lastFlushTimestamp = 0;
         private long printTimes = 0;
 
@@ -1610,7 +1610,7 @@ public class CommitLog implements Swappable {
     /**
      * GroupCommit Service
      */
-    class GroupCommitService extends FlushCommitLogService {
+    public class GroupCommitService extends FlushCommitLogService {
         private volatile LinkedList<GroupCommitRequest> requestsWrite = new LinkedList<>();
         private volatile LinkedList<GroupCommitRequest> requestsRead = new LinkedList<>();
         private final PutMessageSpinLock lock = new PutMessageSpinLock();

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -651,7 +651,7 @@ public class CommitLog implements Swappable {
         } else if (this.defaultMessageStore.getMessageStoreConfig().isDuplicationEnable()) {
             return this.confirmOffset;
         } else {
-            return this.defaultMessageStore.isSyncDiskFlush() ? getFlushedWhere() : getMaxOffset();
+            return this.defaultMessageStore.isSyncDiskFlush()  ? getFlushedWhere() : getMaxOffset();
         }
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1483,7 +1483,7 @@ public class CommitLog implements Swappable {
         }
     }
 
-    public class FlushRealTimeService extends FlushCommitLogService {
+    class FlushRealTimeService extends FlushCommitLogService {
         private long lastFlushTimestamp = 0;
         private long printTimes = 0;
 
@@ -1610,7 +1610,7 @@ public class CommitLog implements Swappable {
     /**
      * GroupCommit Service
      */
-    public class GroupCommitService extends FlushCommitLogService {
+    class GroupCommitService extends FlushCommitLogService {
         private volatile LinkedList<GroupCommitRequest> requestsWrite = new LinkedList<>();
         private volatile LinkedList<GroupCommitRequest> requestsRead = new LinkedList<>();
         private final PutMessageSpinLock lock = new PutMessageSpinLock();

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -2814,7 +2814,11 @@ public class DefaultMessageStore implements MessageStore {
         }
 
         public boolean isCommitLogAvailable() {
-            return this.reputFromOffset < DefaultMessageStore.this.getConfirmOffset();
+            return this.reputFromOffset < getReputEndOffset();
+        }
+
+        protected long getReputEndOffset() {
+            return DefaultMessageStore.this.getMessageStoreConfig().isReadUnCommitted() ? DefaultMessageStore.this.commitLog.getMaxOffset() : DefaultMessageStore.this.commitLog.getConfirmOffset();
         }
 
         public void doReput() {
@@ -2834,12 +2838,12 @@ public class DefaultMessageStore implements MessageStore {
                 try {
                     this.reputFromOffset = result.getStartOffset();
 
-                    for (int readSize = 0; readSize < result.getSize() && reputFromOffset < DefaultMessageStore.this.getConfirmOffset() && doNext; ) {
+                    for (int readSize = 0; readSize < result.getSize() && reputFromOffset < getReputEndOffset() && doNext; ) {
                         DispatchRequest dispatchRequest =
                             DefaultMessageStore.this.commitLog.checkMessageAndReturnSize(result.getByteBuffer(), false, false, false);
                         int size = dispatchRequest.getBufferSize() == -1 ? dispatchRequest.getMsgSize() : dispatchRequest.getBufferSize();
 
-                        if (reputFromOffset + size > DefaultMessageStore.this.getConfirmOffset()) {
+                        if (reputFromOffset + size > getReputEndOffset()) {
                             doNext = false;
                             break;
                         }
@@ -3127,7 +3131,7 @@ public class DefaultMessageStore implements MessageStore {
                 try {
                     this.reputFromOffset = result.getStartOffset();
 
-                    for (int readSize = 0; readSize < result.getSize() && reputFromOffset < DefaultMessageStore.this.getConfirmOffset() && doNext; ) {
+                    for (int readSize = 0; readSize < result.getSize() && reputFromOffset < getReputEndOffset() && doNext; ) {
                         ByteBuffer byteBuffer = result.getByteBuffer();
 
                         int totalSize = preCheckMessageAndReturnSize(byteBuffer);

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -413,11 +413,11 @@ public class MessageStoreConfig {
 
     private int topicQueueLockNum = 32;
 
-     /**
-      * If readUnCommitted is true, the dispatch of the consume queue will exceed the confirmOffset, which may cause the client to read uncommitted messages.
-      * For example, reput offset exceeding the flush offset during synchronous disk flushing.
-      */
-     private boolean readUnCommitted = false;
+    /**
+     * If readUnCommitted is true, the dispatch of the consume queue will exceed the confirmOffset, which may cause the client to read uncommitted messages.
+     * For example, reput offset exceeding the flush offset during synchronous disk flushing.
+     */
+    private boolean readUnCommitted = false;
 
     public boolean isEnabledAppendPropCRC() {
         return enabledAppendPropCRC;

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -413,6 +413,12 @@ public class MessageStoreConfig {
 
     private int topicQueueLockNum = 32;
 
+     /**
+      * If readUnCommitted is true, the dispatch of the consume queue will exceed the confirmOffset, which may cause the client to read uncommitted messages.
+      * For example, reput offset exceeding the flush offset during synchronous disk flushing.
+      */
+     private boolean readUnCommitted = false;
+
     public boolean isEnabledAppendPropCRC() {
         return enabledAppendPropCRC;
     }
@@ -671,7 +677,6 @@ public class MessageStoreConfig {
     public void setForceVerifyPropCRC(boolean forceVerifyPropCRC) {
         this.forceVerifyPropCRC = forceVerifyPropCRC;
     }
-
 
     public String getStorePathCommitLog() {
         if (storePathCommitLog == null) {
@@ -1818,5 +1823,13 @@ public class MessageStoreConfig {
 
     public void setTopicQueueLockNum(int topicQueueLockNum) {
         this.topicQueueLockNum = topicQueueLockNum;
+    }
+
+    public boolean isReadUnCommitted() {
+        return readUnCommitted;
+    }
+
+    public void setReadUnCommitted(boolean readUnCommitted) {
+        this.readUnCommitted = readUnCommitted;
     }
 }

--- a/store/src/test/java/org/apache/rocketmq/store/ReputMessageServiceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/ReputMessageServiceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.store;
+
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.UUID;
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.message.MessageDecoder;
+
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageExtBrokerInner;
+import org.apache.rocketmq.store.config.FlushDiskType;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+public class ReputMessageServiceTest {
+    private DefaultMessageStore syncFlushMessageStore;
+    private DefaultMessageStore asyncFlushMessageStore;
+    private final String topic = "FooBar";
+    private final String tmpdir = System.getProperty("java.io.tmpdir");
+    private final String storePathRootParentDir = (StringUtils.endsWith(tmpdir, File.separator) ? tmpdir : tmpdir + File.separator) + UUID.randomUUID();
+    private SocketAddress bornHost;
+    private SocketAddress storeHost;
+
+    @Before
+    public void init() throws Exception {
+        File file = new File(storePathRootParentDir);
+        UtilAll.deleteFile(file);
+        syncFlushMessageStore = buildMessageStore(FlushDiskType.SYNC_FLUSH);
+        asyncFlushMessageStore = buildMessageStore(FlushDiskType.ASYNC_FLUSH);
+        assertTrue(syncFlushMessageStore.load());
+        assertTrue(asyncFlushMessageStore.load());
+        syncFlushMessageStore.start();
+        asyncFlushMessageStore.start();
+        storeHost = new InetSocketAddress(InetAddress.getLocalHost(), 8123);
+        bornHost = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0);
+    }
+
+    private DefaultMessageStore buildMessageStore(FlushDiskType flushDiskType) throws Exception {
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setHaListenPort(0);
+        messageStoreConfig.setFlushDiskType(flushDiskType);
+        messageStoreConfig.setStorePathRootDir(storePathRootParentDir + File.separator + flushDiskType);
+        messageStoreConfig.setStorePathCommitLog(storePathRootParentDir + File.separator + flushDiskType + File.separator + "commitlog");
+        BrokerConfig brokerConfig = new BrokerConfig();
+        brokerConfig.setLongPollingEnable(false);
+        DefaultMessageStore messageStore = new DefaultMessageStore(messageStoreConfig, mock(BrokerStatsManager.class), null, brokerConfig, null);
+        // Mock flush disk service
+        Field field = CommitLog.class.getDeclaredField("flushManager");
+        field.setAccessible(true);
+        FlushManager flushManager = mock(FlushManager.class);
+        CompletableFuture<PutMessageStatus> completableFuture = new CompletableFuture<>();
+        completableFuture.complete(PutMessageStatus.PUT_OK);
+        when(flushManager.handleDiskFlush(any(AppendMessageResult.class), any(MessageExt.class))).thenReturn(completableFuture);
+        field.set(messageStore.getCommitLog(), flushManager);
+        return messageStore;
+    }
+
+    @Test
+    public void testReputEndOffset_whenSyncFlush() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            assertEquals(PutMessageStatus.PUT_OK, syncFlushMessageStore.putMessage(buildMessage()).getPutMessageStatus());
+        }
+        assertEquals(1580, syncFlushMessageStore.getMaxPhyOffset());
+        assertEquals(0, syncFlushMessageStore.getCommitLog().getFlushedWhere());
+        // wait for cq dispatch
+        Thread.sleep(3000);
+        assertEquals(0, syncFlushMessageStore.getCommitLog().getFlushedWhere());
+        assertEquals(0, syncFlushMessageStore.getMaxOffsetInQueue(topic, 0));
+        GetMessageResult getMessageResult = syncFlushMessageStore.getMessage("testGroup", topic, 0, 0, 32, null);
+        assertEquals(GetMessageStatus.NO_MESSAGE_IN_QUEUE, getMessageResult.getStatus());
+    }
+
+    @Test
+    public void testReputEndOffset_whenAsyncFlush() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            assertEquals(PutMessageStatus.PUT_OK, asyncFlushMessageStore.putMessage(buildMessage()).getPutMessageStatus());
+        }
+        assertEquals(1580, asyncFlushMessageStore.getMaxPhyOffset());
+        assertEquals(0, asyncFlushMessageStore.getCommitLog().getFlushedWhere());
+        // wait for cq dispatch
+        Thread.sleep(3000);
+        assertEquals(0, asyncFlushMessageStore.getCommitLog().getFlushedWhere());
+        assertEquals(10, asyncFlushMessageStore.getMaxOffsetInQueue(topic, 0));
+        GetMessageResult getMessageResult = asyncFlushMessageStore.getMessage("testGroup", topic, 0, 0, 32, null);
+        assertEquals(10, getMessageResult.getMessageCount());
+    }
+
+    private MessageExtBrokerInner buildMessage() {
+        MessageExtBrokerInner msg = new MessageExtBrokerInner();
+        msg.setTopic(topic);
+        msg.setTags("TAG1");
+        msg.setBody("Once, there was a chance for me!".getBytes());
+        msg.setKeys(String.valueOf(System.currentTimeMillis()));
+        msg.setQueueId(0);
+        msg.setSysFlag(0);
+        msg.setBornTimestamp(System.currentTimeMillis());
+        msg.setStoreHost(storeHost);
+        msg.setBornHost(bornHost);
+        msg.setPropertiesString(MessageDecoder.messageProperties2String(msg.getProperties()));
+        return msg;
+    }
+
+    @After
+    public void destroy() throws Exception {
+        if (this.syncFlushMessageStore != null) {
+            syncFlushMessageStore.shutdown();
+            syncFlushMessageStore.destroy();
+        }
+        if (this.asyncFlushMessageStore != null) {
+            asyncFlushMessageStore.shutdown();
+            asyncFlushMessageStore.destroy();
+        }
+        File file = new File(storePathRootParentDir);
+        UtilAll.deleteFile(file);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8239 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Under the condition of synchronous disk flushing, unflushed messages should be unacknowledged messages. Such messages should not be consumed prematurely, as this would lead to the consumption offset moving forward, resulting in potential phantom reads and message loss on the consumer side.

Therefore, in this PR, the dispatch offset of the ConsumeQueue is restricted to be before the disk flush offset to prevent consumers from experiencing phantom reads.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

Add a UT
