### PR TITLE
[ISSUE #9756] Fix the issue where the port is always 10911 when starting  broker with brokerStartup

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -124,6 +124,10 @@ public class BrokerStartup {
         NettyClientConfig nettyClientConfig = new NettyClientConfig();
         MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
         AuthConfig authConfig = new AuthConfig();
+
+        nettyServerConfig.setListenPort(10911);
+        messageStoreConfig.setHaListenPort(0);
+
         Properties properties = new Properties();
         if (StringUtils.isNotBlank(filePath)) {
             systemConfigFileHelper.setFile(filePath);
@@ -160,9 +164,6 @@ public class BrokerStartup {
         NettyServerConfig nettyServerConfig = configContext.getNettyServerConfig();
         AuthConfig authConfig = configContext.getAuthConfig();
         Properties properties = configContext.getProperties();
-
-        nettyServerConfig.setListenPort(10911);
-        configContext.getMessageStoreConfig().setHaListenPort(0);
 
         if (null == brokerConfig.getRocketmqHome()) {
             System.out.printf("Please set the %s variable in your environment " +


### PR DESCRIPTION
Change-Id: I0bbefa0a9d0079de6f3f4b9068b3ea586dbccfe0

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9756

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
