### PR TITLE
[ISSUE #8882]Change the compare method for acl signature to improve the security.

### DIFF
--- a/acl/src/main/java/org/apache/rocketmq/acl/common/AclUtils.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/common/AclUtils.java
@@ -63,8 +63,7 @@ public class AclUtils {
     }
 
     public static String calSignature(byte[] data, String secretKey) {
-        String signature = AclSigner.calSignature(data, secretKey);
-        return signature;
+        return AclSigner.calSignature(data, secretKey);
     }
 
     public static void IPv6AddressCheck(String netAddress) {

--- a/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
@@ -22,6 +22,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -618,7 +619,8 @@ public class PlainPermissionManager {
 
         // Check the signature
         String signature = AclUtils.calSignature(plainAccessResource.getContent(), ownedAccess.getSecretKey());
-        if (!signature.equals(plainAccessResource.getSignature())) {
+        if (plainAccessResource.getSignature() == null
+            || !MessageDigest.isEqual(signature.getBytes(), plainAccessResource.getSignature().getBytes())) {
             throw new AclException(String.format("Check signature failed for accessKey=%s", plainAccessResource.getAccessKey()));
         }
 

--- a/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/plain/PlainPermissionManager.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.acl.PermissionChecker;
 import org.apache.rocketmq.acl.common.AclConstants;
 import org.apache.rocketmq.acl.common.AclException;
+import org.apache.rocketmq.acl.common.AclSigner;
 import org.apache.rocketmq.acl.common.AclUtils;
 import org.apache.rocketmq.acl.common.Permission;
 import org.apache.rocketmq.common.AclConfig;
@@ -620,7 +621,7 @@ public class PlainPermissionManager {
         // Check the signature
         String signature = AclUtils.calSignature(plainAccessResource.getContent(), ownedAccess.getSecretKey());
         if (plainAccessResource.getSignature() == null
-            || !MessageDigest.isEqual(signature.getBytes(), plainAccessResource.getSignature().getBytes())) {
+            || !MessageDigest.isEqual(signature.getBytes(AclSigner.DEFAULT_CHARSET), plainAccessResource.getSignature().getBytes(AclSigner.DEFAULT_CHARSET))) {
             throw new AclException(String.format("Check signature failed for accessKey=%s", plainAccessResource.getAccessKey()));
         }
 

--- a/auth/src/main/java/org/apache/rocketmq/auth/authentication/chain/DefaultAuthenticationHandler.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authentication/chain/DefaultAuthenticationHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.auth.authentication.chain;
 
+import java.security.MessageDigest;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
@@ -62,7 +63,8 @@ public class DefaultAuthenticationHandler implements Handler<DefaultAuthenticati
             throw new AuthenticationException("User:{} is disabled.", context.getUsername());
         }
         String signature = AclSigner.calSignature(context.getContent(), user.getPassword());
-        if (!StringUtils.equals(signature, context.getSignature())) {
+        if (context.getSignature() == null
+            || !MessageDigest.isEqual(signature.getBytes(), context.getSignature().getBytes())) {
             throw new AuthenticationException("check signature failed.");
         }
     }

--- a/auth/src/main/java/org/apache/rocketmq/auth/authentication/chain/DefaultAuthenticationHandler.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authentication/chain/DefaultAuthenticationHandler.java
@@ -64,7 +64,7 @@ public class DefaultAuthenticationHandler implements Handler<DefaultAuthenticati
         }
         String signature = AclSigner.calSignature(context.getContent(), user.getPassword());
         if (context.getSignature() == null
-            || !MessageDigest.isEqual(signature.getBytes(), context.getSignature().getBytes())) {
+            || !MessageDigest.isEqual(signature.getBytes(AclSigner.DEFAULT_CHARSET), context.getSignature().getBytes(AclSigner.DEFAULT_CHARSET))) {
             throw new AuthenticationException("check signature failed.");
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Change the compare method for acl signature to improve the security.

Fixes #8882

### Brief Description

Use the MessageDigest.isEqual method instead of the StringUtils.equals method.

### How Did You Test This Change?

