### PR TITLE
[ISSUE #8366] Eliminate deadlocks during the client shutdown process.

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -421,7 +421,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                     if (null == prevCW) {
                         LOGGER.info("closeChannel: the channel[{}] has been removed from the channel table before", addrRemote);
                         removeItemFromTable = false;
-                    } else if (prevCW.getChannel() != channel) {
+                    } else if (prevCW.isWrapperOf(channel)) {
                         LOGGER.info("closeChannel: the channel[{}] has been closed before, and has been created again, nothing to do.",
                             addrRemote);
                         removeItemFromTable = false;

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -463,12 +463,10 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                     for (Map.Entry<String, ChannelWrapper> entry : channelTables.entrySet()) {
                         String key = entry.getKey();
                         ChannelWrapper prev = entry.getValue();
-                        if (prev.getChannel() != null) {
-                            if (prev.getChannel() == channel) {
-                                prevCW = prev;
-                                addrRemote = key;
-                                break;
-                            }
+                        if (prev.isWrapperOf(channel)) {
+                            prevCW = prev;
+                            addrRemote = key;
+                            break;
                         }
                     }
 
@@ -1020,6 +1018,13 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
 
         public boolean isWritable() {
             return getChannel().isWritable();
+        }
+
+        public boolean isWrapperOf(Channel channel) {
+            if (this.channelFuture.channel() != null && this.channelFuture.channel() == channel) {
+                return true;
+            }
+            return false;
         }
 
         private Channel getChannel() {


### PR DESCRIPTION
… a channel, no longer acquire a read lock.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8366 

### Brief Description
<img width="858" alt="截屏2024-07-05 15 38 50" src="https://github.com/apache/rocketmq/assets/11780013/9414ae94-a62c-43fd-9f43-d4da1d25483a">

`ChannelWrapper.getChannel()` needs to hold the read lock. When determining if `ChannelWrapper` is the wrapper for a channel, no longer acquire a read lock. 
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

