### PR TITLE
Fixed NullPointerException in CommandUtil.fetchBrokerNameByAddr

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
@@ -176,7 +176,7 @@ public class CommandUtil {
         while (it.hasNext()) {
             Map.Entry<String, BrokerData> entry = it.next();
             HashMap<Long, String> brokerAddrs = entry.getValue().getBrokerAddrs();
-            if (brokerAddrs.containsValue(addr)) {
+            if (brokerAddrs != null && brokerAddrs.containsValue(addr)) {
                 return entry.getKey();
             }
         }

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/CommandUtilTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/CommandUtilTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -99,6 +100,16 @@ public class CommandUtilTest {
     public void testFetchMasterAddrByClusterName() throws InterruptedException, MQBrokerException, RemotingTimeoutException, RemotingSendRequestException, RemotingConnectException {
         Set<String> result = CommandUtil.fetchMasterAddrByClusterName(defaultMQAdminExtImpl, "default-cluster");
         assertThat(result.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testFetchBrokerNameByAddrThrowsCorrectExceptionWhenNothingFound() {
+        assertThatThrownBy( () -> {
+            CommandUtil.fetchBrokerNameByAddr(defaultMQAdminExtImpl, "127.0.0.2:10911");
+        })
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Make sure the specified clusterName exists or the name server connected to is correct.");
+
     }
 
     @Test

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/CommandUtilTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/CommandUtilTest.java
@@ -104,9 +104,7 @@ public class CommandUtilTest {
 
     @Test
     public void testFetchBrokerNameByAddrThrowsCorrectExceptionWhenNothingFound() {
-        assertThatThrownBy( () -> {
-            CommandUtil.fetchBrokerNameByAddr(defaultMQAdminExtImpl, "127.0.0.2:10911");
-        })
+        assertThatThrownBy(() -> CommandUtil.fetchBrokerNameByAddr(defaultMQAdminExtImpl, "127.0.0.2:10911"))
                 .isInstanceOf(Exception.class)
                 .hasMessageContaining("Make sure the specified clusterName exists or the name server connected to is correct.");
 


### PR DESCRIPTION
Fixed NullPointerException in CommandUtil.fetchBrokerNameByAddr if address does not get found.