### PR TITLE
[ISSUE #9288] Support the disablement of producer registration and fast channel shutdown

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ClientChannelAttributeHelper.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ClientChannelAttributeHelper.java
@@ -1,0 +1,61 @@
+package org.apache.rocketmq.broker.client;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ClientChannelAttributeHelper {
+    private static final AttributeKey<String> ATTR_CG = AttributeKey.valueOf("CHANNEL_CONSUMER_GROUP");
+    private static final AttributeKey<String> ATTR_PG = AttributeKey.valueOf("CHANNEL_PRODUCER_GROUP");
+    private static final String SEPARATOR = "|";
+
+    public static void addProducerGroup(Channel channel, String group) {
+        addGroup(channel, group, ATTR_PG);
+    }
+
+    public static void addConsumerGroup(Channel channel, String group) {
+        addGroup(channel, group, ATTR_CG);
+    }
+
+    public static List<String> getProducerGroups(Channel channel) {
+        return getGroups(channel, ATTR_PG);
+    }
+
+    public static List<String> getConsumerGroups(Channel channel) {
+        return getGroups(channel, ATTR_CG);
+    }
+
+    private static void addGroup(Channel channel, String group, AttributeKey<String> key) {
+        if (null == channel || !channel.isActive()) {  // no side effect if check active status.
+            return;
+        }
+        if (null == group || group.length() == 0 || null == key) {
+            return;
+        }
+        String groups = channel.attr(key).get();
+        if (null == groups) {
+            channel.attr(key).set(group + SEPARATOR);
+        } else {
+            if (groups.contains(SEPARATOR + group + SEPARATOR)) {
+                return;
+            } else {
+                channel.attr(key).compareAndSet(groups, groups + group + SEPARATOR);
+            }
+        }
+    }
+
+    private static List<String> getGroups(Channel channel, AttributeKey<String> key) {
+        if (null == channel) {
+            return Collections.emptyList();
+        }
+        if (null == key) {
+            return Collections.emptyList();
+        }
+        String groups = channel.attr(key).get();
+        return null == groups ? Collections.<String>emptyList() : Arrays.asList(groups.split("\\|"));
+    }
+
+}

--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ClientChannelAttributeHelper.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ClientChannelAttributeHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.rocketmq.broker.client;
 
 import io.netty.channel.Channel;

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientManager.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientManager.java
@@ -85,4 +85,8 @@ public class MQClientManager {
     public void removeClientFactory(final String clientId) {
         this.factoryTable.remove(clientId);
     }
+
+    public ConcurrentMap<String, MQClientInstance> getFactoryTable() {
+        return factoryTable;
+    }
 }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -1395,6 +1395,14 @@ public class MQClientInstance {
         return clientConfig;
     }
 
+    public ConcurrentMap<String, MQProducerInner> getProducerTable() {
+        return producerTable;
+    }
+
+    public ConcurrentMap<String, MQConsumerInner> getConsumerTable() {
+        return consumerTable;
+    }
+
     public TopicRouteData queryTopicRouteData(String topic) {
         TopicRouteData data = this.getAnExistTopicRouteData(topic);
         if (data == null) {

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -426,6 +426,10 @@ public class BrokerConfig extends BrokerIdentity {
     private long popInflightMessageThreshold = 10000;
     private boolean enablePopMessageThreshold = false;
 
+    private boolean enableFastChannelEventProcess = false;
+    private boolean printChannelGroups = false;
+    private int  printChannelGroupsMinNum = 5;
+
     private int splitRegistrationSize = 800;
 
     /**
@@ -454,6 +458,8 @@ public class BrokerConfig extends BrokerIdentity {
     private boolean allowRecallWhenBrokerNotWriteable = true;
 
     private boolean recallMessageEnable = false;
+
+    private boolean enableRegisterProducer = true;
 
     public String getConfigBlackList() {
         return configBlackList;
@@ -1903,6 +1909,30 @@ public class BrokerConfig extends BrokerIdentity {
         this.enableSplitRegistration = enableSplitRegistration;
     }
 
+    public boolean isEnableFastChannelEventProcess() {
+        return enableFastChannelEventProcess;
+    }
+
+    public void setEnableFastChannelEventProcess(boolean enableFastChannelEventProcess) {
+        this.enableFastChannelEventProcess = enableFastChannelEventProcess;
+    }
+
+    public boolean isPrintChannelGroups() {
+        return printChannelGroups;
+    }
+
+    public void setPrintChannelGroups(boolean printChannelGroups) {
+        this.printChannelGroups = printChannelGroups;
+    }
+
+    public int getPrintChannelGroupsMinNum() {
+        return printChannelGroupsMinNum;
+    }
+
+    public void setPrintChannelGroupsMinNum(int printChannelGroupsMinNum) {
+        this.printChannelGroupsMinNum = printChannelGroupsMinNum;
+    }
+
     public int getSplitRegistrationSize() {
         return splitRegistrationSize;
     }
@@ -2005,5 +2035,13 @@ public class BrokerConfig extends BrokerIdentity {
 
     public void setRecallMessageEnable(boolean recallMessageEnable) {
         this.recallMessageEnable = recallMessageEnable;
+    }
+
+    public boolean isEnableRegisterProducer() {
+        return enableRegisterProducer;
+    }
+
+    public void setEnableRegisterProducer(boolean enableRegisterProducer) {
+        this.enableRegisterProducer = enableRegisterProducer;
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -430,7 +430,7 @@ public class BrokerConfig extends BrokerIdentity {
 
     private boolean enableFastChannelEventProcess = false;
     private boolean printChannelGroups = false;
-    private int  printChannelGroupsMinNum = 5;
+    private int printChannelGroupsMinNum = 5;
 
     private int splitRegistrationSize = 800;
 


### PR DESCRIPTION
support reject producer when not transaction producer

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9288 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
1. The current broker retains all producer channel information, which can consume a significant amount of resources when there are a large number of producers. In non-transactional message scenarios, the producer channel information is not useful. It would be beneficial to consider adding a switch to not record PID information in these scenarios.
2. Support fast channel event processing to improve the speed of disconnection.
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
