### PR TITLE
[ISSUE #8599] Fix send fail without retry when get GO_AWAY twice

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -79,7 +79,8 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
         ResponseCode.SYSTEM_BUSY,
         ResponseCode.NO_PERMISSION,
         ResponseCode.NO_BUYER_ID,
-        ResponseCode.NOT_IN_CURRENT_UNIT
+        ResponseCode.NOT_IN_CURRENT_UNIT,
+        ResponseCode.GO_AWAY
     ));
 
     /**

--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -769,7 +769,7 @@ public class DefaultMQProducerTest {
     @Test
     public void assertGetRetryResponseCodes() {
         assertNotNull(producer.getRetryResponseCodes());
-        assertEquals(7, producer.getRetryResponseCodes().size());
+        assertEquals(8, producer.getRetryResponseCodes().size());
     }
 
     @Test

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -278,6 +278,7 @@ public abstract class NettyRemotingAbstract {
                     "please go away");
                 response.setOpaque(opaque);
                 writeResponse(ctx.channel(), cmd, response);
+                log.info("proxy is shutting down, write response GO_AWAY. channel={}, requestCode={}, opaque={}", ctx.channel(), cmd.getCode(), opaque);
                 return;
             }
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8599

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
