### PR TITLE
fixed typo of RocketMQ_Example.md

### DIFF
--- a/docs/cn/RocketMQ_Example.md
+++ b/docs/cn/RocketMQ_Example.md
@@ -645,7 +645,7 @@ RocketMQ只定义了一些基本语法来支持这个特性。你也可以很容
 
 只有使用push模式的消费者才能用使用SQL92标准的sql语句，接口如下：
 ```
-public void subscribe(finalString topic, final MessageSelector messageSelector)
+public void subscribe(final String topic, final MessageSelector messageSelector)
 ```
 
 ### 5.2 使用样例


### PR DESCRIPTION
fixed typo worlds 'finalString'


### Which Issue(s) This PR Fixes

Fixes just typo problem 'finalString' without issue

### Brief Description

Fixes just typo problem 'finalString' without issue

### How Did You Test This Change?

Fixes just typo problem 'finalString' without issue
