### PR TITLE
[ISSUE #9809] Fix NPE in getAcl when subject is null

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerImpl.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerImpl.java
@@ -176,19 +176,26 @@ public class AuthorizationMetadataManagerImpl implements AuthorizationMetadataMa
 
     @Override
     public CompletableFuture<Acl> getAcl(Subject subject) {
-        CompletableFuture<? extends Subject> subjectFuture;
-        if (subject.isSubject(SubjectType.USER)) {
-            User user = (User) subject;
-            subjectFuture = this.getAuthenticationMetadataProvider().getUser(user.getUsername());
-        } else {
-            subjectFuture = CompletableFuture.completedFuture(subject);
-        }
-        return subjectFuture.thenCompose(sub -> {
-            if (sub == null) {
-                throw new AuthorizationException("The subject is not exist.");
+        try {
+            if (subject == null) {
+                throw new AuthorizationException("The subject is null.");
             }
-            return this.getAuthorizationMetadataProvider().getAcl(subject);
-        });
+            CompletableFuture<? extends Subject> subjectFuture;
+            if (subject.isSubject(SubjectType.USER)) {
+                User user = (User) subject;
+                subjectFuture = this.getAuthenticationMetadataProvider().getUser(user.getUsername());
+            } else {
+                subjectFuture = CompletableFuture.completedFuture(subject);
+            }
+            return subjectFuture.thenCompose(sub -> {
+                if (sub == null) {
+                    throw new AuthorizationException("The subject is not exist.");
+                }
+                return this.getAuthorizationMetadataProvider().getAcl(sub);
+            });
+        } catch (Exception e) {
+            return this.handleException(e);
+        }
     }
 
     @Override

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/manager/AuthorizationMetadataManagerTest.java
@@ -204,6 +204,21 @@ public class AuthorizationMetadataManagerTest {
     }
 
     @Test
+    public void testGetAclWithNullSubject() {
+        if (MixAll.isMac()) {
+            return;
+        }
+        AuthorizationException authorizationException = Assert.assertThrows(AuthorizationException.class, () -> {
+            try {
+                this.authorizationMetadataManager.getAcl(null).join();
+            } catch (Exception e) {
+                AuthTestHelper.handleException(e);
+            }
+        });
+        Assert.assertEquals("The subject is null.", authorizationException.getMessage());
+    }
+
+    @Test
     public void listAcl() {
         if (MixAll.isMac()) {
             return;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9809 

### Brief Description

Provide more user-friendly error messages.

And in the `subjectFuture#thenCompose` method, use the correct `sub`, not `subject`.

### How Did You Test This Change?

unit test and local test

<img width="833" height="178" alt="Image" src="https://github.com/user-attachments/assets/f557e26b-e08e-4748-835a-01fe66772967" />
