### PR TITLE
[ISSUE #8707] Fix artifact download failure in CI after action upgrade

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -96,6 +96,7 @@ jobs:
           a=(`ls versionlist`)
           printf '%s\n' "${a[@]}" | jq -R . | jq -s .
           echo version-json=`printf '%s\n' "${a[@]}" | jq -R . | jq -s .` >> $GITHUB_OUTPUT
+
   deploy:
     if: ${{ success() }}
     name: Deploy RocketMQ

--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -85,7 +85,7 @@ jobs:
     outputs:
       version-json: ${{ steps.show_versions.outputs.version-json }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download versionlist
         with:
           name: versionlist

--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -25,7 +25,7 @@ jobs:
         java-version: ["8"]
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -2,7 +2,7 @@ name: PUSH-CI
 
 on:
   push:
-    branches: [master, develop, fix-push-ci]
+    branches: [master, develop]
   #schedule:
   #  - cron: "0 18 * * *" # TimeZone: UTC 0
 
@@ -15,6 +15,7 @@ env:
 
 jobs:
   dist-tar:
+    if: github.repository == 'apache/rocketmq'
     name: Build dist tar
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -79,7 +80,9 @@ jobs:
 
   
   list-version:
-    if: always()
+    if: >
+      github.repository == 'apache/rocketmq' && 
+      always()
     name: List version
     needs: [docker]
     runs-on: ubuntu-latest

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -52,7 +52,7 @@ jobs:
           repository: apache/rocketmq-docker.git
           ref: master
           path: rocketmq-docker
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download distribution tar
         with:
           name: rocketmq
@@ -87,7 +87,7 @@ jobs:
     outputs:
       version-json: ${{ steps.show_versions.outputs.version-json }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download versionlist
         with:
           name: versionlist

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -2,7 +2,7 @@ name: PUSH-CI
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master, develop, fix-push-ci]
   #schedule:
   #  - cron: "0 18 * * *" # TimeZone: UTC 0
 
@@ -15,7 +15,6 @@ env:
 
 jobs:
   dist-tar:
-    if: github.repository == 'apache/rocketmq'
     name: Build dist tar
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -80,9 +79,7 @@ jobs:
 
   
   list-version:
-    if: >
-      github.repository == 'apache/rocketmq' && 
-      always()
+    if: always()
     name: List version
     needs: [docker]
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot-automation.yml
+++ b/.github/workflows/snapshot-automation.yml
@@ -91,7 +91,7 @@ jobs:
           repository: apache/rocketmq-docker.git
           ref: master
           path: rocketmq-docker
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download distribution tar
         with:
           name: rocketmq
@@ -125,7 +125,7 @@ jobs:
     outputs:
       version-json: ${{ steps.show_versions.outputs.version-json }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download versionlist
         with:
           name: versionlist


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#8707](https://github.com/apache/rocketmq/issues/8707)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
After upgrading @actions/upload-artifact to v4, @actions/download-artifact wasn't updated, causing issues with downloading artifacts. This PR upgrades both actions to v4, resolving the issue and allowing the artifact to be downloaded successfully.
