### PR TITLE
[ISSUE #9300] Periodic cleanup of inactive items in StatsItemSet

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -130,6 +130,8 @@ public class BrokerConfig extends BrokerIdentity {
     private boolean accountStatsEnable = true;
     private boolean accountStatsPrintZeroValues = true;
 
+    private int maxStatsIdleTimeInMinutes = -1;
+
     private boolean transferMsgByHeap = true;
 
     private String regionId = MixAll.DEFAULT_TRACE_REGION_ID;
@@ -1533,6 +1535,14 @@ public class BrokerConfig extends BrokerIdentity {
 
     public void setAccountStatsPrintZeroValues(boolean accountStatsPrintZeroValues) {
         this.accountStatsPrintZeroValues = accountStatsPrintZeroValues;
+    }
+
+    public int getMaxStatsIdleTimeInMinutes() {
+        return maxStatsIdleTimeInMinutes;
+    }
+
+    public void setMaxStatsIdleTimeInMinutes(int maxStatsIdleTimeInMinutes) {
+        this.maxStatsIdleTimeInMinutes = maxStatsIdleTimeInMinutes;
     }
 
     public boolean isLockInStrictMode() {

--- a/common/src/main/java/org/apache/rocketmq/common/stats/MomentStatsItem.java
+++ b/common/src/main/java/org/apache/rocketmq/common/stats/MomentStatsItem.java
@@ -31,6 +31,7 @@ public class MomentStatsItem {
     private final String statsKey;
     private final ScheduledExecutorService scheduledExecutorService;
     private final Logger log;
+    private long lastUpdateTimestamp = System.currentTimeMillis();
 
     public MomentStatsItem(String statsName, String statsKey,
         ScheduledExecutorService scheduledExecutorService, Logger log) {
@@ -71,5 +72,13 @@ public class MomentStatsItem {
 
     public String getStatsName() {
         return statsName;
+    }
+
+    public long getLastUpdateTimestamp() {
+        return lastUpdateTimestamp;
+    }
+
+    public void setLastUpdateTimestamp(long lastUpdateTimestamp) {
+        this.lastUpdateTimestamp = lastUpdateTimestamp;
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/stats/MomentStatsItemSet.java
+++ b/common/src/main/java/org/apache/rocketmq/common/stats/MomentStatsItemSet.java
@@ -24,9 +24,12 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 
 public class MomentStatsItemSet {
+    private static final Logger COMMERCIAL_LOG = LoggerFactory.getLogger(LoggerName.COMMERCIAL_LOGGER_NAME);
     private final ConcurrentMap<String/* key */, MomentStatsItem> statsItemTable =
         new ConcurrentHashMap<>(128);
     private final String statsName;
@@ -72,6 +75,13 @@ public class MomentStatsItemSet {
     public void setValue(final String statsKey, final int value) {
         MomentStatsItem statsItem = this.getAndCreateStatsItem(statsKey);
         statsItem.getValue().set(value);
+        statsItem.setLastUpdateTimestamp(System.currentTimeMillis());
+    }
+
+    public void setValue(final String statsKey, final long value) {
+        MomentStatsItem statsItem = this.getAndCreateStatsItem(statsKey);
+        statsItem.getValue().set(value);
+        statsItem.setLastUpdateTimestamp(System.currentTimeMillis());
     }
 
     public void delValueByInfixKey(final String statsKey, String separator) {
@@ -108,5 +118,18 @@ public class MomentStatsItemSet {
         }
 
         return statsItem;
+    }
+
+    public void cleanResource(int maxStatsIdleTimeInMinutes) {
+        COMMERCIAL_LOG.info("CleanStatisticItem: kind:{}, size:{}", statsName, this.statsItemTable.size());
+        Iterator<Entry<String, MomentStatsItem>> it = this.statsItemTable.entrySet().iterator();
+        while (it.hasNext()) {
+            Entry<String, MomentStatsItem> next = it.next();
+            MomentStatsItem statsItem = next.getValue();
+            if (System.currentTimeMillis() - statsItem.getLastUpdateTimestamp() > maxStatsIdleTimeInMinutes * 60 * 1000L) {
+                it.remove();
+                COMMERCIAL_LOG.info("CleanStatisticItem: removeKind:{}, removeKey:{}", statsName, statsItem.getStatsKey());
+            }
+        }
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/stats/StatsItem.java
+++ b/common/src/main/java/org/apache/rocketmq/common/stats/StatsItem.java
@@ -38,6 +38,7 @@ public class StatsItem {
 
     private final String statsName;
     private final String statsKey;
+    private long lastUpdateTimestamp = System.currentTimeMillis();
     private final ScheduledExecutorService scheduledExecutorService;
 
     private final Logger logger;
@@ -228,6 +229,14 @@ public class StatsItem {
 
     public LongAdder getTimes() {
         return times;
+    }
+
+    public long getLastUpdateTimestamp() {
+        return lastUpdateTimestamp;
+    }
+
+    public void setLastUpdateTimestamp(long lastUpdateTimestamp) {
+        this.lastUpdateTimestamp = lastUpdateTimestamp;
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9300 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
StatsItemSet and MomentStatsItem record a large amount of statistics for topics and consumers. Currently, they are only cleaned up when the resource is deleted. If a resource is abandoned by the user but not actually deleted, this statistical information will remain in memory indefinitely.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
