### PR TITLE
[ISSUE #9654] Optimize the bufferLocal size of the TimerMessageStore

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -74,6 +74,7 @@ public class MessageStoreConfig {
     private int timerFlushIntervalMs = 1000;
     private int timerGetMessageThreadNum = 3;
     private int timerPutMessageThreadNum = 3;
+    private int timerMessageBufferSize = 512;
 
     private boolean timerEnableDisruptor = false;
 
@@ -1669,6 +1670,14 @@ public class MessageStoreConfig {
 
     public void setTimerPutMessageThreadNum(int timerPutMessageThreadNum) {
         this.timerPutMessageThreadNum = timerPutMessageThreadNum;
+    }
+
+    public int getTimerMessageBufferSize() {
+        return timerMessageBufferSize;
+    }
+
+    public void setTimerMessageBufferSize(int timerMessageBufferSize) {
+        this.timerMessageBufferSize = timerMessageBufferSize;
     }
 
     public boolean isTimerEnableDisruptor() {

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -74,7 +74,6 @@ public class MessageStoreConfig {
     private int timerFlushIntervalMs = 1000;
     private int timerGetMessageThreadNum = 3;
     private int timerPutMessageThreadNum = 3;
-    private int timerMessageBufferSize = 512;
 
     private boolean timerEnableDisruptor = false;
 
@@ -1670,14 +1669,6 @@ public class MessageStoreConfig {
 
     public void setTimerPutMessageThreadNum(int timerPutMessageThreadNum) {
         this.timerPutMessageThreadNum = timerPutMessageThreadNum;
-    }
-
-    public int getTimerMessageBufferSize() {
-        return timerMessageBufferSize;
-    }
-
-    public void setTimerMessageBufferSize(int timerMessageBufferSize) {
-        this.timerMessageBufferSize = timerMessageBufferSize;
     }
 
     public boolean isTimerEnableDisruptor() {

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -198,7 +198,7 @@ public class TimerMessageStore {
         bufferLocal = new ThreadLocal<ByteBuffer>() {
             @Override
             protected ByteBuffer initialValue() {
-                return ByteBuffer.allocateDirect(storeConfig.getMaxMessageSize() + 100);
+                return ByteBuffer.allocateDirect(storeConfig.getMaxMessageSize() + storeConfig.getTimerMessageBufferSize());
             }
         };
 

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -198,7 +198,10 @@ public class TimerMessageStore {
         bufferLocal = new ThreadLocal<ByteBuffer>() {
             @Override
             protected ByteBuffer initialValue() {
-                return ByteBuffer.allocateDirect(storeConfig.getMaxMessageSize() + storeConfig.getTimerMessageBufferSize());
+                int maxMessageBodySize = storeConfig.getMaxMessageSize();
+                int maxMessageSize = Integer.MAX_VALUE - maxMessageBodySize >= 64 * 1024 ?
+                        maxMessageBodySize + 64 * 1024 : Integer.MAX_VALUE;
+                return ByteBuffer.allocateDirect(maxMessageSize);
             }
         };
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9654 

### Brief Description
There is a variable called bufferLocal in TimerMessageStore, which is used to store a single message from the commitlog. The initial size of bufferLocal is currently set to maxMessageSize plus 100 bytes. Since some properties may be added during the intermediate stages of scheduled messages, the maximum message size can exceed maxMessageSize. Although an extra 100 bytes is reserved during initialization, in some scenarios this is not sufficient, resulting in message read failures and subsequently blocking the entire scheduled message process.


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
