### PR TITLE
[ISSUE #9693] Add writeWithoutMmap configuration to prevent JVM crash when device becomes read-only

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
@@ -172,16 +172,17 @@ public class AllocateMappedFileService extends ServiceThread {
                 long beginTime = System.currentTimeMillis();
 
                 MappedFile mappedFile;
+                boolean writeWithoutMmap = messageStore.getMessageStoreConfig().isWriteWithoutMmap();
                 if (messageStore.isTransientStorePoolEnable()) {
                     try {
                         mappedFile = ServiceLoader.load(MappedFile.class).iterator().next();
                         mappedFile.init(req.getFilePath(), req.getFileSize(), messageStore.getTransientStorePool());
                     } catch (RuntimeException e) {
                         log.warn("Use default implementation.");
-                        mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), messageStore.getTransientStorePool());
+                        mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), messageStore.getTransientStorePool(), writeWithoutMmap);
                     }
                 } else {
-                    mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize());
+                    mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), writeWithoutMmap);
                 }
 
                 long elapsedTime = UtilAll.computeElapsedTimeMilliseconds(beginTime);
@@ -195,7 +196,9 @@ public class AllocateMappedFileService extends ServiceThread {
                 if (mappedFile.getFileSize() >= this.messageStore.getMessageStoreConfig()
                     .getMappedFileSizeCommitLog()
                     &&
-                    this.messageStore.getMessageStoreConfig().isWarmMapedFileEnable()) {
+                    this.messageStore.getMessageStoreConfig().isWarmMapedFileEnable()
+                    &&
+                    !this.messageStore.getMessageStoreConfig().isWriteWithoutMmap()) {
                     mappedFile.warmMappedFile(this.messageStore.getMessageStoreConfig().getFlushDiskType(),
                         this.messageStore.getMessageStoreConfig().getFlushLeastPagesWhenWarmMapedFile());
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -118,7 +118,8 @@ public class CommitLog implements Swappable {
         } else {
             this.mappedFileQueue = new MappedFileQueue(storePath,
                 messageStore.getMessageStoreConfig().getMappedFileSizeCommitLog(),
-                messageStore.getAllocateMappedFileService());
+                messageStore.getAllocateMappedFileService(),
+                messageStore.getMessageStoreConfig().isWriteWithoutMmap());
         }
 
         this.defaultMessageStore = messageStore;

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -98,7 +98,8 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
             + File.separator + topic
             + File.separator + queueId;
 
-        this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null);
+        this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, 
+            messageStore.getMessageStoreConfig().isWriteWithoutMmap());
 
         this.byteBufferIndex = ByteBuffer.allocate(CQ_STORE_UNIT_SIZE);
 
@@ -108,7 +109,8 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                 queueId,
                 StorePathConfigHelper.getStorePathConsumeQueueExt(messageStore.getMessageStoreConfig().getStorePathRootDir()),
                 messageStore.getMessageStoreConfig().getMappedFileSizeConsumeQueueExt(),
-                messageStore.getMessageStoreConfig().getBitMapLengthConsumeQueueExt()
+                messageStore.getMessageStoreConfig().getBitMapLengthConsumeQueueExt(),
+                messageStore.getMessageStoreConfig().isWriteWithoutMmap()
             );
         }
     }

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -98,8 +98,12 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
             + File.separator + topic
             + File.separator + queueId;
 
-        this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, 
-            messageStore.getMessageStoreConfig().isWriteWithoutMmap());
+        boolean writeWithoutMmap = false;
+        if (messageStore.getMessageStoreConfig() != null) {
+            writeWithoutMmap = messageStore.getMessageStoreConfig().isWriteWithoutMmap();
+        }
+
+        this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, writeWithoutMmap);
 
         this.byteBufferIndex = ByteBuffer.allocate(CQ_STORE_UNIT_SIZE);
 
@@ -110,7 +114,7 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
                 StorePathConfigHelper.getStorePathConsumeQueueExt(messageStore.getMessageStoreConfig().getStorePathRootDir()),
                 messageStore.getMessageStoreConfig().getMappedFileSizeConsumeQueueExt(),
                 messageStore.getMessageStoreConfig().getBitMapLengthConsumeQueueExt(),
