### PR TITLE
[ISSUE #9439] Add escape for win in the method returning broker configuration

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -1066,6 +1066,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         String content = this.brokerController.getConfiguration().getAllConfigsFormatString();
         if (content != null && content.length() > 0) {
             try {
+                content = MixAll.adjustConfigForPlatform(content);
                 response.setBody(content.getBytes(MixAll.DEFAULT_CHARSET));
             } catch (UnsupportedEncodingException e) {
                 LOGGER.error("AdminBrokerProcessor#getBrokerConfig: unexpected error, caller={}",

--- a/common/src/main/java/org/apache/rocketmq/common/MixAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MixAll.java
@@ -557,4 +557,13 @@ public class MixAll {
             && !topic.startsWith(TopicValidator.SYSTEM_TOPIC_PREFIX)
             && !topic.equals(TopicValidator.RMQ_SYS_SCHEDULE_TOPIC);
     }
+
+    public static String adjustConfigForPlatform(String config) {
+        if (StringUtils.isNotBlank(config)) {
+            if (isWindows()) {
+                config = StringUtils.replace(config, "\\", "\\\\");
+            }
+        }
+        return config;
+    }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
@@ -85,4 +85,43 @@ public class MixAllTest {
         testLmq = "%LMQ%GID_TEST";
         assertThat(MixAll.isLmq(testLmq)).isTrue();
     }
+
+    @Test
+    public void testAdjustConfigForPlatform_OnWindows() {
+        if (MixAll.isWindows()) {
+            String configWithSingleBackslash = "data\\path\\config\\file.properties";
+            String adjusted = MixAll.adjustConfigForPlatform(configWithSingleBackslash);
+            assertThat(adjusted).isEqualTo("data\\\\path\\\\config\\\\file.properties");
+
+            String configWithMultipleBackslashes = "C:\\\\RocketMQ\\\\logs\\\\broker.log";
+            adjusted = MixAll.adjustConfigForPlatform(configWithMultipleBackslashes);
+            assertThat(adjusted).isEqualTo("C:\\\\\\\\RocketMQ\\\\\\\\logs\\\\\\\\broker.log");
+
+            String configWithoutBackslash = "listenPort=10911";
+            adjusted = MixAll.adjustConfigForPlatform(configWithoutBackslash);
+            assertThat(adjusted).isEqualTo("listenPort=10911");
+
+            String emptyConfig = "";
+            adjusted = MixAll.adjustConfigForPlatform(emptyConfig);
+            assertThat(adjusted).isEqualTo("");
+
+            adjusted = MixAll.adjustConfigForPlatform(null);
+            assertThat(adjusted).isNull();
+        } else {
+            String configWithSingleBackslash = "/home/rocketmq/conf/broker.conf";
+            String adjusted = MixAll.adjustConfigForPlatform(configWithSingleBackslash);
+            assertThat(adjusted).isEqualTo("/home/rocketmq/conf/broker.conf");
+
+            String linuxPathWithBackslash = "some\\directory\\file.txt";
+            adjusted = MixAll.adjustConfigForPlatform(linuxPathWithBackslash);
+            assertThat(adjusted).isEqualTo("some\\directory\\file.txt");
+
+            String emptyConfig = "";
+            adjusted = MixAll.adjustConfigForPlatform(emptyConfig);
+            assertThat(adjusted).isEqualTo("");
+
+            adjusted = MixAll.adjustConfigForPlatform(null);
+            assertThat(adjusted).isNull();
+        }
+    }
 }

--- a/container/src/main/java/org/apache/rocketmq/container/BrokerContainerProcessor.java
+++ b/container/src/main/java/org/apache/rocketmq/container/BrokerContainerProcessor.java
@@ -291,6 +291,7 @@ public class BrokerContainerProcessor implements NettyRequestProcessor {
         String content = this.brokerContainer.getConfiguration().getAllConfigsFormatString();
         if (content != null && content.length() > 0) {
             try {
+                content = MixAll.adjustConfigForPlatform(content);
                 response.setBody(content.getBytes(MixAll.DEFAULT_CHARSET));
             } catch (UnsupportedEncodingException e) {
                 LOGGER.error("", e);

--- a/controller/src/main/java/org/apache/rocketmq/controller/processor/ControllerRequestProcessor.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/processor/ControllerRequestProcessor.java
@@ -311,6 +311,7 @@ public class ControllerRequestProcessor implements NettyRequestProcessor {
         String content = this.controllerManager.getConfiguration().getAllConfigsFormatString();
         if (content != null && content.length() > 0) {
             try {
+                content = MixAll.adjustConfigForPlatform(content);
                 response.setBody(content.getBytes(MixAll.DEFAULT_CHARSET));
             } catch (UnsupportedEncodingException e) {
                 log.error("getConfig error, ", e);

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
@@ -658,6 +658,7 @@ public class DefaultRequestProcessor implements NettyRequestProcessor {
         String content = this.namesrvController.getConfiguration().getAllConfigsFormatString();
         if (StringUtils.isNotBlank(content)) {
             try {
+                content = MixAll.adjustConfigForPlatform(content);
                 response.setBody(content.getBytes(MixAll.DEFAULT_CHARSET));
             } catch (UnsupportedEncodingException e) {
                 log.error("getConfig error, ", e);


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Fixes #9439

### Brief Description

utilize MixAll.isWindows for platform-specific escaping

Affected files:
- `MixAll.java`: utilize MixAll.isWindows for platform-specific escaping

### How Did You Test This Change?

![image](https://github.com/user-attachments/assets/87e5ea27-dfaf-49f5-ad1c-e15ed2f6059b)
The above is before the modification, you can see the bug. The following is after the modification, you can see the program returns normally.
![image](https://github.com/user-attachments/assets/2be07ec3-b215-4417-ab55-d5ae91fb4181)
