### PR TITLE
[ISSUE #9156] Use fastjson2 in AclUtils#getAclRPCHook

### DIFF
--- a/acl/src/main/java/org/apache/rocketmq/acl/common/AclUtils.java
+++ b/acl/src/main/java/org/apache/rocketmq/acl/common/AclUtils.java
@@ -23,7 +23,7 @@ import java.io.PrintWriter;
 import java.util.Map;
 import java.util.SortedMap;
 
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;

--- a/acl/src/test/java/org/apache/rocketmq/acl/common/AclUtilsTest.java
+++ b/acl/src/test/java/org/apache/rocketmq/acl/common/AclUtilsTest.java
@@ -36,9 +36,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AclUtilsTest {
@@ -54,7 +52,7 @@ public class AclUtilsTest {
         addressList.add("1.1.1.2");
         addressList.add("1.1.1.3");
         addressList.add("1.1.1.4");
-        assertEquals(newAddressList, addressList);
+        Assert.assertEquals(newAddressList, addressList);
 
         // IPv6 test
         String ipv6Address = "1:ac41:9987::bb22:666:{1,2,3,4}";
@@ -67,7 +65,7 @@ public class AclUtilsTest {
         ipv6AddressList.add("1:ac41:9987::bb22:666:2");
         ipv6AddressList.add("1:ac41:9987::bb22:666:3");
         ipv6AddressList.add("1:ac41:9987::bb22:666:4");
-        assertEquals(newIPv6AddressList, ipv6AddressList);
+        Assert.assertEquals(newIPv6AddressList, ipv6AddressList);
     }
 
     @Test
@@ -77,9 +75,9 @@ public class AclUtilsTest {
         for (int i = 0; i < 6; i++) {
             boolean isScope = AclUtils.isScope(address, 4);
             if (i == 3) {
-                assertTrue(isScope);
+                Assert.assertTrue(isScope);
             } else {
-                assertFalse(isScope);
+                Assert.assertFalse(isScope);
             }
             address = address + ".12";
         }
@@ -89,46 +87,46 @@ public class AclUtilsTest {
     public void testIsScope_Array() {
         String[] address = StringUtils.split("12.12.12.12", ".");
         boolean isScope = AclUtils.isScope(address, 4);
-        assertTrue(isScope);
+        Assert.assertTrue(isScope);
         isScope = AclUtils.isScope(address, 3);
-        assertTrue(isScope);
+        Assert.assertTrue(isScope);
 
         address = StringUtils.split("12.12.1222.1222", ".");
         isScope = AclUtils.isScope(address, 4);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
         isScope = AclUtils.isScope(address, 3);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
 
         // IPv6 test
         address = StringUtils.split("1050:0000:0000:0000:0005:0600:300c:326b", ":");
         isScope = AclUtils.isIPv6Scope(address, 8);
-        assertTrue(isScope);
+        Assert.assertTrue(isScope);
         isScope = AclUtils.isIPv6Scope(address, 4);
-        assertTrue(isScope);
+        Assert.assertTrue(isScope);
 
         address = StringUtils.split("1050:9876:0000:0000:0005:akkg:300c:326b", ":");
         isScope = AclUtils.isIPv6Scope(address, 8);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
         isScope = AclUtils.isIPv6Scope(address, 4);
-        assertTrue(isScope);
+        Assert.assertTrue(isScope);
 
         address = StringUtils.split(AclUtils.expandIP("1050::0005:akkg:300c:326b", 8), ":");
         isScope = AclUtils.isIPv6Scope(address, 8);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
         isScope = AclUtils.isIPv6Scope(address, 4);
-        assertTrue(isScope);
+        Assert.assertTrue(isScope);
     }
 
     @Test
     public void testIsScope_String() {
         for (int i = 0; i < 256; i++) {
             boolean isScope = AclUtils.isScope(i + "");
-            assertTrue(isScope);
+            Assert.assertTrue(isScope);
         }
         boolean isScope = AclUtils.isScope("-1");
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
         isScope = AclUtils.isScope("256");
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
     }
 
     @Test
@@ -138,9 +136,9 @@ public class AclUtilsTest {
             Assert.assertTrue(isScope);
         }
         boolean isScope = AclUtils.isScope(-1);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
         isScope = AclUtils.isScope(256);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
 
         // IPv6 test
         int min = Integer.parseInt("0", 16);
@@ -150,62 +148,62 @@ public class AclUtilsTest {
             Assert.assertTrue(isScope);
         }
         isScope = AclUtils.isIPv6Scope(-1);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
         isScope = AclUtils.isIPv6Scope(max + 1);
-        assertFalse(isScope);
+        Assert.assertFalse(isScope);
     }
 
     @Test
     public void testIsAsterisk() {
         boolean isAsterisk = AclUtils.isAsterisk("*");
-        assertTrue(isAsterisk);
+        Assert.assertTrue(isAsterisk);
 
         isAsterisk = AclUtils.isAsterisk(",");
-        assertFalse(isAsterisk);
+        Assert.assertFalse(isAsterisk);
     }
 
     @Test
     public void testIsComma() {
         boolean isColon = AclUtils.isComma(",");
-        assertTrue(isColon);
+        Assert.assertTrue(isColon);
 
         isColon = AclUtils.isComma("-");
-        assertFalse(isColon);
+        Assert.assertFalse(isColon);
     }
 
     @Test
     public void testIsMinus() {
         boolean isMinus = AclUtils.isMinus("-");
-        assertTrue(isMinus);
+        Assert.assertTrue(isMinus);
 
         isMinus = AclUtils.isMinus("*");
-        assertFalse(isMinus);
+        Assert.assertFalse(isMinus);
     }
 
     @Test
     public void testV6ipProcess() {
         String remoteAddr = "5::7:6:1-200:*";
-        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0007:0006");
+        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0007:0006");
 
         remoteAddr = "5::7:6:1-200";
-        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
+        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
         remoteAddr = "5::7:6:*";
-        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
+        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
 
         remoteAddr = "5:7:6:*";
-        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0007:0006");
+        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0007:0006");
     }
 
     @Test
     public void testExpandIP() {
-        assertEquals(AclUtils.expandIP("::", 8), "0000:0000:0000:0000:0000:0000:0000:0000");
-        assertEquals(AclUtils.expandIP("::1", 8), "0000:0000:0000:0000:0000:0000:0000:0001");
-        assertEquals(AclUtils.expandIP("3::", 8), "0003:0000:0000:0000:0000:0000:0000:0000");
-        assertEquals(AclUtils.expandIP("2::2", 8), "0002:0000:0000:0000:0000:0000:0000:0002");
-        assertEquals(AclUtils.expandIP("4::aac4:92", 8), "0004:0000:0000:0000:0000:0000:AAC4:0092");
-        assertEquals(AclUtils.expandIP("ab23:56:901a::cc6:765:bb:9011", 8), "AB23:0056:901A:0000:0CC6:0765:00BB:9011");
-        assertEquals(AclUtils.expandIP("ab23:56:901a:1:cc6:765:bb:9011", 8), "AB23:0056:901A:0001:0CC6:0765:00BB:9011");
-        assertEquals(AclUtils.expandIP("5::7:6", 6), "0005:0000:0000:0000:0007:0006");
+        Assert.assertEquals(AclUtils.expandIP("::", 8), "0000:0000:0000:0000:0000:0000:0000:0000");
+        Assert.assertEquals(AclUtils.expandIP("::1", 8), "0000:0000:0000:0000:0000:0000:0000:0001");
+        Assert.assertEquals(AclUtils.expandIP("3::", 8), "0003:0000:0000:0000:0000:0000:0000:0000");
+        Assert.assertEquals(AclUtils.expandIP("2::2", 8), "0002:0000:0000:0000:0000:0000:0000:0002");
+        Assert.assertEquals(AclUtils.expandIP("4::aac4:92", 8), "0004:0000:0000:0000:0000:0000:AAC4:0092");
+        Assert.assertEquals(AclUtils.expandIP("ab23:56:901a::cc6:765:bb:9011", 8), "AB23:0056:901A:0000:0CC6:0765:00BB:9011");
+        Assert.assertEquals(AclUtils.expandIP("ab23:56:901a:1:cc6:765:bb:9011", 8), "AB23:0056:901A:0001:0CC6:0765:00BB:9011");
+        Assert.assertEquals(AclUtils.expandIP("5::7:6", 6), "0005:0000:0000:0000:0007:0006");
     }
 
     @SuppressWarnings("unchecked")
@@ -213,8 +211,8 @@ public class AclUtilsTest {
     public void testGetYamlDataObject() throws IOException {
         try (InputStream is = AclUtilsTest.class.getClassLoader().getResourceAsStream("conf/plain_acl_correct.yml")) {
             Map<String, Object> map = AclUtils.getYamlDataObject(is, Map.class);
-            assertNotNull(map);
-            assertFalse(map.isEmpty());
+            Assert.assertNotNull(map);
+            Assert.assertFalse(map.isEmpty());
         }
     }
 
@@ -232,7 +230,7 @@ public class AclUtilsTest {
     public void writeDataObject2YamlFileTest() throws IOException {
         String targetFileName = randomTmpFile();
         File transport = new File(targetFileName);
-        assertTrue(transport.createNewFile());
+        Assert.assertTrue(transport.createNewFile());
         transport.deleteOnExit();
 
         PlainAccessData aclYamlMap = new PlainAccessData();
@@ -255,14 +253,14 @@ public class AclUtilsTest {
         };
         accounts.add(accountsMap);
         aclYamlMap.setAccounts(accounts);
-        assertTrue(AclUtils.writeDataObject(targetFileName, aclYamlMap));
+        Assert.assertTrue(AclUtils.writeDataObject(targetFileName, aclYamlMap));
     }
 
     @Test
     public void updateExistedYamlFileTest() throws IOException {
         String targetFileName = randomTmpFile();
         File transport = new File(targetFileName);
-        assertTrue(transport.createNewFile());
+        Assert.assertTrue(transport.createNewFile());
         transport.deleteOnExit();
 
         PlainAccessData aclYamlMap = new PlainAccessData();
@@ -286,21 +284,21 @@ public class AclUtilsTest {
 
         PlainAccessData readableMap = AclUtils.getYamlDataObject(targetFileName, PlainAccessData.class);
         List<String> updatedGlobalWhiteRemoteAddrs = readableMap.getGlobalWhiteRemoteAddresses();
-        assertEquals("192.168.1.2", updatedGlobalWhiteRemoteAddrs.get(0));
+        Assert.assertEquals("192.168.1.2", updatedGlobalWhiteRemoteAddrs.get(0));
     }
 
     @Test
     public void getYamlDataIgnoreFileNotFoundExceptionTest() {
 
         JSONObject yamlDataObject = AclUtils.getYamlDataObject("plain_acl.yml", JSONObject.class);
-        assertNull(yamlDataObject);
+        Assert.assertNull(yamlDataObject);
     }
 
     @Test
     public void getAclRPCHookTest() throws IOException {
         try (InputStream is = AclUtilsTest.class.getClassLoader().getResourceAsStream("conf/plain_acl_incomplete.yml")) {
             RPCHook incompleteContRPCHook = AclUtils.getAclRPCHook(is);
-            assertNull(incompleteContRPCHook);
+            Assert.assertNull(incompleteContRPCHook);
         }
     }
 

--- a/acl/src/test/java/org/apache/rocketmq/acl/common/AclUtilsTest.java
+++ b/acl/src/test/java/org/apache/rocketmq/acl/common/AclUtilsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.acl.common;
 
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.acl.plain.PlainAccessData;
 import org.apache.rocketmq.common.PlainAccessConfig;
@@ -32,7 +32,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class AclUtilsTest {
 
@@ -47,7 +54,7 @@ public class AclUtilsTest {
         addressList.add("1.1.1.2");
         addressList.add("1.1.1.3");
         addressList.add("1.1.1.4");
-        Assert.assertEquals(newAddressList, addressList);
+        assertEquals(newAddressList, addressList);
 
         // IPv6 test
         String ipv6Address = "1:ac41:9987::bb22:666:{1,2,3,4}";
@@ -60,7 +67,7 @@ public class AclUtilsTest {
         ipv6AddressList.add("1:ac41:9987::bb22:666:2");
         ipv6AddressList.add("1:ac41:9987::bb22:666:3");
         ipv6AddressList.add("1:ac41:9987::bb22:666:4");
-        Assert.assertEquals(newIPv6AddressList, ipv6AddressList);
+        assertEquals(newIPv6AddressList, ipv6AddressList);
     }
 
     @Test
@@ -70,9 +77,9 @@ public class AclUtilsTest {
         for (int i = 0; i < 6; i++) {
             boolean isScope = AclUtils.isScope(address, 4);
             if (i == 3) {
-                Assert.assertTrue(isScope);
+                assertTrue(isScope);
             } else {
-                Assert.assertFalse(isScope);
+                assertFalse(isScope);
             }
             address = address + ".12";
         }
@@ -82,46 +89,46 @@ public class AclUtilsTest {
     public void testIsScope_Array() {
         String[] address = StringUtils.split("12.12.12.12", ".");
         boolean isScope = AclUtils.isScope(address, 4);
-        Assert.assertTrue(isScope);
+        assertTrue(isScope);
         isScope = AclUtils.isScope(address, 3);
-        Assert.assertTrue(isScope);
+        assertTrue(isScope);
 
         address = StringUtils.split("12.12.1222.1222", ".");
         isScope = AclUtils.isScope(address, 4);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
         isScope = AclUtils.isScope(address, 3);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
 
         // IPv6 test
         address = StringUtils.split("1050:0000:0000:0000:0005:0600:300c:326b", ":");
         isScope = AclUtils.isIPv6Scope(address, 8);
-        Assert.assertTrue(isScope);
+        assertTrue(isScope);
         isScope = AclUtils.isIPv6Scope(address, 4);
-        Assert.assertTrue(isScope);
+        assertTrue(isScope);
 
         address = StringUtils.split("1050:9876:0000:0000:0005:akkg:300c:326b", ":");
         isScope = AclUtils.isIPv6Scope(address, 8);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
         isScope = AclUtils.isIPv6Scope(address, 4);
-        Assert.assertTrue(isScope);
+        assertTrue(isScope);
 
         address = StringUtils.split(AclUtils.expandIP("1050::0005:akkg:300c:326b", 8), ":");
         isScope = AclUtils.isIPv6Scope(address, 8);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
         isScope = AclUtils.isIPv6Scope(address, 4);
-        Assert.assertTrue(isScope);
+        assertTrue(isScope);
     }
 
     @Test
     public void testIsScope_String() {
         for (int i = 0; i < 256; i++) {
             boolean isScope = AclUtils.isScope(i + "");
-            Assert.assertTrue(isScope);
+            assertTrue(isScope);
         }
         boolean isScope = AclUtils.isScope("-1");
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
         isScope = AclUtils.isScope("256");
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
     }
 
     @Test
@@ -131,9 +138,9 @@ public class AclUtilsTest {
             Assert.assertTrue(isScope);
         }
         boolean isScope = AclUtils.isScope(-1);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
         isScope = AclUtils.isScope(256);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
 
         // IPv6 test
         int min = Integer.parseInt("0", 16);
@@ -143,62 +150,62 @@ public class AclUtilsTest {
             Assert.assertTrue(isScope);
         }
         isScope = AclUtils.isIPv6Scope(-1);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
         isScope = AclUtils.isIPv6Scope(max + 1);
-        Assert.assertFalse(isScope);
+        assertFalse(isScope);
     }
 
     @Test
     public void testIsAsterisk() {
         boolean isAsterisk = AclUtils.isAsterisk("*");
-        Assert.assertTrue(isAsterisk);
+        assertTrue(isAsterisk);
 
         isAsterisk = AclUtils.isAsterisk(",");
-        Assert.assertFalse(isAsterisk);
+        assertFalse(isAsterisk);
     }
 
     @Test
     public void testIsComma() {
         boolean isColon = AclUtils.isComma(",");
-        Assert.assertTrue(isColon);
+        assertTrue(isColon);
 
         isColon = AclUtils.isComma("-");
-        Assert.assertFalse(isColon);
+        assertFalse(isColon);
     }
 
     @Test
     public void testIsMinus() {
         boolean isMinus = AclUtils.isMinus("-");
-        Assert.assertTrue(isMinus);
+        assertTrue(isMinus);
 
         isMinus = AclUtils.isMinus("*");
-        Assert.assertFalse(isMinus);
+        assertFalse(isMinus);
     }
 
     @Test
     public void testV6ipProcess() {
         String remoteAddr = "5::7:6:1-200:*";
-        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0007:0006");
+        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0007:0006");
 
         remoteAddr = "5::7:6:1-200";
-        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
+        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
         remoteAddr = "5::7:6:*";
-        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
+        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0000:0000:0000:0000:0007:0006");
 
         remoteAddr = "5:7:6:*";
-        Assert.assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0007:0006");
+        assertEquals(AclUtils.v6ipProcess(remoteAddr), "0005:0007:0006");
     }
 
     @Test
     public void testExpandIP() {
-        Assert.assertEquals(AclUtils.expandIP("::", 8), "0000:0000:0000:0000:0000:0000:0000:0000");
-        Assert.assertEquals(AclUtils.expandIP("::1", 8), "0000:0000:0000:0000:0000:0000:0000:0001");
-        Assert.assertEquals(AclUtils.expandIP("3::", 8), "0003:0000:0000:0000:0000:0000:0000:0000");
-        Assert.assertEquals(AclUtils.expandIP("2::2", 8), "0002:0000:0000:0000:0000:0000:0000:0002");
-        Assert.assertEquals(AclUtils.expandIP("4::aac4:92", 8), "0004:0000:0000:0000:0000:0000:AAC4:0092");
-        Assert.assertEquals(AclUtils.expandIP("ab23:56:901a::cc6:765:bb:9011", 8), "AB23:0056:901A:0000:0CC6:0765:00BB:9011");
-        Assert.assertEquals(AclUtils.expandIP("ab23:56:901a:1:cc6:765:bb:9011", 8), "AB23:0056:901A:0001:0CC6:0765:00BB:9011");
-        Assert.assertEquals(AclUtils.expandIP("5::7:6", 6), "0005:0000:0000:0000:0007:0006");
+        assertEquals(AclUtils.expandIP("::", 8), "0000:0000:0000:0000:0000:0000:0000:0000");
+        assertEquals(AclUtils.expandIP("::1", 8), "0000:0000:0000:0000:0000:0000:0000:0001");
+        assertEquals(AclUtils.expandIP("3::", 8), "0003:0000:0000:0000:0000:0000:0000:0000");
+        assertEquals(AclUtils.expandIP("2::2", 8), "0002:0000:0000:0000:0000:0000:0000:0002");
+        assertEquals(AclUtils.expandIP("4::aac4:92", 8), "0004:0000:0000:0000:0000:0000:AAC4:0092");
+        assertEquals(AclUtils.expandIP("ab23:56:901a::cc6:765:bb:9011", 8), "AB23:0056:901A:0000:0CC6:0765:00BB:9011");
+        assertEquals(AclUtils.expandIP("ab23:56:901a:1:cc6:765:bb:9011", 8), "AB23:0056:901A:0001:0CC6:0765:00BB:9011");
+        assertEquals(AclUtils.expandIP("5::7:6", 6), "0005:0000:0000:0000:0007:0006");
     }
 
     @SuppressWarnings("unchecked")
@@ -206,8 +213,8 @@ public class AclUtilsTest {
     public void testGetYamlDataObject() throws IOException {
         try (InputStream is = AclUtilsTest.class.getClassLoader().getResourceAsStream("conf/plain_acl_correct.yml")) {
             Map<String, Object> map = AclUtils.getYamlDataObject(is, Map.class);
-            Assert.assertNotNull(map);
-            Assert.assertFalse(map.isEmpty());
+            assertNotNull(map);
+            assertFalse(map.isEmpty());
         }
     }
 
@@ -225,7 +232,7 @@ public class AclUtilsTest {
     public void writeDataObject2YamlFileTest() throws IOException {
         String targetFileName = randomTmpFile();
         File transport = new File(targetFileName);
-        Assert.assertTrue(transport.createNewFile());
+        assertTrue(transport.createNewFile());
         transport.deleteOnExit();
 
         PlainAccessData aclYamlMap = new PlainAccessData();
@@ -248,14 +255,14 @@ public class AclUtilsTest {
         };
         accounts.add(accountsMap);
         aclYamlMap.setAccounts(accounts);
-        Assert.assertTrue(AclUtils.writeDataObject(targetFileName, aclYamlMap));
+        assertTrue(AclUtils.writeDataObject(targetFileName, aclYamlMap));
     }
 
     @Test
     public void updateExistedYamlFileTest() throws IOException {
         String targetFileName = randomTmpFile();
         File transport = new File(targetFileName);
-        Assert.assertTrue(transport.createNewFile());
+        assertTrue(transport.createNewFile());
         transport.deleteOnExit();
 
         PlainAccessData aclYamlMap = new PlainAccessData();
@@ -279,21 +286,42 @@ public class AclUtilsTest {
 
         PlainAccessData readableMap = AclUtils.getYamlDataObject(targetFileName, PlainAccessData.class);
         List<String> updatedGlobalWhiteRemoteAddrs = readableMap.getGlobalWhiteRemoteAddresses();
-        Assert.assertEquals("192.168.1.2", updatedGlobalWhiteRemoteAddrs.get(0));
+        assertEquals("192.168.1.2", updatedGlobalWhiteRemoteAddrs.get(0));
     }
 
     @Test
     public void getYamlDataIgnoreFileNotFoundExceptionTest() {
 
         JSONObject yamlDataObject = AclUtils.getYamlDataObject("plain_acl.yml", JSONObject.class);
-        Assert.assertNull(yamlDataObject);
+        assertNull(yamlDataObject);
     }
 
     @Test
     public void getAclRPCHookTest() throws IOException {
         try (InputStream is = AclUtilsTest.class.getClassLoader().getResourceAsStream("conf/plain_acl_incomplete.yml")) {
             RPCHook incompleteContRPCHook = AclUtils.getAclRPCHook(is);
-            Assert.assertNull(incompleteContRPCHook);
+            assertNull(incompleteContRPCHook);
         }
+    }
+
+    @Test
+    public void testGetAclRPCHookByFileName() {
+        RPCHook actual = AclUtils.getAclRPCHook(Objects.requireNonNull(AclUtilsTest.class.getResource("/acl_hook/plain_acl.yml")).getPath());
+        assertNotNull(actual);
+        assertTrue(actual instanceof AclClientRPCHook);
+        assertAclClientRPCHook((AclClientRPCHook) actual);
+    }
+
+    @Test
+    public void testGetAclRPCHookByInputStream() {
+        RPCHook actual = AclUtils.getAclRPCHook(Objects.requireNonNull(AclUtilsTest.class.getResourceAsStream("/acl_hook/plain_acl.yml")));
+        assertNotNull(actual);
+        assertTrue(actual instanceof AclClientRPCHook);
+        assertAclClientRPCHook((AclClientRPCHook) actual);
+    }
+
+    private void assertAclClientRPCHook(final AclClientRPCHook actual) {
+        assertEquals("rocketmq2", actual.getSessionCredentials().getAccessKey());
+        assertEquals("12345678", actual.getSessionCredentials().getSecretKey());
     }
 }

--- a/acl/src/test/resources/acl_hook/plain_acl.yml
+++ b/acl/src/test/resources/acl_hook/plain_acl.yml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+## suggested format
+
+- accessKey: rocketmq2
+  secretKey: 12345678
+  whiteRemoteAddress: 192.168.1.*
+  admin: true


### PR DESCRIPTION
Fixes #9156,  use fastjson2 to replace fastjson1.
