### PR TITLE
[ISSUE #9064] Optimize transaction message callback check logic

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -197,13 +197,13 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                 long nextOpOffset = pullResult.getNextBeginOffset();
                 int putInQueueCount = 0;
                 int escapeFailCnt = 0;
-                Long removedOpOffset;
 
                 while (true) {
                     if (System.currentTimeMillis() - startTime > MAX_PROCESS_TIME_LIMIT) {
                         log.info("Queue={} process time reach max={}", messageQueue, MAX_PROCESS_TIME_LIMIT);
                         break;
                     }
+                    Long removedOpOffset;
                     if ((removedOpOffset = removeMap.remove(i)) != null) {
                         log.debug("Half offset {} has been committed/rolled back", i);
                         opMsgMap.get(removedOpOffset).remove(i);

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -456,8 +456,8 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
             if (-1 == prepareQueueOffset) {
                 return false;
             } else {
-                if (removeMap.containsKey(prepareQueueOffset)) {
-                    long tmpOpOffset = removeMap.remove(prepareQueueOffset);
+                Long tmpOpOffset;
+                if ((tmpOpOffset = removeMap.remove(prepareQueueOffset)) != null) {
                     doneOpOffset.add(tmpOpOffset);
                     log.info("removeMap contain prepareQueueOffset. real_topic={},uniqKey={},immunityTime={},offset={}",
                             msgExt.getUserProperty(MessageConst.PROPERTY_REAL_TOPIC),

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -203,7 +203,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                         log.info("Queue={} process time reach max={}", messageQueue, MAX_PROCESS_TIME_LIMIT);
                         break;
                     }
-                    Long removedOpOffset;
+                    Long removedOpOffset = null;
                     if ((removedOpOffset = removeMap.remove(i)) != null) {
                         log.debug("Half offset {} has been committed/rolled back", i);
                         opMsgMap.get(removedOpOffset).remove(i);
@@ -456,7 +456,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
             if (-1 == prepareQueueOffset) {
                 return false;
             } else {
-                Long tmpOpOffset;
+                Long tmpOpOffset = null;
                 if ((tmpOpOffset = removeMap.remove(prepareQueueOffset)) != null) {
                     doneOpOffset.add(tmpOpOffset);
                     log.info("removeMap contain prepareQueueOffset. real_topic={},uniqKey={},immunityTime={},offset={}",

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -197,15 +197,15 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                 long nextOpOffset = pullResult.getNextBeginOffset();
                 int putInQueueCount = 0;
                 int escapeFailCnt = 0;
+                Long removedOpOffset;
 
                 while (true) {
                     if (System.currentTimeMillis() - startTime > MAX_PROCESS_TIME_LIMIT) {
                         log.info("Queue={} process time reach max={}", messageQueue, MAX_PROCESS_TIME_LIMIT);
                         break;
                     }
-                    if (removeMap.containsKey(i)) {
+                    if ((removedOpOffset = removeMap.remove(i)) != null) {
                         log.debug("Half offset {} has been committed/rolled back", i);
-                        Long removedOpOffset = removeMap.remove(i);
                         opMsgMap.get(removedOpOffset).remove(i);
                         if (opMsgMap.get(removedOpOffset).size() == 0) {
                             opMsgMap.remove(removedOpOffset);

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -203,7 +203,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                         log.info("Queue={} process time reach max={}", messageQueue, MAX_PROCESS_TIME_LIMIT);
                         break;
                     }
-                    Long removedOpOffset = null;
+                    Long removedOpOffset;
                     if ((removedOpOffset = removeMap.remove(i)) != null) {
                         log.debug("Half offset {} has been committed/rolled back", i);
                         opMsgMap.get(removedOpOffset).remove(i);
@@ -456,7 +456,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
             if (-1 == prepareQueueOffset) {
                 return false;
             } else {
-                Long tmpOpOffset = null;
+                Long tmpOpOffset;
                 if ((tmpOpOffset = removeMap.remove(prepareQueueOffset)) != null) {
                     doneOpOffset.add(tmpOpOffset);
                     log.info("removeMap contain prepareQueueOffset. real_topic={},uniqKey={},immunityTime={},offset={}",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
fixes #9064 

### Brief Description
事务消息， 回查判断RMQ_SYS_TRANS_HALF_TOPIC消息是否在RMQ_SYS_TRANS_OP_HALF_TOPIC 中，优化判断方式。之前代码是先判断Map.containsKey，然后进行removeKey，新的方式是直接removeKey ！= null。之前如果Map.containsKey为真，还需要进行额外的一步removeKey操作，新的方式removeKey！= null，即判断了Map是否存在key，又移出了对应的key，提升了一点点性能。
﻿
Transactional messages: The process involves checking whether messages in RMQ_SYS_TRANS_HALF_TOPIC exist in RMQ_SYS_TRANS_OP_HALF_TOPIC, with an optimized approach for verification. Previously, the code first used Map.containsKey to check existence and then performed removeKey. The new approach directly uses removeKey != null.

In the previous method, if Map.containsKey returned true, an additional removeKey operation was required. In contrast, the new approach both checks if the key exists in the Map and removes the corresponding key in one step, offering a slight performance improvement.


### How Did You Test This Change?
经过多轮测试，在Map.containsKey 为true为false概率各为50%的情况，第二种方案明显优于第一种方案。而实际生产环境中，事务回查状态为Unknown的场景应该小于50%，在高并发大数据量场景下，个人认为这个小改动对性能还是有一些提升。

After multiple rounds of testing, when the probabilities of Map.containsKey being true or false are both 50%, the second approach consistently outperforms the first. In actual production environments, the probability of transactional checks being in an “Unknown” state should be less than 50%. Therefore, I believe this small adjustment provides a minor but meaningful performance improvement.
![image](https://github.com/user-attachments/assets/28deccb5-c0da-4814-89fc-59a0afcf9657)



