### PR TITLE
[ISSUE #8438] Fix broker return two messages when query message and index service bug

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -460,6 +460,9 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
         if (flatFileStore != null) {
             flatFileStore.shutdown();
         }
+        if (indexService != null) {
+            indexService.shutdown();
+        }
         if (storeExecutor != null) {
             storeExecutor.shutdown();
         }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
@@ -90,6 +90,7 @@ public class FlatAppendFile {
     public void initOffset(long offset) {
         if (this.fileSegmentTable.isEmpty()) {
             FileSegment fileSegment = fileSegmentFactory.createSegment(fileType, filePath, offset);
+            fileSegment.initPosition(fileSegment.getSize());
             this.flushFileSegmentMeta(fileSegment);
             this.fileSegmentTable.add(fileSegment);
         }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -287,8 +287,12 @@ public class IndexStoreFile implements IndexFile {
                     buffer.position(this.getItemPosition(slotValue));
                     buffer.get(bytes);
                     IndexItem indexItem = new IndexItem(bytes);
+                    long storeTimestamp = indexItem.getTimeDiff() + beginTimestamp.get();
                     if (hashCode == indexItem.getHashCode()) {
-                        result.add(indexItem);
+                        if (hashCode == indexItem.getHashCode() &&
+                            beginTime <= storeTimestamp && storeTimestamp <= endTime) {
+                            result.add(indexItem);
+                        }
                         if (result.size() > maxCount) {
                             break;
                         }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -288,11 +288,9 @@ public class IndexStoreFile implements IndexFile {
                     buffer.get(bytes);
                     IndexItem indexItem = new IndexItem(bytes);
                     long storeTimestamp = indexItem.getTimeDiff() + beginTimestamp.get();
-                    if (hashCode == indexItem.getHashCode()) {
-                        if (hashCode == indexItem.getHashCode() &&
-                            beginTime <= storeTimestamp && storeTimestamp <= endTime) {
-                            result.add(indexItem);
-                        }
+                    if (hashCode == indexItem.getHashCode() &&
+                        beginTime <= storeTimestamp && storeTimestamp <= endTime) {
+                        result.add(indexItem);
                         if (result.size() > maxCount) {
                             break;
                         }


### PR DESCRIPTION
Fix broker return two messages when query message and index service bug

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8438

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
