### PR TITLE
[ISSUE #9358] Timediff should multiply 1000 when query message from tiered storage

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -285,7 +285,7 @@ public class IndexStoreFile implements IndexFile {
                 buffer.position(this.getItemPosition(slotValue));
                 buffer.get(bytes);
                 IndexItem indexItem = new IndexItem(bytes);
-                long storeTimestamp = indexItem.getTimeDiff() + beginTimestamp.get();
+                long storeTimestamp = indexItem.getTimeDiff() * 1000L + beginTimestamp.get();
                 if (hashCode == indexItem.getHashCode() &&
                     beginTime <= storeTimestamp && storeTimestamp <= endTime) {
                     result.add(indexItem);
@@ -353,7 +353,7 @@ public class IndexStoreFile implements IndexFile {
                 for (int i = 0; i < size; i++) {
                     itemBuffer.get(bytes);
                     IndexItem indexItem = new IndexItem(bytes);
-                    long storeTimestamp = indexItem.getTimeDiff() + beginTimestamp.get();
+                    long storeTimestamp = indexItem.getTimeDiff() * 1000L + beginTimestamp.get();
                     if (hashCode == indexItem.getHashCode() &&
                         beginTime <= storeTimestamp && storeTimestamp <= endTime &&
                         result.size() < maxCount) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9358 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
