### PR TITLE
[ISSUE #8829] Keep data version while reload and XXXConfigManagerV2 turns off sync

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v2/ConfigStorage.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v2/ConfigStorage.java
@@ -87,8 +87,8 @@ public class ConfigStorage extends AbstractRocksDBStorage {
     protected void initAbleWalWriteOptions() {
         this.ableWalWriteOptions = new WriteOptions();
 
-        // For metadata, prioritize data integrity
-        this.ableWalWriteOptions.setSync(true);
+        // Given that fdatasync is kind of expensive, sync-WAL for every write cannot be afforded.
+        this.ableWalWriteOptions.setSync(false);
 
         // We need WAL for config changes
         this.ableWalWriteOptions.setDisableWAL(false);

--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v2/SubscriptionGroupManagerV2.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v2/SubscriptionGroupManagerV2.java
@@ -72,7 +72,7 @@ public class SubscriptionGroupManagerV2 extends SubscriptionGroupManager {
             while (iterator.isValid()) {
                 SubscriptionGroupConfig subscriptionGroupConfig = parseSubscription(iterator.key(), iterator.value());
                 if (null != subscriptionGroupConfig) {
-                    super.updateSubscriptionGroupConfigWithoutPersist(subscriptionGroupConfig);
+                    super.putSubscriptionGroupConfig(subscriptionGroupConfig);
                 }
                 iterator.next();
             }

--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v2/TopicConfigManagerV2.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v2/TopicConfigManagerV2.java
@@ -76,7 +76,7 @@ public class TopicConfigManagerV2 extends TopicConfigManager {
                 byte[] value = iterator.value();
                 TopicConfig topicConfig = parseTopicConfig(key, value);
                 if (null != topicConfig) {
-                    super.updateSingleTopicConfigWithoutPersist(topicConfig);
+                    super.putTopicConfig(topicConfig);
                 }
                 iterator.next();
             }


### PR DESCRIPTION
Two minor changes are included:
1, no need to update data version while reload; 
2, config-storage fdatasync on write proves to be too expensive, turn it off

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

To #8829 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
