### PR TITLE
[ISSUE #9630] Fixed Remoting client port, not gRPC port

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/LocalTopicRouteService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/LocalTopicRouteService.java
@@ -61,7 +61,12 @@ public class LocalTopicRouteService extends TopicRouteService {
         String topicName) throws Exception {
         MessageQueueView messageQueueView = getAllMessageQueueView(ctx, topicName);
         TopicRouteData topicRouteData = messageQueueView.getTopicRouteData();
-        return new ProxyTopicRouteData(topicRouteData, grpcPort);
+        
+        if (requestHostAndPortList != null && !requestHostAndPortList.isEmpty()) {
+            return new ProxyTopicRouteData(topicRouteData, requestHostAndPortList);
+        } else {
+            return new ProxyTopicRouteData(topicRouteData, grpcPort);
+        }
     }
 
     @Override

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/LocalTopicRouteServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/LocalTopicRouteServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.proxy.service.route;
 
 import com.google.common.net.HostAndPort;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.broker.BrokerController;
@@ -100,6 +101,24 @@ public class LocalTopicRouteServiceTest extends BaseServiceTest {
             Lists.newArrayList(new Address(Address.AddressScheme.IPv4, HostAndPort.fromParts(
                 HostAndPort.fromString(BROKER_ADDR).getHost(),
                 ConfigurationManager.getProxyConfig().getGrpcServerPort()))),
+            proxyTopicRouteData.getBrokerDatas().get(0).getBrokerAddrs().get(MixAll.MASTER_ID));
+    }
+
+    @Test
+    public void testGetTopicRouteForProxyWithRemotingClient() throws Throwable {
+        ProxyContext ctx = ProxyContext.create();
+        
+        List<Address> remotingAddressList = Lists.newArrayList(
+            new Address(Address.AddressScheme.IPv4, HostAndPort.fromParts(
+                HostAndPort.fromString(BROKER_ADDR).getHost(),
+                ConfigurationManager.getProxyConfig().getRemotingListenPort()))
+        );
+        
+        ProxyTopicRouteData proxyTopicRouteData = this.topicRouteService.getTopicRouteForProxy(ctx, remotingAddressList, TOPIC);
+
+        assertEquals(1, proxyTopicRouteData.getBrokerDatas().size());
+        assertEquals(
+            remotingAddressList,
             proxyTopicRouteData.getBrokerDatas().get(0).getBrokerAddrs().get(MixAll.MASTER_ID));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes


<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id
Fix #9630 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
The LocalTopicRouteService.getTopicRouteForProxy() method always uses the grpcPort to create the ProxyTopicRouteData.
However, the Remoting client should receive the Remoting port, not the gRPC port.

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
