### PR TITLE
[ISSUE #9870] Ensure metadata provider cache executors are shutdown correctly

### DIFF
--- a/auth/src/test/java/org/apache/rocketmq/auth/authentication/provider/LocalAuthenticationMetadataProviderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authentication/provider/LocalAuthenticationMetadataProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.auth.authentication.provider;
+
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.auth.helper.AuthTestHelper;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LocalAuthenticationMetadataProviderTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testShutdownReleasesCacheExecutor() throws Exception {
+        AuthConfig authConfig = AuthTestHelper.createDefaultConfig();
+        authConfig.setAuthConfigPath(tempFolder.newFolder("auth-test").getAbsolutePath());
+
+        LocalAuthenticationMetadataProvider provider = new LocalAuthenticationMetadataProvider();
+        // Initialize provider to create the internal cache refresh executor
+        provider.initialize(authConfig, () -> null);
+
+        // After initialize, the executor should exist and not be shutdown
+        Assert.assertNotNull(provider.cacheRefreshExecutor);
+        Assert.assertFalse(provider.cacheRefreshExecutor.isShutdown());
+
+        // Shutdown provider should also shutdown its executor and free resources
+        provider.shutdown();
+
+        // Verify that the cache refresh executor has been shutdown
+        Assert.assertTrue(provider.cacheRefreshExecutor.isShutdown());
+    }
+}

--- a/auth/src/test/java/org/apache/rocketmq/auth/authentication/provider/LocalAuthenticationMetadataProviderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authentication/provider/LocalAuthenticationMetadataProviderTest.java
@@ -37,11 +37,11 @@ public class LocalAuthenticationMetadataProviderTest {
         // Initialize provider to create the internal cache refresh executor
         provider.initialize(authConfig, () -> null);
 
-        // After initialize, the executor should exist and not be shutdown
+        // After initialization, the executor should exist and not be shutdown
         Assert.assertNotNull(provider.cacheRefreshExecutor);
         Assert.assertFalse(provider.cacheRefreshExecutor.isShutdown());
 
-        // Shutdown provider should also shutdown its executor and free resources
+        // Shutdown provider should also shutdown its executor to release resources
         provider.shutdown();
 
         // Verify that the cache refresh executor has been shutdown

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProviderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.auth.authorization.provider;
+
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.auth.helper.AuthTestHelper;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LocalAuthorizationMetadataProviderTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testShutdownReleasesCacheExecutor() throws Exception {
+        AuthConfig authConfig = AuthTestHelper.createDefaultConfig();
+        authConfig.setAuthConfigPath(tempFolder.newFolder("auth-test").getAbsolutePath());
+
+        LocalAuthorizationMetadataProvider provider = new LocalAuthorizationMetadataProvider();
+        // Initialize provider so that the internal cache refresh executor is created
+        provider.initialize(authConfig, () -> null);
+
+        // Verify that the scheduled executor is created and still running after initialize
+        Assert.assertNotNull(provider.cacheRefreshExecutor);
+        Assert.assertFalse(provider.cacheRefreshExecutor.isShutdown());
+
+        // When provider is shutdown, the executor should also be terminated to avoid thread leak
+        provider.shutdown();
+
+        // Verify that the cache refresh executor is properly shutdown
+        Assert.assertTrue(provider.cacheRefreshExecutor.isShutdown());
+    }
+}

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProviderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/provider/LocalAuthorizationMetadataProviderTest.java
@@ -34,17 +34,17 @@ public class LocalAuthorizationMetadataProviderTest {
         authConfig.setAuthConfigPath(tempFolder.newFolder("auth-test").getAbsolutePath());
 
         LocalAuthorizationMetadataProvider provider = new LocalAuthorizationMetadataProvider();
-        // Initialize provider so that the internal cache refresh executor is created
+        // Initialize provider to create the internal cache refresh executor
         provider.initialize(authConfig, () -> null);
 
-        // Verify that the scheduled executor is created and still running after initialize
+        // After initialization, the executor should exist and not be shutdown
         Assert.assertNotNull(provider.cacheRefreshExecutor);
         Assert.assertFalse(provider.cacheRefreshExecutor.isShutdown());
 
-        // When provider is shutdown, the executor should also be terminated to avoid thread leak
+        // Shutdown provider should also shutdown its executor to release resources
         provider.shutdown();
 
-        // Verify that the cache refresh executor is properly shutdown
+        // Verify that the cache refresh executor has been shutdown
         Assert.assertTrue(provider.cacheRefreshExecutor.isShutdown());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9870 

### Brief Description

Ensure that cache executors in metadata providers are properly released to avoid resource leaks.


### How Did You Test This Change?

unit test
