### PR TITLE
[ISSUE #8544] Restore retry mechanism in unit test pipeline

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -54,3 +54,13 @@ jobs:
           name: jvm-crash-logs
           path: /Users/runner/work/rocketmq/rocketmq/broker/hs_err_pid*.log
           retention-days: 1
+
+      - name: Retry if failed
+        # if it failed , retry 2 times at most
+        if: failure() && fromJSON(github.run_attempt) < 3
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Attempting to retry workflow..."
+          gh workflow run rerun-workflow.yml -F run_id=${{ github.run_id }}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#8544 ](https://github.com/apache/rocketmq/issues/8544)

### Brief Description
This PR reintroduces the retry mechanism for the CI workflow, which was inadvertently removed due to a merge conflict
