### PR TITLE
[#ISSUE 9841] Improve Resource Management in TimerWheel to Prevent File Handle Leaks

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
@@ -44,6 +44,8 @@ public class TimerWheel {
     public final int precisionMs;
     private final String fileName;
     private MappedByteBuffer mappedByteBuffer;
+    private RandomAccessFile randomAccessFile;
+    private FileChannel fileChannel;
     private final ByteBuffer byteBuffer;
     private final ThreadLocal<ByteBuffer> localBuffer = new ThreadLocal<ByteBuffer>() {
         @Override
@@ -69,7 +71,6 @@ public class TimerWheel {
         File file = new File(finalFileName);
         UtilAll.ensureDirOK(file.getParent());
 
-        RandomAccessFile randomAccessFile = null;
         try {
             randomAccessFile = new RandomAccessFile(finalFileName, "rw");
             if (file.exists() && randomAccessFile.length() != 0 &&
@@ -79,7 +80,8 @@ public class TimerWheel {
             }
             randomAccessFile.setLength(wheelLength);
             if (snapOffset < 0) {
-                mappedByteBuffer = randomAccessFile.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, wheelLength);
+                fileChannel = randomAccessFile.getChannel();
+                mappedByteBuffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, wheelLength);
                 assert wheelLength == mappedByteBuffer.remaining();
             }
             this.byteBuffer = ByteBuffer.allocateDirect(wheelLength);
@@ -90,10 +92,6 @@ public class TimerWheel {
         } catch (IOException e) {
             log.error("map file " + finalFileName + " Failed. ", e);
             throw e;
-        } finally {
-            if (randomAccessFile != null) {
-                randomAccessFile.close();
-            }
         }
     }
 
@@ -114,6 +112,13 @@ public class TimerWheel {
         UtilAll.cleanBuffer(this.mappedByteBuffer);
         UtilAll.cleanBuffer(this.byteBuffer);
         localBuffer.remove();
+
+        try {
+            this.fileChannel.close();
+            this.fileChannel = null;
+        } catch (Throwable t) {
+            log.error("Shutdown error in timer wheel", t);
+        }
     }
 
     public void flush() {

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
@@ -92,6 +92,11 @@ public class TimerWheel {
         } catch (IOException e) {
             log.error("map file " + finalFileName + " Failed. ", e);
             throw e;
+        } finally {
+            if (randomAccessFile != null) {
+                randomAccessFile.close();
+                randomAccessFile = null;
+            }
         }
     }
 

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
@@ -43,9 +43,9 @@ public class TimerWheel {
     public final int slotsTotal;
     public final int precisionMs;
     private final String fileName;
-    private MappedByteBuffer mappedByteBuffer;
-    private RandomAccessFile randomAccessFile;
-    private FileChannel fileChannel;
+    private final MappedByteBuffer mappedByteBuffer;
+    private final RandomAccessFile randomAccessFile;
+    private final FileChannel fileChannel;
     private final ByteBuffer byteBuffer;
     private final ThreadLocal<ByteBuffer> localBuffer = new ThreadLocal<ByteBuffer>() {
         @Override
@@ -83,6 +83,9 @@ public class TimerWheel {
                 fileChannel = randomAccessFile.getChannel();
                 mappedByteBuffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, wheelLength);
                 assert wheelLength == mappedByteBuffer.remaining();
+            } else {
+                fileChannel = null;
+                mappedByteBuffer = null;
             }
             this.byteBuffer = ByteBuffer.allocateDirect(wheelLength);
             this.byteBuffer.put(Files.readAllBytes(file.toPath()));
@@ -92,11 +95,6 @@ public class TimerWheel {
         } catch (IOException e) {
             log.error("map file " + finalFileName + " Failed. ", e);
             throw e;
-        } finally {
-            if (randomAccessFile != null) {
-                randomAccessFile.close();
-                randomAccessFile = null;
-            }
         }
     }
 
@@ -120,7 +118,6 @@ public class TimerWheel {
 
         try {
             this.fileChannel.close();
-            this.fileChannel = null;
         } catch (Throwable t) {
             log.error("Shutdown error in timer wheel", t);
         }

--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerWheel.java
@@ -86,6 +86,7 @@ public class TimerWheel {
             } else {
                 fileChannel = null;
                 mappedByteBuffer = null;
+                randomAccessFile.close();
             }
             this.byteBuffer = ByteBuffer.allocateDirect(wheelLength);
             this.byteBuffer.put(Files.readAllBytes(file.toPath()));


### PR DESCRIPTION
- Move RandomAccessFile and FileChannel to instance variables
- Close FileChannel in shutdown() method instead of constructor finally block
- This ensures proper resource cleanup and prevents file handle leaks

Change-Id: If6f0bdd555e5f6fdd5c44ca8404f7918b45cf67b
Co-developed-by: Cursor <noreply@cursor.com>

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9841 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
