### PR TITLE
[ISSUE #9341]: Fix Namespace v2 not taking effect

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -427,6 +427,7 @@ public class ClientConfig {
 
     public void setNamespaceV2(String namespaceV2) {
         this.namespaceV2 = namespaceV2;
+        this.namespace = namespaceV2;
     }
 
     public AccessChannel getAccessChannel() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9341 

Currently, namespace v2 is not actually taking effect for the RocketMQ broker, which has caused some confusion among users as shown below:
https://github.com/apache/rocketmq-spring/issues/722
#9341

Therefore, for the sake of backward compatibility, it is advisable to set the namespace field—despite it being marked as deprecated—to avoid confusing users.


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
1、setNamespaceV2.
2、produce some messages for `Topic A` under `namespace A `.
3、consumer from the some `Topic A` under `namespace B`.
4、No message received from consumer.
