### PR TITLE
[ISSUE #8942] Add incGroupAckNums and incGroupCkNums to LmqBrokerStatsManager

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -237,7 +237,7 @@ public class BrokerController {
     protected final BlockingQueue<Runnable> endTransactionThreadPoolQueue;
     protected final BlockingQueue<Runnable> adminBrokerThreadPoolQueue;
     protected final BlockingQueue<Runnable> loadBalanceThreadPoolQueue;
-    protected final BrokerStatsManager brokerStatsManager;
+    protected BrokerStatsManager brokerStatsManager;
     protected final List<SendMessageHook> sendMessageHookList = new ArrayList<>();
     protected final List<ConsumeMessageHook> consumeMessageHookList = new ArrayList<>();
     protected MessageStore messageStore;
@@ -2303,6 +2303,10 @@ public class BrokerController {
 
     public BrokerStatsManager getBrokerStatsManager() {
         return brokerStatsManager;
+    }
+
+    public void setBrokerStatsManager(BrokerStatsManager brokerStatsManager) {
+        this.brokerStatsManager = brokerStatsManager;
     }
 
     public List<SendMessageHook> getSendMessageHookList() {

--- a/store/src/main/java/org/apache/rocketmq/store/stats/LmqBrokerStatsManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/stats/LmqBrokerStatsManager.java
@@ -50,6 +50,33 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
         super.incGroupGetSize(lmqGroup, lmqTopic, incValue);
     }
 
+
+    @Override
+    public void incGroupAckNums(final String group, final String topic, final int incValue) {
+        String lmqGroup = group;
+        String lmqTopic = topic;
+        if (MixAll.isLmq(group)) {
+            lmqGroup = MixAll.LMQ_PREFIX;
+        }
+        if (MixAll.isLmq(topic)) {
+            lmqTopic = MixAll.LMQ_PREFIX;
+        }
+        super.incGroupAckNums(lmqGroup, lmqTopic, incValue);
+    }
+
+    @Override
+    public void incGroupCkNums(final String group, final String topic, final int incValue) {
+        String lmqGroup = group;
+        String lmqTopic = topic;
+        if (MixAll.isLmq(group)) {
+            lmqGroup = MixAll.LMQ_PREFIX;
+        }
+        if (MixAll.isLmq(topic)) {
+            lmqTopic = MixAll.LMQ_PREFIX;
+        }
+        super.incGroupCkNums(lmqGroup, lmqTopic, incValue);
+    }
+
     @Override
     public void incGroupGetLatency(final String group, final String topic, final int queueId, final int incValue) {
         String lmqGroup = group;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8942
- Add incGroupAckNums and incGroupCkNums to LmqBrokerStatsManager
- Add a setBrokerStatsManager method to enhance extensibility, allowing for more fine-grained control to be implemented externally.
**Alternatively, we could discuss the removal of the LmqBrokerStatsManager class, as it appears to have limited value in my opinion.**

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
