### PR TITLE
[#8579]Update the startup script of RocketMQ on Windows

### DIFF
--- a/distribution/bin/runbroker.cmd
+++ b/distribution/bin/runbroker.cmd
@@ -28,8 +28,8 @@ set CLASSPATH=.;%BASE_DIR%conf;%BASE_DIR%lib\*;"%CLASSPATH%"
 rem ===========================================================================================
 rem  JVM Configuration
 rem ===========================================================================================
-for /f "tokens=2 delims=" %%v in ('java -version 2^>^&1 ^| findstr /i "version"') do (
-    for /f "tokens=1 delims=." %%m in ("%%v") do set "JAVA_MAJOR_VERSION=%%m"
+for /f tokens^=2^ delims^=^" %%v in ('java -version 2^>^&1 ^| findstr /i "version"') do (
+    for /f delims^=^. %%m in ("%%v") do set "JAVA_MAJOR_VERSION=%%m"
 )
 
 if "%JAVA_MAJOR_VERSION%"=="" (

--- a/distribution/bin/runserver.cmd
+++ b/distribution/bin/runserver.cmd
@@ -29,14 +29,13 @@ set CLASSPATH=.;%BASE_DIR%conf;%BASE_DIR%lib\*;%CLASSPATH%
 REM Example of JAVA_MAJOR_VERSION value: '1', '9', '10', '11', ...
 REM '1' means releases before Java 9
 
-for /f "tokens=2 delims=" %%v in ('java -version 2^>^&1 ^| findstr /i "version"') do (
-    for /f "tokens=1 delims=." %%m in ("%%v") do set "JAVA_MAJOR_VERSION=%%m"
+for /f tokens^=2^ delims^=^" %%v in ('java -version 2^>^&1 ^| findstr /i "version"') do (
+    for /f delims^=^. %%m in ("%%v") do set "JAVA_MAJOR_VERSION=%%m"
 )
 
 if "%JAVA_MAJOR_VERSION%"=="" (
     set "JAVA_MAJOR_VERSION=0"
 )
-
 if %JAVA_MAJOR_VERSION% lss 17 (
    set "JAVA_OPT=%JAVA_OPT% -server -Xms2g -Xmx2g -Xmn1g -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
    set "JAVA_OPT=%JAVA_OPT% -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8 -XX:-UseParNewGC"


### PR DESCRIPTION

### Which Issue(s) This PR Fixes

[8579](https://github.com/apache/rocketmq/issues/8579)

Fixes #issue_id

### Brief Description
There is a problem with obtaining the JDK version script in Windows, so I modified it；
I don't know much about different JDK versions (mainly divided by 17), and only made modifications to the issues I found



### How Did You Test This Change?

I can run it normally on my computer

"JAVA_MAJOR_VERSION=**" is the log I added during debugging

run with java 17
![image](https://github.com/user-attachments/assets/c5139dd1-906a-4355-8054-b2c2834b2f6e)
run with java 8
![image](https://github.com/user-attachments/assets/81861940-1b1d-461f-991e-ca8a8f1e14f5)

