### PR TITLE
[ISSUE #9769] Add tls.ciphers and tls.protocols in system properties

### DIFF
--- a/docs/cn/Configuration_TLS.md
+++ b/docs/cn/Configuration_TLS.md
@@ -52,6 +52,10 @@ tls.server.certPath=/opt/certFiles/server.pem
 tls.server.authClient=false
 # The store path of trusted certificates for verifying the client endpoint's certificate
 tls.server.trustCertPath=/opt/certFiles/ca.pem
+# The ciphers in TLS
+# tls.ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+# The protocols in TLS
+# tls.protocols=TLSv1.2,TLSv1.3
 ```
 
 如果需要客户端连接时也进行认证，则还需要在该文件中增加以下内容
@@ -66,6 +70,10 @@ tls.client.certPath=/opt/certFiles/client.pem
 tls.client.authServer=false                    
 # The store path of trusted certificates for verifying the server endpoint's certificate
 tls.client.trustCertPath=/opt/certFiles/ca.pem
+# The ciphers in TLS
+# tls.ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+# The protocols in TLS
+# tls.protocols=TLSv1.2,TLSv1.3
 ```
 
 
@@ -96,6 +104,10 @@ tls.client.keyPassword=123456
 tls.client.certPath=/opt/certFiles/client.pem               
 # The store path of trusted certificates for verifying the server endpoint's certificate
 tls.client.trustCertPath=/opt/certFiles/ca.pem
+# The ciphers in TLS
+# tls.ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+# The protocols in TLS
+# tls.protocols=TLSv1.2,TLSv1.3
 ```
 
 JVM中需要加以下参数.tls.config.file的值需要使用之前创建的文件：

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolTlsHelper.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolTlsHelper.java
@@ -94,6 +94,7 @@ public class MultiProtocolTlsHelper extends TlsHelper {
             ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
             ApplicationProtocolNames.HTTP_2));
 
+        moreTlsConfig(sslContextBuilder);
         return sslContextBuilder.build();
     }
 

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/TlsSystemConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/TlsSystemConfig.java
@@ -39,6 +39,9 @@ public class TlsSystemConfig {
     public static final String TLS_CLIENT_AUTHSERVER = "tls.client.authServer";
     public static final String TLS_CLIENT_TRUSTCERTPATH = "tls.client.trustCertPath";
 
+    public static final String TLS_CIPHERS = "tls.ciphers";
+    public static final String TLS_PROTOCOLS = "tls.protocols";
+
 
     /**
      * To determine whether use SSL in client-side, include SDK client and BrokerOuterAPI
@@ -122,4 +125,22 @@ public class TlsSystemConfig {
      * except {@link TlsSystemConfig#tlsMode} and {@link TlsSystemConfig#tlsEnable}
      */
     public static String tlsConfigFile = System.getProperty(TLS_CONFIG_FILE, "/etc/rocketmq/tls.properties");
+
+    /**
+     * The ciphers to be used in TLS
+     * <ol>
+     *     <li>If null, use the default ciphers</li>
+     *     <li>Otherwise, use the ciphers specified in this string, eg: -Dtls.ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256</li>
+     * </ol>
+     */
+    public static String tlsCiphers = System.getProperty(TLS_CIPHERS, null);
+
+    /**
+     * The protocols to be used in TLS
+     * <ol>
+     *     <li>If null, use the default protocols</li>
+     *     <li>Otherwise, use the protocols specified in this string, eg: -Dtls.protocols=TLSv1.2,TLSv1.3</li>
+     * </ol>
+     */
+    public static String tlsProtocols = System.getProperty(TLS_PROTOCOLS, null);
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes


Fixes #9769

### Brief Description

add tls.ciphers tls.procotols

### How Did You Test This Change?
start nameserver/broker with parameter 
``` 
-Dtls.ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 
-Dtls.protocols=TLSv1.2
```

use openssl command to check ciphers and protocols 
``` 
openssl s_client -connect 127.0.0.1:9876 -tls1_2 -cipher ECDHE-RSA-AES256-GCM-SHA384 | egrep 'Cipher|Protocol'
openssl s_client -connect 127.0.0.1:10928 -tls1_2 -cipher ECDHE-RSA-AES256-GCM-SHA384 | egrep 'Cipher|Protocol'
openssl s_client -connect 127.0.0.1:10930 -tls1_2 -cipher ECDHE-RSA-AES256-GCM-SHA384 | egrep 'Cipher|Protocol'
```
test example pic:
<img width="1350" height="251" alt="image" src="https://github.com/user-attachments/assets/0a55e0c1-a17c-46a4-a639-b9259a5d795e" />
