### PR TITLE
[ISSUE #8313] Fix the issue that Remoting producer cannot end transactions in time

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
@@ -334,6 +334,12 @@ public class DefaultMessagingProcessor extends AbstractStartAndShutdown implemen
     }
 
     @Override
+    public void addTransactionData(ProxyContext ctx, String brokerName, String topic, String producerGroup,
+        long tranStateTableOffset, long commitLogOffset, String transactionId) {
+        this.transactionProcessor.addTransactionData(ctx, brokerName, topic, producerGroup, tranStateTableOffset, commitLogOffset, transactionId);
+    }
+
+    @Override
     public ProxyRelayService getProxyRelayService() {
         return this.serviceManager.getProxyRelayService();
     }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/MessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/MessagingProcessor.java
@@ -317,6 +317,16 @@ public interface MessagingProcessor extends StartAndShutdown {
         String topic
     );
 
+    void addTransactionData(
+        ProxyContext ctx,
+        String brokerName,
+        String topic,
+        String producerGroup,
+        long tranStateTableOffset,
+        long commitLogOffset,
+        String transactionId
+    );
+
     ProxyRelayService getProxyRelayService();
 
     MetadataService getMetadataService();

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ProducerProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ProducerProcessor.java
@@ -139,8 +139,7 @@ public class ProducerProcessor extends AbstractProcessor {
                 producerGroup,
                 sendResult.getQueueOffset(),
                 id.getOffset(),
-                sendResult.getTransactionId(),
-                messageList.get(0)
+                sendResult.getTransactionId()
             );
         } catch (Throwable t) {
             log.warn("fillTransactionData failed. messageQueue: {}, sendResult: {}", messageQueue, sendResult, t);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/TransactionProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/TransactionProcessor.java
@@ -74,4 +74,10 @@ public class TransactionProcessor extends AbstractProcessor {
     public void addTransactionSubscription(ProxyContext ctx, String producerGroup, String topic) {
         this.serviceManager.getTransactionService().addTransactionSubscription(ctx, producerGroup, topic);
     }
+
+    public void addTransactionData(ProxyContext ctx, String brokerName, String topic, String producerGroup,
+        long tranStateTableOffset, long commitLogOffset, String transactionId) {
+        this.serviceManager.getTransactionService().addTransactionDataByBrokerName(
+            ctx, brokerName, topic, producerGroup, tranStateTableOffset, commitLogOffset, transactionId);
+    }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/relay/AbstractProxyRelayService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/relay/AbstractProxyRelayService.java
@@ -49,8 +49,7 @@ public abstract class AbstractProxyRelayService implements ProxyRelayService {
             group,
             header.getTranStateTableOffset(),
             header.getCommitLogOffset(),
-            header.getTransactionId(),
-            messageExt);
+            header.getTransactionId());
         if (transactionData == null) {
             throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR,
                 String.format("add transaction data failed. request:%s, message:%s", command, messageExt));

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/transaction/AbstractTransactionService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/transaction/AbstractTransactionService.java
@@ -18,7 +18,6 @@
 package org.apache.rocketmq.proxy.service.transaction;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.common.utils.StartAndShutdown;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
@@ -29,14 +28,12 @@ public abstract class AbstractTransactionService implements TransactionService, 
     protected TransactionDataManager transactionDataManager = new TransactionDataManager();
 
     @Override
-    public TransactionData addTransactionDataByBrokerAddr(ProxyContext ctx, String brokerAddr, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId,
-        Message message) {
-        return this.addTransactionDataByBrokerName(ctx, this.getBrokerNameByAddr(brokerAddr), topic, producerGroup, tranStateTableOffset, commitLogOffset, transactionId, message);
+    public TransactionData addTransactionDataByBrokerAddr(ProxyContext ctx, String brokerAddr, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId) {
+        return this.addTransactionDataByBrokerName(ctx, this.getBrokerNameByAddr(brokerAddr), topic, producerGroup, tranStateTableOffset, commitLogOffset, transactionId);
     }
 
     @Override
-    public TransactionData addTransactionDataByBrokerName(ProxyContext ctx, String brokerName, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId,
-        Message message) {
+    public TransactionData addTransactionDataByBrokerName(ProxyContext ctx, String brokerName, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId) {
         if (StringUtils.isBlank(brokerName)) {
             return null;
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/transaction/TransactionService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/transaction/TransactionService.java
@@ -17,7 +17,6 @@
 package org.apache.rocketmq.proxy.service.transaction;
 
 import java.util.List;
-import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 
 public interface TransactionService {
@@ -30,11 +29,9 @@ public interface TransactionService {
 
     void unSubscribeAllTransactionTopic(ProxyContext ctx, String group);
 
-    TransactionData addTransactionDataByBrokerAddr(ProxyContext ctx, String brokerAddr, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId,
-        Message message);
+    TransactionData addTransactionDataByBrokerAddr(ProxyContext ctx, String brokerAddr, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId);
 
-    TransactionData addTransactionDataByBrokerName(ProxyContext ctx, String brokerName, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId,
-        Message message);
+    TransactionData addTransactionDataByBrokerName(ProxyContext ctx, String brokerName, String topic, String producerGroup, long tranStateTableOffset, long commitLogOffset, String transactionId);
 
     EndTransactionRequestData genEndTransactionRequestHeader(ProxyContext ctx, String topic, String producerGroup, Integer commitOrRollback,
         boolean fromTransactionCheck, String msgId, String transactionId);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ProducerProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ProducerProcessorTest.java
@@ -103,7 +103,7 @@ public class ProducerProcessorTest extends BaseProcessorTest {
             anyString(),
             tranStateTableOffsetCaptor.capture(),
             commitLogOffsetCaptor.capture(),
-            anyString(), any())).thenReturn(mock(TransactionData.class));
+            anyString())).thenReturn(mock(TransactionData.class));
 
         List<SendResult> sendResultList = this.producerProcessor.sendMessage(
             createContext(),
@@ -159,7 +159,7 @@ public class ProducerProcessorTest extends BaseProcessorTest {
             anyString(),
             tranStateTableOffsetCaptor.capture(),
             commitLogOffsetCaptor.capture(),
-            anyString(), any())).thenReturn(mock(TransactionData.class));
+            anyString())).thenReturn(mock(TransactionData.class));
 
         List<SendResult> sendResultList = this.producerProcessor.sendMessage(
             createContext(),

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/transaction/AbstractTransactionServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/transaction/AbstractTransactionServiceTest.java
@@ -88,8 +88,7 @@ public class AbstractTransactionServiceTest extends InitConfigTest {
             PRODUCER_GROUP,
             RANDOM.nextLong(),
             RANDOM.nextLong(),
-            txId,
-            message
+            txId
         );
         assertNotNull(transactionData);
 
@@ -132,8 +131,7 @@ public class AbstractTransactionServiceTest extends InitConfigTest {
             PRODUCER_GROUP,
             RANDOM.nextLong(),
             RANDOM.nextLong(),
-            txId,
-            message
+            txId
         );
         transactionService.onSendCheckTransactionStateFailed(ProxyContext.createForInner(this.getClass()), PRODUCER_GROUP, transactionData);
         assertNull(transactionService.genEndTransactionRequestHeader(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8313 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

1. Add new method addTransactionData(...) to interface MessagingProcessor
2. After successfully sending a transaction message, add data to TransationDataManager by calling MessagingProcessor.addTransactionData
3. Refactor TransactionService: remove never used parameter 'Message' in TransactionService#addTransactionDataByBrokerAddr and TransactionService#addTransactionDataByBrokerName

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

<img width="2136" alt="image" src="https://github.com/apache/rocketmq/assets/103550934/fee16974-2ee9-40b0-bdb3-729784d154de">
<img width="1668" alt="image" src="https://github.com/apache/rocketmq/assets/103550934/f57b2132-4094-4e3a-b5d0-24cbb493f5dc">

After this change, committed messages can be consumed immediately.
