### PR TITLE
[ISSUE #9497] Fix IndexOutOfBoundsException in getEarliestMessageTime when running in IPv6 environment

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
@@ -179,6 +179,18 @@ public class NetworkUtil {
         }
     }
 
+    public static String denormalizeHostAddress(final String bracketedAddress) {
+        if (bracketedAddress == null) {
+            return null;
+        }
+
+        if (bracketedAddress.startsWith("[") && bracketedAddress.endsWith("]")) {
+            return bracketedAddress.substring(1, bracketedAddress.length() - 1);
+        } else {
+            return bracketedAddress;
+        }
+    }
+
     public static SocketAddress string2SocketAddress(final String addr) {
         int split = addr.lastIndexOf(":");
         String host = addr.substring(0, split);
@@ -208,6 +220,20 @@ public class NetworkUtil {
             }
         } catch (SecurityException e) {
             //Ignore
+        }
+        return false;
+    }
+
+    // valid various ipv6 format like:
+    // with scope 2001:0db8:85a3:0000:0000:8a2e:0370:7334%eth0
+    // with bracketed [2001:0db8:85a3:0000:0000:8a2e:0370:7334]
+    public static boolean validCommonInet6Address(String ipOrCidr) {
+        String  ipWithoutBracketed = denormalizeHostAddress(ipOrCidr);
+        if (ipWithoutBracketed != null && ipWithoutBracketed.length() != 0) {
+            InetAddressValidator validator = InetAddressValidator.getInstance();
+            if (validator.isValidInet6Address(ipWithoutBracketed.split("%")[0])) {
+                return true;
+            }
         }
         return false;
     }

--- a/common/src/test/java/org/apache/rocketmq/common/utils/IPAddressUtilsTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/IPAddressUtilsTest.java
@@ -18,6 +18,8 @@ package org.apache.rocketmq.common.utils;
 
 import org.junit.Test;
 
+import static org.apache.rocketmq.common.utils.NetworkUtil.validCommonInet6Address;
+
 public class IPAddressUtilsTest {
 
     @Test
@@ -72,4 +74,19 @@ public class IPAddressUtilsTest {
         assert IPAddressUtils.isValidIPOrCidr(ipv4Cidr);
         assert IPAddressUtils.isValidIPOrCidr(ipv6Cidr);
     }
+
+    @Test
+    public void isValidIPv6Common() {
+        String ipv6WithoutScope = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+        assert validCommonInet6Address(ipv6WithoutScope);
+        String ipv6WithScope = "2001:0db8:85a3:0000:0000:8a2e:0370:7334%eth0";
+        assert validCommonInet6Address(ipv6WithScope);
+        String ipv6WithBracketedAndScope = "[2001:0db8:85a3:0000:0000:8a2e:0370:7334%eth0]";
+        assert validCommonInet6Address(ipv6WithBracketedAndScope);
+        String ipv4 = "192.168.1.0";
+        assert !validCommonInet6Address(ipv4);
+        String ipv4Cidr = "192.168.1.0/24";
+        assert !validCommonInet6Address(ipv4Cidr);
+    }
+
 }

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -58,7 +58,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.rocketmq.common.AbstractBrokerRunnable;
 import org.apache.rocketmq.common.BoundaryType;
 import org.apache.rocketmq.common.BrokerConfig;
@@ -82,6 +81,7 @@ import org.apache.rocketmq.common.running.RunningStats;
 import org.apache.rocketmq.common.sysflag.MessageSysFlag;
 import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.common.utils.CleanupPolicyUtils;
+import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.common.utils.QueueTypeUtils;
 import org.apache.rocketmq.common.utils.ServiceProvider;
 import org.apache.rocketmq.common.utils.ThreadUtils;
@@ -1197,8 +1197,7 @@ public class DefaultMessageStore implements MessageStore {
             minPhyOffset += DLedgerEntry.BODY_OFFSET;
         }
         int size = MessageDecoder.MESSAGE_STORE_TIMESTAMP_POSITION + 8;
-        InetAddressValidator validator = InetAddressValidator.getInstance();
-        if (validator.isValidInet6Address(this.brokerConfig.getBrokerIP1())) {
+        if (NetworkUtil.validCommonInet6Address(this.brokerConfig.getBrokerIP1())) {
             size = MessageDecoder.MESSAGE_STORE_TIMESTAMP_POSITION + 20;
         }
         return this.getCommitLog().pickupStoreTimestamp(minPhyOffset, size);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9497 

### Brief Description
to solve getEarliestMessageTime throw expception problem in ipv6 env

[<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->](https://github.com/apache/rocketmq/pull/8567)

### How Did You Test This Change?
1. in unit test, test various ipv6, like [2001:0db8:85a3:0000:0000:8a2e:0370:7334%eth0]
2. test in ipv6 envirment and ipv4, no exception throw
