### PR TITLE
feat:When starting the broker and nameserver, the xmx, xms, and xmn p…

### DIFF
--- a/distribution/bin/runbroker.sh
+++ b/distribution/bin/runbroker.sh
@@ -57,6 +57,17 @@ export CLASSPATH=.:${BASE_DIR}/conf:${BASE_DIR}/lib/*:${CLASSPATH}
 # The RAMDisk initializing size in MB on Darwin OS for gc-log
 DIR_SIZE_IN_MB=600
 
+if [ "$JVM_OPT_XMX" = "" ]; then
+   export JVM_OPT_XMX="8g"
+fi
+if [ "$JVM_OPT_XMS" = "" ]; then
+    export JVM_OPT_XMS="8g"
+fi
+
+if [ "$JVM_OPT_XMN" = "" ]; then
+    export JVM_OPT_XMN="4g"
+fi
+
 choose_gc_log_directory()
 {
     case "`uname`" in
@@ -84,7 +95,7 @@ choose_gc_options()
 {
     JAVA_MAJOR_VERSION=$("$JAVA" -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//' | cut -d'.' -f1)
     if [ -z "$JAVA_MAJOR_VERSION" ] || [ "$JAVA_MAJOR_VERSION" -lt "8" ] ; then
-      JAVA_OPT="${JAVA_OPT} -Xmn4g -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8 -XX:-UseParNewGC"
+      JAVA_OPT="${JAVA_OPT} -Xmn$JVM_OPT_XMN -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8 -XX:-UseParNewGC"
     else
       JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0"
     fi
@@ -100,7 +111,7 @@ choose_gc_options()
 
 choose_gc_log_directory
 
-JAVA_OPT="${JAVA_OPT} -server -Xms8g -Xmx8g"
+JAVA_OPT="${JAVA_OPT} -server -Xms$JVM_OPT_XMS -Xmx$JVM_OPT_XMX"
 choose_gc_options
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT} -XX:+AlwaysPreTouch"

--- a/distribution/bin/runserver.sh
+++ b/distribution/bin/runserver.sh
@@ -57,6 +57,17 @@ export CLASSPATH=.:${BASE_DIR}/conf:${BASE_DIR}/lib/*:${CLASSPATH}
 # The RAMDisk initializing size in MB on Darwin OS for gc-log
 DIR_SIZE_IN_MB=600
 
+if [ "$JVM_OPT_XMX" = "" ]; then
+   export JVM_OPT_XMX="4g"
+fi
+if [ "$JVM_OPT_XMS" = "" ]; then
+    export JVM_OPT_XMS="4g"
+fi
+
+if [ "$JVM_OPT_XMN" = "" ]; then
+    export JVM_OPT_XMN="2g"
+fi
+
 choose_gc_log_directory()
 {
     case "`uname`" in
@@ -86,12 +97,12 @@ choose_gc_options()
     # '1' means releases before Java 9
     JAVA_MAJOR_VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F '.' '{print $1}')
     if [ -z "$JAVA_MAJOR_VERSION" ] || [ "$JAVA_MAJOR_VERSION" -lt "9" ] ; then
-      JAVA_OPT="${JAVA_OPT} -server -Xms4g -Xmx4g -Xmn2g -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
+      JAVA_OPT="${JAVA_OPT} -server -Xms$JVM_OPT_XMS -Xmx$JVM_OPT_XMX -Xmn$JVM_OPT_XMN -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
       JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8 -XX:-UseParNewGC"
       JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:${GC_LOG_DIR}/rmq_srv_gc_%p_%t.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
       JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"
     else
-      JAVA_OPT="${JAVA_OPT} -server -Xms4g -Xmx4g -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
+      JAVA_OPT="${JAVA_OPT} -server -Xms$JVM_OPT_XMS -Xm$JVM_OPT_XMX -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
       JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0"
       JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${GC_LOG_DIR}/rmq_srv_gc_%p_%t.log:time,tags:filecount=5,filesize=30M"
     fi


### PR DESCRIPTION
[ISSUE #8697]When starting the broker and nameserver, the xmx, xms, and xmn parameters in the JVM can be passed
### Which Issue(s) This PR Fixes
Fixes #8697 
### Brief Description
Modify the runbroker. sh and runserver. sh files to include judgments for xmx, xms, and xmn. If not passed in, use the default values.
### How Did You Test This Change?