### PR TITLE
fix variables match annotation (@RocketMQResource)

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ResetOffsetRequestHeader.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ResetOffsetRequestHeader.java
@@ -31,11 +31,11 @@ public class ResetOffsetRequestHeader extends TopicQueueRequestHeader {
 
     @CFNotNull
     @RocketMQResource(ResourceType.GROUP)
-    private String topic;
+    private String group;
 
     @CFNotNull
     @RocketMQResource(ResourceType.TOPIC)
-    private String group;
+    private String topic;
 
     private int queueId = -1;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8820

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

The class `ResetOffsetRequestHeader` set wrong `@RocketMQResource` value in fields `topic`, `group`.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

No test.