### PR TITLE
[#8859] Fix duplicate mapped file in mutil commitlog store path mode.

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
@@ -39,7 +39,7 @@ import org.apache.rocketmq.store.logfile.MappedFile;
 public class AllocateMappedFileService extends ServiceThread {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.STORE_LOGGER_NAME);
     private static int waitTimeOut = 1000 * 5;
-    private ConcurrentMap<String, AllocateRequest> requestTable =
+    private ConcurrentMap<String/*FileName*/, AllocateRequest> requestTable =
         new ConcurrentHashMap<>();
     private PriorityBlockingQueue<AllocateRequest> requestQueue =
         new PriorityBlockingQueue<>();
@@ -48,6 +48,11 @@ public class AllocateMappedFileService extends ServiceThread {
 
     public AllocateMappedFileService(DefaultMessageStore messageStore) {
         this.messageStore = messageStore;
+    }
+
+    public String getCachedMappedFilePath(long createOffset) {
+        AllocateRequest req = requestTable.get(UtilAll.offset2FileName(createOffset));
+        return req == null ? null : req.getFilePath();
     }
 
     public MappedFile putRequestAndReturnMappedFile(String nextFilePath, String nextNextFilePath, int fileSize) {
@@ -59,14 +64,15 @@ public class AllocateMappedFileService extends ServiceThread {
             }
         }
 
+        String nextFileName = nextFilePath.substring(nextFilePath.lastIndexOf("/") + 1);
         AllocateRequest nextReq = new AllocateRequest(nextFilePath, fileSize);
-        boolean nextPutOK = this.requestTable.putIfAbsent(nextFilePath, nextReq) == null;
+        boolean nextPutOK = this.requestTable.putIfAbsent(nextFileName, nextReq) == null;
 
         if (nextPutOK) {
             if (canSubmitRequests <= 0) {
                 log.warn("[NOTIFYME]TransientStorePool is not enough, so create mapped file error, " +
                     "RequestQueueSize : {}, StorePoolSize: {}", this.requestQueue.size(), this.messageStore.remainTransientStoreBufferNumbs());
-                this.requestTable.remove(nextFilePath);
+                this.requestTable.remove(nextFileName);
                 return null;
             }
             boolean offerOK = this.requestQueue.offer(nextReq);
@@ -76,13 +82,14 @@ public class AllocateMappedFileService extends ServiceThread {
             canSubmitRequests--;
         }
 
+        String nextNextFileName = nextNextFilePath.substring(nextNextFilePath.lastIndexOf("/") + 1);
         AllocateRequest nextNextReq = new AllocateRequest(nextNextFilePath, fileSize);
-        boolean nextNextPutOK = this.requestTable.putIfAbsent(nextNextFilePath, nextNextReq) == null;
+        boolean nextNextPutOK = this.requestTable.putIfAbsent(nextNextFileName, nextNextReq) == null;
         if (nextNextPutOK) {
             if (canSubmitRequests <= 0) {
                 log.warn("[NOTIFYME]TransientStorePool is not enough, so skip preallocate mapped file, " +
                     "RequestQueueSize : {}, StorePoolSize: {}", this.requestQueue.size(), this.messageStore.remainTransientStoreBufferNumbs());
-                this.requestTable.remove(nextNextFilePath);
+                this.requestTable.remove(nextNextFileName);
             } else {
                 boolean offerOK = this.requestQueue.offer(nextNextReq);
                 if (!offerOK) {
@@ -96,7 +103,7 @@ public class AllocateMappedFileService extends ServiceThread {
             return null;
         }
 
-        AllocateRequest result = this.requestTable.get(nextFilePath);
+        AllocateRequest result = this.requestTable.get(nextFileName);
         try {
             if (result != null) {
                 messageStore.getPerfCounter().startTick("WAIT_MAPFILE_TIME_MS");
@@ -106,7 +113,7 @@ public class AllocateMappedFileService extends ServiceThread {
                     log.warn("create mmap timeout " + result.getFilePath() + " " + result.getFileSize());
                     return null;
                 } else {
-                    this.requestTable.remove(nextFilePath);
+                    this.requestTable.remove(nextFileName);
                     return result.getMappedFile();
                 }
             } else {
@@ -156,7 +163,8 @@ public class AllocateMappedFileService extends ServiceThread {
         AllocateRequest req = null;
         try {
             req = this.requestQueue.take();
-            AllocateRequest expectedRequest = this.requestTable.get(req.getFilePath());
+            String fileName = req.getFilePath().substring(req.getFilePath().lastIndexOf("/") + 1);
+            AllocateRequest expectedRequest = this.requestTable.get(fileName);
             if (null == expectedRequest) {
                 log.warn("this mmap request expired, maybe cause timeout " + req.getFilePath() + " "
                     + req.getFileSize());

--- a/store/src/test/java/org/apache/rocketmq/store/MultiPathMappedFileQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/MultiPathMappedFileQueueTest.java
@@ -18,12 +18,19 @@
 package org.apache.rocketmq.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.apache.rocketmq.store.logfile.MappedFile;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
 import org.junit.Test;
 
 
@@ -152,5 +159,44 @@ public class MultiPathMappedFileQueueTest {
 
         mappedFileQueue.shutdown(1000);
         mappedFileQueue.destroy();
+    }
+
+    @Test
+    public void testUniqueNextNextMappedFile() throws IOException {
+        Set<String> fullStorePath = new HashSet<>();
+
+        MessageStoreConfig config = new MessageStoreConfig();
+        config.setStorePathCommitLog("target/unit_test_store/a" + MixAll.MULTI_PATH_SPLITTER
+            + "target/unit_test_store/b" + MixAll.MULTI_PATH_SPLITTER
+            + "target/unit_test_store/c");
+
+        DefaultMessageStore messageStore = new DefaultMessageStore(config,
+            new BrokerStatsManager("CommitlogTest", true),
+            (topic, queueId, logicOffset, tagsCode, msgStoreTime, filterBitMap, properties) -> {},
+            new BrokerConfig(),
+            new ConcurrentHashMap<>());
+
+        AllocateMappedFileService allocateMappedFileService = new AllocateMappedFileService(messageStore);
+        allocateMappedFileService.start();
+
+        MappedFileQueue mappedFileQueue = new MultiPathMappedFileQueue(config, 1024, allocateMappedFileService, () -> fullStorePath);
+        String[] storePaths = config.getStorePathCommitLog().trim().split(MixAll.MULTI_PATH_SPLITTER);
+        assertThat(storePaths.length).isEqualTo(3);
+
+        // the nextFilePath is "target/unit_test_store/a/00000000000000000000"
+        // the first invoke will insert nextNextFilePath "target/unit_test_store/b/00000000000000001024" into requestTable
+        mappedFileQueue.tryCreateMappedFile(0);
+
+        // mark target/unit_test_store/b/ as full
+        fullStorePath.add("target/unit_test_store/b");
+        // the nextFilePath is still "target/unit_test_store/b/00000000000000001024"
+        MappedFile mappedFile1 = mappedFileQueue.tryCreateMappedFile(1024);
+
+        assertThat(mappedFile1).isNotNull();
+        assertThat(mappedFile1.getFile().getPath()).isEqualTo("target/unit_test_store/b/00000000000000001024");
+
+        mappedFileQueue.shutdown(1000);
+        mappedFileQueue.destroy();
+        allocateMappedFileService.shutdown();
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8859 

### Brief Description
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
I changed the key of the requestTable in the AllocateMappedFileService class from the FilePath to the FileName(this must be the only one), and then added a getCachedMappedFilePath method to provide to the MultiPathMappedFileQueue to check whether the MappedFile of a specified offset MappedFile create request has been submitted, and if so, obtain the cached FilePath, otherwise a new path is generated based on the previous rules.

### How Did You Test This Change?
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
I make a unit test to recurrence this case in testUniqueNextNextMappedFile().

In the previous implementation, the results obtained were as shown in the picture below, the MappedFile 00000000000000001024 repeatedly appear in directory a and directory b.
![9daf3e5014d7447a1328fbb5da7a1382](https://github.com/user-attachments/assets/4ff7f0c7-6f46-40e2-a580-16e4a709cf55)

This problem was solved in the new implementation and the result is as follows:
![45446178a8a361c316316b62997e64eb](https://github.com/user-attachments/assets/971f681d-0f46-4ea1-a8c6-b47a8940a161)


