### PR TITLE
[ISSUE #8810] Fix independent execution of e2e and benchmark deployments

### DIFF
--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -103,7 +103,7 @@ jobs:
 
   deploy-e2e:
     if: ${{ success() }}
-    name: Deploy RocketMQ
+    name: Deploy RocketMQ For E2E
     needs: [list-version,docker]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -137,7 +137,7 @@ jobs:
 
   deploy-benchmark:
     if: ${{ success() }}
-    name: Deploy RocketMQ
+    name: Deploy RocketMQ For Benchmarking
     needs: [list-version,docker]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -312,7 +312,7 @@ jobs:
 
   clean-e2e:
     if: always()
-    name: Clean
+    name: Clean E2E
     needs: [ list-version, test-e2e-grpc-java, test-e2e-golang, test-e2e-remoting-java ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -330,7 +330,7 @@ jobs:
           
   clean-benchmark:
     if: always()
-    name: Clean
+    name: Clean Benchmarking
     needs: [ benchmark-test ]
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -301,7 +301,7 @@ jobs:
           min-send-tps-threshold: "12000"
           max-rt-ms-threshold: "500"
           avg-rt-ms-threshold: "10"
-          max-2c-rt-ms-threshold: "100"
+          max-2c-rt-ms-threshold: "150"
           avg-2c-rt-ms-threshold: "10"
       - name: Upload test report
         if: always()

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -294,7 +294,7 @@ jobs:
         with:
           action: "performance-benchmark"
           ask-config: "${{ secrets.ASK_CONFIG_VIRGINA }}"
-          job-id: 1
+          job-id: "001-${{ strategy.job-index }}"
           # The time to run the test, 15 minutes
           test-time: "900"
           # Some thresholds set in advance
@@ -331,7 +331,7 @@ jobs:
   clean-benchmark:
     if: always()
     name: Clean Benchmarking
-    needs: [ benchmark-test ]
+    needs: [ list-version, benchmark-test ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -101,7 +101,7 @@ jobs:
           printf '%s\n' "${a[@]}" | jq -R . | jq -s .
           echo version-json=`printf '%s\n' "${a[@]}" | jq -R . | jq -s .` >> $GITHUB_OUTPUT
 
-  deploy:
+  deploy-e2e:
     if: ${{ success() }}
     name: Deploy RocketMQ
     needs: [list-version,docker]
@@ -110,9 +110,7 @@ jobs:
     strategy:
       matrix:
         version: ${{ fromJSON(needs.list-version.outputs.version-json) }}
-        test-type: [e2e, benchmark]
     steps:
-      - run: echo "Running ${{ matrix.test-type }}... "
       - uses: apache/rocketmq-test-tool@7d84d276ad7755b1dc5cf9657a7a9bff6ae6d288
         name: Deploy rocketmq
         with:
@@ -137,10 +135,44 @@ jobs:
                 repository: ${{env.DOCKER_REPO}}
                 tag: ${{ matrix.version }}
 
+  deploy-benchmark:
+    if: ${{ success() }}
+    name: Deploy RocketMQ
+    needs: [list-version,docker]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.list-version.outputs.version-json) }}
+    steps:
+      - uses: apache/rocketmq-test-tool@7d84d276ad7755b1dc5cf9657a7a9bff6ae6d288
+        name: Deploy rocketmq
+        with:
+          action: "deploy"
+          ask-config: "${{ secrets.ASK_CONFIG_VIRGINA }}"
+          test-version: "${{ matrix.version }}"
+          chart-git: "https://ghproxy.com/https://github.com/apache/rocketmq-docker.git"
+          chart-branch: "master"
+          chart-path: "./rocketmq-k8s-helm"
+          job-id: "001-${{ strategy.job-index }}"
+          helm-values: |
+            nameserver:
+              image:
+                repository: ${{env.DOCKER_REPO}}
+                tag: ${{ matrix.version }}
+            broker:
+              image:
+                repository: ${{env.DOCKER_REPO}}
+                tag: ${{ matrix.version }}
+            proxy:
+              image:
+                repository: ${{env.DOCKER_REPO}}
+                tag: ${{ matrix.version }}
+
   test-e2e-grpc-java:
     if: ${{ success() }}
     name: Test E2E grpc java
-    needs: [list-version, deploy]
+    needs: [list-version, deploy-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -176,7 +208,7 @@ jobs:
   test-e2e-golang:
     if: ${{ success() }}
     name: Test E2E golang
-    needs: [list-version, deploy]
+    needs: [list-version, deploy-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -217,7 +249,7 @@ jobs:
   test-e2e-remoting-java:
     if: ${{ success() }}
     name: Test E2E remoting java
-    needs: [ list-version, deploy ]
+    needs: [ list-version, deploy-e2e ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -254,7 +286,7 @@ jobs:
     if: ${{ success() }}
     runs-on: ubuntu-latest
     name: Performance benchmark test
-    needs: [ list-version, deploy ]
+    needs: [ list-version, deploy-benchmark ]
     timeout-minutes: 60
     steps:
       - uses: apache/rocketmq-test-tool/benchmark-runner@ce372e5f3906ca1891e4918b05be14608eae608e
@@ -278,18 +310,16 @@ jobs:
           name: benchmark-report
           path: benchmark/
 
-  clean:
+  clean-e2e:
     if: always()
     name: Clean
-    needs: [list-version, test-e2e-grpc-java, test-e2e-golang, test-e2e-remoting-java, benchmark-test]
+    needs: [ list-version, test-e2e-grpc-java, test-e2e-golang, test-e2e-remoting-java ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
         version: ${{ fromJSON(needs.list-version.outputs.version-json) }}
-        test-type: [ e2e, benchmark ]
     steps:
-      - run: echo "Cleaning ${{ matrix.test-type }}... "
       - uses: apache/rocketmq-test-tool@7d84d276ad7755b1dc5cf9657a7a9bff6ae6d288
         name: clean
         with:
@@ -298,3 +328,20 @@ jobs:
           test-version: "${{ matrix.version }}"
           job-id: ${{ strategy.job-index }}
           
+  clean-benchmark:
+    if: always()
+    name: Clean
+    needs: [ benchmark-test ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.list-version.outputs.version-json) }}
+    steps:
+      - uses: apache/rocketmq-test-tool@7d84d276ad7755b1dc5cf9657a7a9bff6ae6d288
+        name: clean
+        with:
+          action: "clean"
+          ask-config: "${{ secrets.ASK_CONFIG_VIRGINA }}"
+          test-version: "${{ matrix.version }}"
+          job-id: "001-${{ strategy.job-index }}"


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#8810 ](https://github.com/apache/rocketmq/issues/8810)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
This PR modifies the workflow to ensure that the e2e and benchmark deployments are independent. If one deployment fails, it no longer blocks the execution of the other deployment's tasks.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
[The test workflow](https://github.com/chi3316/rocketmq/actions/runs/11285198990)