-                messageStore.getMessageStoreConfig().isWriteWithoutMmap()
+                writeWithoutMmap
             );
         }
     }

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueueExt.java
@@ -90,6 +90,42 @@ public class ConsumeQueueExt {
         }
     }
 
+    /**
+     * Constructor with writeWithoutMmap support.
+     *
+     * @param topic topic
+     * @param queueId id of queue
+     * @param storePath root dir of files to store.
+     * @param mappedFileSize file size
+     * @param bitMapLength bit map length.
+     * @param writeWithoutMmap whether to use RandomAccessFile instead of MappedByteBuffer
+     */
+    public ConsumeQueueExt(final String topic,
+        final int queueId,
+        final String storePath,
+        final int mappedFileSize,
+        final int bitMapLength,
+        final boolean writeWithoutMmap) {
+
+        this.storePath = storePath;
+        this.mappedFileSize = mappedFileSize;
+
+        this.topic = topic;
+        this.queueId = queueId;
+
+        String queueDir = this.storePath
+            + File.separator + topic
+            + File.separator + queueId;
+
+        this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, writeWithoutMmap);
+
+        if (bitMapLength > 0) {
+            this.tempContainer = ByteBuffer.allocate(
+                bitMapLength / Byte.SIZE
+            );
+        }
+    }
+
     public long getTotalSize() {
         return this.mappedFileQueue.getTotalFileSize();
     }

