### PR TITLE
[ISSUE #8972] Adding the EnableLmqStats option allows monitoring of LMQ statistics at runtime

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -341,7 +341,7 @@ public class BrokerController {
         this.messageStoreConfig = messageStoreConfig;
         this.authConfig = authConfig;
         this.setStoreHost(new InetSocketAddress(this.getBrokerConfig().getBrokerIP1(), getListenPort()));
-        this.brokerStatsManager = messageStoreConfig.isEnableLmq() ? new LmqBrokerStatsManager(this.brokerConfig.getBrokerClusterName(), this.brokerConfig.isEnableDetailStat()) : new BrokerStatsManager(this.brokerConfig.getBrokerClusterName(), this.brokerConfig.isEnableDetailStat());
+        this.brokerStatsManager = messageStoreConfig.isEnableLmq() ? new LmqBrokerStatsManager(this.brokerConfig) : new BrokerStatsManager(this.brokerConfig.getBrokerClusterName(), this.brokerConfig.isEnableDetailStat());
         this.broadcastOffsetManager = new BroadcastOffsetManager(this);
         if (ConfigManagerVersion.V2.getVersion().equals(brokerConfig.getConfigManagerVersion())) {
             this.configStorage = new ConfigStorage(messageStoreConfig.getStorePathRootDir());

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -435,6 +435,9 @@ public class BrokerConfig extends BrokerIdentity {
 
     private boolean appendCkAsync = false;
 
+
+    private boolean enableLmqStats = false;
+
     /**
      * V2 is recommended in cases where LMQ feature is extensively used.
      */
@@ -1903,6 +1906,14 @@ public class BrokerConfig extends BrokerIdentity {
 
     public void setAppendCkAsync(boolean appendCkAsync) {
         this.appendCkAsync = appendCkAsync;
+    }
+
+    public boolean isEnableLmqStats() {
+        return enableLmqStats;
+    }
+
+    public void setEnableLmqStats(boolean enableLmqStats) {
+        this.enableLmqStats = enableLmqStats;
     }
 
     public String getConfigManagerVersion() {

--- a/store/src/main/java/org/apache/rocketmq/store/stats/LmqBrokerStatsManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/stats/LmqBrokerStatsManager.java
@@ -16,23 +16,29 @@
  */
 package org.apache.rocketmq.store.stats;
 
+import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.MixAll;
 
 public class LmqBrokerStatsManager extends BrokerStatsManager {
 
-    public LmqBrokerStatsManager(String clusterName, boolean enableQueueStat) {
-        super(clusterName, enableQueueStat);
+    private final BrokerConfig brokerConfig;
+
+    public LmqBrokerStatsManager(BrokerConfig brokerConfig) {
+        super(brokerConfig.getBrokerClusterName(), brokerConfig.isEnableDetailStat());
+        this.brokerConfig = brokerConfig;
     }
 
     @Override
     public void incGroupGetNums(final String group, final String topic, final int incValue) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.incGroupGetNums(lmqGroup, lmqTopic, incValue);
     }
@@ -41,25 +47,28 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
     public void incGroupGetSize(final String group, final String topic, final int incValue) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.incGroupGetSize(lmqGroup, lmqTopic, incValue);
     }
-
 
     @Override
     public void incGroupAckNums(final String group, final String topic, final int incValue) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.incGroupAckNums(lmqGroup, lmqTopic, incValue);
     }
@@ -68,11 +77,13 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
     public void incGroupCkNums(final String group, final String topic, final int incValue) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.incGroupCkNums(lmqGroup, lmqTopic, incValue);
     }
@@ -81,11 +92,13 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
     public void incGroupGetLatency(final String group, final String topic, final int queueId, final int incValue) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.incGroupGetLatency(lmqGroup, lmqTopic, queueId, incValue);
     }
@@ -94,11 +107,13 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
     public void incSendBackNums(final String group, final String topic) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.incSendBackNums(lmqGroup, lmqTopic);
     }
@@ -107,11 +122,13 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
     public double tpsGroupGetNums(final String group, final String topic) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         return super.tpsGroupGetNums(lmqGroup, lmqTopic);
     }
@@ -121,11 +138,13 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
         final long fallBehind) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.recordDiskFallBehindTime(lmqGroup, lmqTopic, queueId, fallBehind);
     }
@@ -135,11 +154,13 @@ public class LmqBrokerStatsManager extends BrokerStatsManager {
         final long fallBehind) {
         String lmqGroup = group;
         String lmqTopic = topic;
-        if (MixAll.isLmq(group)) {
-            lmqGroup = MixAll.LMQ_PREFIX;
-        }
-        if (MixAll.isLmq(topic)) {
-            lmqTopic = MixAll.LMQ_PREFIX;
+        if (!brokerConfig.isEnableLmqStats()) {
+            if (MixAll.isLmq(group)) {
+                lmqGroup = MixAll.LMQ_PREFIX;
+            }
+            if (MixAll.isLmq(topic)) {
+                lmqTopic = MixAll.LMQ_PREFIX;
+            }
         }
         super.recordDiskFallBehindSize(lmqGroup, lmqTopic, queueId, fallBehind);
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8972

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

The current LMQ statistics are not enabled by default, presumably due to the large volume of data. However, there are times when we might need to obtain LMQ statistics. Therefore, a switch, enableLmqStats, has been added to control the collection of LMQ statistics at runtime

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
