### PR TITLE
使用自定义remotingServer对象

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -441,16 +441,20 @@ public class BrokerController {
     }
 
     protected void initializeRemotingServer() throws CloneNotSupportedException {
-        this.remotingServer = new NettyRemotingServer(this.nettyServerConfig, this.clientHousekeepingService);
-        NettyServerConfig fastConfig = (NettyServerConfig) this.nettyServerConfig.clone();
-
-        int listeningPort = nettyServerConfig.getListenPort() - 2;
-        if (listeningPort < 0) {
-            listeningPort = 0;
+        if (this.remotingServer == null) {
+            this.remotingServer = new NettyRemotingServer(this.nettyServerConfig, this.clientHousekeepingService);
         }
-        fastConfig.setListenPort(listeningPort);
+        if (this.fastRemotingServer == null) {
+            NettyServerConfig fastConfig = (NettyServerConfig)this.nettyServerConfig.clone();
 
-        this.fastRemotingServer = new NettyRemotingServer(fastConfig, this.clientHousekeepingService);
+            int listeningPort = nettyServerConfig.getListenPort() - 2;
+            if (listeningPort < 0) {
+                listeningPort = 0;
+            }
+            fastConfig.setListenPort(listeningPort);
+
+            this.fastRemotingServer = new NettyRemotingServer(fastConfig, this.clientHousekeepingService);
+        }
     }
 
     /**


### PR DESCRIPTION
当使用brokerController进行初始化调用recoverAndInitService函数时，此初始化处添加判断，以此在调用recoverAndInitService函数前可先set remotingServer或 fastRemotingServer进行初始化设置操作

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
