### PR TITLE
Fix IllegalStateException during app shutdown caused by premature shutdown trigger

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/AsyncTraceDispatcher.java
@@ -226,7 +226,13 @@ public class AsyncTraceDispatcher implements TraceDispatcher {
                     }
                 }
             }, "ShutdownHookMQTrace");
-            Runtime.getRuntime().addShutdownHook(shutDownHook);
+            
+
+            try {
+                Runtime.getRuntime().addShutdownHook(shutDownHook);
+            } catch (IllegalStateException e) {
+                // ignore - VM is already shutting down
+            }
         }
     }
 


### PR DESCRIPTION
in k8s cluster, when deploy a workload,  in pod A  the app is starting. then deploy again right now, pod A will be destoryed. sometimes error log: java.lang.IllegalStateException: Shutdown in progress

In Idea, we break a point on this line, then start the app. then click shutdown, will reproduce this.

![image](https://github.com/user-attachments/assets/c9492011-886a-49cd-bb63-408dea5203f5)
