### PR TITLE
[ISSUE #8701] Fix documentation for brokerAddrTable property in MQClientInstance.java

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -118,7 +118,7 @@ public class MQClientInstance {
     private final Lock lockHeartbeat = new ReentrantLock();
 
     /**
-     * The container which stores the brokerClusterInfo. The key of the map is the brokerCluster name.
+     * The container which stores the brokerClusterInfo. The key of the map is the broker name.
      * And the value is the broker instance list that belongs to the broker cluster.
      * For the sub map, the key is the id of single broker instance, and the value is the address.
      */


### PR DESCRIPTION
Clarified that the key of the brokerAddrTable map is the brokerName, not brokerClusterName, to prevent ambiguity.
Closes #8701