### PR TITLE
[ISSUE #8594] Tiered storage shouldn't access remote when it comes to dispatch or query topic whose reserved time is not configured

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -375,7 +375,10 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
 
     @Override
     public QueryMessageResult queryMessage(String topic, String key, int maxNum, long begin, long end) {
-        return queryMessageAsync(topic, key, maxNum, begin, end).join();
+        if (MessageStoreUtil.ifTopicExistInRemote(metadataStore.getTopic(topic), this)) {
+            return queryMessageAsync(topic, key, maxNum, begin, end).join();
+        }
+        return next.queryMessage(topic, key, maxNum, begin, end);
     }
 
     @Override

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
@@ -101,6 +101,9 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
         if (stopped || topicFilter != null && topicFilter.filterTopic(request.getTopic())) {
             return;
         }
+        if (!MessageStoreUtil.ifTopicExistInRemote(messageStore.getMetadataStore().getTopic(request.getTopic()), messageStore)) {
+            return;
+        }
         flatFileStore.computeIfAbsent(
             new MessageQueue(request.getTopic(), brokerName, request.getQueueId()));
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
@@ -24,6 +24,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.tieredstore.TieredMessageStore;
+import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
 import org.apache.rocketmq.tieredstore.metadata.entity.TopicMetadata;
 
 public class MessageStoreUtil {
@@ -105,5 +106,14 @@ public class MessageStoreUtil {
     public static boolean ifTopicExistInRemote(TopicMetadata topicMetadata, TieredMessageStore messageStore) {
         long clusterReservedTime = messageStore.getDefaultStore().getMessageStoreConfig().getFileReservedTime();
         return topicMetadata != null && topicMetadata.getReserveTime() > clusterReservedTime;
+    }
+
+    public static void updateTopicReservedTime(MetadataStore metadataStore, String topic, long reservedTime) {
+        TopicMetadata topicMetadata = metadataStore.getTopic(topic);
+        if (topicMetadata == null) {
+            return;
+        }
+        topicMetadata.setReserveTime(reservedTime);
+        metadataStore.updateTopic(topicMetadata);
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
@@ -104,6 +104,6 @@ public class MessageStoreUtil {
 
     public static boolean ifTopicExistInRemote(TopicMetadata topicMetadata, TieredMessageStore messageStore) {
         long clusterReservedTime = messageStore.getDefaultStore().getMessageStoreConfig().getFileReservedTime();
-        return topicMetadata.getReserveTime() > clusterReservedTime;
+        return topicMetadata != null && topicMetadata.getReserveTime() > clusterReservedTime;
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
@@ -23,6 +23,8 @@ import java.security.NoSuchAlgorithmException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.tieredstore.TieredMessageStore;
+import org.apache.rocketmq.tieredstore.metadata.entity.TopicMetadata;
 
 public class MessageStoreUtil {
 
@@ -98,5 +100,10 @@ public class MessageStoreUtil {
 
     public static long fileName2Offset(final String fileName) {
         return Long.parseLong(fileName.substring(fileName.length() - 20));
+    }
+
+    public static boolean ifTopicExistInRemote(TopicMetadata topicMetadata, TieredMessageStore messageStore) {
+        long clusterReservedTime = messageStore.getDefaultStore().getMessageStoreConfig().getFileReservedTime();
+        return topicMetadata.getReserveTime() > clusterReservedTime;
     }
 }

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -47,8 +47,6 @@ import org.apache.rocketmq.store.queue.CqUnit;
 import org.apache.rocketmq.tieredstore.core.MessageStoreFetcher;
 import org.apache.rocketmq.tieredstore.file.FlatFileStore;
 import org.apache.rocketmq.tieredstore.file.FlatMessageFile;
-import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
-import org.apache.rocketmq.tieredstore.metadata.entity.TopicMetadata;
 import org.apache.rocketmq.tieredstore.provider.PosixFileSegment;
 import org.apache.rocketmq.tieredstore.util.MessageFormatUtil;
 import org.apache.rocketmq.tieredstore.util.MessageFormatUtilTest;

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -47,6 +47,8 @@ import org.apache.rocketmq.store.queue.CqUnit;
 import org.apache.rocketmq.tieredstore.core.MessageStoreFetcher;
 import org.apache.rocketmq.tieredstore.file.FlatFileStore;
 import org.apache.rocketmq.tieredstore.file.FlatMessageFile;
+import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
+import org.apache.rocketmq.tieredstore.metadata.entity.TopicMetadata;
 import org.apache.rocketmq.tieredstore.provider.PosixFileSegment;
 import org.apache.rocketmq.tieredstore.util.MessageFormatUtil;
 import org.apache.rocketmq.tieredstore.util.MessageFormatUtilTest;
@@ -96,6 +98,7 @@ public class TieredMessageStoreTest {
 
         defaultStore = Mockito.mock(DefaultMessageStore.class);
         Mockito.when(defaultStore.load()).thenReturn(true);
+        Mockito.when(defaultStore.getMessageStoreConfig()).thenReturn(new MessageStoreConfig());
 
         currentStore = new TieredMessageStore(context, defaultStore);
         Assert.assertNotNull(currentStore.getStoreConfig());
@@ -131,6 +134,10 @@ public class TieredMessageStoreTest {
         currentStore.load();
 
         FlatMessageFile flatFile = currentStore.getFlatFileStore().computeIfAbsent(mq);
+        MetadataStore metadataStore = currentStore.metadataStore;
+        TopicMetadata topicMetadata = metadataStore.getTopic(mq.getTopic());
+        topicMetadata.setReserveTime(144);
+        currentStore.getMetadataStore().updateTopic(topicMetadata);
         Assert.assertNotNull(flatFile);
         currentStore.dispatcher.doScheduleDispatch(flatFile, true).join();
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -134,10 +134,7 @@ public class TieredMessageStoreTest {
         currentStore.load();
 
         FlatMessageFile flatFile = currentStore.getFlatFileStore().computeIfAbsent(mq);
-        MetadataStore metadataStore = currentStore.metadataStore;
-        TopicMetadata topicMetadata = metadataStore.getTopic(mq.getTopic());
-        topicMetadata.setReserveTime(144);
-        currentStore.getMetadataStore().updateTopic(topicMetadata);
+        MessageStoreUtil.updateTopicReservedTime(currentStore.getMetadataStore(), mq.getTopic(), 144);
         Assert.assertNotNull(flatFile);
         currentStore.dispatcher.doScheduleDispatch(flatFile, true).join();
 
@@ -309,6 +306,9 @@ public class TieredMessageStoreTest {
         when(defaultStore.getEarliestMessageTime()).thenReturn(100L);
         Assert.assertEquals(2, currentStore.queryMessage(mq.getTopic(), "key", 32, 0, 99).getMessageMapedList().size());
         Assert.assertEquals(1, currentStore.queryMessage(mq.getTopic(), "key", 32, 100, 200).getMessageMapedList().size());
+        MessageStoreUtil.updateTopicReservedTime(currentStore.getMetadataStore(), mq.getTopic(), -1);
+        Assert.assertEquals(1, currentStore.queryMessage(mq.getTopic(), "key", 32, 0, 200).getMessageMapedList().size());
+        MessageStoreUtil.updateTopicReservedTime(currentStore.getMetadataStore(), mq.getTopic(), 144);
         Assert.assertEquals(3, currentStore.queryMessage(mq.getTopic(), "key", 32, 0, 200).getMessageMapedList().size());
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
@@ -132,6 +132,15 @@ public class MessageStoreDispatcherImplTest {
         FlatMessageFile flatFile = fileStore.getFlatFile(mq);
         Assert.assertNotNull(flatFile);
 
+        MessageQueue ignoredMq = new MessageQueue("ignored", storeConfig.getBrokerName(), 0);
+        DispatchRequest ignoredRequest = new DispatchRequest(ignoredMq.getTopic(), ignoredMq.getQueueId(),
+            MessageFormatUtil.getCommitLogOffset(buffer), buffer.remaining(), 0L,
+            MessageFormatUtil.getStoreTimeStamp(buffer), 0L,
+            "", "", 0, 0L, new HashMap<>());
+        metadataStore.addTopic(ignoredMq.getTopic(), -1);
+        dispatcher.dispatch(ignoredRequest);
+        Assert.assertNull(fileStore.getFlatFile(ignoredMq));
+
         // init offset
         dispatcher.doScheduleDispatch(flatFile, true).join();
         Assert.assertEquals(100L, flatFile.getConsumeQueueMinOffset());

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
@@ -71,15 +71,17 @@ public class MessageStoreDispatcherImplTest {
 
     @Before
     public void init() {
+        String topic = "StoreTest";
         storeConfig = new MessageStoreConfig();
         storeConfig.setBrokerName("brokerName");
         storeConfig.setStorePathRootDir(storePath);
         storeConfig.setTieredStoreFilePath(storePath);
         storeConfig.setTieredBackendServiceProvider(PosixFileSegment.class.getName());
-        mq = new MessageQueue("StoreTest", storeConfig.getBrokerName(), 1);
+        mq = new MessageQueue(topic, storeConfig.getBrokerName(), 1);
         metadataStore = new DefaultMetadataStore(storeConfig);
         executor = new MessageStoreExecutor();
         fileStore = new FlatFileStore(storeConfig, metadataStore, executor);
+        metadataStore.addTopic(topic, 144);
     }
 
     @After
@@ -95,6 +97,7 @@ public class MessageStoreDispatcherImplTest {
         MessageStore defaultStore = Mockito.mock(MessageStore.class);
         Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(100L);
         Mockito.when(defaultStore.getMaxOffsetInQueue(anyString(), anyInt())).thenReturn(200L);
+        Mockito.when(defaultStore.getMessageStoreConfig()).thenReturn(new org.apache.rocketmq.store.config.MessageStoreConfig());
 
         messageStore = Mockito.mock(TieredMessageStore.class);
         IndexService indexService =
@@ -105,6 +108,7 @@ public class MessageStoreDispatcherImplTest {
         Mockito.when(messageStore.getStoreExecutor()).thenReturn(executor);
         Mockito.when(messageStore.getFlatFileStore()).thenReturn(fileStore);
         Mockito.when(messageStore.getIndexService()).thenReturn(indexService);
+        Mockito.when(messageStore.getMetadataStore()).thenReturn(metadataStore);
 
         // mock message
         ByteBuffer buffer = MessageFormatUtilTest.buildMockedMessageBuffer();
@@ -160,6 +164,7 @@ public class MessageStoreDispatcherImplTest {
     @Test
     public void dispatchServiceTest() {
         MessageStore defaultStore = Mockito.mock(MessageStore.class);
+        Mockito.when(defaultStore.getMessageStoreConfig()).thenReturn(new org.apache.rocketmq.store.config.MessageStoreConfig());
         messageStore = Mockito.mock(TieredMessageStore.class);
         IndexService indexService =
             new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
@@ -168,6 +173,7 @@ public class MessageStoreDispatcherImplTest {
         Mockito.when(messageStore.getStoreExecutor()).thenReturn(executor);
         Mockito.when(messageStore.getFlatFileStore()).thenReturn(fileStore);
         Mockito.when(messageStore.getIndexService()).thenReturn(indexService);
+        Mockito.when(messageStore.getMetadataStore()).thenReturn(metadataStore);
 
         // construct flat file
         ByteBuffer buffer = MessageFormatUtilTest.buildMockedMessageBuffer();


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8594 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
