### PR TITLE
When changing the invisible time, the request should be rejected if the queueOffset equals maxOffset

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ChangeInvisibleTimeProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ChangeInvisibleTimeProcessor.java
@@ -130,7 +130,7 @@ public class ChangeInvisibleTimeProcessor implements NettyRequestProcessor {
         } catch (ConsumeQueueException e) {
             throw new RemotingCommandException("Failed to get max consume offset", e);
         }
-        if (requestHeader.getOffset() < minOffset || requestHeader.getOffset() > maxOffset) {
+        if (requestHeader.getOffset() < minOffset || requestHeader.getOffset() >= maxOffset) {
             response.setCode(ResponseCode.NO_MESSAGE);
             return CompletableFuture.completedFuture(response);
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

When changing the invisible time, the request should be rejected if the queueOffset equals maxOffset

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
