### PR TITLE
[ISSUE #8920] Make TLS certificate watch interval configurable

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -83,6 +83,7 @@ public class ProxyConfig implements ConfigFile {
     private boolean tlsTestModeEnable = true;
     private String tlsKeyPath = ConfigurationManager.getProxyHome() + "/conf/tls/rocketmq.key";
     private String tlsCertPath = ConfigurationManager.getProxyHome() + "/conf/tls/rocketmq.crt";
+    private int tlsCertWatchIntervalMs = 60 * 60 * 1000; // 1 hour
     /**
      * gRPC
      */
@@ -323,6 +324,14 @@ public class ProxyConfig implements ConfigFile {
         } catch (Exception e) {
             log.error("parse delay level failed. messageDelayLevel:{}", messageDelayLevel, e);
         }
+    }
+
+    public int getTlsCertWatchIntervalMs() {
+        return tlsCertWatchIntervalMs;
+    }
+
+    public void setTlsCertWatchIntervalMs(int tlsCertWatchIntervalMs) {
+        this.tlsCertWatchIntervalMs = tlsCertWatchIntervalMs;
     }
 
     public String getRocketMQClusterName() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.apache.rocketmq.proxy.service.cert;
+
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.utils.StartAndShutdown;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
@@ -39,7 +40,7 @@ public class TlsCertificateManager implements StartAndShutdown {
                     ConfigurationManager.getProxyConfig().getTlsKeyPath()
                 },
                 new CertKeyFileWatchListener(),
-                60 * 60 * 1000 /* 1 hour */
+                ConfigurationManager.getProxyConfig().getTlsCertWatchIntervalMs()
             );
         } catch (Exception e) {
             log.error("Failed to initialize TLS certificate watch service", e);
@@ -107,7 +108,7 @@ public class TlsCertificateManager implements StartAndShutdown {
             for (TlsContextReloadListener listener : reloadListeners) {
                 try {
                     listener.onTlsContextReload();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     log.error("Failed to notify TLS context reload to listener: " + listener, e);
                 }
             }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes
This PR makes the watch interval for TLS certificate and key files configurable in the Proxy module.

Previously, the interval was hardcoded to 1 hour, which is not flexible for different production environments. A new configuration property tlsCertWatchIntervalMs has been introduced in ProxyConfig with a default value of 1 hour (60 * 60 * 1000ms), which is more reasonable for most use cases.

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #8920 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
