### PR TITLE
[ISSUE #8565] Set specific permissions to trigger the workflow retry mechanism

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -8,6 +8,9 @@ on:
       - develop
       - bazel
 
+permissions:
+  actions: write
+
 jobs:
   build:
     name: "bazel-compile (${{ matrix.os }})"

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -4,6 +4,10 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches: [master, develop, bazel]
+
+permissions:
+  actions: write
+
 jobs:
   java_build:
     name: "maven-compile (${{ matrix.os }}, JDK-${{ matrix.jdk }})"

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -5,6 +5,9 @@ on:
       run_id:
         required: true
 
+permissions:
+  actions: write
+
 jobs:
   rerun:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes [#8564](https://github.com/apache/rocketmq/issues/8565)

### Brief Description

This PR updates the workflow to explicitly set GH_TOKEN with actions: write permission, ensuring that the retry mechanism can trigger after a workflow failure
