### PR TITLE
[ISSUE #8837] Remove netty codec threads for better performance

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
@@ -78,8 +78,8 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
     @Override
     protected ChannelPipeline configChannel(SocketChannel ch) {
         return ch.pipeline()
-            .addLast(this.getDefaultEventExecutorGroup(), HANDSHAKE_HANDLER_NAME, new HandshakeHandler())
-            .addLast(this.getDefaultEventExecutorGroup(),
+            .addLast(HANDSHAKE_HANDLER_NAME, new HandshakeHandler())
+            .addLast(
                 new IdleStateHandler(0, 0, nettyServerConfig.getServerChannelMaxIdleTimeSeconds()),
                 new ProtocolNegotiationHandler(this.remotingProtocolHandler)
                     .addProtocolHandler(this.http2ProtocolProxyHandler)

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
@@ -24,7 +24,6 @@ public class NettyServerConfig implements Cloneable {
      */
     private String bindAddress = "0.0.0.0";
     private int listenPort = 0;
-    private int serverWorkerThreads = 8;
     private int serverCallbackExecutorThreads = 0;
     private int serverSelectorThreads = 3;
     private int serverOnewaySemaphoreValue = 256;
@@ -64,14 +63,6 @@ public class NettyServerConfig implements Cloneable {
 
     public void setListenPort(int listenPort) {
         this.listenPort = listenPort;
-    }
-
-    public int getServerWorkerThreads() {
-        return serverWorkerThreads;
-    }
-
-    public void setServerWorkerThreads(int serverWorkerThreads) {
-        this.serverWorkerThreads = serverWorkerThreads;
     }
 
     public int getServerSelectorThreads() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8837

### Brief Description
In the current implementation, a codec thread pool is set up for Netty, which is used to perform tasks such as encoding/decoding, and statistics.

We found that removing the codec thread pool and directly assigning these computational tasks to the NIO selector threads results in performance improvement.

Since these tasks do not involve IO operations, they will not block the NIO selector threads.

Our stress test results show that removing the codec thread pool can achieve higher TPS (5% increase) and also reduce CPU usage (4% reduction).

### How Did You Test This Change?
