### PR TITLE
[RIP-79] Route Change Notification

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
@@ -50,7 +50,12 @@ import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.common.utils.ThreadUtils;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.remoting.RemotingServer;
+import org.apache.rocketmq.remoting.common.RemotingHelper;
 import org.apache.rocketmq.remoting.protocol.EpochEntry;
+import org.apache.rocketmq.remoting.protocol.LanguageCode;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.body.SyncStateSet;
 import org.apache.rocketmq.remoting.protocol.header.controller.ElectMasterResponseHeader;
 import org.apache.rocketmq.remoting.protocol.header.controller.GetMetaDataResponseHeader;
@@ -64,6 +69,8 @@ import org.apache.rocketmq.store.ha.autoswitch.BrokerMetadata;
 import org.apache.rocketmq.store.ha.autoswitch.TempBrokerMetadata;
 
 import com.alibaba.fastjson2.JSON;
+
+import io.netty.channel.Channel;
 
 import static org.apache.rocketmq.remoting.protocol.ResponseCode.CONTROLLER_BROKER_METADATA_NOT_EXIST;
 
@@ -324,6 +331,20 @@ public class ReplicasManager {
         }
     }
 
+    private RemotingCommand buildNotify(String newMasterAddress) {
+        RemotingCommand switchNotify = RemotingCommand.createRequestCommand(
+            RequestCode.ROUTE_EVENT,
+            null
+        );
+
+        switchNotify.addExtField("newMasterAddr", newMasterAddress);
+        switchNotify.addExtField("oldMasterAddr", this.brokerAddress);
+        switchNotify.addExtField("Event", "SWITCH");
+        switchNotify.setLanguage(LanguageCode.JAVA);
+
+        return switchNotify;
+    }
+
     public void changeToSlave(final String newMasterAddress, final int newMasterEpoch, Long newMasterBrokerId) {
         synchronized (this) {
             if (newMasterEpoch > this.masterEpoch) {
@@ -357,6 +378,22 @@ public class ReplicasManager {
 
                 // Notify ha service, change to slave
                 this.haService.changeToSlave(newMasterAddress, newMasterEpoch, brokerControllerId);
+
+                RemotingServer remotingServer = brokerController.getRemotingServer();
+
+                Set<Channel> activeChannels = remotingServer.getActiveChannels();
+
+                RemotingCommand switchNotify = buildNotify(newMasterAddress);
+
+                activeChannels.forEach(channel -> {
+                    if (channel.isActive()) {
+                        try {
+                            remotingServer.invokeOneway(channel, switchNotify, 3000);
+                        } catch (Exception e) {
+                            LOGGER.warn("Notify client failed: {}", RemotingHelper.parseChannelRemoteAddr(channel), e);
+                        }
+                    }
+                });
 
                 this.brokerController.getTopicConfigManager().getDataVersion().nextVersion(newMasterEpoch);
                 registerBrokerWhenRoleChange();

--- a/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
@@ -17,10 +17,13 @@
 
 package org.apache.rocketmq.broker.controller;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -35,11 +38,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.out.BrokerOuterAPI;
 import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.Pair;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.common.utils.ThreadUtils;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
@@ -55,6 +62,8 @@ import org.apache.rocketmq.store.config.BrokerRole;
 import org.apache.rocketmq.store.ha.autoswitch.AutoSwitchHAService;
 import org.apache.rocketmq.store.ha.autoswitch.BrokerMetadata;
 import org.apache.rocketmq.store.ha.autoswitch.TempBrokerMetadata;
+
+import com.alibaba.fastjson2.JSON;
 
 import static org.apache.rocketmq.remoting.protocol.ResponseCode.CONTROLLER_BROKER_METADATA_NOT_EXIST;
 
@@ -234,6 +243,42 @@ public class ReplicasManager {
         }
     }
 
+    private void sendRouteChangeEvent(int newMasterEpoch) {
+        DefaultMQProducer producer = new DefaultMQProducer("ROUTE_EVENT_PRODUCER");
+
+        try {
+            producer.setNamesrvAddr(
+                StringUtils.join(this.brokerController.getBrokerConfig().getNamesrvAddr(), ";")
+            );
+            producer.setSendMsgTimeout(5000);
+            producer.start();
+
+            Map<String, Object> eventData = new HashMap<>();
+            eventData.put("eventType", "SWITCH");
+            eventData.put("brokerName", this.brokerConfig.getBrokerName());
+            eventData.put("brokerId", this.brokerControllerId);
+            eventData.put("masterEpoch", newMasterEpoch);
+            eventData.put("timestamp", System.currentTimeMillis());
+
+            Message msg = new Message(
+                TopicValidator.RMQ_ROUTE_EVENT_TOPIC,
+                "",
+                JSON.toJSONString(eventData).getBytes(StandardCharsets.UTF_8)
+            );
+
+            msg.putUserProperty("__SYS_FLAG__", "SWITCH");
+            msg.putUserProperty("BROKER_NAME", this.brokerConfig.getBrokerName());
+
+            SendResult sendResult = producer.send(msg);
+            LOGGER.info("Sent master change event: {}", sendResult);
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to send master change event", e);
+        } finally {
+            producer.shutdown();
+        }
+    }
+
     public void changeToMaster(final int newMasterEpoch, final int syncStateSetEpoch, final Set<Long> syncStateSet) throws Exception {
         synchronized (this) {
             if (newMasterEpoch > this.masterEpoch) {
@@ -260,6 +305,7 @@ public class ReplicasManager {
 
                 // Notify ha service, change to master
                 this.haService.changeToMaster(newMasterEpoch);
+                sendRouteChangeEvent(newMasterEpoch);
 
                 this.brokerController.getBrokerConfig().setBrokerId(MixAll.MASTER_ID);
                 this.brokerController.getMessageStoreConfig().setBrokerRole(BrokerRole.SYNC_MASTER);

--- a/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
@@ -266,6 +266,7 @@ public class ReplicasManager {
             eventData.put("brokerId", this.brokerControllerId);
             eventData.put("masterEpoch", newMasterEpoch);
             eventData.put("timestamp", System.currentTimeMillis());
+            eventData.put("affectedTopic", this.brokerController.getTopicConfigManager().getTopicConfigTable().keySet().toArray());
 
             Message msg = new Message(
                 TopicValidator.RMQ_ROUTE_EVENT_TOPIC,

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -223,6 +223,16 @@ public class TopicConfigManager extends ConfigManager {
                 this.topicConfigTable.put(topicConfig.getTopicName(), topicConfig);
             }
         }
+
+        {
+            // TopicValidator.RMQ_ROUTE_EVENT_TOPIC
+            String topic = TopicValidator.RMQ_ROUTE_EVENT_TOPIC;
+            TopicConfig topicConfig = new TopicConfig(topic);
+            TopicValidator.addSystemTopic(topic);
+            topicConfig.setReadQueueNums(1);
+            topicConfig.setWriteQueueNums(1);
+            putTopicConfig(topicConfig);
+        }
     }
 
     public TopicConfig putTopicConfig(TopicConfig topicConfig) {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
@@ -86,6 +86,10 @@ public class ClientRemotingProcessor implements NettyRequestProcessor {
 
             case RequestCode.PUSH_REPLY_MESSAGE_TO_CLIENT:
                 return this.receiveReplyMessage(ctx, request);
+
+            case RequestCode.ROUTE_EVENT:
+                return this.processRouteEventNotify(request, ctx);
+
             default:
                 break;
         }
@@ -292,4 +296,11 @@ public class ClientRemotingProcessor implements NettyRequestProcessor {
                 correlationId, bornHost);
         }
     }
+
+    private RemotingCommand processRouteEventNotify(RemotingCommand request, ChannelHandlerContext ctx) {
+        this.mqClientFactory.updateTopicRouteInfoFromNameServer();
+        return RemotingCommand.createResponseCommand(null);
+
+    }
+
 }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -322,6 +322,8 @@ public class MQClientAPIImpl implements NameServerUpdateCallback, StartAndShutdo
         this.remotingClient.registerProcessor(RequestCode.CONSUME_MESSAGE_DIRECTLY, this.clientRemotingProcessor, null);
 
         this.remotingClient.registerProcessor(RequestCode.PUSH_REPLY_MESSAGE_TO_CLIENT, this.clientRemotingProcessor, null);
+
+        this.remotingClient.registerProcessor(RequestCode.ROUTE_EVENT, this.clientRemotingProcessor, null);
     }
 
     public List<String> getNameServerAddressList() {

--- a/common/src/main/java/org/apache/rocketmq/common/topic/TopicValidator.java
+++ b/common/src/main/java/org/apache/rocketmq/common/topic/TopicValidator.java
@@ -32,6 +32,7 @@ public class TopicValidator {
     public static final String RMQ_SYS_SELF_TEST_TOPIC = "SELF_TEST_TOPIC";
     public static final String RMQ_SYS_OFFSET_MOVED_EVENT = "OFFSET_MOVED_EVENT";
     public static final String RMQ_SYS_ROCKSDB_OFFSET_TOPIC = "CHECKPOINT_TOPIC";
+    public static final String RMQ_ROUTE_EVENT_TOPIC = "ROUTE_EVENT_TOPIC";
 
     public static final String SYSTEM_TOPIC_PREFIX = "rmq_sys_";
     public static final String SYNC_BROKER_MEMBER_GROUP_PREFIX = SYSTEM_TOPIC_PREFIX + "SYNC_BROKER_MEMBER_";
@@ -57,6 +58,7 @@ public class TopicValidator {
         SYSTEM_TOPIC_SET.add(RMQ_SYS_SELF_TEST_TOPIC);
         SYSTEM_TOPIC_SET.add(RMQ_SYS_OFFSET_MOVED_EVENT);
         SYSTEM_TOPIC_SET.add(RMQ_SYS_ROCKSDB_OFFSET_TOPIC);
+        SYSTEM_TOPIC_SET.add(RMQ_ROUTE_EVENT_TOPIC);
 
         NOT_ALLOWED_SEND_TOPIC_SET.add(RMQ_SYS_SCHEDULE_TOPIC);
         NOT_ALLOWED_SEND_TOPIC_SET.add(RMQ_SYS_TRANS_HALF_TOPIC);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/ClusterTopicRouteService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/ClusterTopicRouteService.java
@@ -24,9 +24,14 @@ import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 
 public class ClusterTopicRouteService extends TopicRouteService {
+    private final RouteEventSubscriber eventSubscriber;
 
     public ClusterTopicRouteService(MQClientAPIFactory mqClientAPIFactory) {
         super(mqClientAPIFactory);
+
+        this.eventSubscriber = new RouteEventSubscriber(topic -> {
+            markCacheDirty(topic);
+        });
     }
 
     @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/RouteEventSubscriber.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/RouteEventSubscriber.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.route;
+
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.topic.TopicValidator;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+
+import com.alibaba.fastjson2.JSON;
+
+public class RouteEventSubscriber {
+    private final Consumer<String> dirtyMarker;
+    private final DefaultMQPushConsumer consumer;
+
+    public RouteEventSubscriber(Consumer<String> dirtyMarker) {
+        this.dirtyMarker = dirtyMarker;
+        this.consumer = createSimplifiedConsumer();
+        startListening();
+    }
+
+    private DefaultMQPushConsumer createSimplifiedConsumer() {
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer(
+            "ProxyRouteSubGroup_" + ManagementFactory.getRuntimeMXBean().getName()
+        );
+
+        consumer.setNamesrvAddr(config.getNamesrvAddr());
+        consumer.setPullBatchSize(10);
+        consumer.setConsumeThreadMin(1);
+        consumer.setConsumeThreadMax(1);
+
+        return consumer;
+    }
+
+    private void startListening() {
+        try {
+            consumer.subscribe(TopicValidator.RMQ_ROUTE_EVENT_TOPIC, "*");
+
+            consumer.registerMessageListener((MessageListenerConcurrently) (msgs, context) -> {
+                processMessages(msgs);
+                return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+            });
+
+            consumer.start();
+        } catch (MQClientException e) {
+        }
+    }
+
+    private void processMessages(List<MessageExt> msgs) {
+        for (MessageExt msg : msgs) {
+            try {
+                String json = new String(msg.getBody(), StandardCharsets.UTF_8);
+                Map<String, Object> event = JSON.parseObject(json, Map.class);
+
+                Object[] topics = (Object[]) event.get("affectedTopic");
+                for (Object topicObj : topics) {
+                    String topic = (String) topicObj;
+                    dirtyMarker.accept(topic);
+                }
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    public void shutdown() {
+        consumer.shutdown();
+    }
+}

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/RemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/RemotingServer.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.remoting;
 
 import io.netty.channel.Channel;
+
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import org.apache.rocketmq.common.Pair;
 import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
@@ -35,6 +37,8 @@ public interface RemotingServer extends RemotingService {
     int localListenPort();
 
     Pair<NettyRequestProcessor, ExecutorService> getProcessorPair(final int requestCode);
+
+    Set<Channel> getActiveChannels();
 
     Pair<NettyRequestProcessor, ExecutorService> getDefaultProcessorPair();
 

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -79,8 +79,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
@@ -105,6 +108,10 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
     private final HashedWheelTimer timer = new HashedWheelTimer(r -> new Thread(r, "ServerHouseKeepingService"));
 
     private DefaultEventExecutorGroup defaultEventExecutorGroup;
+
+    private final Set<Channel> activeChannels = Collections.newSetFromMap(
+        new ConcurrentHashMap<Channel, Boolean>()
+    );
 
     /**
      * NettyRemotingServer may hold multiple SubRemotingServer, each server will be stored in this container with a
@@ -413,6 +420,11 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         return this.publicExecutor;
     }
 
+    @Override
+    public Set<Channel> getActiveChannels() {
+        return new HashSet<>(activeChannels);
+    }
+
     private void printRemotingCodeDistribution() {
         if (distributionHandler != null) {
             String inBoundSnapshotString = distributionHandler.getInBoundSnapshotString();
@@ -594,6 +606,8 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             log.info("NETTY SERVER PIPELINE: channelActive, the channel[{}]", remoteAddress);
             super.channelActive(ctx);
 
+            NettyRemotingServer.this.activeChannels.add(ctx.channel());
+
             if (NettyRemotingServer.this.channelEventListener != null) {
                 NettyRemotingServer.this.putNettyEvent(new NettyEvent(NettyEventType.CONNECT, remoteAddress, ctx.channel()));
             }
@@ -604,6 +618,8 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             final String remoteAddress = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
             log.info("NETTY SERVER PIPELINE: channelInactive, the channel[{}]", remoteAddress);
             super.channelInactive(ctx);
+
+            NettyRemotingServer.this.activeChannels.remove(ctx.channel());
 
             if (NettyRemotingServer.this.channelEventListener != null) {
                 NettyRemotingServer.this.putNettyEvent(new NettyEvent(NettyEventType.CLOSE, remoteAddress, ctx.channel()));
@@ -681,6 +697,11 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         @Override
         public Pair<NettyRequestProcessor, ExecutorService> getProcessorPair(final int requestCode) {
             return this.processorTable.get(requestCode);
+        }
+
+        @Override
+        public Set<Channel> getActiveChannels() {
+            return null;
         }
 
         @Override

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
@@ -51,6 +51,8 @@ public class RequestCode {
 
     public static final int HEART_BEAT = 34;
 
+    public static final int ROUTE_EVENT = 299;
+
     public static final int UNREGISTER_CLIENT = 35;
 
     public static final int CONSUMER_SEND_MSG_BACK = 36;


### PR DESCRIPTION
The ​​route update mechanism in RocketMQ​​ currently relies on a periodic polling approach by Clients and Proxy. This passive update mechanism causes some issues during route events (e.g., master/slave switch, Broker shutdown):
1. Clients persistently ​​use outdated routing information​​, leading to write failures when sending requests to deactivated Brokers
2. Connections to destroyed IP addresses result in ​​complete communication breakdown​​
3. New resources cannot be promptly utilized for ​​load balancing​​
Fundamentally, operations during polling intervals rely on ​​incorrect routing decisions​​, compromising service high availability.

To address this, I would like to start an email thread to discuss the ​​RIP-79 Route Change Notification​​, reconstructing the route synchronization mechanism to achieve ​​event-driven route state synchronization​​.

The redesigned architecture can resolves ​​untimely route updates​​: Clients no longer connect to invalid nodes, ​​eliminating service interruptions​​ during master/slave switches, and new resources can be ​​immediately discovered and leveraged​​. Additionally, ​​redundant query pressure​​ on NameServer is reduced through merged update requests and a lazy update policy.

Relevant work is already in progress. Proposal documentation is available here:
https://docs.google.com/document/d/1iMQQ0wDO4dULGpjsKyq6kCbcsUL0JjNcii-KbM90a18/edit?usp=sharing