### PR TITLE
Relax topic length constraint when creating retry and dlq topics

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/topic/TopicValidator.java
+++ b/common/src/main/java/org/apache/rocketmq/common/topic/TopicValidator.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.common.topic;
 
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
 
 public class TopicValidator {
@@ -111,7 +112,9 @@ public class TopicValidator {
             return new ValidateTopicResult(false, "The specified topic contains illegal characters, allowing only ^[%|a-zA-Z0-9_-]+$");
         }
 
-        if (topic.length() > TOPIC_MAX_LENGTH) {
+        if (!topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX) &&
+            !topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX) &&
+            topic.length() > TOPIC_MAX_LENGTH) {
             return new ValidateTopicResult(false, "The specified topic is longer than topic max length.");
         }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9479 

### Brief Description
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Add two more conditions in the if statement of validateTopic method to additionally check whether the validating topic is dlq or retry topic and if it is then skip the topic length validation.
![image](https://github.com/user-attachments/assets/10874ffb-e304-4dba-b85c-5f4e94488532)

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

Built a snapshot of this change and tested creating dlq and retry topics of length greater than 127. 

