### PR TITLE
fix RequestCode overflowed issues:8868

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
@@ -88,13 +88,13 @@ public class RequestCode {
 
     public static final int GET_TIMER_METRICS = 61;
 
-    public static final int POP_MESSAGE = 200050;
-    public static final int ACK_MESSAGE = 200051;
-    public static final int BATCH_ACK_MESSAGE = 200151;
-    public static final int PEEK_MESSAGE = 200052;
-    public static final int CHANGE_MESSAGE_INVISIBLETIME = 200053;
-    public static final int NOTIFICATION = 200054;
-    public static final int POLLING_INFO = 200055;
+    public static final short POP_MESSAGE = 3442;
+    public static final short ACK_MESSAGE = 3443;
+    public static final short BATCH_ACK_MESSAGE = 3543;
+    public static final short PEEK_MESSAGE = 3444;
+    public static final short CHANGE_MESSAGE_INVISIBLETIME = 3445;
+    public static final short NOTIFICATION = 3446;
+    public static final short POLLING_INFO = 3447;
 
     public static final int PUT_KV_CONFIG = 100;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8868

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

**Description:**  
The following message request codes exceed the maximum value for a short integer (32767), resulting in an overflow. The original values are as follows:

```java
public static final int POP_MESSAGE = 200050;
public static final int ACK_MESSAGE = 200051;
public static final int BATCH_ACK_MESSAGE = 200151;
public static final int PEEK_MESSAGE = 200052;
public static final int CHANGE_MESSAGE_INVISIBLETIME = 200053;
public static final int NOTIFICATION = 200054;
public static final int POLLING_INFO = 200055;
```

**Actual Values After Overflow:**  
Due to the overflow, the actual values of these constants are:

```java
public static final int POP_MESSAGE = 3442;
public static final int ACK_MESSAGE = 3443;
public static final int BATCH_ACK_MESSAGE = 3543;
public static final int PEEK_MESSAGE = 3444;
public static final int CHANGE_MESSAGE_INVISIBLETIME = 3445;
public static final int NOTIFICATION = 3446;
public static final int POLLING_INFO = 3447;
```

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

unit test
