### PR TITLE
[ISSUE #8316] Fix the issue that pending transaction messages may never be checked

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -184,6 +184,7 @@ public class ProxyConfig implements ConfigFile {
     private long transactionDataExpireScanPeriodMillis = Duration.ofSeconds(10).toMillis();
     private long transactionDataMaxWaitClearMillis = Duration.ofSeconds(30).toMillis();
     private long transactionDataExpireMillis = Duration.ofSeconds(30).toMillis();
+    private long transactionGroupOfflineTimeoutMillis = Duration.ofSeconds(120).toMillis();
     private int transactionDataMaxNum = 15;
 
     private long longPollingReserveTimeInMillis = 100;
@@ -1024,6 +1025,14 @@ public class ProxyConfig implements ConfigFile {
 
     public void setTransactionDataExpireMillis(long transactionDataExpireMillis) {
         this.transactionDataExpireMillis = transactionDataExpireMillis;
+    }
+
+    public long getTransactionGroupOfflineTimeoutMillis() {
+        return transactionGroupOfflineTimeoutMillis;
+    }
+
+    public void setTransactionGroupOfflineTimeoutMillis(long transactionGroupOfflineTimeoutMillis) {
+        this.transactionGroupOfflineTimeoutMillis = transactionGroupOfflineTimeoutMillis;
     }
 
     public int getTransactionDataMaxNum() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8316

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

When determine if the producer group is offline in ClusterTransactionService#scanProducerHeartBeat, take the last addTransactionSubscription timestamp into account


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

<img width="1668" alt="image" src="https://github.com/apache/rocketmq/assets/103550934/e3fc82ed-6b22-465e-ba6d-c8c0468e8743">