### PR TITLE
[ISSUE #8454] Active brokers number should be initailized to 1 in broker heartbeat manager.

### DIFF
--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/DefaultBrokerHeartbeatManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/DefaultBrokerHeartbeatManager.java
@@ -184,7 +184,7 @@ public class DefaultBrokerHeartbeatManager implements BrokerHeartbeatManager {
             .forEach(id -> {
                 map.computeIfAbsent(id.getClusterName(), k -> new HashMap<>());
                 map.get(id.getClusterName()).compute(id.getBrokerName(), (broker, num) ->
-                    num == null ? 0 : num + 1
+                    num == null ? 1 : num + 1
                 );
             });
         return map;

--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/RaftBrokerHeartBeatManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/RaftBrokerHeartBeatManager.java
@@ -263,7 +263,7 @@ public class RaftBrokerHeartBeatManager implements BrokerHeartbeatManager {
             .forEach(id -> {
                 map.computeIfAbsent(id.getClusterName(), k -> new HashMap<>());
                 map.get(id.getClusterName()).compute(id.getBrokerName(), (broker, num) ->
-                    num == null ? 0 : num + 1
+                    num == null ? 1 : num + 1
                 );
             });
         return map;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8454

### Brief Description

active brokers number should be initailized to 1 in broker heartbeat manager.

### How Did You Test This Change?

wait to add test cases for this two class.
