### PR TITLE
[ISSUE #9587]Optimize the process of starting recovery and update checkpoint

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -768,6 +768,11 @@ public class CommitLog implements Swappable {
                             byteBuffer = mappedFile.sliceByteBuffer();
                             processOffset = mappedFile.getFileFromOffset();
                             mappedFileOffset = 0;
+                            // do not wait to all mapped files process done, so we can process continue for next restart
+                            if (!this.defaultMessageStore.getBrokerConfig().isEnableControllerMode()) {
+                                this.setConfirmOffset(lastValidMsgPhyOffset);
+                                this.defaultMessageStore.getStoreCheckpoint().flush();
+                            }
                             log.info("recover next physics file, " + mappedFile.getFileName());
                         }
                     }


### PR DESCRIPTION
… checkpoint when not in controller mode

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9587

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Currently, during a recovery, especially an abnormal recovery, multiple commitlog files are scanned. If there are many commitlogs,

During this scan, it seems that checkpoints are not flushed. This can cause problems in a container environment where, if health check execution is not completed within the health check time, restarting the container will require another checkpoint, resulting in startup failures. In this case, you need to manually adjust the health check interval.

It is reasonable to flush the progress during recovery as well. This allows the container to continue without having to start over.


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

just review the code