### PR TITLE
[ISSUE #9491] Remove the volatile declaration for the two variables requestsWrite and requestsRead in the GroupCommitService class 

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1610,8 +1610,8 @@ public class CommitLog implements Swappable {
      * GroupCommit Service
      */
     class GroupCommitService extends FlushCommitLogService {
-        private volatile LinkedList<GroupCommitRequest> requestsWrite = new LinkedList<>();
-        private volatile LinkedList<GroupCommitRequest> requestsRead = new LinkedList<>();
+        private LinkedList<GroupCommitRequest> requestsWrite = new LinkedList<>();
+        private LinkedList<GroupCommitRequest> requestsRead = new LinkedList<>();
         private final PutMessageSpinLock lock = new PutMessageSpinLock();
 
         public void putRequest(final GroupCommitRequest request) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
Fixes #9491

### Brief Description

### How Did You Test This Change?

