### PR TITLE
fix: listacl typo. resolves @issue9345

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/auth/ListAclSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/auth/ListAclSubCommand.java
@@ -63,7 +63,7 @@ public class ListAclSubCommand implements SubCommand {
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("r", "resource", true, "the resource of acl to filter.");
+        opt = new Option("r", "resource", true, "the resources of acl to filter.");
         opt.setRequired(false);
         options.addOption(opt);
 


### PR DESCRIPTION
### This PR Fixes
Fixes #9345 

### Brief Description
This pull request fixes a typo in the option description of the ListAclSubCommand class.
Specifically, it changes "the resources of acl to filter." to use the correct word "resources" instead of the incorrect "resource" in the description for the -r/--resource option.

### How Did You Test This Change?
This change only modifies a string in the command-line option description, so no functional code is affected.
I verified the change by reviewing the help output of the command to ensure the description now displays correctly.
No additional tests are required.