### PR TITLE
[ISSUE #9758] Fix resource filter does not take effect in the listAcl

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProvider.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProvider.java
@@ -148,8 +148,10 @@ public class LocalAuthorizationMetadataProvider implements AuthorizationMetadata
                     if (CollectionUtils.isEmpty(entries)) {
                         continue;
                     }
-                    if (StringUtils.isNotBlank(resourceFilter) && !subjectKey.contains(resourceFilter)) {
-                        entries.removeIf(entry -> !entry.toResourceStr().contains(resourceFilter));
+                    if (StringUtils.isNotBlank(resourceFilter)) {
+                        entries.removeIf(entry ->
+                                entry.toResourceStr() == null || !entry.toResourceStr().contains(resourceFilter)
+                        );
                     }
                     if (CollectionUtils.isEmpty(entries)) {
                         policyIterator.remove();

--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProvider.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProvider.java
@@ -149,9 +149,7 @@ public class LocalAuthorizationMetadataProvider implements AuthorizationMetadata
                         continue;
                     }
                     if (StringUtils.isNotBlank(resourceFilter)) {
-                        entries.removeIf(entry ->
-                                entry.toResourceStr() == null || !entry.toResourceStr().contains(resourceFilter)
-                        );
+                        entries.removeIf(entry -> !entry.toResourceStr().contains(resourceFilter));
                     }
                     if (CollectionUtils.isEmpty(entries)) {
                         policyIterator.remove();

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerTest.java
@@ -220,6 +220,10 @@ public class AuthorizationMetadataManagerTest {
             "192.168.0.0/24,10.10.0.0/24", Decision.ALLOW);
         this.authorizationMetadataManager.createAcl(acl2).join();
 
+        Acl acl3 = AuthTestHelper.buildAcl("User:test-2", "Topic:acl-2,Group:acl-2", "PUB,SUB",
+            "192.168.0.0/24,10.10.0.0/24", Decision.ALLOW);
+        this.authorizationMetadataManager.createAcl(acl3).join();
+
         List<Acl> acls1 = this.authorizationMetadataManager.listAcl(null, null).join();
         Assert.assertEquals(acls1.size(), 2);
 
@@ -235,13 +239,17 @@ public class AuthorizationMetadataManagerTest {
 
         List<Acl> acls5 = this.authorizationMetadataManager.listAcl(null, "test-1").join();
         Assert.assertEquals(acls5.size(), 1);
-        Assert.assertEquals(acls4.get(0).getPolicy(PolicyType.CUSTOM).getEntries().size(), 1);
+        Assert.assertEquals(acls5.get(0).getPolicy(PolicyType.CUSTOM).getEntries().size(), 2);
 
         List<Acl> acls6 = this.authorizationMetadataManager.listAcl("User:abc", null).join();
         Assert.assertTrue(CollectionUtils.isEmpty(acls6));
 
         List<Acl> acls7 = this.authorizationMetadataManager.listAcl(null, "Topic:abc").join();
         Assert.assertTrue(CollectionUtils.isEmpty(acls7));
+
+        List<Acl> acls8 = this.authorizationMetadataManager.listAcl("test-2", "test-2").join();
+        Assert.assertEquals(acls8.size(), 1);
+        Assert.assertEquals(acls8.get(0).getPolicy(PolicyType.CUSTOM).getEntries().size(), 2);
     }
 
     private void clearAllUsers() {

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerTest.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.auth.authorization.exception.AuthorizationException;
 import org.apache.rocketmq.auth.authorization.factory.AuthorizationFactory;
 import org.apache.rocketmq.auth.authorization.model.Acl;
 import org.apache.rocketmq.auth.authorization.model.Policy;
+import org.apache.rocketmq.auth.authorization.model.PolicyEntry;
 import org.apache.rocketmq.auth.authorization.model.Resource;
 import org.apache.rocketmq.auth.config.AuthConfig;
 import org.apache.rocketmq.auth.helper.AuthTestHelper;
@@ -249,7 +250,11 @@ public class AuthorizationMetadataManagerTest {
 
         List<Acl> acls8 = this.authorizationMetadataManager.listAcl("test-2", "test-2").join();
         Assert.assertEquals(acls8.size(), 1);
-        Assert.assertEquals(acls8.get(0).getPolicy(PolicyType.CUSTOM).getEntries().size(), 2);
+        List<PolicyEntry> policyEntries = acls8.get(0).getPolicy(PolicyType.CUSTOM).getEntries();
+        Assert.assertEquals(policyEntries.size(), 2);
+        for (PolicyEntry policyEntry : policyEntries) {
+            Assert.assertTrue(policyEntry.toResourceStr().contains("test-2"));
+        }
     }
 
     private void clearAllUsers() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

Fixes #9758 

### Brief Description

Fixed the issue where the resource filter keyword in listAcl did not take effect

### How Did You Test This Change?

1. There are a total of 3 ACL rules in the cluster.

<img width="898" height="105" alt="image" src="https://github.com/user-attachments/assets/ef2ede21-e09e-4b51-a465-75ef7ae141e9" />

2. When the resource filter string is a substring of the user, it also filters as expected.

<img width="904" height="80" alt="image" src="https://github.com/user-attachments/assets/2e893654-2459-4120-96a1-bb7a482ff850" />