--- a/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MappedFileQueue.java
@@ -53,12 +53,25 @@ public class MappedFileQueue implements Swappable {
     protected long committedWhere = 0;
 
     protected volatile long storeTimestamp = 0;
+    
+    /**
+     * Configuration flag to use RandomAccessFile instead of MappedByteBuffer for writing
+     */
+    protected boolean writeWithoutMmap = false;
 
     public MappedFileQueue(final String storePath, int mappedFileSize,
         AllocateMappedFileService allocateMappedFileService) {
         this.storePath = storePath;
         this.mappedFileSize = mappedFileSize;
         this.allocateMappedFileService = allocateMappedFileService;
+    }
+
+    public MappedFileQueue(final String storePath, int mappedFileSize,
+        AllocateMappedFileService allocateMappedFileService, boolean writeWithoutMmap) {
+        this.storePath = storePath;
+        this.mappedFileSize = mappedFileSize;
+        this.allocateMappedFileService = allocateMappedFileService;
+        this.writeWithoutMmap = writeWithoutMmap;
     }
 
     public void checkSelf() {
@@ -266,7 +279,7 @@ public class MappedFileQueue implements Swappable {
             }
 
             try {
-                MappedFile mappedFile = new DefaultMappedFile(file.getPath(), mappedFileSize);
+                MappedFile mappedFile = new DefaultMappedFile(file.getPath(), mappedFileSize, writeWithoutMmap);
 
                 mappedFile.setWrotePosition(this.mappedFileSize);
                 mappedFile.setFlushedPosition(this.mappedFileSize);
@@ -356,7 +369,7 @@ public class MappedFileQueue implements Swappable {
                     nextNextFilePath, this.mappedFileSize);
         } else {
             try {
-                mappedFile = new DefaultMappedFile(nextFilePath, this.mappedFileSize);
+                mappedFile = new DefaultMappedFile(nextFilePath, this.mappedFileSize, this.writeWithoutMmap);
             } catch (IOException e) {
                 log.error("create mappedFile exception", e);
             }

--- a/store/src/main/java/org/apache/rocketmq/store/MultiPathMappedFileQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MultiPathMappedFileQueue.java
@@ -39,7 +39,8 @@ public class MultiPathMappedFileQueue extends MappedFileQueue {
     public MultiPathMappedFileQueue(MessageStoreConfig messageStoreConfig, int mappedFileSize,
                                     AllocateMappedFileService allocateMappedFileService,
                                     Supplier<Set<String>> fullStorePathsSupplier) {
-        super(messageStoreConfig.getStorePathCommitLog(), mappedFileSize, allocateMappedFileService);
+        super(messageStoreConfig.getStorePathCommitLog(), mappedFileSize, allocateMappedFileService, 
+              messageStoreConfig.isWriteWithoutMmap());
         this.config = messageStoreConfig;
         this.fullStorePathsSupplier = fullStorePathsSupplier;
     }

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -238,6 +238,13 @@ public class MessageStoreConfig {
     private int transientStorePoolSize = 5;
     private boolean fastFailIfNoBufferInStorePool = false;
 
+    /**
+     * When true, use RandomAccessFile for writing instead of MappedByteBuffer.
+     * This can be useful for certain scenarios where mmap is not desired.
+     */
+    @ImportantField
+    private boolean writeWithoutMmap = false;
+
     // DLedger message store config
     private boolean enableDLegerCommitLog = false;
     private String dLegerGroup;
@@ -1138,6 +1145,14 @@ public class MessageStoreConfig {
 
     public void setTransientStorePoolEnable(final boolean transientStorePoolEnable) {
         this.transientStorePoolEnable = transientStorePoolEnable;
+    }
+
+    public boolean isWriteWithoutMmap() {
+        return writeWithoutMmap;
+    }
+
+    public void setWriteWithoutMmap(final boolean writeWithoutMmap) {
+        this.writeWithoutMmap = writeWithoutMmap;
     }
 
     public int getTransientStorePoolSize() {

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -107,10 +107,12 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
 
         if (StringUtils.isBlank(subfolder)) {
             String queueDir = this.storePath + File.separator + topic + File.separator + queueId;
-            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null);
+            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, 
+                messageStore.getMessageStoreConfig().isWriteWithoutMmap());
         } else {
             String queueDir = this.storePath + File.separator + topic + File.separator + queueId + File.separator + subfolder;
-            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null);
+            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, 
+                messageStore.getMessageStoreConfig().isWriteWithoutMmap());
         }
 
         this.byteBufferItem = ByteBuffer.allocate(CQ_STORE_UNIT_SIZE);

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -105,14 +105,19 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
         this.topic = topic;
         this.queueId = queueId;
 
+        boolean writeWithoutMmap = false;
+        if (messageStore.getMessageStoreConfig() != null) {
+            writeWithoutMmap = messageStore.getMessageStoreConfig().isWriteWithoutMmap();
+        }
+
         if (StringUtils.isBlank(subfolder)) {
             String queueDir = this.storePath + File.separator + topic + File.separator + queueId;
-            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, 
-                messageStore.getMessageStoreConfig().isWriteWithoutMmap());
+            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null,
+                writeWithoutMmap);
         } else {
             String queueDir = this.storePath + File.separator + topic + File.separator + queueId + File.separator + subfolder;
-            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null, 
-                messageStore.getMessageStoreConfig().isWriteWithoutMmap());
+            this.mappedFileQueue = new MappedFileQueue(queueDir, mappedFileSize, null,
+                writeWithoutMmap);
         }
 
         this.byteBufferItem = ByteBuffer.allocate(CQ_STORE_UNIT_SIZE);

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.logfile;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.common.UtilAll;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultMappedFileConcurrencyTest {
+
+    private String storePath;
+    private String fileName;
+    private int fileSize = 1024 * 1024; // 1MB
+    private static final int THREAD_COUNT = 10;
+    private static final int OPERATIONS_PER_THREAD = 100;
+
+    @Before
+    public void setUp() throws Exception {
+        storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
+        fileName = storePath + File.separator + "00000000000000000000";
+        UtilAll.ensureDirOK(storePath);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        UtilAll.deleteFile(new File(storePath));
+    }
+
+    @Test
+    public void testConcurrentWriteWithoutMmap() throws Exception {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+            CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger errorCount = new AtomicInteger(0);
+            
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                final int threadId = i;
+                executor.submit(() -> {
+                    try {
+                        for (int j = 0; j < OPERATIONS_PER_THREAD; j++) {
+                            String data = String.format("Thread-%d-Operation-%d", threadId, j);
+                            byte[] bytes = data.getBytes();
+                            
+                            boolean result = mappedFile.appendMessage(bytes);
+                            if (result) {
+                                successCount.incrementAndGet();
+                            } else {
+                                errorCount.incrementAndGet();
+                            }
+                        }
+                    } catch (Exception e) {
+                        errorCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            
+            latch.await();
+            executor.shutdown();
+            
+            // Success count: successCount.get()
+            // Error count: errorCount.get()
+            // Final wrote position: mappedFile.getWrotePosition()
+            
+            // All operations should succeed
+            Assert.assertEquals("All write operations should succeed", 
+                THREAD_COUNT * OPERATIONS_PER_THREAD, successCount.get());
+            Assert.assertEquals("No errors should occur", 0, errorCount.get());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testConcurrentWriteWithMmap() throws Exception {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, false);
+        
+        try {
+            ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+            CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger errorCount = new AtomicInteger(0);
+            
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                final int threadId = i;
+                executor.submit(() -> {
+                    try {
+                        for (int j = 0; j < OPERATIONS_PER_THREAD; j++) {
+                            String data = String.format("Thread-%d-Operation-%d", threadId, j);
+                            byte[] bytes = data.getBytes();
+                            
+                            boolean result = mappedFile.appendMessage(bytes);
+                            if (result) {
+                                successCount.incrementAndGet();
+                            } else {
+                                errorCount.incrementAndGet();
+                            }
+                        }
+                    } catch (Exception e) {
+                        errorCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            
+            latch.await();
+            executor.shutdown();
+            
+            // Success count: successCount.get()
+            // Error count: errorCount.get()
+            // Final wrote position: mappedFile.getWrotePosition()
+            
+            // All operations should succeed
+            Assert.assertEquals("All write operations should succeed", 
+                THREAD_COUNT * OPERATIONS_PER_THREAD, successCount.get());
+            Assert.assertEquals("No errors should occur", 0, errorCount.get());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testConcurrentFlush() throws Exception {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Write some data first
+            for (int i = 0; i < 100; i++) {
+                String data = "Test data " + i;
+                mappedFile.appendMessage(data.getBytes());
+            }
+            
+            ExecutorService executor = Executors.newFixedThreadPool(5);
+            CountDownLatch latch = new CountDownLatch(5);
+            AtomicInteger flushCount = new AtomicInteger(0);
+            
+            for (int i = 0; i < 5; i++) {
+                executor.submit(() -> {
+                    try {
+                        int flushed = mappedFile.flush(0);
+                        if (flushed > 0) {
+                            flushCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            
+            latch.await();
+            executor.shutdown();
+            
+            Assert.assertTrue("At least one flush should succeed", flushCount.get() > 0);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+}

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.logfile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.message.MessageExtBrokerInner;
+import org.apache.rocketmq.common.message.MessageExtBatch;
+import org.apache.rocketmq.store.AppendMessageCallback;
+import org.apache.rocketmq.store.AppendMessageResult;
+import org.apache.rocketmq.store.AppendMessageStatus;
+import org.apache.rocketmq.store.CompactionAppendMsgCallback;
+import org.apache.rocketmq.store.PutMessageContext;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultMappedFileErrorHandlingTest {
+
+    private String storePath;
+    private String fileName;
+    private int fileSize = 1024 * 1024; // 1MB
+
+    @Before
+    public void setUp() throws Exception {
+        storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
+        fileName = storePath + File.separator + "00000000000000000000";
+        UtilAll.ensureDirOK(storePath);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        UtilAll.deleteFile(new File(storePath));
+    }
+
+    @Test
+    public void testAppendMessageCallbackErrorHandling() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Test with a callback that returns an error
+            AppendMessageCallback errorCallback = new AppendMessageCallback() {
+                @Override
+                public AppendMessageResult doAppend(long fileFromOffset, ByteBuffer byteBuffer, 
+                    int maxBlank, MessageExtBrokerInner msg, 
+                    PutMessageContext putMessageContext) {
+                    return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
+                }
+                
+                @Override
+                public AppendMessageResult doAppend(long fileFromOffset, ByteBuffer byteBuffer, 
+                    int maxBlank, MessageExtBatch messageExtBatch, 
+                    PutMessageContext putMessageContext) {
+                    return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
+                }
+            };
+            
+            // Create a mock message
+            MessageExtBrokerInner msg = new MessageExtBrokerInner();
+            msg.setBody("test message".getBytes());
+            
+            AppendMessageResult result = mappedFile.appendMessage(msg, errorCallback, new PutMessageContext("test-topic"));
+            
+            Assert.assertEquals("Should return error status", 
+                AppendMessageStatus.UNKNOWN_ERROR, result.getStatus());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testCompactionAppendMsgCallbackErrorHandling() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Test with a callback that returns an error
+            CompactionAppendMsgCallback errorCallback = new CompactionAppendMsgCallback() {
+                @Override
+                public AppendMessageResult doAppend(ByteBuffer bbDest, long fileFromOffset, 
+                    int maxBlank, ByteBuffer bbSrc) {
+                    return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
+                }
+            };
+            
+            ByteBuffer testBuffer = ByteBuffer.wrap("test data".getBytes());
+            AppendMessageResult result = mappedFile.appendMessage(testBuffer, errorCallback);
+            
+            Assert.assertEquals("Should return error status", 
+                AppendMessageStatus.UNKNOWN_ERROR, result.getStatus());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testWriteWithoutMmapWithNullRandomAccessFile() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Simulate the case where randomAccessFile is null
+            // This should fall back to normal behavior
+            byte[] testData = "test data".getBytes();
+            boolean result = mappedFile.appendMessage(testData);
+            
+            // Should still work, but using MappedByteBuffer
+            Assert.assertTrue("Should still work with null RandomAccessFile", result);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testLargeDataWrite() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Test writing data that's close to the file size limit
+            byte[] largeData = new byte[fileSize - 100]; // Leave some space
+            for (int i = 0; i < largeData.length; i++) {
+                largeData[i] = (byte) (i % 256);
+            }
+            
+            boolean result = mappedFile.appendMessage(largeData);
+            Assert.assertTrue("Should successfully write large data", result);
+            Assert.assertEquals("Wrote position should match data size", 
+                largeData.length, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testWriteBeyondFileSize() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Fill the file almost completely
+            byte[] data = new byte[fileSize - 10];
+            boolean result = mappedFile.appendMessage(data);
+            Assert.assertTrue("Should successfully write data", result);
+            
+            // Try to write more data than remaining space
+            byte[] overflowData = new byte[20]; // More than remaining 10 bytes
+            result = mappedFile.appendMessage(overflowData);
+            Assert.assertFalse("Should fail to write beyond file size", result);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testFlushErrorHandling() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Write some data
+            byte[] testData = "test data for flush".getBytes();
+            mappedFile.appendMessage(testData);
+            
+            // Flush should succeed
+            int flushedPosition = mappedFile.flush(0);
+            Assert.assertTrue("Flush should succeed", flushedPosition > 0);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testAppendMessageWithOffset() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            byte[] testData = "Hello, RocketMQ!".getBytes();
+            
+            // Test with valid offset
+            boolean result = mappedFile.appendMessage(testData, 0, testData.length);
+            Assert.assertTrue("Should successfully append with valid offset", result);
+            
+            // Test with invalid offset (beyond array length)
+            result = mappedFile.appendMessage(testData, testData.length + 1, 1);
+            Assert.assertFalse("Should fail with invalid offset", result);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+}

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.logfile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.rocketmq.common.UtilAll;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultMappedFilePerformanceTest {
+
+    private String storePath;
+    private String fileName;
+    private int fileSize = 10 * 1024 * 1024; // 10MB
+    private static final int WRITE_COUNT = 10000;
+    private static final int DATA_SIZE = 1024; // 1KB per write
+
+    @Before
+    public void setUp() throws Exception {
+        storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
+        fileName = storePath + File.separator + "00000000000000000000";
+        UtilAll.ensureDirOK(storePath);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        UtilAll.deleteFile(new File(storePath));
+    }
+
+    @Test
+    public void testWriteWithoutMmapPerformance() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            byte[] testData = new byte[DATA_SIZE];
+            for (int i = 0; i < testData.length; i++) {
+                testData[i] = (byte) (i % 256);
+            }
+            
+            long startTime = System.currentTimeMillis();
+            
+            for (int i = 0; i < WRITE_COUNT; i++) {
+                boolean result = mappedFile.appendMessage(testData);
+                Assert.assertTrue("Write should succeed", result);
+            }
+            
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            
+            // WriteWithoutMmap Performance:
+            //   Writes: WRITE_COUNT
+            //   Data size per write: DATA_SIZE bytes
+            //   Total data: (WRITE_COUNT * DATA_SIZE / 1024) KB
+            //   Duration: duration ms
+            //   Throughput: (WRITE_COUNT * DATA_SIZE / 1024.0 / duration * 1000) KB/s
+            
+            Assert.assertEquals("Wrote position should match expected", 
+                WRITE_COUNT * DATA_SIZE, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testWriteWithMmapPerformance() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, false);
+        
+        try {
+            byte[] testData = new byte[DATA_SIZE];
+            for (int i = 0; i < testData.length; i++) {
+                testData[i] = (byte) (i % 256);
+            }
+            
+            long startTime = System.currentTimeMillis();
+            
+            for (int i = 0; i < WRITE_COUNT; i++) {
+                boolean result = mappedFile.appendMessage(testData);
+                Assert.assertTrue("Write should succeed", result);
+            }
+            
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            
+            // WriteWithMmap Performance:
+            //   Writes: WRITE_COUNT
+            //   Data size per write: DATA_SIZE bytes
+            //   Total data: (WRITE_COUNT * DATA_SIZE / 1024) KB
+            //   Duration: duration ms
+            //   Throughput: (WRITE_COUNT * DATA_SIZE / 1024.0 / duration * 1000) KB/s
+            
+            Assert.assertEquals("Wrote position should match expected", 
+                WRITE_COUNT * DATA_SIZE, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testFlushPerformance() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Write some data first
+            byte[] testData = new byte[DATA_SIZE];
+            for (int i = 0; i < testData.length; i++) {
+                testData[i] = (byte) (i % 256);
+            }
+            
+            for (int i = 0; i < 1000; i++) {
+                mappedFile.appendMessage(testData);
+            }
+            
+            long startTime = System.currentTimeMillis();
+            
+            int flushedPosition = mappedFile.flush(0);
+            
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            
+            // Flush Performance:
+            //   Flushed position: flushedPosition
+            //   Duration: duration ms
+            
+            Assert.assertTrue("Flush should succeed", flushedPosition > 0);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testByteBufferWritePerformance() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            ByteBuffer testBuffer = ByteBuffer.allocate(DATA_SIZE);
+            for (int i = 0; i < DATA_SIZE; i++) {
+                testBuffer.put((byte) (i % 256));
+            }
+            
+            long startTime = System.currentTimeMillis();
+            
+            for (int i = 0; i < WRITE_COUNT; i++) {
+                testBuffer.rewind();
+                boolean result = mappedFile.appendMessage(testBuffer);
+                Assert.assertTrue("Write should succeed", result);
+            }
+            
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            
+            // ByteBuffer Write Performance:
+            //   Writes: WRITE_COUNT
+            //   Data size per write: DATA_SIZE bytes
+            //   Total data: (WRITE_COUNT * DATA_SIZE / 1024) KB
+            //   Duration: duration ms
+            //   Throughput: (WRITE_COUNT * DATA_SIZE / 1024.0 / duration * 1000) KB/s
+            
+            Assert.assertEquals("Wrote position should match expected", 
+                WRITE_COUNT * DATA_SIZE, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testMixedWriteOperations() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            byte[] testData = new byte[DATA_SIZE];
+            for (int i = 0; i < testData.length; i++) {
+                testData[i] = (byte) (i % 256);
+            }
+            
+            long startTime = System.currentTimeMillis();
+            
+            // Mix of different write operations
+            for (int i = 0; i < WRITE_COUNT / 4; i++) {
+                // appendMessage(byte[])
+                boolean result1 = mappedFile.appendMessage(testData);
+                Assert.assertTrue("Write should succeed", result1);
+                
+                // appendMessage(byte[], offset, length)
+                boolean result2 = mappedFile.appendMessage(testData, 0, testData.length);
+                Assert.assertTrue("Write should succeed", result2);
+                
+                // appendMessage(ByteBuffer)
+                ByteBuffer buffer = ByteBuffer.wrap(testData);
+                boolean result3 = mappedFile.appendMessage(buffer);
+                Assert.assertTrue("Write should succeed", result3);
+                
+                // appendMessageUsingFileChannel(byte[])
+                boolean result4 = mappedFile.appendMessageUsingFileChannel(testData);
+                Assert.assertTrue("Write should succeed", result4);
+            }
+            
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            
+            // Mixed Write Operations Performance:
+            //   Total operations: WRITE_COUNT
+            //   Data size per operation: DATA_SIZE bytes
+            //   Total data: (WRITE_COUNT * DATA_SIZE / 1024) KB
+            //   Duration: duration ms
+            //   Throughput: (WRITE_COUNT * DATA_SIZE / 1024.0 / duration * 1000) KB/s
+            
+            Assert.assertEquals("Wrote position should match expected", 
+                WRITE_COUNT * DATA_SIZE, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+}

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.logfile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.store.TransientStorePool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultMappedFileWriteWithoutMmapTest {
+
+    private String storePath;
+    private String fileName;
+    private int fileSize = 1024 * 1024; // 1MB
+
+    @Before
+    public void setUp() throws Exception {
+        storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
+        fileName = storePath + File.separator + "00000000000000000000";
+        UtilAll.ensureDirOK(storePath);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        UtilAll.deleteFile(new File(storePath));
+    }
+
+    @Test
+    public void testWriteWithoutMmapEnabled() throws IOException {
+        // Test with writeWithoutMmap = true
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            // Test appendMessage with byte array
+            byte[] testData = "Hello, RocketMQ!".getBytes();
+            boolean result = mappedFile.appendMessage(testData);
+            Assert.assertTrue("Should successfully append message", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length, mappedFile.getWrotePosition());
+            
+            // Test appendMessage with ByteBuffer
+            ByteBuffer buffer = ByteBuffer.wrap("Test ByteBuffer".getBytes());
+            result = mappedFile.appendMessage(buffer);
+            Assert.assertTrue("Should successfully append ByteBuffer", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length + "Test ByteBuffer".length(), mappedFile.getWrotePosition());
+            
+            // Test flush
+            int flushedPosition = mappedFile.flush(0);
+            Assert.assertTrue("Flush should succeed", flushedPosition > 0);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testWriteWithoutMmapDisabled() throws IOException {
+        // Test with writeWithoutMmap = false (default behavior)
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, false);
+        
+        try {
+            // Test appendMessage with byte array
+            byte[] testData = "Hello, RocketMQ!".getBytes();
+            boolean result = mappedFile.appendMessage(testData);
+            Assert.assertTrue("Should successfully append message", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length, mappedFile.getWrotePosition());
+            
+            // Test appendMessage with ByteBuffer
+            ByteBuffer buffer = ByteBuffer.wrap("Test ByteBuffer".getBytes());
+            result = mappedFile.appendMessage(buffer);
+            Assert.assertTrue("Should successfully append ByteBuffer", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length + "Test ByteBuffer".length(), mappedFile.getWrotePosition());
+            
+            // Test flush
+            int flushedPosition = mappedFile.flush(0);
+            Assert.assertTrue("Flush should succeed", flushedPosition > 0);
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testWriteWithoutMmapWithTransientStorePool() throws IOException {
+        // Test with writeWithoutMmap = true and TransientStorePool
+        TransientStorePool transientStorePool = new TransientStorePool(5, fileSize);
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, transientStorePool, true);
+        
+        try {
+            // Test appendMessage with byte array
+            byte[] testData = "Hello, RocketMQ with TransientStorePool!".getBytes();
+            boolean result = mappedFile.appendMessage(testData);
+            Assert.assertTrue("Should successfully append message", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testAppendMessageWithOffset() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            byte[] testData = "Hello, RocketMQ with offset!".getBytes();
+            boolean result = mappedFile.appendMessage(testData, 0, testData.length);
+            Assert.assertTrue("Should successfully append message with offset", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+
+    @Test
+    public void testAppendMessageUsingFileChannel() throws IOException {
+        DefaultMappedFile mappedFile = new DefaultMappedFile(fileName, fileSize, true);
+        
+        try {
+            byte[] testData = "Hello, RocketMQ using FileChannel!".getBytes();
+            boolean result = mappedFile.appendMessageUsingFileChannel(testData);
+            Assert.assertTrue("Should successfully append message using FileChannel", result);
+            Assert.assertEquals("Wrote position should be updated", testData.length, mappedFile.getWrotePosition());
+            
+        } finally {
+            mappedFile.destroy(0);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9693 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
