### PR TITLE
[ISSUE #8607] Exclude loopback addresses when iterating over local network interfaces

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
@@ -129,6 +129,10 @@ public class NetworkUtil {
             ArrayList<InetAddress> ipv6Result = new ArrayList<>();
             List<InetAddress> localInetAddressList = getLocalInetAddressList();
             for (InetAddress inetAddress : localInetAddressList) {
+                // Skip loopback addresses
+                if (inetAddress.isLoopbackAddress()) {
+                    continue;
+                }
                 if (inetAddress instanceof Inet6Address) {
                     ipv6Result.add(inetAddress);
                 } else {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#8607](https://github.com/apache/rocketmq/issues/8607) 

### Brief Description
This PR addresses an issue in the `NetworkUtil` class where the loopback address (`127.0.0.1`) might be mistakenly selected when all available IP addresses are internal. The fix involves ensuring that loopback addresses are excluded when traversing `localInetAddressList`.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

[The test workflow](https://github.com/chi3316/rocketmq/actions/runs/10615521348)