### PR TITLE
[ISSUE #9709] Add enableRunningFlagsInFlush configuration switch for CommitLog

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
@@ -173,16 +173,18 @@ public class AllocateMappedFileService extends ServiceThread {
 
                 MappedFile mappedFile;
                 boolean writeWithoutMmap = messageStore.getMessageStoreConfig().isWriteWithoutMmap();
+                RunningFlags runningFlags = messageStore.getMessageStoreConfig().isEnableRunningFlagsInFlush() 
+                    ? messageStore.getRunningFlags() : null;
                 if (messageStore.isTransientStorePoolEnable()) {
                     try {
                         mappedFile = ServiceLoader.load(MappedFile.class).iterator().next();
-                        mappedFile.init(req.getFilePath(), req.getFileSize(), messageStore.getRunningFlags(), messageStore.getTransientStorePool());
+                        mappedFile.init(req.getFilePath(), req.getFileSize(), runningFlags, messageStore.getTransientStorePool());
                     } catch (RuntimeException e) {
                         log.warn("Use default implementation.");
-                        mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), messageStore.getRunningFlags(), messageStore.getTransientStorePool(), writeWithoutMmap);
+                        mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), runningFlags, messageStore.getTransientStorePool(), writeWithoutMmap);
                     }
                 } else {
-                    mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), messageStore.getRunningFlags(), writeWithoutMmap);
+                    mappedFile = new DefaultMappedFile(req.getFilePath(), req.getFileSize(), runningFlags, writeWithoutMmap);
                 }
 
                 long elapsedTime = UtilAll.computeElapsedTimeMilliseconds(beginTime);

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -111,15 +111,18 @@ public class CommitLog implements Swappable {
 
     public CommitLog(final DefaultMessageStore messageStore) {
         String storePath = messageStore.getMessageStoreConfig().getStorePathCommitLog();
+        RunningFlags runningFlags = messageStore.getMessageStoreConfig().isEnableRunningFlagsInFlush() 
+            ? messageStore.getRunningFlags() : null;
+        
         if (storePath.contains(MixAll.MULTI_PATH_SPLITTER)) {
             this.mappedFileQueue = new MultiPathMappedFileQueue(messageStore.getMessageStoreConfig(),
                 messageStore.getMessageStoreConfig().getMappedFileSizeCommitLog(),
-                messageStore.getAllocateMappedFileService(), this::getFullStorePaths, messageStore.getRunningFlags());
+                messageStore.getAllocateMappedFileService(), this::getFullStorePaths, runningFlags);
         } else {
             this.mappedFileQueue = new MappedFileQueue(storePath,
                 messageStore.getMessageStoreConfig().getMappedFileSizeCommitLog(),
                 messageStore.getAllocateMappedFileService(),
-                messageStore.getRunningFlags(),
+                runningFlags,
                 messageStore.getMessageStoreConfig().isWriteWithoutMmap());
         }
 

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -283,6 +283,13 @@ public class MessageStoreConfig {
     private boolean autoMessageVersionOnTopicLen = true;
 
     /**
+     * Whether to use runningFlags when flushing data to disk.
+     * When disabled, runningFlags will be set to null during MappedFileQueue and MappedFile initialization.
+     */
+    @ImportantField
+    private boolean enableRunningFlagsInFlush = false;
+
+    /**
      * It cannot be changed after the broker is started.
      * Modifications need to be restarted to take effect.
      */
@@ -2041,5 +2048,13 @@ public class MessageStoreConfig {
 
     public void setEnableAcceleratedRecovery(boolean enableAcceleratedRecovery) {
         this.enableAcceleratedRecovery = enableAcceleratedRecovery;
+    }
+
+    public boolean isEnableRunningFlagsInFlush() {
+        return enableRunningFlagsInFlush;
+    }
+
+    public void setEnableRunningFlagsInFlush(boolean enableRunningFlagsInFlush) {
+        this.enableRunningFlagsInFlush = enableRunningFlagsInFlush;
     }
 }


### PR DESCRIPTION
…control

- Add configuration to control runningFlags usage in CommitLog (default: false)
- Update CommitLog and AllocateMappedFileService to respect the configuration
- Users can enable runningFlags validation as needed

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9709

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
