### PR TITLE
Revert "[ISSUE #9176] Fix pop message header missing fields when enable ACL 2.0"

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
@@ -234,7 +234,6 @@ public class PopMessageProcessor implements NettyRequestProcessor {
         final PopMessageRequestHeader requestHeader =
             request.decodeCommandCustomHeader(PopMessageRequestHeader.class, true);
         final PopMessageResponseHeader responseHeader = (PopMessageResponseHeader) response.readCustomHeader();
-        requestHeader.setBornTime(System.currentTimeMillis());
 
         // Pop mode only supports consumption in cluster load balancing mode
         brokerController.getConsumerManager().compensateBasicConsumerInfo(


### PR DESCRIPTION
When there is a time difference between the client and the server, it can cause issues with suspending long-polling POP requests.