### PR TITLE
[ISSUE #9728] fix: Broker startup failed when the consumequeue last mappfile was empty

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -565,18 +565,24 @@ public class ConsumeQueue implements ConsumeQueueInterface, FileQueueLifeCycle {
         SelectMappedBufferResult lastRecord = null;
         try {
             int maxReadablePosition = lastMappedFile.getReadPosition();
-            lastRecord = lastMappedFile.selectMappedBuffer(maxReadablePosition - ConsumeQueue.CQ_STORE_UNIT_SIZE,
-                ConsumeQueue.CQ_STORE_UNIT_SIZE);
-            if (null != lastRecord) {
-                ByteBuffer buffer = lastRecord.getByteBuffer();
-                long commitLogOffset = buffer.getLong();
-                if (commitLogOffset < minCommitLogOffset) {
-                    // Keep the largest known consume offset, even if this consume-queue contains no valid entries at
-                    // all. Let minLogicOffset point to a future slot.
-                    this.minLogicOffset = lastMappedFile.getFileFromOffset() + maxReadablePosition;
-                    log.info("ConsumeQueue[topic={}, queue-id={}] contains no valid entries. Min-offset is assigned as: {}.",
-                        topic, queueId, getMinOffsetInQueue());
-                    return;
+            /*
+                if maxReadablePosition is less than ConsumeQueue.CQ_STORE_UNIT_SIZE,
+                it means the last file is empty and we need skip it otherwise selectMappedBuffer will throw IllegalArgumentException
+             */
+            if (maxReadablePosition >= ConsumeQueue.CQ_STORE_UNIT_SIZE) {
+                lastRecord = lastMappedFile.selectMappedBuffer(maxReadablePosition - ConsumeQueue.CQ_STORE_UNIT_SIZE,
+                        ConsumeQueue.CQ_STORE_UNIT_SIZE);
+                if (null != lastRecord) {
+                    ByteBuffer buffer = lastRecord.getByteBuffer();
+                    long commitLogOffset = buffer.getLong();
+                    if (commitLogOffset < minCommitLogOffset) {
+                        // Keep the largest known consume offset, even if this consume-queue contains no valid entries at
+                        // all. Let minLogicOffset point to a future slot.
+                        this.minLogicOffset = lastMappedFile.getFileFromOffset() + maxReadablePosition;
+                        log.info("ConsumeQueue[topic={}, queue-id={}] contains no valid entries. Min-offset is assigned as: {}.",
+                                topic, queueId, getMinOffsetInQueue());
+                        return;
+                    }
                 }
             }
         } finally {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes ##9728

### Brief Description
fix: Broker startup failed when the consumequeue last mappfile was empty
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
use bugfix branch update broker which start failed in this case and broker start normall
<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
