### PR TITLE
Fixed error message of CommandUtil.fetchMasterAddrByBrokerName

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/CommandUtil.java
@@ -144,7 +144,7 @@ public class CommandUtil {
                 return addr;
             }
         }
-        throw new Exception(String.format("No broker address for broker name %s.%n", brokerData));
+        throw new Exception(String.format("No broker address for broker name %s.", brokerName));
     }
 
     public static Set<String> fetchMasterAndSlaveAddrByBrokerName(final MQAdminExt adminExt, final String brokerName)


### PR DESCRIPTION
Fixed error message of CommandUtil.fetchMasterAddrByBrokerName so that it returns the correct broker name.