### PR TITLE
[ISSUE #9752] Fix time dequeue latency unit to milliseconds

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/metrics/DefaultStoreMetricsManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/metrics/DefaultStoreMetricsManager.java
@@ -185,7 +185,7 @@ public class DefaultStoreMetricsManager implements StoreMetricsManager {
                 .ofLongs()
                 .buildWithCallback(measurement -> {
                     TimerMessageStore timerMessageStore = messageStore.getTimerMessageStore();
-                    measurement.record(timerMessageStore.getDequeueBehind(), this.newAttributesBuilder().build());
+                    measurement.record(timerMessageStore.getDequeueBehindMillis(), this.newAttributesBuilder().build());
                 });
             this.timingMessages = meter.gaugeBuilder(GAUGE_TIMING_MESSAGES)
                 .setDescription("Current message number in timing")


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #9752

### Brief Description

The delay time units of time tasks are inconsistent.

### How Did You Test This Change?
