### PR TITLE
[ISSUE-9632] Fix: Pop Long-polling Not Awakened for V1 Retry Messages

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLongPollingService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLongPollingService.java
@@ -163,15 +163,12 @@ public class PopLongPollingService extends ServiceThread {
         Long tagsCode, long msgStoreTime, byte[] filterBitMap, Map<String, String> properties) {
         String prefix = MixAll.RETRY_GROUP_TOPIC_PREFIX;
         if (topic.startsWith(prefix)) {
-            // 从properties获取原始topic名称
             String originTopic = properties.get(MessageConst.PROPERTY_ORIGIN_TOPIC);
-            //根据原始topic和retryTopic，最后获得retryTopic对应的cid (可能还可以与topicCidMap验证一下)
-            String suffix = "_" + originTopic; //这里把下划线换成加号也是一样的
+            String suffix = "_" + originTopic;
             String cid = topic.substring(prefix.length(), topic.length() - suffix.length());
             POP_LOGGER.info("Processing retry topic: {}, originTopic: {}, properties: {}",
-                    topic, originTopic, properties); //grep "Processing retry topic" ~/logs/rocketmqlogs/pop.log可以看到日志
+                    topic, originTopic, properties);
             POP_LOGGER.info("Extracted cid: {} from retry topic: {}", cid, topic);
-            //然后调用包含cid的notifyMessageArriving
             long interval = brokerController.getBrokerConfig().getPopLongPollingForceNotifyInterval();
             boolean force = interval > 0L && offset % interval == 0L;
             if (queueId >= 0) {
@@ -179,10 +176,10 @@ public class PopLongPollingService extends ServiceThread {
             }
             notifyMessageArriving(originTopic, queueId, cid, force, tagsCode, msgStoreTime, filterBitMap, properties);
         } else {
-            //普通消息（非重试消息）还是走之前的逻辑不变
             notifyMessageArriving(topic, queueId, offset, tagsCode, msgStoreTime, filterBitMap, properties);
         }
     }
+    
     public void notifyMessageArriving(final String topic, final int queueId, long offset,
         Long tagsCode, long msgStoreTime, byte[] filterBitMap, Map<String, String> properties) {
         ConcurrentHashMap<String, Byte> cids = topicCidMap.get(topic);

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -129,6 +129,7 @@ public class PopReviveService extends ServiceThread {
         if (messageExt.getReconsumeTimes() == 0 || msgInner.getProperties().get(MessageConst.PROPERTY_FIRST_POP_TIME) == null) {
             msgInner.getProperties().put(MessageConst.PROPERTY_FIRST_POP_TIME, String.valueOf(popCheckPoint.getPopTime()));
         }
+        msgInner.getProperties().computeIfAbsent(MessageConst.PROPERTY_ORIGIN_TOPIC, k -> popCheckPoint.getTopic());
         msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgInner.getProperties()));
         addRetryTopicIfNotExist(msgInner.getTopic(), popCheckPoint.getCId());
         PutMessageResult putMessageResult = brokerController.getEscapeBridge().putMessageToSpecificQueue(msgInner);

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java
@@ -24,6 +24,7 @@ public class MessageConst {
     public static final String PROPERTY_WAIT_STORE_MSG_OK = "WAIT";
     public static final String PROPERTY_DELAY_TIME_LEVEL = "DELAY";
     public static final String PROPERTY_RETRY_TOPIC = "RETRY_TOPIC";
+    public static final String PROPERTY_ORIGIN_TOPIC = "ORIGIN_TOPIC"; //Distinct for retry topic
     public static final String PROPERTY_REAL_TOPIC = "REAL_TOPIC";
     public static final String PROPERTY_REAL_QUEUE_ID = "REAL_QID";
     public static final String PROPERTY_TRANSACTION_PREPARED = "TRAN_MSG";
@@ -113,6 +114,7 @@ public class MessageConst {
         STRING_HASH_SET.add(PROPERTY_WAIT_STORE_MSG_OK);
         STRING_HASH_SET.add(PROPERTY_DELAY_TIME_LEVEL);
         STRING_HASH_SET.add(PROPERTY_RETRY_TOPIC);
+        STRING_HASH_SET.add(PROPERTY_ORIGIN_TOPIC);
         STRING_HASH_SET.add(PROPERTY_REAL_TOPIC);
         STRING_HASH_SET.add(PROPERTY_REAL_QUEUE_ID);
         STRING_HASH_SET.add(PROPERTY_TRANSACTION_PREPARED);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes
https://github.com/apache/rocketmq/issues/9632
<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9632

### Brief Description
1. topicCidMap是PopLongPollingService的一个核心数据结构，存储Topic下的消费者组映射，由两层map构成，内层map存储的key就是消费者组ID (ConsumerGroup/CID)，在polling方法中被赋值。
2. 借助这个数据结构，我设计了反向查找机制，避免了字符串解析的歧义问题
  a. 通过遍历topicCidMap中的所有topic-consumerGroup组合
  b. 对每个组合重建V1重试Topic名称，与输入的重试Topic进行匹配
3. 当发现多个原始Topic都能生成相同的重试Topic时，标记为hasDuplicatedTopic
  a. 在有歧义的情况下，返回原始的重试Topic名称，避免错误的消息路由，不会因为Topic命名冲突导致消息通知错误（虽然如果有冲突，错误一定会发生的，但不会因为这段代码的修改引起）

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
