### PR TITLE
[ISSUE #8875] Fix HAConnection leak

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAService.java
@@ -350,8 +350,8 @@ public class DefaultHAService implements HAService {
                                         + sc.socket().getRemoteSocketAddress());
                                     try {
                                         HAConnection conn = createConnection(sc);
-                                        conn.start();
                                         DefaultHAService.this.addConnection(conn);
+                                        conn.start();
                                     } catch (Exception e) {
                                         log.error("new HAConnection exception", e);
                                         sc.close();


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#issue_id](https://github.com/apache/rocketmq/issues/8875)

### Brief Description

在一些异常场景，可以模拟对ha端口的探活测试，由于conn.start会马上启动线程，在足够快失败的场景，会先执行removeConnection动作，而后再执行addConnection动作，最终造成connection泄漏，滞留 HaService 的connectionList里面，累积造成内存溢出风险。


### How Did You Test This Change?
使用python脚本进行ha端口10912的高频探活验证是否还存在内存泄漏

# -*- coding:UTF-8 -*-
import sys
import socket
import time
sys.path.append(".")
def tcp_health_check(host, port):
    now = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
    try:
        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        sock.settimeout(1)
        sock.connect((host, port))
        sock.sendall(now.encode())
        print("{}TCP连接成功:{}:{}".format(now,host,port))
        sock.close()
        return True
    except socket.error as e:
        print("TCP连接失败: {}".format(e))
        if sock:
            sock.close()
        return False


def main():
    host = '127.0.0.1'  
    port = 8081  

    while True:
        result = tcp_health_check('127.0.0.1' , 10912)
        time.sleep(0.5)


if __name__ == "__main__":
    main()
