### PR TITLE
[ISSUE 9072]Fix the permission check for retry topic to get topic route.

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
@@ -182,8 +182,13 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
             Resource group;
             switch (command.getCode()) {
                 case RequestCode.GET_ROUTEINFO_BY_TOPIC:
-                    topic = Resource.ofTopic(fields.get(TOPIC));
-                    result.add(DefaultAuthorizationContext.of(subject, topic, Arrays.asList(Action.PUB, Action.SUB, Action.GET), sourceIp));
+                    if (NamespaceUtil.isRetryTopic(fields.get(TOPIC))) {
+                        group = Resource.ofGroup(fields.get(TOPIC));
+                        result.add(DefaultAuthorizationContext.of(subject, group, Arrays.asList(Action.SUB, Action.GET), sourceIp));
+                    } else {
+                        topic = Resource.ofTopic(fields.get(TOPIC));
+                        result.add(DefaultAuthorizationContext.of(subject, topic, Arrays.asList(Action.PUB, Action.SUB, Action.GET), sourceIp));
+                    }
                     break;
                 case RequestCode.SEND_MESSAGE:
                     if (NamespaceUtil.isRetryTopic(fields.get(TOPIC))) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

When a client fails to consume multiple times, a message is sent to the retry topic. If ACL 2.0 is used, querying the routing of the retry topic may result in a permission denied issue.

Fixes #9072

### Brief Description

When obtaining the routing for the retry topic, authentication is performed according to the Group's permissions, and there is no need to separately authorize the retry topic.

### How Did You Test This Change?


