### PR TITLE
[ISSUE #9106] Fix revive backoff retry not effective in Pop Consumption based on rocksdb

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -496,10 +496,13 @@ public class PopConsumerService extends ServiceThread {
                     if (record.getAttemptTimes() < brokerConfig.getPopReviveMaxAttemptTimes()) {
                         long backoffInterval = 1000L * REWRITE_INTERVALS_IN_SECONDS[
                             Math.min(REWRITE_INTERVALS_IN_SECONDS.length, record.getAttemptTimes())];
-                        record.setInvisibleTime(record.getInvisibleTime() + backoffInterval);
-                        record.setAttemptTimes(record.getAttemptTimes() + 1);
-                        failureList.add(record);
-                        log.warn("PopConsumerService revive backoff retry, record={}", record);
+                        long nextInvisibleTime = record.getInvisibleTime() + backoffInterval;
+                        PopConsumerRecord retryRecord = new PopConsumerRecord(record.getPopTime(), record.getGroupId(),
+                            record.getTopicId(), record.getQueueId(), record.getRetryFlag(), nextInvisibleTime,
+                            record.getOffset(), record.getAttemptId());
+                        retryRecord.setAttemptTimes(record.getAttemptTimes() + 1);
+                        failureList.add(retryRecord);
+                        log.warn("PopConsumerService revive backoff retry, record={}", retryRecord);
                     } else {
                         log.error("PopConsumerService drop record, message may be lost, record={}", record);
                     }

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceTest.java
@@ -386,6 +386,42 @@ public class PopConsumerServiceTest {
     }
 
     @Test
+    public void reviveBackoffRetryTest() {
+        Mockito.when(brokerController.getEscapeBridge()).thenReturn(Mockito.mock(EscapeBridge.class));
+        PopConsumerService consumerServiceSpy = Mockito.spy(consumerService);
+
+        consumerService.getPopConsumerStore().start();
+
+        long popTime = 1000000000L;
+        long invisibleTime = 60 * 1000L;
+        PopConsumerRecord record = new PopConsumerRecord();
+        record.setPopTime(popTime);
+        record.setInvisibleTime(invisibleTime);
+        record.setTopicId("topic");
+        record.setGroupId("group");
+        record.setQueueId(0);
+        record.setOffset(0);
+        consumerService.getPopConsumerStore().writeRecords(Collections.singletonList(record));
+
+        Mockito.doReturn(CompletableFuture.completedFuture(Triple.of(Mockito.mock(MessageExt.class), "", false)))
+            .when(consumerServiceSpy).getMessageAsync(any(PopConsumerRecord.class));
+        Mockito.when(brokerController.getEscapeBridge().putMessageToSpecificQueue(any(MessageExtBrokerInner.class))).thenReturn(
+            new PutMessageResult(PutMessageStatus.UNKNOWN_ERROR, new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR))
+        );
+
+        long visibleTimestamp = popTime + invisibleTime;
+
+        // revive fails
+        Assert.assertEquals(1, consumerServiceSpy.revive(visibleTimestamp, 1));
+        // should be invisible now
+        Assert.assertEquals(0, consumerService.getPopConsumerStore().scanExpiredRecords(visibleTimestamp, 1).size());
+        // will be visible again in 10 seconds
+        Assert.assertEquals(1, consumerService.getPopConsumerStore().scanExpiredRecords(visibleTimestamp + 10 * 1000, 1).size());
+
+        consumerService.shutdown();
+    }
+
+    @Test
     public void transferToFsStoreTest() {
         Assert.assertNotNull(consumerService.getServiceName());
         List<PopConsumerRecord> consumerRecordList = IntStream.range(0, 3)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9106 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

When revive is needed to be retried, the original PopConsumerRecord object and the retry one should be independent of each other.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

Unit Test.
