### PR TITLE
Replace byte array zeroing loop with Arrays.fill and specify charset in String construction

### DIFF
--- a/filter/src/main/java/org/apache/rocketmq/filter/util/BitsArray.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/util/BitsArray.java
@@ -16,6 +16,7 @@
  */
 
 package org.apache.rocketmq.filter.util;
+import java.util.Arrays;
 
 /**
  * Wrapper of bytes array, in order to operate single bit easily.
@@ -45,9 +46,7 @@ public class BitsArray implements Cloneable {
             temp++;
         }
         bytes = new byte[temp];
-        for (int i = 0; i < bytes.length; i++) {
-            bytes[i] = (byte) 0x00;
-        }
+        Arrays.fill(bytes, (byte) 0x00); // 替换为 Arrays.fill()
     }
 
     private BitsArray(byte[] bytes, int bitLength) {

--- a/filter/src/main/java/org/apache/rocketmq/filter/util/BitsArray.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/util/BitsArray.java
@@ -46,7 +46,7 @@ public class BitsArray implements Cloneable {
             temp++;
         }
         bytes = new byte[temp];
-        Arrays.fill(bytes, (byte) 0x00); // 替换为 Arrays.fill()
+        Arrays.fill(bytes, (byte) 0x00); 
     }
 
     private BitsArray(byte[] bytes, int bitLength) {

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/SendMessageCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/SendMessageCommandTest.java
@@ -42,6 +42,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+
+
 public class SendMessageCommandTest {
 
     private static SendMessageCommand sendMessageCommand = new SendMessageCommand();
@@ -85,7 +88,7 @@ public class SendMessageCommandTest {
             sendMessageCommand.buildCommandlineOptions(options), new DefaultParser());
         sendMessageCommand.execute(commandLine, options, null);
         System.setOut(out);
-        String s = new String(bos.toByteArray());
+        String s = new String(bos.toByteArray(),StandardCharsets.UTF_8);
         Assert.assertTrue(s.contains("SEND_OK"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9460 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
This PR improves code readability and portability by replacing manual byte array zeroing and by explicitly specifying a charset when converting bytes to string.
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
These changes are refactorings that do not alter functionality. Existing unit tests continue to pass. Manual testing was also performed to ensure behavior remains consistent.