### PR TITLE
[ISSUE #9042] Update createTimerMessageStore call with new parameter

### DIFF
--- a/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
@@ -379,7 +379,7 @@ public class TimerMessageStoreTest {
         String topic = "TimerTest_testDeleteTimerMessage";
         String collisionTopic = "TimerTest_testDeleteTimerMessage_collision";
 
-        TimerMessageStore timerMessageStore = createTimerMessageStore(null);
+        TimerMessageStore timerMessageStore = createTimerMessageStore(null , false);
         timerMessageStore.load();
         timerMessageStore.start(true);
 

--- a/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
@@ -259,8 +259,7 @@ public class TimerMessageStoreTest {
                 latch.countDown();
             }
         }).start();
-        latch.await(10, TimeUnit.SECONDS);
-
+        latch.await(5, TimeUnit.SECONDS);
         assertTrue(timerMessageStore.dequeuePutQueue.isEmpty());
         verify(mockMessageStore, times(6)).putMessage(any(MessageExtBrokerInner.class));
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#9042 ](https://github.com/apache/rocketmq/issues/9042)

### Brief Description

This PR resolves a compilation error caused by an outdated method parameter in `TimerMessageStoreTest`. The `createTimerMessageStore` method's parameters were updated previously, but a later PR did not rebase to the latest code, leading to mismatched method calls. 

