### PR TITLE
[ISSUE #8755] batch send support compression

### DIFF
--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -260,6 +260,20 @@ public class DefaultMQProducerTest {
     }
 
     @Test
+    public void testBatchSendBigMessage() throws RemotingException, InterruptedException, MQClientException, MQBrokerException {
+        when(mQClientAPIImpl.getTopicRouteInfoFromNameServer(anyString(), anyLong())).thenReturn(createTopicRoute());
+        List<Message> msgs = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Message message = new Message();
+            message.setTopic("test");
+            message.setBody((new String(bigMessage.getBody()) + i).getBytes());
+            msgs.add(message);
+        }
+        SendResult sendResult = producer.send(msgs);
+        assertThat(sendResult.getSendStatus()).isEqualTo(SendStatus.SEND_OK);
+    }
+
+    @Test
     public void testBatchSendMessageAsync()
         throws RemotingException, MQClientException, InterruptedException, MQBrokerException {
         final AtomicInteger cc = new AtomicInteger(0);

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -659,8 +659,19 @@ public class MessageDecoder {
     }
 
     public static byte[] encodeMessage(Message message) {
+        try {
+            return encodeMessage(message,null,null);
+        } catch (IOException e) {
+            //should not happen because not doing compress
+            throw new RuntimeException(e);
+        }
+    }
+    public static byte[] encodeMessage(Message message, Compressor compressor,Integer compressLevel) throws IOException {
         //only need flag, body, properties
         byte[] body = message.getBody();
+        if (compressor != null) {
+            body = compressor.compress(body,compressLevel);
+        }
         int bodyLen = body.length;
         String properties = messageProperties2String(message.getProperties());
         byte[] propertiesBytes = properties.getBytes(CHARSET_UTF8);
@@ -729,11 +740,20 @@ public class MessageDecoder {
     }
 
     public static byte[] encodeMessages(List<Message> messages) {
+        try {
+            return encodeMessages(messages, null,null);
+        } catch (IOException e) {
+            //should not happen because not doing compress
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static byte[] encodeMessages(List<Message> messages, Compressor compressor, Integer compressLevel) throws IOException {
         //TO DO refactor, accumulate in one buffer, avoid copies
         List<byte[]> encodedMessages = new ArrayList<>(messages.size());
         int allSize = 0;
         for (Message message : messages) {
-            byte[] tmp = encodeMessage(message);
+            byte[] tmp = encodeMessage(message,compressor,compressLevel);
             encodedMessages.add(tmp);
             allSize += tmp.length;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,9 @@
                             <excludes>
                                 <exclude>**/NormalMsgDelayIT.java</exclude>
                             </excludes>
+                            <includes>
+                                <include>**/BatchSendIT.java</include>
+                            </includes>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -506,9 +506,6 @@
                             <excludes>
                                 <exclude>**/NormalMsgDelayIT.java</exclude>
                             </excludes>
-                            <includes>
-                                <include>**/BatchSendIT.java</include>
-                            </includes>
                         </configuration>
                         <executions>
                             <execution>

--- a/test/src/main/java/org/apache/rocketmq/test/factory/ConsumerFactory.java
+++ b/test/src/main/java/org/apache/rocketmq/test/factory/ConsumerFactory.java
@@ -85,13 +85,13 @@ public class ConsumerFactory {
         DefaultMQPullConsumer defaultMQPullConsumer = new DefaultMQPullConsumer(consumerGroup);
         defaultMQPullConsumer.setInstanceName(UUID.randomUUID().toString());
         defaultMQPullConsumer.setNamesrvAddr(nsAddr);
-        if(start){
+        if (start) {
             defaultMQPullConsumer.start();
         }
         return defaultMQPullConsumer;
     }
 
     public static DefaultMQPullConsumer getRMQPullConsumer(String nsAddr, String consumerGroup) throws Exception {
-       return getRMQPullConsumer(nsAddr, consumerGroup, true);
+        return getRMQPullConsumer(nsAddr, consumerGroup, true);
     }
 }

--- a/test/src/main/java/org/apache/rocketmq/test/factory/ConsumerFactory.java
+++ b/test/src/main/java/org/apache/rocketmq/test/factory/ConsumerFactory.java
@@ -81,11 +81,17 @@ public class ConsumerFactory {
         return client;
     }
 
-    public static DefaultMQPullConsumer getRMQPullConsumer(String nsAddr, String consumerGroup) throws Exception {
+    public static DefaultMQPullConsumer getRMQPullConsumer(String nsAddr, String consumerGroup, boolean start) throws Exception {
         DefaultMQPullConsumer defaultMQPullConsumer = new DefaultMQPullConsumer(consumerGroup);
         defaultMQPullConsumer.setInstanceName(UUID.randomUUID().toString());
         defaultMQPullConsumer.setNamesrvAddr(nsAddr);
-        defaultMQPullConsumer.start();
+        if(start){
+            defaultMQPullConsumer.start();
+        }
         return defaultMQPullConsumer;
+    }
+
+    public static DefaultMQPullConsumer getRMQPullConsumer(String nsAddr, String consumerGroup) throws Exception {
+       return getRMQPullConsumer(nsAddr, consumerGroup, true);
     }
 }

--- a/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
+++ b/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
@@ -266,8 +266,12 @@ public class BatchSendIT extends BaseConf {
                 Assert.assertEquals(i + startOffset, messageExt.getQueueOffset());
                 Assert.assertEquals(batchTopic, messageExt.getTopic());
                 Assert.assertEquals(messageQueue.getQueueId(), messageExt.getQueueId());
+                if(bodyLen!=messageExt.getBody().length){
+                    logger.error("decompress fail? {} {}",i,messageExt);
+                }
                 Assert.assertEquals(bodyLen, messageExt.getBody().length);
                 Assert.assertTrue((messageExt.getSysFlag() & MessageSysFlag.COMPRESSED_FLAG) != 0);
+                Assert.assertTrue(messageExt.getStoreSize()<bodyLen);
             }
         }
     }

--- a/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
+++ b/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
@@ -253,8 +253,11 @@ public class BatchSendIT extends BaseConf {
         }
         Thread.sleep(300);
         {
-            DefaultMQPullConsumer defaultMQPullConsumer = ConsumerFactory.getRMQPullConsumer(NAMESRV_ADDR, "group");
+            // not start to set decodeDecompressBody independent of
+            // system property ClientConfig.DECODE_DECOMPRESS_BODY(com.rocketmq.decompress.body) config
+            DefaultMQPullConsumer defaultMQPullConsumer = ConsumerFactory.getRMQPullConsumer(NAMESRV_ADDR, "group",false);
             defaultMQPullConsumer.setDecodeDecompressBody(true);
+            defaultMQPullConsumer.start();
             long startOffset = 5;
             PullResult pullResult = defaultMQPullConsumer.pullBlockIfNotFound(messageQueue, "*", startOffset, batchCount * batchNum);
             Assert.assertEquals(PullStatus.FOUND, pullResult.getPullStatus());
@@ -266,9 +269,6 @@ public class BatchSendIT extends BaseConf {
                 Assert.assertEquals(i + startOffset, messageExt.getQueueOffset());
                 Assert.assertEquals(batchTopic, messageExt.getTopic());
                 Assert.assertEquals(messageQueue.getQueueId(), messageExt.getQueueId());
-                if (bodyLen != messageExt.getBody().length) {
-                    logger.error("decompress fail? {} {}", i, messageExt);
-                }
                 Assert.assertEquals(bodyLen, messageExt.getBody().length);
                 Assert.assertTrue((messageExt.getSysFlag() & MessageSysFlag.COMPRESSED_FLAG) != 0);
                 Assert.assertTrue(messageExt.getStoreSize() < bodyLen);

--- a/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
+++ b/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
@@ -37,6 +37,7 @@ import org.apache.rocketmq.common.message.MessageBatch;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.sysflag.MessageSysFlag;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.store.DefaultMessageStore;
@@ -253,7 +254,7 @@ public class BatchSendIT extends BaseConf {
         Thread.sleep(300);
         {
             DefaultMQPullConsumer defaultMQPullConsumer = ConsumerFactory.getRMQPullConsumer(NAMESRV_ADDR, "group");
-
+            defaultMQPullConsumer.setDecodeDecompressBody(true);
             long startOffset = 5;
             PullResult pullResult = defaultMQPullConsumer.pullBlockIfNotFound(messageQueue, "*", startOffset, batchCount * batchNum);
             Assert.assertEquals(PullStatus.FOUND, pullResult.getPullStatus());
@@ -266,6 +267,7 @@ public class BatchSendIT extends BaseConf {
                 Assert.assertEquals(batchTopic, messageExt.getTopic());
                 Assert.assertEquals(messageQueue.getQueueId(), messageExt.getQueueId());
                 Assert.assertEquals(bodyLen, messageExt.getBody().length);
+                Assert.assertTrue((messageExt.getSysFlag() & MessageSysFlag.COMPRESSED_FLAG) != 0);
             }
         }
     }

--- a/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
+++ b/test/src/test/java/org/apache/rocketmq/test/client/producer/batch/BatchSendIT.java
@@ -266,12 +266,12 @@ public class BatchSendIT extends BaseConf {
                 Assert.assertEquals(i + startOffset, messageExt.getQueueOffset());
                 Assert.assertEquals(batchTopic, messageExt.getTopic());
                 Assert.assertEquals(messageQueue.getQueueId(), messageExt.getQueueId());
-                if(bodyLen!=messageExt.getBody().length){
-                    logger.error("decompress fail? {} {}",i,messageExt);
+                if (bodyLen != messageExt.getBody().length) {
+                    logger.error("decompress fail? {} {}", i, messageExt);
                 }
                 Assert.assertEquals(bodyLen, messageExt.getBody().length);
                 Assert.assertTrue((messageExt.getSysFlag() & MessageSysFlag.COMPRESSED_FLAG) != 0);
-                Assert.assertTrue(messageExt.getStoreSize()<bodyLen);
+                Assert.assertTrue(messageExt.getStoreSize() < bodyLen);
             }
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

closes #8755 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
by default, `DefaultMQProducer` will compress message body when body length is longer than 4k, but if send with batch(`send(
        Collection<Message> msgs)`), body are not compressed.
this pr compress each message body when average length is larger than 4k
 
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

send and receive batch messages with 8k body(larger than 4k default compress length), check commit log content is compressed. consume message body is 8k length.
