### PR TITLE
[ISSUE #9290] Improve Namesrv health check: auto-close unhealthy channel on repeated failures

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -75,6 +75,8 @@ public class ClientConfig {
     private boolean useHeartbeatV2 = Boolean.parseBoolean(System.getProperty(HEART_BEAT_V2, "false"));
 
     private boolean useTLS = TlsSystemConfig.tlsEnable;
+    private boolean enableNamesrvCheck = false;
+    private int maxClientNamesrvCheckFailedCnt = 3;
 
     private String socksProxyConfig = System.getProperty(SOCKS_PROXY_CONFIG, "{}");
 
@@ -515,6 +517,22 @@ public class ClientConfig {
         this.traceTopic = traceTopic;
     }
 
+    public boolean isEnableNamesrvCheck() {
+        return enableNamesrvCheck;
+    }
+
+    public void setEnableNamesrvCheck(boolean enableNamesrvCheck) {
+        this.enableNamesrvCheck = enableNamesrvCheck;
+    }
+
+    public int getMaxClientNamesrvCheckFailedCnt() {
+        return maxClientNamesrvCheckFailedCnt;
+    }
+
+    public void setMaxClientNamesrvCheckFailedCnt(int maxClientNamesrvCheckFailedCnt) {
+        this.maxClientNamesrvCheckFailedCnt = maxClientNamesrvCheckFailedCnt;
+    }
+
     @Override
     public String toString() {
         return "ClientConfig{" +
@@ -548,6 +566,8 @@ public class ClientConfig {
             ", enableHeartbeatChannelEventListener=" + enableHeartbeatChannelEventListener +
             ", enableTrace=" + enableTrace +
             ", traceTopic='" + traceTopic + '\'' +
+            ", enableNamesrvCheck=" + enableNamesrvCheck +
+            ", maxClientNamesrvCheckFailedCnt=" + maxClientNamesrvCheckFailedCnt +
             '}';
     }
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -1216,4 +1216,18 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
             }
         }
     }
+
+    public void closeUnHealthyNamesrvChannel() {
+        String namesrvAddr = namesrvAddrChoosed.get();
+        // Namesrv is not selected, no need to check
+        if (namesrvAddr == null) {
+            return;
+        }
+        NettyRemotingClient.ChannelWrapper cw = this.channelTables.get(namesrvAddr);
+        // No connection is established, no need to be removed cache
+        if (cw == null) {
+            return;
+        }
+        this.closeChannel(namesrvAddr, cw.getChannelFuture().channel());
+    }
 }


### PR DESCRIPTION
…not disconnect if there is a problem with the network.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9290

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
