### PR TITLE
[ISSUE #8997] Ensure there is an opportunity to send a retry message when broker no response

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -780,7 +780,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                         long curTimeout = timeout - costTime;
                         // In order to prevent the broker from being unresponsive for a long time and thus being unable to retry next time,
                         // if there is another chance for retry next time, the maximum sending time is modified to the maximum sendMsgMaxTimeoutPerRequest.
-                        if(defaultMQProducer.getSendMsgMaxTimeoutPerRequest() > -1 && times + 1 < timesTotal
+                        if (defaultMQProducer.getSendMsgMaxTimeoutPerRequest() > -1 && times + 1 < timesTotal
                                 && curTimeout > defaultMQProducer.getSendMsgMaxTimeoutPerRequest()) {
                             curTimeout = defaultMQProducer.getSendMsgMaxTimeoutPerRequest();
                         }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -116,6 +116,11 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     private int sendMsgTimeout = 3000;
 
     /**
+     * Max timeout for sending messages per request.
+     */
+    private int sendMsgMaxTimeoutPerRequest = -1;
+
+    /**
      * Compress message body threshold, namely, message body larger than 4k will be compressed on default.
      */
     private int compressMsgBodyOverHowmuch = 1024 * 4;
@@ -1257,6 +1262,14 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
 
     public void setSendMsgTimeout(int sendMsgTimeout) {
         this.sendMsgTimeout = sendMsgTimeout;
+    }
+
+    public int getSendMsgMaxTimeoutPerRequest() {
+        return sendMsgMaxTimeoutPerRequest;
+    }
+
+    public void setSendMsgMaxTimeoutPerRequest(int sendMsgMaxTimeoutPerRequest) {
+        this.sendMsgMaxTimeoutPerRequest = sendMsgMaxTimeoutPerRequest;
     }
 
     public int getCompressMsgBodyOverHowmuch() {


### PR DESCRIPTION
… response

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8997

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
当broker处于半死不活的状态时（gc，os内存不足等等原因），此时表现无法及时响应客户端的请求。
针对客户端同步发送消息，默认是带有重试策略的。可是此种情况下，客户端可能并没有重试的机会。
详见[分析](https://blog.csdn.net/a417930422/article/details/103489927)。

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
新增的参数sendMsgMaxTimeoutPerRequest，默认情况下不会影响现有的重试逻辑。
模拟broker暂停的情况，并针对各种情况进行了[测试](https://blog.csdn.net/a417930422/article/details/103489927#test)，情况如下：
![image](https://github.com/user-attachments/assets/a15ebd3f-25ff-4cfa-84ee-58cb4adb270f)


