### PR TITLE
add import/export command and test #6972

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -60,5 +60,9 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/MQAdminUtils.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/MQAdminUtils.java
@@ -49,7 +49,7 @@ import static org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappin
 import static org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingUtils.getMappingDetailFromConfig;
 
 public class MQAdminUtils {
-
+    public static final int PROGRESS_BAR_WIDTH = 60;
 
     public static ClientMetadata getBrokerMetadata(DefaultMQAdminExt defaultMQAdminExt) throws InterruptedException, RemotingConnectException, RemotingTimeoutException, RemotingSendRequestException, MQBrokerException {
         ClientMetadata clientMetadata  = new ClientMetadata();
@@ -338,5 +338,27 @@ public class MQAdminUtils {
             }
         }
         return result;
+    }
+
+    public static void printProgressWithFixedWidth(long total, long current) {
+        String prefix = "Progress:[";
+        String suffix = String.format("]%d/%d=%d%c", current, total, (int) ((double) current * 100) / total, '%');
+        String arrow = ">";
+        if (current != 0) {
+            for (long x = 0; x < PROGRESS_BAR_WIDTH + prefix.length() + suffix.length(); x++) {
+                System.out.print("\b");
+            }
+        }
+        System.out.print(prefix);
+        long i = current * PROGRESS_BAR_WIDTH / total;
+        for (long j = 0; j < i - arrow.length(); j++) {
+            System.out.print("=");
+        }
+
+        System.out.print(arrow);
+        for (long k = 0; k < PROGRESS_BAR_WIDTH - i; k++) {
+            System.out.print(" ");
+        }
+        System.out.print(suffix);
     }
 }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -85,6 +85,8 @@ import org.apache.rocketmq.tools.command.ha.HAStatusSubCommand;
 import org.apache.rocketmq.tools.command.message.CheckMsgSendRTCommand;
 import org.apache.rocketmq.tools.command.message.ConsumeMessageCommand;
 import org.apache.rocketmq.tools.command.message.DumpCompactionLogCommand;
+import org.apache.rocketmq.tools.command.message.ExportMessageCommand;
+import org.apache.rocketmq.tools.command.message.ImportMessageCommand;
 import org.apache.rocketmq.tools.command.message.PrintMessageByQueueCommand;
 import org.apache.rocketmq.tools.command.message.PrintMessageSubCommand;
 import org.apache.rocketmq.tools.command.message.QueryMsgByIdSubCommand;
