### PR TITLE
[ISSUE #8517] Fix client send UNREGISTER_CLIENT request twice may cause proxy NPE

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivity.java
@@ -125,22 +125,30 @@ public class ClientManagerActivity extends AbstractRemotingActivity {
         final String producerGroup = requestHeader.getProducerGroup();
         if (producerGroup != null) {
             RemotingChannel channel = this.remotingChannelManager.removeProducerChannel(context, producerGroup, ctx.channel());
-            ClientChannelInfo clientChannelInfo = new ClientChannelInfo(
-                channel,
-                requestHeader.getClientID(),
-                request.getLanguage(),
-                request.getVersion());
-            this.messagingProcessor.unRegisterProducer(context, producerGroup, clientChannelInfo);
+            if (channel != null) {
+                ClientChannelInfo clientChannelInfo = new ClientChannelInfo(
+                    channel,
+                    requestHeader.getClientID(),
+                    request.getLanguage(),
+                    request.getVersion());
+                this.messagingProcessor.unRegisterProducer(context, producerGroup, clientChannelInfo);
+            } else {
+                log.warn("unregister producer failed, channel not exist, may has been removed, producerGroup={}, channel={}", producerGroup, ctx.channel());
+            }
         }
         final String consumerGroup = requestHeader.getConsumerGroup();
         if (consumerGroup != null) {
             RemotingChannel channel = this.remotingChannelManager.removeConsumerChannel(context, consumerGroup, ctx.channel());
-            ClientChannelInfo clientChannelInfo = new ClientChannelInfo(
-                channel,
-                requestHeader.getClientID(),
-                request.getLanguage(),
-                request.getVersion());
-            this.messagingProcessor.unRegisterConsumer(context, consumerGroup, clientChannelInfo);
+            if (channel != null) {
+                ClientChannelInfo clientChannelInfo = new ClientChannelInfo(
+                    channel,
+                    requestHeader.getClientID(),
+                    request.getLanguage(),
+                    request.getVersion());
+                this.messagingProcessor.unRegisterConsumer(context, consumerGroup, clientChannelInfo);
+            } else {
+                log.warn("unregister consumer failed, channel not exist, may has been removed, consumerGroup={}, channel={}", consumerGroup, ctx.channel());
+            }
         }
         response.setCode(ResponseCode.SUCCESS);
         response.setRemark("");


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8517

### Brief Description
client send UNREGISTER_CLIENT request twice may cause proxy NPE
check channel is null before use it, if channel is null, log warn instead of NPE
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
