### PR TITLE
[ISSUE #9680] Improve RocksDB compaction filter factory resource management

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/ConsumeQueueCompactionFilterFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/ConsumeQueueCompactionFilterFactory.java
@@ -16,20 +16,20 @@
  */
 package org.apache.rocketmq.store.rocksdb;
 
+import java.util.function.LongSupplier;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
-import org.apache.rocketmq.store.MessageStore;
 import org.rocksdb.AbstractCompactionFilter;
 import org.rocksdb.AbstractCompactionFilterFactory;
 import org.rocksdb.RemoveConsumeQueueCompactionFilter;
 
 public class ConsumeQueueCompactionFilterFactory extends AbstractCompactionFilterFactory<RemoveConsumeQueueCompactionFilter> {
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggerName.ROCKSDB_LOGGER_NAME);
-    private final MessageStore messageStore;
+    private final LongSupplier minPhyOffsetSupplier;
 
-    public ConsumeQueueCompactionFilterFactory(final MessageStore messageStore) {
-        this.messageStore = messageStore;
+    public ConsumeQueueCompactionFilterFactory(final LongSupplier minPhyOffsetSupplier) {
+        this.minPhyOffsetSupplier = minPhyOffsetSupplier;
     }
 
     @Override
@@ -39,7 +39,7 @@ public class ConsumeQueueCompactionFilterFactory extends AbstractCompactionFilte
 
     @Override
     public RemoveConsumeQueueCompactionFilter createCompactionFilter(final AbstractCompactionFilter.Context context) {
-        long minPhyOffset = this.messageStore.getMinPhyOffset();
+        long minPhyOffset = this.minPhyOffsetSupplier.getAsLong();
         LOGGER.info("manualCompaction minPhyOffset: {}, isFull: {}, isManual: {}",
                 minPhyOffset, context.isFullCompaction(), context.isManualCompaction());
         return new RemoveConsumeQueueCompactionFilter(minPhyOffset);

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
@@ -44,15 +44,15 @@ public class RocksDBOptionsFactory {
     public static ColumnFamilyOptions createCQCFOptions(final MessageStore messageStore,
         ConsumeQueueCompactionFilterFactory consumeQueueCompactionFilterFactory) {
         BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig().
-            setFormatVersion(5).
-            setIndexType(IndexType.kBinarySearch).
-            setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash).
-            setDataBlockHashTableUtilRatio(0.75).
-            setBlockSize(32 * SizeUnit.KB).
-            setMetadataBlockSize(4 * SizeUnit.KB).
-            setFilterPolicy(new BloomFilter(16, false)).
-            setCacheIndexAndFilterBlocks(false).
-            setCacheIndexAndFilterBlocksWithHighPriority(true).
+                setFormatVersion(5).
+                setIndexType(IndexType.kBinarySearch).
+                setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash).
+                setDataBlockHashTableUtilRatio(0.75).
+                setBlockSize(32 * SizeUnit.KB).
+                setMetadataBlockSize(4 * SizeUnit.KB).
+                setFilterPolicy(new BloomFilter(16, false)).
+                setCacheIndexAndFilterBlocks(false).
+                setCacheIndexAndFilterBlocksWithHighPriority(true).
                 setPinL0FilterAndIndexBlocksInCache(false).
                 setPinTopLevelIndexAndFilter(true).
                 setBlockCache(new LRUCache(1024 * SizeUnit.MB, 8, false)).
@@ -73,9 +73,8 @@ public class RocksDBOptionsFactory {
             .getRocksdbCompressionType();
         CompressionType bottomMostCompressionType = CompressionType.getCompressionType(bottomMostCompressionTypeOpt);
         CompressionType compressionType = CompressionType.getCompressionType(compressionTypeOpt);
-
         return columnFamilyOptions.setMaxWriteBufferNumber(4).
-                setWriteBufferSize(32 * SizeUnit.MB).  // speed up cq rocksdb open test
+                setWriteBufferSize(128 * SizeUnit.MB).
                 setMinWriteBufferNumberToMerge(1).
                 setTableFormatConfig(blockBasedTableConfig).
                 setMemTableConfig(new SkipListMemTableConfig()).
@@ -84,20 +83,19 @@ public class RocksDBOptionsFactory {
                 setNumLevels(7).
                 setCompactionPriority(CompactionPriority.MinOverlappingRatio).
                 setCompactionStyle(CompactionStyle.UNIVERSAL).
-            setCompactionOptionsUniversal(compactionOption).
-            setMaxCompactionBytes(100 * SizeUnit.GB).
-            setSoftPendingCompactionBytesLimit(100 * SizeUnit.GB).
-            setHardPendingCompactionBytesLimit(256 * SizeUnit.GB).
-            setLevel0FileNumCompactionTrigger(2).
-            setLevel0SlowdownWritesTrigger(8).
-            setLevel0StopWritesTrigger(10).
-            setTargetFileSizeBase(256 * SizeUnit.MB).
-            setTargetFileSizeMultiplier(2).
-            setMergeOperator(new StringAppendOperator()).
-            setCompactionFilterFactory(consumeQueueCompactionFilterFactory).
-            setReportBgIoStats(true).
+                setCompactionOptionsUniversal(compactionOption).
+                setMaxCompactionBytes(100 * SizeUnit.GB).
+                setSoftPendingCompactionBytesLimit(100 * SizeUnit.GB).
+                setHardPendingCompactionBytesLimit(256 * SizeUnit.GB).
+                setLevel0FileNumCompactionTrigger(2).
+                setLevel0SlowdownWritesTrigger(8).
+                setLevel0StopWritesTrigger(10).
+                setTargetFileSizeBase(256 * SizeUnit.MB).
+                setTargetFileSizeMultiplier(2).
+                setMergeOperator(new StringAppendOperator()).
+                setCompactionFilterFactory(new ConsumeQueueCompactionFilterFactory(messageStore::getMinPhyOffset)).
+                setReportBgIoStats(true).
                 setOptimizeFiltersForHits(true);
-
     }
 
     public static ColumnFamilyOptions createOffsetCFOptions() {

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
@@ -41,17 +41,18 @@ import org.rocksdb.util.SizeUnit;
 
 public class RocksDBOptionsFactory {
 
-    public static ColumnFamilyOptions createCQCFOptions(final MessageStore messageStore) {
+    public static ColumnFamilyOptions createCQCFOptions(final MessageStore messageStore,
+        ConsumeQueueCompactionFilterFactory consumeQueueCompactionFilterFactory) {
         BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig().
-                setFormatVersion(5).
-                setIndexType(IndexType.kBinarySearch).
-                setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash).
-                setDataBlockHashTableUtilRatio(0.75).
-                setBlockSize(32 * SizeUnit.KB).
-                setMetadataBlockSize(4 * SizeUnit.KB).
-                setFilterPolicy(new BloomFilter(16, false)).
-                setCacheIndexAndFilterBlocks(false).
-                setCacheIndexAndFilterBlocksWithHighPriority(true).
+            setFormatVersion(5).
+            setIndexType(IndexType.kBinarySearch).
+            setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash).
+            setDataBlockHashTableUtilRatio(0.75).
+            setBlockSize(32 * SizeUnit.KB).
+            setMetadataBlockSize(4 * SizeUnit.KB).
+            setFilterPolicy(new BloomFilter(16, false)).
+            setCacheIndexAndFilterBlocks(false).
+            setCacheIndexAndFilterBlocksWithHighPriority(true).
                 setPinL0FilterAndIndexBlocksInCache(false).
                 setPinTopLevelIndexAndFilter(true).
                 setBlockCache(new LRUCache(1024 * SizeUnit.MB, 8, false)).
@@ -72,8 +73,9 @@ public class RocksDBOptionsFactory {
             .getRocksdbCompressionType();
         CompressionType bottomMostCompressionType = CompressionType.getCompressionType(bottomMostCompressionTypeOpt);
         CompressionType compressionType = CompressionType.getCompressionType(compressionTypeOpt);
+
         return columnFamilyOptions.setMaxWriteBufferNumber(4).
-                setWriteBufferSize(128 * SizeUnit.MB).
+                setWriteBufferSize(32 * SizeUnit.MB).  // speed up cq rocksdb open test
                 setMinWriteBufferNumberToMerge(1).
                 setTableFormatConfig(blockBasedTableConfig).
                 setMemTableConfig(new SkipListMemTableConfig()).
@@ -82,19 +84,20 @@ public class RocksDBOptionsFactory {
                 setNumLevels(7).
                 setCompactionPriority(CompactionPriority.MinOverlappingRatio).
                 setCompactionStyle(CompactionStyle.UNIVERSAL).
-                setCompactionOptionsUniversal(compactionOption).
-                setMaxCompactionBytes(100 * SizeUnit.GB).
-                setSoftPendingCompactionBytesLimit(100 * SizeUnit.GB).
-                setHardPendingCompactionBytesLimit(256 * SizeUnit.GB).
-                setLevel0FileNumCompactionTrigger(2).
-                setLevel0SlowdownWritesTrigger(8).
-                setLevel0StopWritesTrigger(10).
-                setTargetFileSizeBase(256 * SizeUnit.MB).
-                setTargetFileSizeMultiplier(2).
-                setMergeOperator(new StringAppendOperator()).
-                setCompactionFilterFactory(new ConsumeQueueCompactionFilterFactory(messageStore)).
-                setReportBgIoStats(true).
+            setCompactionOptionsUniversal(compactionOption).
+            setMaxCompactionBytes(100 * SizeUnit.GB).
+            setSoftPendingCompactionBytesLimit(100 * SizeUnit.GB).
+            setHardPendingCompactionBytesLimit(256 * SizeUnit.GB).
+            setLevel0FileNumCompactionTrigger(2).
+            setLevel0SlowdownWritesTrigger(8).
+            setLevel0StopWritesTrigger(10).
+            setTargetFileSizeBase(256 * SizeUnit.MB).
+            setTargetFileSizeMultiplier(2).
+            setMergeOperator(new StringAppendOperator()).
+            setCompactionFilterFactory(consumeQueueCompactionFilterFactory).
+            setReportBgIoStats(true).
                 setOptimizeFiltersForHits(true);
+
     }
 
     public static ColumnFamilyOptions createOffsetCFOptions() {

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
@@ -93,7 +93,7 @@ public class RocksDBOptionsFactory {
                 setTargetFileSizeBase(256 * SizeUnit.MB).
                 setTargetFileSizeMultiplier(2).
                 setMergeOperator(new StringAppendOperator()).
-                setCompactionFilterFactory(new ConsumeQueueCompactionFilterFactory(messageStore::getMinPhyOffset)).
+                setCompactionFilterFactory(consumeQueueCompactionFilterFactory).
                 setReportBgIoStats(true).
                 setOptimizeFiltersForHits(true);
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9680

### Brief Description

This PR improves RocksDB compaction filter factory resource management to prevent memory leaks and reduce component coupling. The main changes include:

1. **Refactor ConsumeQueueCompactionFilterFactory**: Replace MessageStore dependency with LongSupplier functional interface to reduce coupling and improve testability
2. **Enhanced Resource Management**: Add proper cleanup logic in ConsumeQueueRocksDBStorage.preShutdown() with null-safety checks
3. **Parameter Injection**: Update RocksDBOptionsFactory to accept external compaction filter factory instances instead of creating them internally

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