@@ -215,6 +217,8 @@ public class MQAdminStartup {
 
         initCommand(new PrintMessageSubCommand());
         initCommand(new PrintMessageByQueueCommand());
+        initCommand(new ExportMessageCommand());
+        initCommand(new ImportMessageCommand());
         initCommand(new SendMsgStatusCommand());
         initCommand(new BrokerConsumeStatsSubCommad());
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/ExportMessageCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/ExportMessageCommand.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.tools.command.message;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.admin.MQAdminUtils;
+import org.apache.rocketmq.tools.command.SubCommand;
+import org.apache.rocketmq.tools.command.SubCommandException;
+
+public class ExportMessageCommand implements SubCommand {
+    public static final String DEFAULT_EXPORT_DIRECTORY = "./rocketmq-export";
+    public static final int MAX_EXPORT_QUEUE_MESSAGE_RANGE = 1000 * 1000;
+    private static final int ASYNC_WRITE_QUEUE_CAPACITY = 1024;
+    private static final int WRITE_INTERVAL_MILLISECONDS = 100;
+    private static final int MAX_WRITE_MESSAGE_SIZE = 256;
+    private final Logger logger = LoggerFactory.getLogger(ImportMessageCommand.class);
+    private DefaultMQPullConsumer defaultMQPullConsumer;
+    private String charsetName;
+    private String bodyFormat;
+
+    @Override
+    public String commandName() {
+        return "exportMessage";
+    }
+
+    @Override
+    public String commandDesc() {
+        return "Export Message";
+    }
+
+    @Override
+    public Options buildCommandlineOptions(Options options) {
+        Option opt = new Option("t", "topic ", true, "topic name");
+        opt.setRequired(true);
+        options.addOption(opt);
+
+        opt = new Option("a", "brokerName ", true, "broker name");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("i", "queueId ", true, "queue id");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("c", "charsetName ", true, "CharsetName(eg: UTF-8,GBK)");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("s", "subExpression ", true, "Subscribe Expression(eg: TagA || TagB)");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("b", "beginTimestamp ", true, "Begin timestamp[currentTimeMillis|yyyy-MM-dd#HH:mm:ss:SSS]");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("e", "endTimestamp ", true, "End timestamp[currentTimeMillis|yyyy-MM-dd#HH:mm:ss:SSS]");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("d", "directory ", true, "Export directory(default:" + DEFAULT_EXPORT_DIRECTORY + "),file path format:./exportDir/topic/brokerName/queueId");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("f", "format ", true, "message body format[base64|json|string],default:base64");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        return options;
+    }
+
+    @Override
+    public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) throws SubCommandException {
+        if (defaultMQPullConsumer == null) {
+            defaultMQPullConsumer = new DefaultMQPullConsumer(MixAll.TOOLS_CONSUMER_GROUP, rpcHook);
+        }
+
+        try {
+            charsetName =
+                !commandLine.hasOption('c') ? "UTF-8" : commandLine.getOptionValue('c').trim();
+
+            String subExpression =
+                !commandLine.hasOption('s') ? "*" : commandLine.getOptionValue('s').trim();
+            String topic = commandLine.getOptionValue('t').trim();
+
+            String brokerName = !commandLine.hasOption('a') ? null : commandLine.getOptionValue('a').trim();
+            int queueId = !commandLine.hasOption('i') ? -1 : Integer.parseInt(commandLine.getOptionValue('i').trim());
+            if (StringUtils.isBlank(brokerName) && queueId != -1) {
+                throw new SubCommandException("Please set the brokerName before queueId!");
+            }
+            String directory =
+                !commandLine.hasOption('d') ? DEFAULT_EXPORT_DIRECTORY : commandLine.getOptionValue('d').trim();
+            bodyFormat =
+                !commandLine.hasOption('f') ? "base64" : commandLine.getOptionValue('f').trim();
+
+            defaultMQPullConsumer.start();
+            Set<MessageQueue> messageQueues = Collections.emptySet();
+            if (StringUtils.isNotBlank(brokerName) && queueId != -1) {
+                messageQueues = Sets.newHashSet(new MessageQueue(topic, brokerName, queueId));
+            } else if (StringUtils.isNotBlank(brokerName) && queueId == -1) {
+                messageQueues = defaultMQPullConsumer.fetchSubscribeMessageQueues(topic).stream().filter(e -> e.getBrokerName().equals(brokerName)).collect(Collectors.toSet());
+            } else if (StringUtils.isBlank(brokerName) && queueId == -1) {
+                messageQueues = defaultMQPullConsumer.fetchSubscribeMessageQueues(topic);
+            }
+
+            String topicDir = directory + File.separator + topic;
+            // FileUtils.forceDeleteOnExit(new File(topicDir));
+            FileUtils.forceMkdirParent(new File(topicDir));
+            ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+            for (MessageQueue mq : messageQueues) {
+                String brokerDir = topicDir + File.separator + mq.getBrokerName();
+                String queueFilepath = brokerDir + File.separator + mq.getQueueId();
+                String offsetFilepath = queueFilepath + ".log";
+                FileUtils.forceMkdir(new File(brokerDir));
+                System.out.printf("export queueFile queueFilepath=%s%n", queueFilepath);
+
+                long minOffset = defaultMQPullConsumer.minOffset(mq);
+                long maxOffset = defaultMQPullConsumer.maxOffset(mq);
+
+                if (commandLine.hasOption('b')) {
+                    String timestampStr = commandLine.getOptionValue('b').trim();
+                    long timeValue = timestampFormat(timestampStr);
+                    minOffset = defaultMQPullConsumer.searchOffset(mq, timeValue);
+                }
+
+                if (commandLine.hasOption('e')) {
+                    String timestampStr = commandLine.getOptionValue('e').trim();
+                    long timeValue = timestampFormat(timestampStr);
+                    maxOffset = defaultMQPullConsumer.searchOffset(mq, timeValue);
+                }
+
+                if (maxOffset - minOffset > MAX_EXPORT_QUEUE_MESSAGE_RANGE) {
+                    System.out.printf("export message range exceed max limit . queueId=%s, minOffset=%s, maxOffset=%s%n", queueId, minOffset, maxOffset);
+                    return;
+                }
+
+                if (!new File(offsetFilepath).exists() || !new File(queueFilepath).exists()) {
+                    FileUtils.forceDeleteOnExit(new File(offsetFilepath));
+                    FileUtils.forceDeleteOnExit(new File(queueFilepath));
+                } else {
+                    String jsonStr = FileUtils.readFileToString(new File(offsetFilepath), StandardCharsets.UTF_8);
+                    JSONObject jsonObject = JSON.parseObject(jsonStr);
+                    Object beginOffsetObj = jsonObject.get("beginOffset");
+                    Object endOffsetObj = jsonObject.get("endOffset");
+                    Long beginOffset = beginOffsetObj instanceof Integer ? ((Integer) beginOffsetObj).longValue() : (Long) beginOffsetObj;
+                    Long endOffset = endOffsetObj instanceof Integer ? ((Integer) endOffsetObj).longValue() : (Long) endOffsetObj;
+                    boolean isOutOfRange = beginOffset == minOffset && maxOffset < endOffset;
+                    if (beginOffset == minOffset && maxOffset == endOffset) {
+                        continue;
+                    } else if (beginOffset != minOffset || isOutOfRange) {
+                        FileUtils.forceDeleteOnExit(new File(queueFilepath));
+                    } else if (beginOffset == minOffset && maxOffset > endOffset) {
+                        // continue to write to message file
+                        minOffset = endOffset;
+                    }
+
+                }
+
+                System.out.printf("export %s minOffset=%s, maxOffset=%s%n", minOffset, maxOffset, mq);
+                try (BufferedWriter messageWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(queueFilepath), charsetName));//
+                     BufferedWriter offsetWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(queueFilepath,false), charsetName));
+                ) {
+                    final AtomicLong messageCounter = new AtomicLong();
+                    final ArrayBlockingQueue<MessageExt> blockingQueue = new ArrayBlockingQueue<MessageExt>(ASYNC_WRITE_QUEUE_CAPACITY);
+                    asyncWriteMessageFile(executor, minOffset, messageWriter, offsetWriter, messageCounter, blockingQueue);
+                    READQ:
+                    for (long offset = minOffset; offset < maxOffset; ) {
+                        try {
+                            PullResult pullResult = defaultMQPullConsumer.pull(mq, subExpression, offset, 32);
+                            offset = pullResult.getNextBeginOffset();
+                            switch (pullResult.getPullStatus()) {
+                                case FOUND:
+                                    MQAdminUtils.printProgressWithFixedWidth(maxOffset - minOffset, messageCounter.get());
+                                    for (MessageExt messageExt : pullResult.getMsgFoundList()) {
+                                        blockingQueue.put(messageExt);
+                                    }
+                                    break;
+                                case NO_MATCHED_MSG:
+                                    System.out.printf("%s no matched msg. status=%s, offset=%s%n", mq, pullResult.getPullStatus(), offset);
+                                    break;
+                                case NO_NEW_MSG:
+                                case OFFSET_ILLEGAL:
+                                    System.out.printf("%s print msg finished. status=%s, offset=%s%n", mq, pullResult.getPullStatus(), offset);
+                                    break READQ;
+                            }
+                        } catch (Exception e) {
+                            logger.error("pull message error. ", e);
+                            return;
+                        }
+                    }
+                    // wait all message write to disk
+                    while (true) {
+                        long writeTotal = messageCounter.get();
+                        if (writeTotal == (maxOffset - minOffset)) {
+                            MQAdminUtils.printProgressWithFixedWidth(maxOffset - minOffset, messageCounter.get());
+                            break;
+                        }
+                        // when exception, exit
+                        if (writeTotal < 0) {
+                            MQAdminUtils.printProgressWithFixedWidth(maxOffset - minOffset, messageCounter.get());
+                            return;
+                        }
+                        Thread.sleep(WRITE_INTERVAL_MILLISECONDS);
+                        MQAdminUtils.printProgressWithFixedWidth(maxOffset - minOffset, messageCounter.get());
+                    }
+                    messageWriter.flush();
+                } catch (Exception e) {
+                    logger.error("export message to file error. ", e);
+                }
+                // new line for printProgressWithFixedWidth
+                System.out.printf("%n");
+            }
+            executor.shutdown();
+        } catch (Exception e) {
+            throw new SubCommandException(this.getClass().getSimpleName() + " command failed", e);
+        } finally {
+            defaultMQPullConsumer.shutdown();
+        }
+    }
+
+    private void asyncWriteMessageFile(ScheduledExecutorService executor, long minOffset, BufferedWriter messageWriter,
+        BufferedWriter offsetWriter, AtomicLong messageCounter, ArrayBlockingQueue<MessageExt> blockingQueue) {
+        executor.scheduleWithFixedDelay(() -> {
+            List<MessageExt> messages = new ArrayList<>();
+            blockingQueue.drainTo(messages, MAX_WRITE_MESSAGE_SIZE);
+            if (!messages.isEmpty()) {
+                try {
+                    exportMessage(messageWriter, messages);
+                    int size = messages.size();
+                    offsetWriter.write(JSON.toJSONString(ImmutableMap.of("beginOffset", minOffset, "endOffset", minOffset + messageCounter.get() + size)));
+                    offsetWriter.flush();
+                    messageCounter.addAndGet(size);
+                } catch (Exception e) {
+                    messageCounter.set(Long.MIN_VALUE);
+                    logger.error("write message to file error. ", e);
+                }
+            }
+        }, 1, WRITE_INTERVAL_MILLISECONDS, TimeUnit.MILLISECONDS);
+    }
+
+    private void exportMessage(BufferedWriter writer,
+        List<MessageExt> msgFoundList) throws IOException, SubCommandException {
+        for (MessageExt messageExt : msgFoundList) {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("topic", messageExt.getTopic());
+            jsonObject.put("flag", messageExt.getFlag());
+            jsonObject.put("properties", messageExt.getProperties());
+            jsonObject.put("transactionId", messageExt.getTransactionId());
+            jsonObject.put("msgId", messageExt.getMsgId());
+            jsonObject.put("queueOffset", messageExt.getQueueOffset());
+            jsonObject.put("bodyFormat", this.bodyFormat);
+            jsonObject.put("body", formatBody(messageExt.getBody(), this.bodyFormat, this.charsetName));
+            writer.write(JSON.toJSONString(jsonObject));
+            writer.newLine();
+        }
+    }
+
+    public static Object formatBody(byte[] body, String bodyFormat, String charsetName) throws SubCommandException {
+        switch (bodyFormat) {
+            case "base64":
+                // fastjson default use base64 to encode
+                return body;
+            case "json":
+                return JSON.parseObject(body, Object.class);
+            case "string":
+                return new String(body, Charset.forName(charsetName));
+            default:
+                throw new SubCommandException("bodyFormat not supported! bodyFormat=" + bodyFormat);
+        }
+    }
+
+    private static long timestampFormat(final String value) {
+        long timestamp;
+        try {
+            timestamp = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+
+            timestamp = UtilAll.parseDate(value, UtilAll.YYYY_MM_DD_HH_MM_SS_SSS).getTime();
+        }
+
+        return timestamp;
+    }
+
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/ImportMessageCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/ImportMessageCommand.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.tools.command.message;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.admin.MQAdminUtils;
+import org.apache.rocketmq.tools.command.SubCommand;
+import org.apache.rocketmq.tools.command.SubCommandException;
+
+import static org.apache.rocketmq.tools.command.message.ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
+
+public class ImportMessageCommand implements SubCommand {
+    public static final int BATCH_SEND_SIZE = 32;
+    private DefaultMQProducer producer;
+    private final Logger logger = LoggerFactory.getLogger(ImportMessageCommand.class);
+
+    @Override
+    public String commandName() {
+        return "importMessage";
+    }
+
+    @Override
+    public String commandDesc() {
+        return "Print Message Detail";
+    }
+
+    @Override
+    public Options buildCommandlineOptions(Options options) {
+        Option opt = new Option("t", "topic ", true, "Topic name,will override topic in message file");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("b", "broker ", true, "Send message to target broker");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("i", "qid ", true, "Send message to target queue");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("m", "msgTraceEnable", true, "Message Trace Enable, Default: false");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("c", "charsetName ", true, "CharsetName(default: UTF-8, eg: UTF-8,GBK)");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        opt = new Option("d", "directory", true, "Import directory(default:" + DEFAULT_EXPORT_DIRECTORY + "),file path format:./importDir/topic/brokerName/queueId");
+        opt.setRequired(false);
+        options.addOption(opt);
+
+        return options;
+    }
+
+    @Override
+    public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) throws SubCommandException {
+
+        try {
+            String charsetName = !commandLine.hasOption('c') ? "UTF-8" : commandLine.getOptionValue('c').trim();
+            String topic = !commandLine.hasOption('t') ? null : commandLine.getOptionValue('t').trim();
+            String brokerName = !commandLine.hasOption('b') ? null : commandLine.getOptionValue('b').trim();
+            int queueId = !commandLine.hasOption('i') ? -1 : Integer.parseInt(commandLine.getOptionValue('i').trim());
+            boolean msgTraceEnable = !commandLine.hasOption('m') ? false : Boolean.parseBoolean(commandLine.getOptionValue('m').trim());
+            String directory =
+                !commandLine.hasOption('d') ? DEFAULT_EXPORT_DIRECTORY : commandLine.getOptionValue('d').trim();
+
+            producer = createProducer(rpcHook, msgTraceEnable);
+            File dir = new File(directory);
+            String[] topics = dir.list();
+            if (topics == null || topics.length == 0) {
+                return;
+            }
+            producer.start();
+
+            for (String topicFileName : topics) {
+                String topicPath = directory + File.separator + topicFileName;
+                String[] brokerNames = new File(topicPath).list();
+                if (brokerNames == null || brokerNames.length == 0) {
+                    break;
+                }
+                for (String brokerFileName : brokerNames) {
+                    File brokerDir = new File(topicPath + File.separator + brokerFileName);
+                    File[] queueFiles = brokerDir.listFiles();
+                    if (queueFiles == null || queueFiles.length == 0) {
+                        break;
+                    }
+                    for (File queueFile : queueFiles) {
+                        //get line numbers
+                        int total;
+                        try (Reader fileReader = new InputStreamReader(new FileInputStream(queueFile), charsetName)) {
+                            LineNumberReader lineNumberReader = new LineNumberReader(fileReader);
+                            lineNumberReader.skip(queueFile.length());
+                            total = lineNumberReader.getLineNumber();
+                            lineNumberReader.close();
+                        }
+                        if (total == 0) {
+                            continue;
+                        }
+
+                        System.out.printf("import queueFile=%s%n", queueFile.getAbsolutePath());
+                        List<String> lines = new ArrayList<>(BATCH_SEND_SIZE);
+                        int sendSuccessCount = 0;
+                        MQAdminUtils.printProgressWithFixedWidth(total, sendSuccessCount);
+                        SendResult sendResult;
+                        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(queueFile), charsetName))) {
+                            String msgStr;
+                            do {
+                                msgStr = reader.readLine();
+                                if (msgStr != null) {
+                                    lines.add(msgStr);
+                                }
+                                if (lines.size() % BATCH_SEND_SIZE == 0 || msgStr == null) {
+                                    List<Message> messages = parseMessages(lines, topic, charsetName);
+                                    // send to specified brokerName and queueId
+                                    if (brokerName != null && queueId > -1) {
+                                        MessageQueue messageQueue = new MessageQueue(topic, brokerName, queueId);
+                                        sendResult = producer.send(messages, messageQueue);
+                                    } else {
+                                        sendResult = producer.send(messages);
+                                    }
+                                    if (sendResult.getSendStatus() == SendStatus.SEND_OK || sendResult.getSendStatus() == SendStatus.SLAVE_NOT_AVAILABLE) {
+                                        sendSuccessCount += messages.size();
+                                    } else {
+                                        logger.error("fail send message, sendResult=" + sendResult);
+                                    }
+                                    MQAdminUtils.printProgressWithFixedWidth(total, sendSuccessCount);
+                                    lines.clear();
+                                }
+                            }
+                            while (msgStr != null);
+                            // new line for printProgressWithFixedWidth
+                            System.out.printf("%n");
+                        } catch (IOException e) {
+                            System.out.printf("read file failed, file=%s%n", queueFile.getAbsolutePath());
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(this.getClass().getSimpleName() + " command failed", e);
+        } finally {
+            producer.shutdown();
+        }
+    }
+
+    private static List<Message> parseMessages(List<String> lines, String topic,
+        String charsetName) throws SubCommandException {
+        List<Message> messages = new ArrayList<>(lines.size());
+        for (String line : lines) {
+            JSONObject jsonObject = JSON.parseObject(line);
+            Message m = new Message();
+            // topic from command , override topic in message
+            if (StringUtils.isNotBlank(topic)) {
+                m.setTopic(topic);
+            } else {
+                m.setTopic((String) jsonObject.get("topic"));
+            }
+            m.setFlag((int) jsonObject.get("flag"));
+            MessageAccessor.setProperties(m, (Map<String, String>) jsonObject.get("properties"));
+            m.setTransactionId((String) jsonObject.get("transactionId"));
+            String bodyFormat = (String) jsonObject.get("bodyFormat");
+            Object body = jsonObject.get("body");
+            m.setBody(parseBody(body, bodyFormat, charsetName));
+            messages.add(m);
+        }
+        return messages;
+    }
+
+    private static byte[] parseBody(Object body, String bodyFormat, String charsetName) throws SubCommandException {
+        switch (bodyFormat) {
+            case "base64":
+                return Base64.getDecoder().decode((String) body);
+            case "json":
+                return JSON.toJSONBytes(body);
+            case "string":
+                return ((String) body).getBytes(Charset.forName(charsetName));
+            default:
+                throw new SubCommandException("bodyFormat not supported! bodyFormat=" + bodyFormat);
+        }
+    }
+
+    private DefaultMQProducer createProducer(RPCHook rpcHook, boolean msgTraceEnable) {
+        if (this.producer != null) {
+            return producer;
+        } else {
+            producer = new DefaultMQProducer(null, rpcHook, msgTraceEnable, null);
+            producer.setProducerGroup(Long.toString(System.currentTimeMillis()));
+            return producer;
+        }
+    }
+
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/ExportMessageCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/ExportMessageCommandTest.java
@@ -65,7 +65,6 @@ public class ExportMessageCommandTest {
     private static String topicDir = exportDir + File.separator + "topic1";
     private static String brokerDir = topicDir + File.separator + "broker-a";
     private static String queueFilePath = brokerDir + File.separator + "1";
-    private static String offsetFilePath = queueFilePath + ".log";
 
     private static PullResult mockPullResult() {
         MessageExt msg = new MessageExt();
@@ -167,7 +166,7 @@ public class ExportMessageCommandTest {
     @Test
     public void testRecoverFromOffsetFileWithLessBeginOffset() throws Exception {
         exportDir = ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
-        prepareMessageFileAndOffsetFile(-1, 1);
+        prepareMessageFile(-1, 1);
         Assert.assertTrue(basicExport("base64").contains("100%"));
 
     }
@@ -175,24 +174,14 @@ public class ExportMessageCommandTest {
     @Test
     public void testRecoverFromOffsetFileWithGraterEndOffset() throws Exception {
         exportDir = ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
-        prepareMessageFileAndOffsetFile(0, 2);
+        prepareMessageFile(0, 2);
         Assert.assertTrue(basicExport("base64").contains("100%"));
     }
 
-    @Test
-    public void testRecoverFromOffsetFileNormal() throws Exception {
-        exportDir = ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
-        prepareMessageFileAndOffsetFile(0, 1);
-        // skip export (minOffset and maxOffset) is the same as offsetFile
-        String result = basicExport("base64");
-        Assert.assertFalse(result.contains("100%"));
-    }
-
-    public void prepareMessageFileAndOffsetFile(long beginOffset, long endOffset) throws Exception {
+    public void prepareMessageFile(long beginOffset, long endOffset) throws Exception {
         FileUtils.forceMkdirParent(new File(brokerDir));
         String exportedMessageText = "{\"topic\":\"topic1\",\"flag\":0,\"queueOffset\":0,\"bodyFormat\":\"json\",\"body\":{\"age\":1}}";
         FileUtils.writeLines(new File(queueFilePath), Lists.newArrayList(exportedMessageText));
-        FileUtils.write(new File(offsetFilePath), String.format("{\"beginOffset\":%d,\"endOffset\":%d}", beginOffset, endOffset), StandardCharsets.UTF_8);
     }
 
 }

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/ExportMessageCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/ExportMessageCommandTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.message;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.io.FileUtils;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.assertj.core.util.Lists;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExportMessageCommandTest {
+    private static ExportMessageCommand exportMessageCommand;
+
+    private static final PullResult PULL_RESULT = mockPullResult();
+    private static String exportDir = "./rocketmq-export";
+    private static String topicDir = exportDir + File.separator + "topic1";
+    private static String brokerDir = topicDir + File.separator + "broker-a";
+    private static String queueFilePath = brokerDir + File.separator + "1";
+    private static String offsetFilePath = queueFilePath + ".log";
+
+    private static PullResult mockPullResult() {
+        MessageExt msg = new MessageExt();
+        MessageExt messageExt = new MessageExt();
+        messageExt.setTopic("topic1");
+        messageExt.setBrokerName("broker-a");
+        messageExt.setQueueId(1);
+        msg.setBody("{'age':1}".getBytes(StandardCharsets.UTF_8));
+        messageExt.setBornHost(new InetSocketAddress(10910));
+        messageExt.setStoreHost(new InetSocketAddress(10910));
+        messageExt.setDeliverTimeMs(1L);
+        List<MessageExt> msgFoundList = new ArrayList<>();
+        msgFoundList.add(msg);
+        return new PullResult(PullStatus.FOUND, 1, 0, 1, msgFoundList);
+    }
+
+    @BeforeClass
+    public static void init() throws MQClientException, RemotingException, MQBrokerException, InterruptedException,
+        NoSuchFieldException, IllegalAccessException {
+        exportMessageCommand = new ExportMessageCommand();
+        DefaultMQPullConsumer defaultMQPullConsumer = mock(DefaultMQPullConsumer.class);
+
+        assignPullResult(defaultMQPullConsumer);
+        when(defaultMQPullConsumer.minOffset(any(MessageQueue.class))).thenReturn(Long.valueOf(0));
+        when(defaultMQPullConsumer.maxOffset(any(MessageQueue.class))).thenReturn(Long.valueOf(1));
+
+        final Set<MessageQueue> mqList = new HashSet<>();
+        mqList.add(new MessageQueue("topic1", "broker-a", 1));
+        when(defaultMQPullConsumer.fetchSubscribeMessageQueues(anyString())).thenReturn(mqList);
+
+        Field producerField = ExportMessageCommand.class.getDeclaredField("defaultMQPullConsumer");
+        producerField.setAccessible(true);
+        producerField.set(exportMessageCommand, defaultMQPullConsumer);
+    }
+
+    @AfterClass
+    public static void terminate() throws IOException {
+
+    }
+
+    @Before
+    public void before() throws IOException {
+        new File(exportDir).deleteOnExit();
+    }
+
+    @After
+    public void after() throws IOException {
+        new File(exportDir).deleteOnExit();
+    }
+
+    private static void assignPullResult() {
+        assignPullResult(null);
+    }
+
+    private static void assignPullResult(DefaultMQPullConsumer defaultMQPullConsumer) {
+        try {
+            if (defaultMQPullConsumer == null) {
+                Field producerField = ExportMessageCommand.class.getDeclaredField("defaultMQPullConsumer");
+                producerField.setAccessible(true);
+                defaultMQPullConsumer = (DefaultMQPullConsumer) producerField.get(exportMessageCommand);
+            }
+            when(defaultMQPullConsumer.pull(any(MessageQueue.class), anyString(), anyLong(), anyInt()))
+                .thenReturn(PULL_RESULT);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testExecuteDefault() throws Exception {
+        exportDir = "./rocketmq-export-" + UUID.randomUUID();
+        String result = basicExport("base64");
+        Assert.assertTrue(result.contains("100%"));
+    }
+
+    @Test
+    public void testExecuteJSON() throws Exception {
+        exportDir = "./rocketmq-export-" + UUID.randomUUID();
+        String result = basicExport("json");
+        Assert.assertTrue(result.contains("100%"));
+    }
+
+    private String basicExport(String format) throws SubCommandException {
+        PrintStream out = System.out;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(bos));
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = new String[] {"-t topic1", "-n localhost:9876", "-f " + format, "-d " + exportDir};
+        assignPullResult();
+        CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + exportMessageCommand.commandName(),
+            subargs, exportMessageCommand.buildCommandlineOptions(options), new DefaultParser());
+        exportMessageCommand.execute(commandLine, options, null);
+
+        System.setOut(out);
+        return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testRecoverFromOffsetFileWithLessBeginOffset() throws Exception {
+        exportDir = ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
+        prepareMessageFileAndOffsetFile(-1, 1);
+        Assert.assertTrue(basicExport("base64").contains("100%"));
+
+    }
+
+    @Test
+    public void testRecoverFromOffsetFileWithGraterEndOffset() throws Exception {
+        exportDir = ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
+        prepareMessageFileAndOffsetFile(0, 2);
+        Assert.assertTrue(basicExport("base64").contains("100%"));
+    }
+
+    @Test
+    public void testRecoverFromOffsetFileNormal() throws Exception {
+        exportDir = ExportMessageCommand.DEFAULT_EXPORT_DIRECTORY;
+        prepareMessageFileAndOffsetFile(0, 1);
+        // skip export (minOffset and maxOffset) is the same as offsetFile
+        String result = basicExport("base64");
+        Assert.assertFalse(result.contains("100%"));
+    }
+
+    public void prepareMessageFileAndOffsetFile(long beginOffset, long endOffset) throws Exception {
+        FileUtils.forceMkdirParent(new File(brokerDir));
+        String exportedMessageText = "{\"topic\":\"topic1\",\"flag\":0,\"queueOffset\":0,\"bodyFormat\":\"json\",\"body\":{\"age\":1}}";
+        FileUtils.writeLines(new File(queueFilePath), Lists.newArrayList(exportedMessageText));
+        FileUtils.write(new File(offsetFilePath), String.format("{\"beginOffset\":%d,\"endOffset\":%d}", beginOffset, endOffset), StandardCharsets.UTF_8);
+    }
+
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/ImportMessageCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/ImportMessageCommandTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.tools.command.message;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.io.FileUtils;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.assertj.core.util.Lists;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ImportMessageCommandTest {
+
+    private static ImportMessageCommand importMessageCommand = new ImportMessageCommand();
+
+    @BeforeClass
+    public static void init() throws MQClientException, RemotingException, InterruptedException, MQBrokerException, NoSuchFieldException, IllegalAccessException {
+        DefaultMQProducer defaultMQProducer = mock(DefaultMQProducer.class);
+        SendResult sendResult = new SendResult();
+        sendResult.setMessageQueue(new MessageQueue());
+        sendResult.getMessageQueue().setBrokerName("broker-1");
+        sendResult.getMessageQueue().setQueueId(1);
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+        sendResult.setMsgId("fgwejigherughwueyutyu4t4343t43");
+
+        when(defaultMQProducer.send(anyList())).thenReturn(sendResult);
+        when(defaultMQProducer.send(anyList(), any(MessageQueue.class))).thenReturn(sendResult);
+
+        Field producerField = ImportMessageCommand.class.getDeclaredField("producer");
+        producerField.setAccessible(true);
+        producerField.set(importMessageCommand, defaultMQProducer);
+    }
+
+    @AfterClass
+    public static void terminate() {
+    }
+
+    @Test
+    public void testExecuteDefault() throws SubCommandException, IOException {
+        String importDir = "./rocketmq-import";
+        String topicDir = importDir + File.separator + "topic1";
+        String brokerDir = topicDir + File.separator + "broker-a";
+        FileUtils.forceMkdirParent(new File(brokerDir));
+        File queueFile = new File(brokerDir + File.separator + "1");
+        String exportedMessageText = "{\"topic\":\"topic1\",\"flag\":0,\"queueOffset\":0,\"bodyFormat\":\"json\",\"body\":{\"age\":1}}";
+        FileUtils.writeLines(queueFile, Lists.newArrayList(exportedMessageText));
+
+        PrintStream out = System.out;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(bos));
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = new String[] {"-d " + importDir, "-n localhost:9876"};
+        CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + importMessageCommand.commandName(),
+            subargs, importMessageCommand.buildCommandlineOptions(options), new DefaultParser());
+        importMessageCommand.execute(commandLine, options, null);
+
+        System.setOut(out);
+        String s = new String(bos.toByteArray());
+        Assert.assertTrue(s.contains("100%"));
+        FileUtils.forceDeleteOnExit(new File(importDir));
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #6971
refer failed pull request #6972

### Brief Description

1. migrate message across env: we switch our system from aws to aliyun , some message still not consumed in aws , we should migrate message from aws to aliyun ==> just use exportMessage and importMessage .
2. fix some wrong message: after deploy some bug , the message format is not correct ==> we can exportMessage with json body --> modify message  body --> importMessasge 
3. trace bug in lots of message body  ==> after export message with json/text format  ,we could easily search some keywords to view message detail , such as `grep keyword messageFile ` 

### How Did You Test This Change?

1. exportMessage: mock broker , fetch some messages and export to file , at the same time , show result 100% on system.out
2. importMessage: mock broker , read a message file and send message to broker , at the same time , show result 100% on system.out

### example usage
<img width="1309" alt="WeChatc0e14e48d1e5c6ef1ee135a5141a74bf" src="https://github.com/apache/rocketmq/assets/7055460/c04f8e90-b75b-4f19-b5f0-22a368c81922">

