### PR TITLE
Revert "[ISSUE #9188] Use fastjson2 in org/apache/rocketmq/broker/config/v1"

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
@@ -16,8 +16,12 @@
  */
 package org.apache.rocketmq.broker.config.v1;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import java.io.File;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.RocksDBConfigManager;
 import org.apache.rocketmq.broker.offset.ConsumerOffsetManager;
@@ -29,11 +33,6 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
 import org.rocksdb.CompressionType;
 import org.rocksdb.WriteBatch;
-
-import java.io.File;
-import java.util.Iterator;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentMap;
 
 public class RocksDBConsumerOffsetManager extends ConsumerOffsetManager {
 
@@ -148,7 +147,7 @@ public class RocksDBConsumerOffsetManager extends ConsumerOffsetManager {
         byte[] keyBytes = topicGroupName.getBytes(DataConverter.CHARSET_UTF8);
         RocksDBOffsetSerializeWrapper wrapper = new RocksDBOffsetSerializeWrapper();
         wrapper.setOffsetTable(offsetMap);
-        byte[] valueBytes = JSON.toJSONBytes(wrapper, JSONWriter.Feature.BrowserCompatible);
+        byte[] valueBytes = JSON.toJSONBytes(wrapper, SerializerFeature.BrowserCompatible);
         writeBatch.put(keyBytes, valueBytes);
     }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBSubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBSubscriptionGroupManager.java
@@ -16,9 +16,15 @@
  */
 package org.apache.rocketmq.broker.config.v1;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
-import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.RocksDBConfigManager;
 import org.apache.rocketmq.broker.subscription.SubscriptionGroupManager;
@@ -28,13 +34,6 @@ import org.apache.rocketmq.remoting.protocol.DataVersion;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.rocksdb.CompressionType;
 import org.rocksdb.RocksIterator;
-
-import java.io.File;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiConsumer;
 
 public class RocksDBSubscriptionGroupManager extends SubscriptionGroupManager {
 
@@ -133,7 +132,7 @@ public class RocksDBSubscriptionGroupManager extends SubscriptionGroupManager {
 
         try {
             byte[] keyBytes = groupName.getBytes(DataConverter.CHARSET_UTF8);
-            byte[] valueBytes = JSON.toJSONBytes(subscriptionGroupConfig, JSONWriter.Feature.BrowserCompatible);
+            byte[] valueBytes = JSON.toJSONBytes(subscriptionGroupConfig, SerializerFeature.BrowserCompatible);
             this.rocksDBConfigManager.put(keyBytes, keyBytes.length, valueBytes);
         } catch (Exception e) {
             log.error("kv put sub Failed, {}", subscriptionGroupConfig.toString());
@@ -148,7 +147,7 @@ public class RocksDBSubscriptionGroupManager extends SubscriptionGroupManager {
         if (oldConfig == null) {
             try {
                 byte[] keyBytes = groupName.getBytes(DataConverter.CHARSET_UTF8);
-                byte[] valueBytes = JSON.toJSONBytes(subscriptionGroupConfig, JSONWriter.Feature.BrowserCompatible);
+                byte[] valueBytes = JSON.toJSONBytes(subscriptionGroupConfig, SerializerFeature.BrowserCompatible);
                 this.rocksDBConfigManager.put(keyBytes, keyBytes.length, valueBytes);
             } catch (Exception e) {
                 log.error("kv put sub Failed, {}", subscriptionGroupConfig.toString());

--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBTopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBTopicConfigManager.java
@@ -16,8 +16,11 @@
  */
 package org.apache.rocketmq.broker.config.v1;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.RocksDBConfigManager;
 import org.apache.rocketmq.broker.topic.TopicConfigManager;
@@ -26,10 +29,6 @@ import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.utils.DataConverter;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
 import org.rocksdb.CompressionType;
-
-import java.io.File;
-import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 
 public class RocksDBTopicConfigManager extends TopicConfigManager {
 
@@ -114,7 +113,7 @@ public class RocksDBTopicConfigManager extends TopicConfigManager {
         TopicConfig oldTopicConfig = this.topicConfigTable.put(topicName, topicConfig);
         try {
             byte[] keyBytes = topicName.getBytes(DataConverter.CHARSET_UTF8);
-            byte[] valueBytes = JSON.toJSONBytes(topicConfig, JSONWriter.Feature.BrowserCompatible);
+            byte[] valueBytes = JSON.toJSONBytes(topicConfig, SerializerFeature.BrowserCompatible);
             this.rocksDBConfigManager.put(keyBytes, keyBytes.length, valueBytes);
         } catch (Exception e) {
             log.error("kv put topic Failed, {}", topicConfig.toString(), e);


### PR DESCRIPTION
Reverts apache/rocketmq#9189

In consideration of compatibility for minor versions, this commit will be temporarily reverted.
Once all changes related to fastjson2 are consolidated, we will release them in a new major version.