### PR TITLE
[ISSUE #9776] Make SharedByteBuffer size configurable via MessageStoreConfig.maxMessageSize

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -242,7 +242,7 @@ public class DefaultMessageStore implements MessageStore {
         this.transientStorePool = new TransientStorePool(messageStoreConfig.getTransientStorePoolSize(), messageStoreConfig.getMappedFileSizeCommitLog());
 
         if (messageStoreConfig.isWriteWithoutMmap()) {
-            SharedByteBufferManager.getInstance().init(messageStoreConfig.getMaxMessageSize());
+            SharedByteBufferManager.getInstance().init(messageStoreConfig.getMaxMessageSize(), messageStoreConfig.getSharedByteBufferNum());
         }
 
         this.defaultStoreMetricsManager = new DefaultStoreMetricsManager();

--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -103,6 +103,7 @@ import org.apache.rocketmq.store.kv.CommitLogDispatcherCompaction;
 import org.apache.rocketmq.store.kv.CompactionService;
 import org.apache.rocketmq.store.kv.CompactionStore;
 import org.apache.rocketmq.store.logfile.MappedFile;
+import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.apache.rocketmq.store.metrics.DefaultStoreMetricsManager;
 import org.apache.rocketmq.store.queue.CombineConsumeQueueStore;
 import org.apache.rocketmq.store.queue.ConsumeQueueInterface;
@@ -239,6 +240,10 @@ public class DefaultMessageStore implements MessageStore {
             new ConcurrentReputMessageService() : new ReputMessageService();
 
         this.transientStorePool = new TransientStorePool(messageStoreConfig.getTransientStorePoolSize(), messageStoreConfig.getMappedFileSizeCommitLog());
+
+        if (messageStoreConfig.isWriteWithoutMmap()) {
+            SharedByteBufferManager.getInstance().init(messageStoreConfig.getMaxMessageSize());
+        }
 
         this.defaultStoreMetricsManager = new DefaultStoreMetricsManager();
 

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -488,6 +488,9 @@ public class MessageStoreConfig {
      */
     private boolean enableAcceleratedRecovery = false;
 
+    // Shared byte buffer manager configuration
+    private int sharedByteBufferNum = 16;
+
     public String getRocksdbCompressionType() {
         return rocksdbCompressionType;
     }
@@ -2059,5 +2062,13 @@ public class MessageStoreConfig {
 
     public void setEnableRunningFlagsInFlush(boolean enableRunningFlagsInFlush) {
         this.enableRunningFlagsInFlush = enableRunningFlagsInFlush;
+    }
+
+    public int getSharedByteBufferNum() {
+        return sharedByteBufferNum;
+    }
+
+    public void setSharedByteBufferNum(int sharedByteBufferNum) {
+        this.sharedByteBufferNum = sharedByteBufferNum;
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
@@ -318,8 +318,6 @@ public class DefaultMappedFile extends AbstractMappedFile {
                     } catch (Throwable t) {
                         log.error("Failed to write to mappedFile {}", this.fileName, t);
                         return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
-                    } finally {
-                        sharedByteBuffer.release();
                     }
                 }
 

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
@@ -33,11 +33,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Iterator;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.rocketmq.common.UtilAll;
@@ -116,29 +114,11 @@ public class DefaultMappedFile extends AbstractMappedFile {
      */
     private long stopTimestamp = -1;
 
-    private static int maxSharedNum = 16;
-    private static final SharedByteBuffer[] SHARED_BYTE_BUFFER;
+
 
     protected RunningFlags runningFlags;
 
-    static class SharedByteBuffer {
-        private final ReentrantLock lock;
-        private final ByteBuffer buffer;
 
-        public SharedByteBuffer(int size) {
-            this.lock = new ReentrantLock();
-            this.buffer = ByteBuffer.allocateDirect(size);
-        }
-
-        public void release() {
-            this.lock.unlock();
-        }
-
-        public ByteBuffer acquire() {
-            this.lock.lock();
-            return buffer;
-        }
-    }
 
     static {
         WROTE_POSITION_UPDATER = AtomicIntegerFieldUpdater.newUpdater(DefaultMappedFile.class, "wrotePosition");
@@ -156,18 +136,9 @@ public class DefaultMappedFile extends AbstractMappedFile {
             }
         }
         IS_LOADED_METHOD = isLoaded0method;
-
-        SHARED_BYTE_BUFFER = new SharedByteBuffer[maxSharedNum];
-        for (int i = 0; i < maxSharedNum; i++) {
-            SHARED_BYTE_BUFFER[i] = new SharedByteBuffer(4 * 1024 * 1024);
-        }
     }
 
-    private static SharedByteBuffer borrowSharedByteBuffer() {
-        int idx = ThreadLocalRandom.current().nextInt(maxSharedNum);
-        SharedByteBuffer buffer = SHARED_BYTE_BUFFER[idx];
-        return buffer;
-    }
+
 
     public DefaultMappedFile() {
     }
@@ -324,10 +295,10 @@ public class DefaultMappedFile extends AbstractMappedFile {
         long fileFromOffset = this.getFileFromOffset();
 
         if (currentPos < this.fileSize) {
-            SharedByteBuffer sharedByteBuffer = null;
+            SharedByteBufferManager.SharedByteBuffer sharedByteBuffer = null;
             ByteBuffer byteBuffer;
             if (writeWithoutMmap) {
-                sharedByteBuffer = borrowSharedByteBuffer();
+                sharedByteBuffer = SharedByteBufferManager.getInstance().borrowSharedByteBuffer();
                 byteBuffer = sharedByteBuffer.acquire();
                 byteBuffer.position(0).limit(byteBuffer.capacity());
                 fileFromOffset += currentPos;
@@ -336,24 +307,30 @@ public class DefaultMappedFile extends AbstractMappedFile {
                 byteBuffer.position(currentPos);
             }
 
-            AppendMessageResult result = cb.doAppend(byteBuffer, fileFromOffset, this.fileSize - currentPos, byteBufferMsg);
+            try {
+                AppendMessageResult result = cb.doAppend(byteBuffer, fileFromOffset, this.fileSize - currentPos, byteBufferMsg);
 
-            if (sharedByteBuffer != null) {
-                try {
-                    this.fileChannel.position(currentPos);
-                    byteBuffer.position(0).limit(result.getWroteBytes());
-                    this.fileChannel.write(byteBuffer);
-                } catch (Throwable t) {
-                    log.error("Failed to write to mappedFile {}", this.fileName, t);
-                    return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
-                } finally {
+                if (sharedByteBuffer != null) {
+                    try {
+                        this.fileChannel.position(currentPos);
+                        byteBuffer.position(0).limit(result.getWroteBytes());
+                        this.fileChannel.write(byteBuffer);
+                    } catch (Throwable t) {
+                        log.error("Failed to write to mappedFile {}", this.fileName, t);
+                        return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
+                    } finally {
+                        sharedByteBuffer.release();
+                    }
+                }
+
+                WROTE_POSITION_UPDATER.addAndGet(this, result.getWroteBytes());
+                this.storeTimestamp = result.getStoreTimestamp();
+                return result;
+            } finally {
+                if (sharedByteBuffer != null) {
                     sharedByteBuffer.release();
                 }
             }
-
-            WROTE_POSITION_UPDATER.addAndGet(this, result.getWroteBytes());
-            this.storeTimestamp = result.getStoreTimestamp();
-            return result;
         }
         log.error("MappedFile.appendMessage return null, wrotePosition: {} fileSize: {}", currentPos, this.fileSize);
         return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
@@ -380,10 +357,10 @@ public class DefaultMappedFile extends AbstractMappedFile {
         long fileFromOffset = this.getFileFromOffset();
 
         if (currentPos < this.fileSize) {
-            SharedByteBuffer sharedByteBuffer = null;
+            SharedByteBufferManager.SharedByteBuffer sharedByteBuffer = null;
             ByteBuffer byteBuffer;
             if (writeWithoutMmap) {
-                sharedByteBuffer = borrowSharedByteBuffer();
+                sharedByteBuffer = SharedByteBufferManager.getInstance().borrowSharedByteBuffer();
                 byteBuffer = sharedByteBuffer.acquire();
                 byteBuffer.position(0).limit(byteBuffer.capacity());
                 fileFromOffset += currentPos;
@@ -393,27 +370,31 @@ public class DefaultMappedFile extends AbstractMappedFile {
             }
 
             AppendMessageResult result;
-            if (messageExt instanceof MessageExtBatch && !((MessageExtBatch) messageExt).isInnerBatch()) {
-                // traditional batch message
-                result = cb.doAppend(fileFromOffset, byteBuffer, this.fileSize - currentPos,
-                    (MessageExtBatch) messageExt, putMessageContext);
-            } else if (messageExt instanceof MessageExtBrokerInner) {
-                // traditional single message or newly introduced inner-batch message
-                result = cb.doAppend(fileFromOffset, byteBuffer, this.fileSize - currentPos,
-                    (MessageExtBrokerInner) messageExt, putMessageContext);
-            } else {
-                return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
-            }
-
-            if (sharedByteBuffer != null) {
-                try {
-                    this.fileChannel.position(currentPos);
-                    byteBuffer.position(0).limit(result.getWroteBytes());
-                    this.fileChannel.write(byteBuffer);
-                } catch (Throwable t) {
-                    log.error("Failed to write to mappedFile {}", this.fileName, t);
+            try {
+                if (messageExt instanceof MessageExtBatch && !((MessageExtBatch) messageExt).isInnerBatch()) {
+                    // traditional batch message
+                    result = cb.doAppend(fileFromOffset, byteBuffer, this.fileSize - currentPos,
+                        (MessageExtBatch) messageExt, putMessageContext);
+                } else if (messageExt instanceof MessageExtBrokerInner) {
+                    // traditional single message or newly introduced inner-batch message
+                    result = cb.doAppend(fileFromOffset, byteBuffer, this.fileSize - currentPos,
+                        (MessageExtBrokerInner) messageExt, putMessageContext);
+                } else {
                     return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
-                } finally {
+                }
+
+                if (sharedByteBuffer != null) {
+                    try {
+                        this.fileChannel.position(currentPos);
+                        byteBuffer.position(0).limit(result.getWroteBytes());
+                        this.fileChannel.write(byteBuffer);
+                    } catch (Throwable t) {
+                        log.error("Failed to write to mappedFile {}", this.fileName, t);
+                        return new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR);
+                    }
+                }
+            } finally {
+                if (sharedByteBuffer != null) {
                     sharedByteBuffer.release();
                 }
             }

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
@@ -53,7 +53,7 @@ public class SharedByteBufferManager {
     }
 
     /**
-     * Initialize shared buffers with specified buffer size
+     * Initialize shared buffers with specified messageSize size
      *
      * @param maxMessageSize max messageSize size
      */
@@ -78,7 +78,8 @@ public class SharedByteBufferManager {
      */
     public SharedByteBuffer borrowSharedByteBuffer() {
         if (!initialized) {
-            throw new IllegalStateException("SharedByteBufferManager not initialized");
+            // Initialize with default size if not initialized
+            init(4 * 1024 * 1024); // Default 4MB
         }
         int idx = ThreadLocalRandom.current().nextInt(MAX_SHARED_NUM);
         return sharedByteBuffers[idx];

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.logfile;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Shared byte buffer manager for managing some shared ByteBuffers Buffer size is set based on MessageStoreConfig's
+ * maxMessageSize
+ */
+public class SharedByteBufferManager {
+
+    private static final int MAX_SHARED_NUM = 16;
+    private static volatile SharedByteBufferManager instance;
+    private static final Object lock = new Object();
+
+    private SharedByteBuffer[] sharedByteBuffers;
+    private int bufferSize;
+    private volatile boolean initialized = false;
+
+    private SharedByteBufferManager() {
+        // Private constructor
+    }
+
+    /**
+     * Get singleton instance
+     */
+    public static SharedByteBufferManager getInstance() {
+        if (instance == null) {
+            synchronized (lock) {
+                if (instance == null) {
+                    instance = new SharedByteBufferManager();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Initialize shared buffers with specified buffer size
+     *
+     * @param maxMessageSize max messageSize size
+     */
+    public synchronized void init(int maxMessageSize) {
+        if (!initialized) {
+            //Reserve 64kb for encoding buffer outside body
+            bufferSize = Integer.MAX_VALUE - maxMessageSize >= 64 * 1024 ?
+                maxMessageSize + 64 * 1024 : Integer.MAX_VALUE;
+
+            this.sharedByteBuffers = new SharedByteBuffer[MAX_SHARED_NUM];
+            for (int i = 0; i < MAX_SHARED_NUM; i++) {
+                this.sharedByteBuffers[i] = new SharedByteBuffer(bufferSize);
+            }
+            this.initialized = true;
+        }
+    }
+
+    /**
+     * Borrow a shared buffer
+     *
+     * @return Shared buffer
+     */
+    public SharedByteBuffer borrowSharedByteBuffer() {
+        if (!initialized) {
+            throw new IllegalStateException("SharedByteBufferManager not initialized");
+        }
+        int idx = ThreadLocalRandom.current().nextInt(MAX_SHARED_NUM);
+        return sharedByteBuffers[idx];
+    }
+
+    /**
+     * Get current buffer size
+     *
+     * @return Buffer size
+     */
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    /**
+     * Check if initialized
+     *
+     * @return Whether initialized
+     */
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    /**
+     * Shared byte buffer class
+     */
+    public static class SharedByteBuffer {
+        private final ReentrantLock lock;
+        private final ByteBuffer buffer;
+
+        public SharedByteBuffer(int size) {
+            this.lock = new ReentrantLock();
+            this.buffer = ByteBuffer.allocateDirect(size);
+        }
+
+        public void release() {
+            this.lock.unlock();
+        }
+
+        public ByteBuffer acquire() {
+            this.lock.lock();
+            return buffer;
+        }
+    }
+}

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
@@ -78,7 +78,6 @@ public class SharedByteBufferManager {
      */
     public SharedByteBuffer borrowSharedByteBuffer() {
         if (!initialized) {
-            // Initialize with default size if not initialized
             throw new IllegalStateException("SharedByteBufferManager not initialized");
         }
         int idx = ThreadLocalRandom.current().nextInt(MAX_SHARED_NUM);

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
@@ -79,7 +79,7 @@ public class SharedByteBufferManager {
     public SharedByteBuffer borrowSharedByteBuffer() {
         if (!initialized) {
             // Initialize with default size if not initialized
-            init(4 * 1024 * 1024); // Default 4MB
+            throw new IllegalStateException("SharedByteBufferManager not initialized");
         }
         int idx = ThreadLocalRandom.current().nextInt(MAX_SHARED_NUM);
         return sharedByteBuffers[idx];

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
@@ -28,7 +28,7 @@ public class SharedByteBufferManager {
 
     private static final int MAX_SHARED_NUM = 16;
     private static volatile SharedByteBufferManager instance;
-    private static final Object lock = new Object();
+    private static final Object LOCK = new Object();
 
     private SharedByteBuffer[] sharedByteBuffers;
     private int bufferSize;
@@ -43,7 +43,7 @@ public class SharedByteBufferManager {
      */
     public static SharedByteBufferManager getInstance() {
         if (instance == null) {
-            synchronized (lock) {
+            synchronized (LOCK) {
                 if (instance == null) {
                     instance = new SharedByteBufferManager();
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/SharedByteBufferManager.java
@@ -26,12 +26,12 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class SharedByteBufferManager {
 
-    private static final int MAX_SHARED_NUM = 16;
     private static volatile SharedByteBufferManager instance;
     private static final Object LOCK = new Object();
 
     private SharedByteBuffer[] sharedByteBuffers;
     private int bufferSize;
+    private int maxSharedNum;
     private volatile boolean initialized = false;
 
     private SharedByteBufferManager() {
@@ -53,18 +53,20 @@ public class SharedByteBufferManager {
     }
 
     /**
-     * Initialize shared buffers with specified messageSize size
+     * Initialize shared buffers with specified messageSize size and shared buffer number
      *
      * @param maxMessageSize max messageSize size
+     * @param sharedBufferNum number of shared buffers
      */
-    public synchronized void init(int maxMessageSize) {
+    public synchronized void init(int maxMessageSize, int sharedBufferNum) {
         if (!initialized) {
             //Reserve 64kb for encoding buffer outside body
             bufferSize = Integer.MAX_VALUE - maxMessageSize >= 64 * 1024 ?
                 maxMessageSize + 64 * 1024 : Integer.MAX_VALUE;
 
-            this.sharedByteBuffers = new SharedByteBuffer[MAX_SHARED_NUM];
-            for (int i = 0; i < MAX_SHARED_NUM; i++) {
+            this.maxSharedNum = sharedBufferNum;
+            this.sharedByteBuffers = new SharedByteBuffer[maxSharedNum];
+            for (int i = 0; i < maxSharedNum; i++) {
                 this.sharedByteBuffers[i] = new SharedByteBuffer(bufferSize);
             }
             this.initialized = true;
@@ -80,7 +82,7 @@ public class SharedByteBufferManager {
         if (!initialized) {
             throw new IllegalStateException("SharedByteBufferManager not initialized");
         }
-        int idx = ThreadLocalRandom.current().nextInt(MAX_SHARED_NUM);
+        int idx = ThreadLocalRandom.current().nextInt(maxSharedNum);
         return sharedByteBuffers[idx];
     }
 

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
@@ -42,7 +42,7 @@ public class DefaultMappedFileConcurrencyTest {
         UtilAll.ensureDirOK(storePath);
 
         // Initialize SharedByteBufferManager for tests
-        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024, 16); // 4MB default, 16 shared buffers
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.rocketmq.common.UtilAll;
-import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileConcurrencyTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,6 +41,9 @@ public class DefaultMappedFileConcurrencyTest {
         storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
         fileName = storePath + File.separator + "00000000000000000000";
         UtilAll.ensureDirOK(storePath);
+
+        // Initialize SharedByteBufferManager for tests
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
@@ -45,7 +45,7 @@ public class DefaultMappedFileErrorHandlingTest {
         UtilAll.ensureDirOK(storePath);
 
         // Initialize SharedByteBufferManager for tests
-        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024, 16); // 4MB default, 16 shared buffers
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
@@ -27,7 +27,6 @@ import org.apache.rocketmq.store.AppendMessageResult;
 import org.apache.rocketmq.store.AppendMessageStatus;
 import org.apache.rocketmq.store.CompactionAppendMsgCallback;
 import org.apache.rocketmq.store.PutMessageContext;
-import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileErrorHandlingTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.store.AppendMessageResult;
 import org.apache.rocketmq.store.AppendMessageStatus;
 import org.apache.rocketmq.store.CompactionAppendMsgCallback;
 import org.apache.rocketmq.store.PutMessageContext;
+import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,6 +44,9 @@ public class DefaultMappedFileErrorHandlingTest {
         storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
         fileName = storePath + File.separator + "00000000000000000000";
         UtilAll.ensureDirOK(storePath);
+
+        // Initialize SharedByteBufferManager for tests
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,6 +39,9 @@ public class DefaultMappedFilePerformanceTest {
         storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
         fileName = storePath + File.separator + "00000000000000000000";
         UtilAll.ensureDirOK(storePath);
+
+        // Initialize SharedByteBufferManager for tests
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.common.UtilAll;
-import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFilePerformanceTest.java
@@ -40,7 +40,7 @@ public class DefaultMappedFilePerformanceTest {
         UtilAll.ensureDirOK(storePath);
 
         // Initialize SharedByteBufferManager for tests
-        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024, 16); // 4MB default, 16 shared buffers
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.store.TransientStorePool;
-import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.store.TransientStorePool;
+import org.apache.rocketmq.store.logfile.SharedByteBufferManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +38,9 @@ public class DefaultMappedFileWriteWithoutMmapTest {
         storePath = System.getProperty("user.home") + File.separator + "unitteststore" + System.currentTimeMillis();
         fileName = storePath + File.separator + "00000000000000000000";
         UtilAll.ensureDirOK(storePath);
+
+        // Initialize SharedByteBufferManager for tests
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
     }
 
     @After

--- a/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/logfile/DefaultMappedFileWriteWithoutMmapTest.java
@@ -39,7 +39,7 @@ public class DefaultMappedFileWriteWithoutMmapTest {
         UtilAll.ensureDirOK(storePath);
 
         // Initialize SharedByteBufferManager for tests
-        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024); // 4MB default
+        SharedByteBufferManager.getInstance().init(4 * 1024 * 1024, 16); // 4MB default, 16 shared buffers
     }
 
     @After


### PR DESCRIPTION
Change-Id: Ie3c291ba10b84963fb3ba0af90afa323d9b955ff

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9776
Make SharedByteBuffer size configurable via MessageStoreConfig.maxMessageSize

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
