### PR TITLE
[ISSUE #9875] Optimize the RocksDB config shutdown logic when useSingleRocksDBForAllConfigs is set to true to prevent JVM crashes.

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConfigManager.java
@@ -38,7 +38,6 @@ public class RocksDBConfigManager {
 
     public static final Charset CHARSET = StandardCharsets.UTF_8;
 
-    public volatile boolean isStop = false;
     public ConfigRocksDBStorage configRocksDBStorage = null;
     private FlushOptions flushOptions = null;
     private volatile long lastFlushMemTableMicroSecond = 0;
@@ -72,9 +71,12 @@ public class RocksDBConfigManager {
     }
 
     public boolean init(boolean readOnly) {
-        this.isStop = false;
         this.configRocksDBStorage = ConfigRocksDBStorage.getStore(filePath, readOnly, compressionType);
         return this.configRocksDBStorage.start();
+    }
+
+    public boolean isLoaded() {
+        return this.configRocksDBStorage != null && this.configRocksDBStorage.isLoaded();
     }
 
     public boolean init() {
@@ -113,7 +115,6 @@ public class RocksDBConfigManager {
     }
 
     public boolean stop() {
-        this.isStop = true;
         ConfigRocksDBStorage.shutdown(filePath);
         if (this.flushOptions != null) {
             this.flushOptions.close();
@@ -123,7 +124,7 @@ public class RocksDBConfigManager {
 
     public void flushWAL() {
         try {
-            if (this.isStop) {
+            if (!isLoaded()) {
                 return;
             }
             if (this.configRocksDBStorage != null) {
@@ -183,4 +184,5 @@ public class RocksDBConfigManager {
 
         return configRocksDBStorage.getStatistics();
     }
+
 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
@@ -157,7 +157,7 @@ public class RocksDBConsumerOffsetManager extends ConsumerOffsetManager {
 
     @Override
     public synchronized void persist() {
-        if (!rocksDBConfigManager.isStop) {
+        if (!rocksDBConfigManager.isLoaded()) {
             try (WriteBatch writeBatch = new WriteBatch()) {
                 for (Entry<String, ConcurrentMap<Integer, Long>> entry : this.offsetTable.entrySet()) {
                     putWriteBatch(writeBatch, entry.getKey(), entry.getValue());

--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
@@ -157,7 +157,7 @@ public class RocksDBConsumerOffsetManager extends ConsumerOffsetManager {
 
     @Override
     public synchronized void persist() {
-        if (!rocksDBConfigManager.isLoaded()) {
+        if (rocksDBConfigManager.isLoaded()) {
             try (WriteBatch writeBatch = new WriteBatch()) {
                 for (Entry<String, ConcurrentMap<Integer, Long>> entry : this.offsetTable.entrySet()) {
                     putWriteBatch(writeBatch, entry.getKey(), entry.getValue());

--- a/common/src/main/java/org/apache/rocketmq/common/config/AbstractRocksDBStorage.java
+++ b/common/src/main/java/org/apache/rocketmq/common/config/AbstractRocksDBStorage.java
@@ -481,6 +481,10 @@ public abstract class AbstractRocksDBStorage {
      */
     protected abstract void preShutdown();
 
+    public boolean isLoaded() {
+        return loaded;
+    }
+
     public synchronized boolean shutdown() {
         try {
             if (!this.loaded) {


### PR DESCRIPTION
Change-Id: I309e8d13b6adc46d68146c05ffd7e026e2852ad8

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9875 

### Brief Description

Optimize the RocksDB config shutdown logic when useSingleRocksDBForAllConfigs is set to true to prevent JVM crashes

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
