### PR TITLE
[ISSUE #8615] fix DeleteUserSubCommand command failed when acl2.0 authentication enabled and authorization disabled

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/factory/AuthorizationFactory.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/factory/AuthorizationFactory.java
@@ -29,6 +29,7 @@ import org.apache.rocketmq.auth.authorization.AuthorizationEvaluator;
 import org.apache.rocketmq.auth.authorization.context.AuthorizationContext;
 import org.apache.rocketmq.auth.authorization.manager.AuthorizationMetadataManager;
 import org.apache.rocketmq.auth.authorization.manager.AuthorizationMetadataManagerImpl;
+import org.apache.rocketmq.auth.authorization.provider.AuthorizationDisabledMetadataProvider;
 import org.apache.rocketmq.auth.authorization.provider.AuthorizationMetadataProvider;
 import org.apache.rocketmq.auth.authorization.provider.AuthorizationProvider;
 import org.apache.rocketmq.auth.authorization.provider.DefaultAuthorizationProvider;
@@ -79,6 +80,9 @@ public class AuthorizationFactory {
         }
         return computeIfAbsent(METADATA_PROVIDER_PREFIX + config.getConfigName(), key -> {
             try {
+                if (!config.isAuthorizationEnabled()) {
+                    return AuthorizationDisabledMetadataProvider.INSTANCE;
+                }
                 if (StringUtils.isBlank(config.getAuthorizationMetadataProvider())) {
                     return null;
                 }

--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/provider/AuthorizationDisabledMetadataProvider.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/provider/AuthorizationDisabledMetadataProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.auth.authorization.provider;
+
+import org.apache.rocketmq.auth.authentication.model.Subject;
+import org.apache.rocketmq.auth.authorization.model.Acl;
+import org.apache.rocketmq.auth.config.AuthConfig;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+public final class AuthorizationDisabledMetadataProvider implements AuthorizationMetadataProvider {
+    public final static AuthorizationDisabledMetadataProvider INSTANCE = new AuthorizationDisabledMetadataProvider();
+
+    private AuthorizationDisabledMetadataProvider() {
+    }
+
+    @Override
+    public void initialize(AuthConfig authConfig, Supplier<?> metadataService) {
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public CompletableFuture<Void> createAcl(Acl acl) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteAcl(Subject subject) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> updateAcl(Acl acl) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Acl> getAcl(Subject subject) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<List<Acl>> listAcl(String subjectFilter, String resourceFilter) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/auth/src/test/java/org/apache/rocketmq/auth/authentication/manager/AuthenticationMetadataManagerTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authentication/manager/AuthenticationMetadataManagerTest.java
@@ -141,6 +141,16 @@ public class AuthenticationMetadataManagerTest {
     }
 
     @Test
+    public void deleteUserIfAuthorizationDisabled() {
+        if (MixAll.isMac()) {
+            return;
+        }
+        this.authConfig.setAuthorizationEnabled(false);
+        this.authenticationMetadataManager = AuthenticationFactory.getMetadataManager(this.authConfig);
+        this.authenticationMetadataManager.deleteUser("no_user").join();
+    }
+
+    @Test
     public void getUser() {
         if (MixAll.isMac()) {
             return;

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/provider/AuthorizationDisabledMetadataProviderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/provider/AuthorizationDisabledMetadataProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.auth.authorization.provider;
+
+import org.apache.rocketmq.auth.authentication.model.User;
+import org.apache.rocketmq.auth.authorization.model.Acl;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class AuthorizationDisabledMetadataProviderTest {
+
+    private AuthorizationDisabledMetadataProvider authorizationDisabledMetadataProvider;
+
+    @Before
+    public void setUp() throws Exception {
+        this.authorizationDisabledMetadataProvider = AuthorizationDisabledMetadataProvider.INSTANCE;
+        this.authorizationDisabledMetadataProvider.initialize(new AuthConfig(), null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        this.authorizationDisabledMetadataProvider.shutdown();
+    }
+
+    @Test
+    public void createAcl() {
+        CompletableFuture<Void> future = this.authorizationDisabledMetadataProvider.createAcl(new Acl());
+        Assert.assertTrue(future.isDone());
+    }
+
+    @Test
+    public void deleteAcl() {
+        CompletableFuture<Void> future = this.authorizationDisabledMetadataProvider.deleteAcl(User.of("username"));
+        Assert.assertTrue(future.isDone());
+    }
+
+    @Test
+    public void updateAcl() {
+        CompletableFuture<Void> future = this.authorizationDisabledMetadataProvider.updateAcl(new Acl());
+        Assert.assertTrue(future.isDone());
+    }
+
+    @Test
+    public void getAcl() {
+        CompletableFuture<Acl> future = this.authorizationDisabledMetadataProvider.getAcl(User.of("username"));
+        Assert.assertTrue(future.isDone());
+        Assert.assertNull(future.join());
+    }
+
+    @Test
+    public void listAcl() {
+        CompletableFuture<List<Acl>> future = this.authorizationDisabledMetadataProvider.listAcl(null, null);
+        Assert.assertTrue(future.isDone());
+        Assert.assertNull(future.join());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8615

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
