### PR TITLE
[ISSUE #9555 ]fix the npe in the hashCode method when subscriptionDataSet is null

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/subscription/SubscriptionGroupConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/subscription/SubscriptionGroupConfig.java
@@ -190,7 +190,7 @@ public class SubscriptionGroupConfig {
             prime * result + (int) (whichBrokerWhenConsumeSlowly ^ (whichBrokerWhenConsumeSlowly >>> 32));
         result = prime * result + groupSysFlag;
         result = prime * result + consumeTimeoutMinute;
-        result = prime * result + subscriptionDataSet.hashCode();
+        result = prime * result + ((subscriptionDataSet == null) ? 0 : subscriptionDataSet.hashCode());
         result = prime * result + attributes.hashCode();
         return result;
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes https://github.com/apache/rocketmq/issues/9555

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
