### PR TITLE
[ISSUE #9721] Fix TimerDequeueGetService thread not exiting after shutdown

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -953,6 +953,11 @@ public class TimerMessageStore {
         }
         int checkNum = 0;
         while (true) {
+            if (!isRunningDequeue()) {
+                LOGGER.info("Not Running dequeue, skip checkDequeueLatch for delayedTime:{}", delayedTime);
+                break;
+            }
+            
             if (dequeuePutQueue.size() > 0
                 || !checkStateForGetMessages(AbstractStateService.WAITING)
                 || !checkStateForPutMessages(AbstractStateService.WAITING)) {


### PR DESCRIPTION
- Add isRunningDequeue() check in checkDequeueLatch while loop
- Exit loop immediately when service is stopped to avoid thread blocking
- Ensure moveReadTime is not executed during shutdown process
- Improve system stability and reliability

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9721

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
