### PR TITLE
[ISSUE #9730] Merge enableRunningFlagsInFlush and isWriteWithoutMmap configurations

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/AllocateMappedFileService.java
@@ -173,8 +173,7 @@ public class AllocateMappedFileService extends ServiceThread {
 
                 MappedFile mappedFile;
                 boolean writeWithoutMmap = messageStore.getMessageStoreConfig().isWriteWithoutMmap();
-                RunningFlags runningFlags = messageStore.getMessageStoreConfig().isEnableRunningFlagsInFlush() 
-                    ? messageStore.getRunningFlags() : null;
+                RunningFlags runningFlags = writeWithoutMmap ? null : messageStore.getRunningFlags();
                 if (messageStore.isTransientStorePoolEnable()) {
                     try {
                         mappedFile = ServiceLoader.load(MappedFile.class).iterator().next();

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -111,8 +111,8 @@ public class CommitLog implements Swappable {
 
     public CommitLog(final DefaultMessageStore messageStore) {
         String storePath = messageStore.getMessageStoreConfig().getStorePathCommitLog();
-        RunningFlags runningFlags = messageStore.getMessageStoreConfig().isEnableRunningFlagsInFlush() 
-            ? messageStore.getRunningFlags() : null;
+        boolean writeWithoutMmap = messageStore.getMessageStoreConfig().isWriteWithoutMmap();
+        RunningFlags runningFlags = writeWithoutMmap ? null : messageStore.getRunningFlags();
         
         if (storePath.contains(MixAll.MULTI_PATH_SPLITTER)) {
             this.mappedFileQueue = new MultiPathMappedFileQueue(messageStore.getMessageStoreConfig(),
@@ -123,7 +123,7 @@ public class CommitLog implements Swappable {
                 messageStore.getMessageStoreConfig().getMappedFileSizeCommitLog(),
                 messageStore.getAllocateMappedFileService(),
                 runningFlags,
-                messageStore.getMessageStoreConfig().isWriteWithoutMmap());
+                writeWithoutMmap);
         }
 
         this.defaultMessageStore = messageStore;

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -240,7 +240,8 @@ public class MessageStoreConfig {
 
     /**
      * When true, use RandomAccessFile for writing instead of MappedByteBuffer. This can be useful for certain scenarios
-     * where mmap is not desired.
+     * where mmap is not desired. When enabled, runningFlags will be set to null during MappedFileQueue and MappedFile
+     * initialization to avoid conflicts with non-mmap operations.
      *
      * The configurations writeWithoutMmap and transientStorePoolEnable are mutually exclusive. When both are set to
      * true, only writeWithoutMmap will be effective.
@@ -285,12 +286,6 @@ public class MessageStoreConfig {
      */
     private boolean autoMessageVersionOnTopicLen = true;
 
-    /**
-     * Whether to use runningFlags when flushing data to disk.
-     * When disabled, runningFlags will be set to null during MappedFileQueue and MappedFile initialization.
-     */
-    @ImportantField
-    private boolean enableRunningFlagsInFlush = false;
 
     /**
      * It cannot be changed after the broker is started.
@@ -2053,11 +2048,4 @@ public class MessageStoreConfig {
         this.enableAcceleratedRecovery = enableAcceleratedRecovery;
     }
 
-    public boolean isEnableRunningFlagsInFlush() {
-        return enableRunningFlagsInFlush;
-    }
-
-    public void setEnableRunningFlagsInFlush(boolean enableRunningFlagsInFlush) {
-        this.enableRunningFlagsInFlush = enableRunningFlagsInFlush;
-    }
 }


### PR DESCRIPTION
These two configurations are typically used together and need to be enabled/disabled simultaneously, so merging them simplifies configuration management.

Changes:
- Remove enableRunningFlagsInFlush configuration field and its getter/setter methods
- Update AllocateMappedFileService to use isWriteWithoutMmap for runningFlags logic
- Update CommitLog to use isWriteWithoutMmap for runningFlags logic
- Update writeWithoutMmap documentation to explain runningFlags behavior

Behavior after merge:
- When isWriteWithoutMmap=true: Use RandomAccessFile + set runningFlags to null
- When isWriteWithoutMmap=false: Use MappedByteBuffer + use normal runningFlags

This eliminates the need to manage two separate but related configurations, reducing the chance of misconfiguration and simplifying the codebase.

Change-Id: I053a6ee5c8ba9be825db47940900ce01a8c707b9

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9730 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
