### PR TITLE
Fix unstable test: BrokerOuterAPITest.test_needRegister_timeout

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerOuterAPITest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerOuterAPITest.java
@@ -154,7 +154,7 @@ public class BrokerOuterAPITest {
                 } else if (invocation.getArgument(0) == nameserver2) {
                     return buildResponse(Boolean.FALSE);
                 } else if (invocation.getArgument(0) == nameserver3) {
-                    TimeUnit.MILLISECONDS.sleep(timeOut + 20);
+                    TimeUnit.MILLISECONDS.sleep(timeOut + 100);  // Increase sleep time to force timeout
                     return buildResponse(Boolean.TRUE);
                 }
                 return buildResponse(Boolean.TRUE);


### PR DESCRIPTION
This PR increases the sleep duration in invokeSync() from 20ms to 100ms to improve test stability. The previous 20ms timeout was too short, causing intermittent failures due to minor execution delays. By increasing it to 100ms, we ensure consistent timeout behavior, reducing test flakiness and better simulating real-world network latencies. This change aligns with RocketMQ's expected behavior, making the test more reliable across multiple runs.

Fixes #6654 