### PR TITLE
Avoid NPE for handling client settings null in notifyClientTermination

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -138,6 +138,12 @@ public class ClientActivity extends AbstractMessingActivity {
             String clientId = ctx.getClientID();
             LanguageCode languageCode = LanguageCode.valueOf(ctx.getLanguage());
             Settings clientSettings = grpcClientSettingsManager.removeAndGetClientSettings(ctx);
+            if (clientSettings == null) {
+                future.complete(NotifyClientTerminationResponse.newBuilder()
+                    .setStatus(ResponseBuilder.getInstance().buildStatus(Code.UNRECOGNIZED_CLIENT_TYPE, "cannot find client settings for this client"))
+                    .build());
+                return future;
+            }
 
             switch (clientSettings.getClientType()) {
                 case PRODUCER:


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Avoid NPE for handling client settings null in notifyClientTermination