### PR TITLE
[ISSUE #8311] Adjust needDiscard(...) position

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -260,7 +260,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                             continue;
                         }
 
-                        if (needDiscard(msgExt, transactionCheckMax) || needSkip(msgExt)) {
+                        if (needSkip(msgExt)) {
                             listener.resolveDiscardMsg(msgExt);
                             newOffset = i + 1;
                             i++;
@@ -296,7 +296,13 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                             || opMsg != null && opMsg.get(opMsg.size() - 1).getBornTimestamp() - startTime > transactionTimeout
                             || valueOfCurrentMinusBorn <= -1;
 
-                        if (isNeedCheck) {
+                        if (isNeedCheck) {   
+                            if (needDiscard(msgExt, transactionCheckMax)) {
+                                listener.resolveDiscardMsg(msgExt);
+                                newOffset = i + 1;
+                                i++;
+                                continue;
+                            }
 
                             if (!putBackHalfMsgQueue(msgExt, i)) {
                                 continue;


### PR DESCRIPTION
Fix: 
1. case final check, discard half msg when Incomplete pull of opQueue. May have redundantly push to "TRANS_CHECK_MAX_TIME_TOPIC".
2. case long "PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS", check transaction times unable to reach the "check transaction times unable to reach the maximum number of detections".

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8311 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
