### PR TITLE
[ISSUE #8596] Remove redundant mvn test and log check steps from CI workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Retry if failed
         # if it failed , retry 2 times at most
         if: failure() && fromJSON(github.run_attempt) < 3
+        continue-on-error: true
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -30,9 +30,6 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml
 
-      - name: Run tests with increased memory and debug info
-        run: mvn test -X -Dparallel=none -DargLine="-Xmx1024m -XX:MaxPermSize=256m"
-
       - name: Upload Auth JVM crash logs
         if: failure()
         uses: actions/upload-artifact@v4
@@ -40,12 +37,6 @@ jobs:
           name: jvm-crash-logs
           path: /Users/runner/work/rocketmq/rocketmq/auth/hs_err_pid*.log
           retention-days: 1
-
-      - name: Check for broker JVM crash logs
-        if: failure()
-        run: |
-          echo "Checking for JVM crash logs..."
-          ls -al /Users/runner/work/rocketmq/rocketmq/broker/
 
       - name: Upload broker JVM crash logs
         if: failure()
@@ -58,6 +49,7 @@ jobs:
       - name: Retry if failed
         # if it failed , retry 2 times at most
         if: failure() && fromJSON(github.run_attempt) < 3
+        continue-on-error: true
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#8596 ](https://github.com/apache/rocketmq/issues/8596)

### Brief Description

Removed the redundant mvn test step and the separate JVM crash log check from the CI workflow. These changes simplify the process and improve efficiency.
