### PR TITLE
[ISSUE #8747] Fix PR E2E artifact download issue

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -25,18 +25,18 @@ jobs:
         java-version: ["8"]
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v6
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
-            var matchArtifactRmq = artifacts.data.artifacts.filter((artifact) => {
+            let matchArtifactRmq = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "rocketmq"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifactRmq.id,

--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   docker:
     if: >
+      github.repository == 'apache/rocketmq' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
@@ -74,7 +75,9 @@ jobs:
           path: rocketmq-docker/image-build-ci/versionlist/*
   
   list-version:
-    if: always()
+    if: >
+      github.repository == 'apache/rocketmq' &&
+      always()
     name: List version
     needs: [docker]
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -14,7 +14,6 @@ env:
 jobs:
   docker:
     if: >
-      github.repository == 'apache/rocketmq' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
@@ -75,9 +74,7 @@ jobs:
           path: rocketmq-docker/image-build-ci/versionlist/*
   
   list-version:
-    if: >
-      github.repository == 'apache/rocketmq' &&
-      always()
+    if: always()
     name: List version
     needs: [docker]
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -260,4 +260,3 @@ jobs:
           ask-config: "${{ secrets.ASK_CONFIG_VIRGINA }}"
           test-version: "${{ matrix.version }}"
           job-id: ${{ strategy.job-index }}
-          


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#8747 ](https://github.com/apache/rocketmq/issues/8747)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
This PR resolves the issue with downloading artifacts in the PR E2E workflow by updating the script for downloading the rocketmq artifact. The previous error has been fixed to ensure the workflow runs correctly.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
It can download artifacts correctly. [The test workflow](https://github.com/chi3316/rocketmq/actions/runs/11025091707/job/30619381260)

![image](https://github.com/user-attachments/assets/44ec8e71-23dc-4569-8e54-a597fb356b08)
