### PR TITLE
[ISSUE #8510] Fix CMD Commands in PUSH-CI Pipeline's Test E2E golang Job

### DIFF
--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -190,9 +190,9 @@ jobs:
           test-code-branch: "master"
           test-code-path: golang
           test-cmd: |
-            cd ../common &&  mvn -Prelease -DskipTests clean package -U
-            cd ../rocketmq-admintools && source bin/env.sh
-            cd ../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
+            cd ../../common && mvn -Prelease -DskipTests clean package -U
+            cd bin && source env.sh
+            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && go test ./mqgotest/... -timeout 2m -v
           job-id: 0
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -192,7 +192,7 @@ jobs:
           test-cmd: |
             cd ../../common && mvn -Prelease -DskipTests clean package -U
             cd bin && source env.sh
-            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && go test ./mqgotest/... -timeout 2m -v
+            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
           job-id: 0
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
### Which Issue This PR Fixes

Fixes [#8510 ](https://github.com/apache/rocketmq/issues/8510)

### Brief Description

This pull request updates the `Test E2E golang` job in the `PUSH_CI` pipeline by modifying the CMD commands. The previous CMD commands were causing issues with the execution of Go e2e tests due to incorrect environment setup and file sourcing.