### PR TITLE
[ISSUE #9888] Defer the shutdown behavior of popConsumerService to prevent JVM crash

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -1442,10 +1442,6 @@ public class BrokerController {
             this.pullRequestHoldService.shutdown();
         }
 
-        if (this.popConsumerService != null) {
-            this.popConsumerService.shutdown();
-        }
-
         if (this.popMessageProcessor.getPopLongPollingService() != null) {
             this.popMessageProcessor.getPopLongPollingService().shutdown();
         }
@@ -1639,6 +1635,10 @@ public class BrokerController {
             if (brokerAttachedPlugin != null) {
                 brokerAttachedPlugin.shutdown();
             }
+        }
+
+        if (this.popConsumerService != null) {
+            this.popConsumerService.shutdown();
         }
 
         if (this.messageStore != null) {


### PR DESCRIPTION
Change-Id: Iaa23996d94f81ed3250b8d528338e8502a35cada

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9888 

### Brief Description

RocksDB has already been shut down, but requests are still coming in, causing a JVM crash.

Defer the shutdown behavior of popConsumerService to prevent JVM crash

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
