### PR TITLE
[ISSUE #9726] Abstract StoreMetricsManager interface to support non-DefaultMessageStore implementations

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -113,6 +113,7 @@ import org.apache.rocketmq.store.queue.ReferredIterator;
 import org.apache.rocketmq.store.stats.BrokerStatsManager;
 import org.apache.rocketmq.store.timer.TimerMessageStore;
 import org.apache.rocketmq.store.util.PerfCounter;
+import org.apache.rocketmq.store.metrics.StoreMetricsManager;
 import org.rocksdb.RocksDBException;
 
 public class DefaultMessageStore implements MessageStore {
@@ -1573,6 +1574,7 @@ public class DefaultMessageStore implements MessageStore {
         return this.reputMessageService.behindMs();
     }
 
+    @Override
     public long flushBehindBytes() {
         if (this.messageStoreConfig.isTransientStorePoolEnable()) {
             return this.commitLog.remainHowManyDataToCommit() + this.commitLog.remainHowManyDataToFlush();
@@ -3062,6 +3064,11 @@ public class DefaultMessageStore implements MessageStore {
     }
 
     public DefaultStoreMetricsManager getDefaultStoreMetricsManager() {
+        return defaultStoreMetricsManager;
+    }
+
+    @Override
+    public StoreMetricsManager getStoreMetricsManager() {
         return defaultStoreMetricsManager;
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/MessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageStore.java
@@ -46,6 +46,7 @@ import org.apache.rocketmq.store.queue.ConsumeQueueStoreInterface;
 import org.apache.rocketmq.store.stats.BrokerStatsManager;
 import org.apache.rocketmq.store.timer.TimerMessageStore;
 import org.apache.rocketmq.store.util.PerfCounter;
+import org.apache.rocketmq.store.metrics.StoreMetricsManager;
 import org.rocksdb.RocksDBException;
 
 /**
@@ -512,6 +513,13 @@ public interface MessageStore {
     long dispatchBehindBytes();
 
     /**
+     * Get number of the bytes that have been stored in commit log and not yet flushed to disk.
+     *
+     * @return number of the bytes to flush.
+     */
+    long flushBehindBytes();
+
+    /**
      * Get number of the milliseconds that have been stored in commit log and not yet dispatched to consume queue.
      *
      * @return number of the milliseconds to dispatch.
@@ -906,6 +914,13 @@ public interface MessageStore {
      * @return state machine version
      */
     long getStateMachineVersion();
+
+    /**
+     * Get store metrics manager
+     *
+     * @return store metrics manager
+     */
+    StoreMetricsManager getStoreMetricsManager();
 
     /**
      * Check message and return size

--- a/store/src/main/java/org/apache/rocketmq/store/metrics/DefaultStoreMetricsManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/metrics/DefaultStoreMetricsManager.java
@@ -36,7 +36,7 @@ import org.apache.rocketmq.common.Pair;
 import org.apache.rocketmq.common.metrics.NopLongCounter;
 import org.apache.rocketmq.common.metrics.NopLongHistogram;
 import org.apache.rocketmq.common.metrics.NopObservableLongGauge;
-import org.apache.rocketmq.store.DefaultMessageStore;
+import org.apache.rocketmq.store.MessageStore;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.apache.rocketmq.store.timer.Slot;
 import org.apache.rocketmq.store.timer.TimerMessageStore;
@@ -63,7 +63,7 @@ import static org.apache.rocketmq.store.metrics.DefaultStoreMetricsConstant.LABE
 import static org.apache.rocketmq.store.metrics.DefaultStoreMetricsConstant.LABEL_TIMING_BOUND;
 import static org.apache.rocketmq.store.metrics.DefaultStoreMetricsConstant.LABEL_TOPIC;
 
-public class DefaultStoreMetricsManager {
+public class DefaultStoreMetricsManager implements StoreMetricsManager {
     private Supplier<AttributesBuilder> attributesBuilderSupplier;
     private MessageStoreConfig messageStoreConfig;
 
@@ -109,7 +109,7 @@ public class DefaultStoreMetricsManager {
     }
 
     public void init(Meter meter, Supplier<AttributesBuilder> attributesBuilderSupplier,
-        DefaultMessageStore messageStore) {
+        MessageStore messageStore) {
 
         // Also add some metrics for rocksdb's monitoring.
         this.rocksDBStoreMetricsManager.init(meter, attributesBuilderSupplier, messageStore.getQueueStore());
@@ -322,10 +322,6 @@ public class DefaultStoreMetricsManager {
     // Setter methods for testing
     public void setAttributesBuilderSupplier(Supplier<AttributesBuilder> attributesBuilderSupplier) {
         this.attributesBuilderSupplier = attributesBuilderSupplier;
-    }
-
-    public void setMessageStoreConfig(MessageStoreConfig messageStoreConfig) {
-        this.messageStoreConfig = messageStoreConfig;
     }
 
     public RocksDBStoreMetricsManager getRocksDBStoreMetricsManager() {

--- a/store/src/main/java/org/apache/rocketmq/store/metrics/StoreMetricsManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/metrics/StoreMetricsManager.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.metrics;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.rocketmq.common.Pair;
+import org.apache.rocketmq.store.MessageStore;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.ViewBuilder;
+
+/**
+ * Store metrics manager interface for different message store implementations.
+ * This interface provides a unified way to access metrics functionality
+ * regardless of the underlying message store type.
+ */
+public interface StoreMetricsManager {
+
+    /**
+     * Initialize metrics with the given meter and attributes builder supplier.
+     *
+     * @param meter                     OpenTelemetry meter
+     * @param attributesBuilderSupplier Metrics attributes builder supplier
+     * @param messageStore             The message store instance
+     */
+    void init(Meter meter, Supplier<AttributesBuilder> attributesBuilderSupplier, MessageStore messageStore);
+
+    /**
+     * Get metrics view configuration.
+     *
+     * @return List of instrument selector and view builder pairs
+     */
+    List<Pair<InstrumentSelector, ViewBuilder>> getMetricsView();
+
+}

--- a/store/src/main/java/org/apache/rocketmq/store/plugin/AbstractPluginMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/plugin/AbstractPluginMessageStore.java
@@ -61,6 +61,7 @@ import org.apache.rocketmq.store.queue.ConsumeQueueStoreInterface;
 import org.apache.rocketmq.store.stats.BrokerStatsManager;
 import org.apache.rocketmq.store.timer.TimerMessageStore;
 import org.apache.rocketmq.store.util.PerfCounter;
+import org.apache.rocketmq.store.metrics.StoreMetricsManager;
 import org.rocksdb.RocksDBException;
 
 public abstract class AbstractPluginMessageStore implements MessageStore {
@@ -291,6 +292,11 @@ public abstract class AbstractPluginMessageStore implements MessageStore {
     @Override
     public long dispatchBehindBytes() {
         return next.dispatchBehindBytes();
+    }
+
+    @Override
+    public long flushBehindBytes() {
+        return next.flushBehindBytes();
     }
 
     @Override
@@ -665,5 +671,10 @@ public abstract class AbstractPluginMessageStore implements MessageStore {
     @Override
     public MessageStoreStateMachine getStateMachine() {
         return next.getStateMachine();
+    }
+
+    @Override
+    public StoreMetricsManager getStoreMetricsManager() {
+        return next.getStoreMetricsManager();
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9726

### Brief Description

- Create `StoreMetricsManager` interface to define unified metrics management methods
- Add `getStoreMetricsManager()` method to `MessageStore` interface
- Add `flushBehindBytes()` method to `MessageStore` interface (fixes missing method calls)
- Refactor `DefaultStoreMetricsManager` to implement `StoreMetricsManager` interface
- Update all MessageStore implementations to support the new interface
- Modify `TimerMessageStore` to use `getStoreMetricsManager()` instead of direct type checking

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
