### PR TITLE
[ISSUE #9322] TransactionalMessageServiceImpl static field MAX_PROCESS_TIME_LIMIT is not equals to transactionCheckInterval

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -58,7 +58,10 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
 
     private static final int PULL_MSG_RETRY_NUMBER = 1;
 
-    private static final int MAX_PROCESS_TIME_LIMIT = 60000;
+    /**
+     * keep equals to transactionCheckInterval
+     */
+    private static final int MAX_PROCESS_TIME_LIMIT = 30 * 1000;
     private static final int MAX_RETRY_TIMES_FOR_ESCAPE = 10;
 
     private static final int MAX_RETRY_COUNT_WHEN_HALF_NULL = 1;


### PR DESCRIPTION
…IMIT is not equals to transactionCheckInterval #9322

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9322

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
