### PR TITLE
[ISSUE #9352] Fix wrong value in topic-group cache

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ConsumerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ConsumerManager.java
@@ -241,7 +241,7 @@ public class ConsumerManager {
                 Set<String> prev = this.topicGroupTable.putIfAbsent(subscriptionData.getTopic(), tmp);
                 groups = prev != null ? prev : tmp;
             }
-            groups.add(subscriptionData.getTopic());
+            groups.add(group);
         }
 
         boolean r1 =

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ConsumerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ConsumerManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.broker.client;
 
+import com.google.common.collect.ImmutableSet;
 import io.netty.channel.Channel;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.filter.ConsumerFilterManager;
@@ -179,6 +180,7 @@ public class ConsumerManagerTest {
         register();
         final HashSet<String> consumeGroup = consumerManager.queryTopicConsumeByWho(TOPIC);
         assertFalse(consumeGroup.isEmpty());
+        assertThat(consumerManager.queryTopicConsumeByWho(TOPIC)).isEqualTo(ImmutableSet.of(GROUP));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes wrong value in topic-group cache when registerConsumer  #9352 


### Brief Description
In our use case, we used other methods to manage topic-group mapping, so we missed the test here.


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
In this PR, the unit test is improved, which not only verifies whether the returned result is empty, but also verifies whether the specific value is correct.
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
