### PR TITLE
[ISSUE #8742] Enhance unit test retry mechanism to trigger on PR submission

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -8,9 +8,6 @@ on:
       - develop
       - bazel
 
-permissions:
-  actions: write
-
 jobs:
   build:
     name: "bazel-compile (${{ matrix.os }})"
@@ -24,13 +21,3 @@ jobs:
         run: bazel build --config=remote //...
       - name: Run Tests
         run: bazel test --config=remote //...
-      - name: Retry if failed
-        # if it failed , retry 2 times at most
-        if: failure() && fromJSON(github.run_attempt) < 3
-        continue-on-error: true
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Attempting to retry workflow..."
-          gh workflow run rerun-workflow.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [master, develop, bazel]
 
-permissions:
-  actions: write
-
 jobs:
   java_build:
     name: "maven-compile (${{ matrix.os }}, JDK-${{ matrix.jdk }})"
@@ -45,14 +42,3 @@ jobs:
           name: jvm-crash-logs
           path: /Users/runner/work/rocketmq/rocketmq/broker/hs_err_pid*.log
           retention-days: 1
-
-      - name: Retry if failed
-        # if it failed , retry 2 times at most
-        if: failure() && fromJSON(github.run_attempt) < 3
-        continue-on-error: true
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Attempting to retry workflow..."
-          gh workflow run rerun-workflow.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -1,7 +1,7 @@
 name: Rerun workflow
 on:
   workflow_run:
-    workflows: ["Build and Run Tests by Maven", "Build and Run Tests by Bazel"]
+    workflows: ["Build and Run Tests by Maven"]
     types:
       - completed
 

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -1,21 +1,22 @@
 name: Rerun workflow
 on:
-  workflow_dispatch:
-    inputs:
-      run_id:
-        required: true
+  workflow_run:
+    workflows: ["Build and Run Tests by Maven", "Build and Run Tests by Bazel"]
+    types:
+      - completed
 
 permissions:
   actions: write
 
 jobs:
   rerun:
+    if: github.event.workflow_run.conclusion == 'failure' && fromJSON(github.event.workflow_run.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:
-      - name: rerun ${{ inputs.run_id }}
+      - name: rerun ${{  github.event.workflow_run.id }}
         env:
-          GH_REPO: ${{ github.repository }}
+          GH_REPO: ${{  github.event.workflow_run.id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
-          gh run rerun ${{ inputs.run_id }} --failed
+          gh run watch ${{ github.event.workflow_run.id }} > /dev/null 2>&1
+          gh run rerun ${{ github.event.workflow_run.id }} --failed

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -17,7 +17,6 @@ jobs:
         env:
           GH_REPO:  ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # gh run watch ${{ github.event.workflow_run.id }} > /dev/null 2>&1
         run: |
-          
+          gh run watch ${{ github.event.workflow_run.id }} > /dev/null 2>&1
           gh run rerun ${{ github.event.workflow_run.id }} --failed

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -1,7 +1,7 @@
 name: Rerun workflow
 on:
   workflow_run:
-    workflows: ["Build and Run Tests by Maven"]
+    workflows: ["Build and Run Tests by Maven" , "Build and Run Tests by Bazel"]
     types:
       - completed
 

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: rerun ${{  github.event.workflow_run.id }}
         env:
-          GH_REPO: ${{  github.event.workflow_run.id }}
+          GH_REPO:  ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # gh run watch ${{ github.event.workflow_run.id }} > /dev/null 2>&1
         run: |

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           GH_REPO: ${{  github.event.workflow_run.id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh run watch ${{ github.event.workflow_run.id }} > /dev/null 2>&1
         run: |
-          gh run watch ${{ github.event.workflow_run.id }} > /dev/null 2>&1
+          
           gh run rerun ${{ github.event.workflow_run.id }} --failed


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes


Fixes [#8742 ](https://github.com/apache/rocketmq/issues/8742)

### Brief Description
- Modified the retry mechanism to use the workflow_run event instead of manual rerun.
- Resolved permission issues preventing retry on PR submission.
- Improved automation and stability of unit tests.
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
I tested the change by submitting a PR to my own repository and deliberately introducing errors to check if the retry mechanism would trigger. The result was successful, confirming that the retry function works as intended.

[The test workflow](https://github.com/chi3316/rocketmq/actions/runs/11009360256/job/30568890778?pr=3)

![image](https://github.com/user-attachments/assets/3b6f0abe-921a-4c9d-acf9-6b050c67dce8)

