### PR TITLE
[ISSUE #8917]Topic route return none permission message queues for gRPC client 

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/constant/PermName.java
+++ b/common/src/main/java/org/apache/rocketmq/common/constant/PermName.java
@@ -68,4 +68,8 @@ public class PermName {
     public static boolean isPriority(final int perm) {
         return (perm & PERM_PRIORITY) == PERM_PRIORITY;
     }
+
+    public static boolean isNone(final int perm) {
+        return perm == 0;
+    }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/constant/PermName.java
+++ b/common/src/main/java/org/apache/rocketmq/common/constant/PermName.java
@@ -69,7 +69,7 @@ public class PermName {
         return (perm & PERM_PRIORITY) == PERM_PRIORITY;
     }
 
-    public static boolean isNone(final int perm) {
-        return perm == 0;
+    public static boolean isAccessible(final int perm) {
+        return isReadable(perm) || isWriteable(perm);
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -253,7 +253,7 @@ public class RouteActivity extends AbstractMessingActivity {
             w = queueData.getWriteQueueNums();
         } else if (PermName.isReadable(queueData.getPerm())) {
             r = queueData.getReadQueueNums();
-        } else if (PermName.isNone(queueData.getPerm())) {
+        } else if (!PermName.isAccessible(queueData.getPerm())) {
             n = Math.max(1, Math.max(queueData.getWriteQueueNums(), queueData.getReadQueueNums()));
         }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -244,6 +244,7 @@ public class RouteActivity extends AbstractMessingActivity {
         int r = 0;
         int w = 0;
         int rw = 0;
+        int n = 0;
         if (PermName.isWriteable(queueData.getPerm()) && PermName.isReadable(queueData.getPerm())) {
             rw = Math.min(queueData.getWriteQueueNums(), queueData.getReadQueueNums());
             r = queueData.getReadQueueNums() - rw;
@@ -252,6 +253,8 @@ public class RouteActivity extends AbstractMessingActivity {
             w = queueData.getWriteQueueNums();
         } else if (PermName.isReadable(queueData.getPerm())) {
             r = queueData.getReadQueueNums();
+        } else if (PermName.isNone(queueData.getPerm())) {
+            n = Math.max(queueData.getWriteQueueNums(), queueData.getReadQueueNums());
         }
 
         // r here means readOnly queue nums, w means writeOnly queue nums, while rw means both readable and writable queue nums.
@@ -278,6 +281,15 @@ public class RouteActivity extends AbstractMessingActivity {
             MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
                 .setId(queueIdIndex++)
                 .setPermission(Permission.READ_WRITE)
+                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                .build();
+            messageQueueList.add(messageQueue);
+        }
+
+        for (int i = 0; i < n; i++) {
+            MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
+                .setId(queueIdIndex++)
+                .setPermission(Permission.NONE)
                 .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
                 .build();
             messageQueueList.add(messageQueue);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -254,7 +254,7 @@ public class RouteActivity extends AbstractMessingActivity {
         } else if (PermName.isReadable(queueData.getPerm())) {
             r = queueData.getReadQueueNums();
         } else if (PermName.isNone(queueData.getPerm())) {
-            n = Math.max(queueData.getWriteQueueNums(), queueData.getReadQueueNums());
+            n = Math.max(1, Math.max(queueData.getWriteQueueNums(), queueData.getReadQueueNums()));
         }
 
         // r here means readOnly queue nums, w means writeOnly queue nums, while rw means both readable and writable queue nums.

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -279,6 +279,9 @@ public class RouteActivityTest extends BaseActivityTest {
         assertEquals(2, partitionWith2R2WNoPerm.size());
         assertEquals(2, partitionWith2R2WNoPerm.stream().filter(a -> a.getAcceptMessageTypesValue(0) == MessageType.MESSAGE_TYPE_UNSPECIFIED.getNumber()).count());
         assertEquals(2, partitionWith2R2WNoPerm.stream().filter(a -> a.getPermission() == Permission.NONE).count());
+        assertEquals(0, partitionWith2R2WNoPerm.stream().filter(a -> a.getPermission() == Permission.WRITE).count());
+        assertEquals(0, partitionWith2R2WNoPerm.stream().filter(a -> a.getPermission() == Permission.READ_WRITE).count());
+        assertEquals(0, partitionWith2R2WNoPerm.stream().filter(a -> a.getPermission() == Permission.READ).count());
 
         // test queueData with 0 read queues, 0 write queues, and no permission, expect 1 no permission queue.
         QueueData queueDataWith0R0WNoPerm = createQueueData(0, 0, 0);
@@ -286,6 +289,9 @@ public class RouteActivityTest extends BaseActivityTest {
         assertEquals(1, partitionWith0R0WNoPerm.size());
         assertEquals(1, partitionWith0R0WNoPerm.stream().filter(a -> a.getAcceptMessageTypesValue(0) == MessageType.MESSAGE_TYPE_UNSPECIFIED.getNumber()).count());
         assertEquals(1, partitionWith0R0WNoPerm.stream().filter(a -> a.getPermission() == Permission.NONE).count());
+        assertEquals(0, partitionWith0R0WNoPerm.stream().filter(a -> a.getPermission() == Permission.WRITE).count());
+        assertEquals(0, partitionWith0R0WNoPerm.stream().filter(a -> a.getPermission() == Permission.READ_WRITE).count());
+        assertEquals(0, partitionWith0R0WNoPerm.stream().filter(a -> a.getPermission() == Permission.READ).count());
     }
 
     private static QueueData createQueueData(int r, int w, int perm) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -272,6 +272,20 @@ public class RouteActivityTest extends BaseActivityTest {
         assertEquals(4, partitionWith4R8WPermRW.stream().filter(a -> a.getPermission() == Permission.WRITE).count());
         assertEquals(4, partitionWith4R8WPermRW.stream().filter(a -> a.getPermission() == Permission.READ_WRITE).count());
         assertEquals(0, partitionWith4R8WPermRW.stream().filter(a -> a.getPermission() == Permission.READ).count());
+
+        // test queueData with 2 read queues, 2 write queues, and no permission, expect 2 no permission queues.
+        QueueData queueDataWith2R2WNoPerm = createQueueData(2, 2, 0);
+        List<MessageQueue> partitionWith2R2WNoPerm = this.routeActivity.genMessageQueueFromQueueData(queueDataWith2R2WNoPerm, GRPC_TOPIC, TopicMessageType.UNSPECIFIED, GRPC_BROKER);
+        assertEquals(2, partitionWith2R2WNoPerm.size());
+        assertEquals(2, partitionWith2R2WNoPerm.stream().filter(a -> a.getAcceptMessageTypesValue(0) == MessageType.MESSAGE_TYPE_UNSPECIFIED.getNumber()).count());
+        assertEquals(2, partitionWith2R2WNoPerm.stream().filter(a -> a.getPermission() == Permission.NONE).count());
+
+        // test queueData with 0 read queues, 0 write queues, and no permission, expect 1 no permission queue.
+        QueueData queueDataWith0R0WNoPerm = createQueueData(0, 0, 0);
+        List<MessageQueue> partitionWith0R0WNoPerm = this.routeActivity.genMessageQueueFromQueueData(queueDataWith0R0WNoPerm, GRPC_TOPIC, TopicMessageType.UNSPECIFIED, GRPC_BROKER);
+        assertEquals(1, partitionWith0R0WNoPerm.size());
+        assertEquals(1, partitionWith0R0WNoPerm.stream().filter(a -> a.getAcceptMessageTypesValue(0) == MessageType.MESSAGE_TYPE_UNSPECIFIED.getNumber()).count());
+        assertEquals(1, partitionWith0R0WNoPerm.stream().filter(a -> a.getPermission() == Permission.NONE).count());
     }
 
     private static QueueData createQueueData(int r, int w, int perm) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #8917

### Brief Description

When the queue lacks permission, return queues to allow the client to upload a heartbeat for gRPC Topic route interface.

### How Did You Test This Change?