### PR TITLE
[ISSUE #8510] Fix CI Failure in Test E2E Golang Job of PUSH-CI and PR-E2E-TEST

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -187,6 +187,8 @@ jobs:
           test-cmd: |
             cd ../common &&  mvn -Prelease -DskipTests clean package -U
             cd ../rocketmq-admintools && source bin/env.sh
+            wget https://go.dev/dl/go1.22.6.linux-amd64.tar.gz && \
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.6.linux-amd64.tar.gz
             cd ../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
           job-id: 0
       - name: Publish Test Report

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -190,9 +190,9 @@ jobs:
           test-code-branch: "master"
           test-code-path: golang
           test-cmd: |
-            cd ../common &&  mvn -Prelease -DskipTests clean package -U
-            cd ../rocketmq-admintools && source bin/env.sh
-            cd ../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
+            cd ../../common && mvn -Prelease -DskipTests clean package -U
+            cd bin && source env.sh
+            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && go test ./mqgotest/... -timeout 2m -v
           job-id: 0
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -190,9 +190,9 @@ jobs:
           test-code-branch: "master"
           test-code-path: golang
           test-cmd: |
-            cd ../../common && mvn -Prelease -DskipTests clean package -U
-            cd bin && source env.sh
-            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
+            cd ../common &&  mvn -Prelease -DskipTests clean package -U
+            cd ../rocketmq-admintools && source bin/env.sh
+            cd ../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
           job-id: 0
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -192,6 +192,8 @@ jobs:
           test-cmd: |
             cd ../common &&  mvn -Prelease -DskipTests clean package -U
             cd ../rocketmq-admintools && source bin/env.sh
+            wget https://go.dev/dl/go1.22.6.linux-amd64.tar.gz && \
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.6.linux-amd64.tar.gz
             cd ../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
           job-id: 0
       - name: Publish Test Report

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -192,7 +192,7 @@ jobs:
           test-cmd: |
             cd ../../common && mvn -Prelease -DskipTests clean package -U
             cd bin && source env.sh
-            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && go test ./mqgotest/... -timeout 2m -v
+            cd ../../golang && go get -u github.com/apache/rocketmq-clients/golang && gotestsum --junitfile ./target/surefire-reports/TEST-report.xml ./mqgotest/... -timeout 2m  -v
           job-id: 0
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
### Which Issue This PR Fixes

Fixes [#8510 ](https://github.com/apache/rocketmq/issues/8510)

### Brief Description

This pull request updates the Test E2E golang job in th push-ci and pr-e2e-test  pipeline by adding a command to install the correct version of Go directly in the startup script. The previous setup was causing issues due to the Go version being too low, which led to compatibility problems during the execution of Go e2e tests.