### PR TITLE
[ISSUE #9302] SendMessageContext add message type

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
@@ -380,6 +380,13 @@ public abstract class AbstractSendMessageProcessor implements NettyRequestProces
 
         if (properties.containsKey(MessageConst.PROPERTY_SHARDING_KEY)) {
             sendMessageContext.setMsgType(MessageType.Order_Msg);
+        } else if (properties.containsKey(MessageConst.PROPERTY_DELAY_TIME_LEVEL)
+                || properties.containsKey(MessageConst.PROPERTY_TIMER_DELIVER_MS)
+                || properties.containsKey(MessageConst.PROPERTY_TIMER_DELAY_SEC)
+                || properties.containsKey(MessageConst.PROPERTY_TIMER_DELAY_MS)) {
+            sendMessageContext.setMsgType(MessageType.Delay_Msg);
+        } else if (Boolean.parseBoolean(properties.get(MessageConst.PROPERTY_TRANSACTION_PREPARED))) {
+            sendMessageContext.setMsgType(MessageType.Trans_Msg_Half);
         } else {
             sendMessageContext.setMsgType(MessageType.Normal_Msg);
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9302 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Currently, when setting msgType in SendMessageContext, only normal messages and ordered messages are distinguished. Transactional messages and delayed messages are not differentiated.
In subsequent implementations of the send message hook, it won't be possible to differentiate the actual message type.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
