### PR TITLE
Slave's accessMessageInMemoryMaxRatio should be calculated dynamically

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -140,11 +140,6 @@ public class BrokerStartup {
             }
         }
 
-        if (BrokerRole.SLAVE == messageStoreConfig.getBrokerRole()) {
-            int ratio = messageStoreConfig.getAccessMessageInMemoryMaxRatio() - 10;
-            messageStoreConfig.setAccessMessageInMemoryMaxRatio(ratio);
-        }
-
         // Set broker role according to ha config
         if (!brokerConfig.isEnableControllerMode()) {
             switch (messageStoreConfig.getBrokerRole()) {

--- a/container/src/main/java/org/apache/rocketmq/container/BrokerContainer.java
+++ b/container/src/main/java/org/apache/rocketmq/container/BrokerContainer.java
@@ -367,8 +367,6 @@ public class BrokerContainer implements IBrokerContainer {
             throw new Exception("Can not add broker to container when duplicationEnable is true currently");
         }
 
-        int ratio = storeConfig.getAccessMessageInMemoryMaxRatio() - 10;
-        storeConfig.setAccessMessageInMemoryMaxRatio(Math.max(ratio, 0));
         InnerSalveBrokerController slaveBroker = new InnerSalveBrokerController(this, slaveBrokerConfig, storeConfig);
         BrokerIdentity brokerIdentity = slaveBroker.getBrokerIdentity();
         final InnerSalveBrokerController previousBroker = slaveBrokerControllers.putIfAbsent(brokerIdentity, slaveBroker);

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -908,7 +908,10 @@ public class MessageStoreConfig {
     }
 
     public int getAccessMessageInMemoryMaxRatio() {
-        return accessMessageInMemoryMaxRatio;
+        if (BrokerRole.SLAVE != brokerRole) {
+            return accessMessageInMemoryMaxRatio;
+        }
+        return Math.max(0, accessMessageInMemoryMaxRatio - 10);
     }
 
     public void setAccessMessageInMemoryMaxRatio(int accessMessageInMemoryMaxRatio) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9275

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
