### PR TITLE
[ISSUE #9838] IndexStoreService use forceShutdown when disk is not writable

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/RunningFlags.java
+++ b/store/src/main/java/org/apache/rocketmq/store/RunningFlags.java
@@ -85,6 +85,15 @@ public class RunningFlags {
         return false;
     }
 
+    public boolean isStoreWriteable() {
+        if ((this.flagBits & NOT_WRITEABLE_BIT) == 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+
     //for consume queue, just ignore the DISK_FULL_BIT
     public boolean isCQWriteable() {
         if ((this.flagBits & (NOT_WRITEABLE_BIT | WRITE_LOGICS_QUEUE_ERROR_BIT | WRITE_INDEX_FILE_ERROR_BIT | LOGIC_DISK_FULL_BIT)) == 0) {
@@ -94,7 +103,7 @@ public class RunningFlags {
         return false;
     }
 
-    public boolean getAndMakeNotWriteable() {
+    public boolean getAndMakeStoreNotWriteable() {
         boolean result = this.isWriteable();
         if (result) {
             this.flagBits |= NOT_WRITEABLE_BIT;

--- a/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
@@ -592,7 +592,7 @@ public class DefaultMappedFile extends AbstractMappedFile {
         if (runningFlags == null) {
             return false;
         }
-        return runningFlags.getAndMakeNotWriteable();
+        return runningFlags.getAndMakeStoreNotWriteable();
     }
 
     public boolean isWriteable() {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -465,8 +465,13 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
             dispatcher.shutdown();
         }
         if (indexService != null) {
-            indexService.shutdown();
+            if (defaultStore.getRunningFlags().isStoreWriteable()) {
+                indexService.shutdown();
+            } else {
+                indexService.forceShutdown();
+            }
         }
+
         if (flatFileStore != null) {
             flatFileStore.shutdown();
         }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -338,7 +338,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
                 .thenApply(time -> {
                     Attributes latencyAttributes = TieredStoreMetricsManager.newAttributesBuilder()
                         .put(TieredStoreMetricsConstant.LABEL_OPERATION,
-                                TieredStoreMetricsConstant.OPERATION_API_GET_TIME_BY_OFFSET)
+                            TieredStoreMetricsConstant.OPERATION_API_GET_TIME_BY_OFFSET)
                         .put(TieredStoreMetricsConstant.LABEL_TOPIC, topic)
                         .build();
                     TieredStoreMetricsManager.apiLatency.record(stopwatch.elapsed(TimeUnit.MILLISECONDS), latencyAttributes);
@@ -465,7 +465,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
             dispatcher.shutdown();
         }
         if (indexService != null) {
-            if (defaultStore.getRunningFlags().isStoreWriteable()) {
+            if (defaultStore.getRunningFlags() != null && defaultStore.getRunningFlags().isStoreWriteable()) {
                 indexService.shutdown();
             } else {
                 indexService.forceShutdown();

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexService.java
@@ -61,6 +61,13 @@ public interface IndexService {
     void shutdown();
 
     /**
+     * Force shutdown the index service.
+     */
+    default void forceShutdown() {
+        shutdown();
+    };
+
+    /**
      * Destroys the index service and releases all resources.
      */
     void destroy();

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
@@ -415,6 +415,11 @@ public class IndexStoreService extends ServiceThread implements IndexService {
     }
 
     @Override
+    public void forceShutdown() {
+        super.shutdown();
+    }
+
+    @Override
     public void run() {
         while (!this.isStopped()) {
             long expireTimestamp = System.currentTimeMillis()


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9838 

### Brief Description

IndexStoreService use forceShutdown when disk is not writable

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
