### PR TITLE
[ISSUE #9396] change fastjson dependency scope to runtime

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,6 +40,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
         "junit:junit:4.13.2",
+        "com.alibaba:fastjson:2.0.60",
         "com.alibaba.fastjson2:fastjson2:2.0.60",
         "org.hamcrest:hamcrest-library:1.3",
         "io.netty:netty-all:4.1.65.Final",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,8 +40,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
         "junit:junit:4.13.2",
-        "com.alibaba:fastjson:1.2.76",
-        "com.alibaba.fastjson2:fastjson2:2.0.43",
+        "com.alibaba.fastjson2:fastjson2:2.0.60",
         "org.hamcrest:hamcrest-library:1.3",
         "io.netty:netty-all:4.1.65.Final",
         "org.assertj:assertj-core:3.22.0",
@@ -112,7 +111,6 @@ maven_install(
         "com.alipay.sofa:hessian:3.3.6",
         "io.netty:netty-tcnative-boringssl-static:2.0.48.Final",
         "org.mockito:mockito-junit-jupiter:4.11.0",
-        "com.alibaba.fastjson2:fastjson2:2.0.43",
         "org.junit.jupiter:junit-jupiter-api:5.9.1",
     ],
     fetch_sources = True,

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -44,6 +44,9 @@ java_library(
         "@maven//:io_github_aliyunmq_rocketmq_logback_classic",
         "@maven//:org_apache_rocketmq_rocketmq_rocksdb",
     ],
+    runtime_deps = [
+        "@maven//:com_alibaba_fastjson",
+    ],
 )
 
 java_library(

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,10 +33,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,6 +33,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -688,6 +688,13 @@
                 <type>jar</type>
                 <version>${bcpkix-jdk15on.version}</version>
             </dependency>
+            <!-- Compatibility adaptation for third-party dependencies -->
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>fastjson</artifactId>
+                <version>${fastjson2.version}</version>
+                <scope>runtime</scope>
+            </dependency>
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>
                 <artifactId>fastjson2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,7 @@
         <netty.version>4.1.119.Final</netty.version>
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk15on.version>1.69</bcpkix-jdk15on.version>
-        <fastjson.version>1.2.83</fastjson.version>
-        <fastjson2.version>2.0.43</fastjson2.version>
+        <fastjson2.version>2.0.60</fastjson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <jna.version>4.2.2</jna.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
@@ -688,11 +687,6 @@
                 <scope>runtime</scope>
                 <type>jar</type>
                 <version>${bcpkix-jdk15on.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>fastjson</artifactId>
-                <version>${fastjson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableCompatTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableCompatTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.rocketmq.remoting.protocol;
 
-import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson2.annotation.JSONField;
 import com.alibaba.fastjson2.JSON;
 import org.apache.rocketmq.remoting.protocol.body.BatchAck;
 import org.junit.Test;
@@ -408,10 +408,10 @@ public class RemotingSerializableCompatTest {
     }
     
     private boolean checkCompatible(final Object original, final Class<?> clazz) {
-        String json = com.alibaba.fastjson.JSON.toJSONString(original);
+        String json = JSON.toJSONString(original);
         Object deserialized;
         try {
-            deserialized = com.alibaba.fastjson2.JSON.parseObject(json, clazz);
+            deserialized = JSON.parseObject(json, clazz);
         } catch (Exception e) {
             System.err.printf("Deserialization failed for %s: %s\n", clazz.getName(), e.getMessage());
             return false;


### PR DESCRIPTION
- Change fastjson dependency scope to runtime
- Upgrade fastjson2 version from 2.0.43 to 2.0.60
- Update import statements to use fastjson2 package
- Replace fastjson serialization calls with fastjson2 equivalents
- Clean up redundant dependency declarations in pom files
- Update bazel workspace dependencies accordingly

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9396

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
