### PR TITLE
fix controller mode scanControllerAddress

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
@@ -775,29 +775,33 @@ public class ReplicasManager {
     }
 
     private void scanAvailableControllerAddresses() {
-        if (controllerAddresses == null) {
-            LOGGER.warn("scanAvailableControllerAddresses addresses of controller is null!");
-            return;
-        }
-
-        for (String address : availableControllerAddresses.keySet()) {
-            if (!controllerAddresses.contains(address)) {
-                LOGGER.warn("scanAvailableControllerAddresses remove invalid address {}", address);
-                availableControllerAddresses.remove(address);
+        try {
+            if (controllerAddresses == null) {
+                LOGGER.warn("scanAvailableControllerAddresses addresses of controller is null!");
+                return;
             }
-        }
 
-        for (String address : controllerAddresses) {
-            scanExecutor.submit(() -> {
-                if (brokerOuterAPI.checkAddressReachable(address)) {
-                    availableControllerAddresses.putIfAbsent(address, true);
-                } else {
-                    Boolean value = availableControllerAddresses.remove(address);
-                    if (value != null) {
-                        LOGGER.warn("scanAvailableControllerAddresses remove unconnected address {}", address);
-                    }
+            for (String address : availableControllerAddresses.keySet()) {
+                if (!controllerAddresses.contains(address)) {
+                    LOGGER.warn("scanAvailableControllerAddresses remove invalid address {}", address);
+                    availableControllerAddresses.remove(address);
                 }
-            });
+            }
+
+            for (String address : controllerAddresses) {
+                scanExecutor.submit(() -> {
+                    if (brokerOuterAPI.checkAddressReachable(address)) {
+                        availableControllerAddresses.putIfAbsent(address, true);
+                    } else {
+                        Boolean value = availableControllerAddresses.remove(address);
+                        if (value != null) {
+                            LOGGER.warn("scanAvailableControllerAddresses remove unconnected address {}", address);
+                        }
+                    }
+                });
+            }
+        }catch (Throwable t){
+            LOGGER.error("scanAvailableControllerAddresses unexpected exception", t);
         }
     }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/controller/ReplicasManager.java
@@ -800,7 +800,7 @@ public class ReplicasManager {
                     }
                 });
             }
-        }catch (Throwable t){
+        } catch (final Throwable t) {
             LOGGER.error("scanAvailableControllerAddresses unexpected exception", t);
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->


### Brief Description
增强代码健壮性

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
部署：
rocketmq 5.3.0部署controller模式
一主三从

故障测试：
对其中两个broker做网络延迟故障，网络延迟在1分钟以上。故障恢复发现始终有一个broker不能加入到SyncStateSet里

代码改造后测试：
ReplicasManager的scanControllerAddress线程，在有网络延迟的情况相下确实有可能挂掉，影响AvailableControllerAddress的维护导致AvailableControllerAddress并不包含所有的controller节点，进而影响broker上报心跳到AvailableControllerAddress下的所有controller节点
<img width="1908" height="332" alt="image" src="https://github.com/user-attachments/assets/adfac321-054a-4004-9fbb-6cebad5b5698" />


<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
