### PR TITLE
[ISSUE #8500] Add more test coverage for RocksDBLmqConsumerOffsetManager

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/RocksDBLmqConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/RocksDBLmqConsumerOffsetManagerTest.java
@@ -1,0 +1,68 @@
+package org.apache.rocketmq.broker.offset;
+
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class RocksDBLmqConsumerOffsetManagerTest {
+    private static final String LMQ_GROUP = MixAll.LMQ_PREFIX + "FooBarGroup";
+    private static final String TOPIC = "FooBarTopic";
+    private static final int QUEUE_ID = 0;
+    private static final long OFFSET = 12345;
+
+    private BrokerController brokerController;
+
+    private RocksDBLmqConsumerOffsetManager offsetManager;
+
+    @Before
+    public void setUp() {
+        brokerController = Mockito.mock(BrokerController.class);
+        when(brokerController.getMessageStoreConfig()).thenReturn(Mockito.mock(MessageStoreConfig.class));
+        when(brokerController.getBrokerConfig()).thenReturn(Mockito.mock(BrokerConfig.class));
+        offsetManager = new RocksDBLmqConsumerOffsetManager(brokerController);
+    }
+
+    @Test
+    public void testQueryOffsetForLmq() {
+        // Setup
+        offsetManager.getLmqOffsetTable().put(getKey(), OFFSET);
+        // Execute
+        long actualOffset = offsetManager.queryOffset(LMQ_GROUP, TOPIC, QUEUE_ID);
+        // Verify
+        assertEquals("Offset should match the expected value.", OFFSET, actualOffset);
+    }
+
+    @Test
+    public void testQueryOffsetForNonLmq() {
+        // Setup
+        when(brokerController.getConsumerOffsetManager()).thenReturn(offsetManager);
+        // Since we are mocking and not initializing a real offset manager,
+        // ensure your method has a default or mock behavior for non-LMQ offsets.
+        // Execute
+        long actualOffset = offsetManager.queryOffset(LMQ_GROUP, TOPIC, QUEUE_ID);
+        // Verify
+        // The actual value here depends on your default/mocked behavior for non-LMQ offsets.
+        assertNotNull("Offset should not be null.", actualOffset);
+    }
+
+    @Test
+    public void testCommitOffsetForLmq() {
+        // Execute
+        offsetManager.commitOffset("clientHost", LMQ_GROUP, TOPIC, QUEUE_ID, OFFSET);
+        // Verify
+        Long expectedOffset = offsetManager.getLmqOffsetTable().get(getKey());
+        assertEquals("Offset should be updated correctly.", OFFSET, expectedOffset.longValue());
+    }
+
+    private String getKey() {
+        return TOPIC + "@" + LMQ_GROUP;
+    }
+}

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/RocksDBLmqConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/RocksDBLmqConsumerOffsetManagerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.rocketmq.broker.offset;
 
 import org.apache.rocketmq.broker.BrokerController;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
[Enhancement] Add more test coverage for RocksDBLmqConsumerOffsetManager
Fixes #8500

### Brief Description
Add more test coverage for RocksDBLmqConsumerOffsetManager

### How Did You Test This Change?
run test case successfull.
![test](https://github.com/user-attachments/assets/35bc862b-5b27-4095-8258-1fcc59576513)

PS: TONGYI Lingma provided code generation and programming support.
![通义灵码使用截图](https://github.com/user-attachments/assets/9389ab52-77fe-4ea0-9355-c6afb3e1f3d7)

