### PR TITLE
added channel.isActive() to clientIsOffline adn relevant test case

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -146,7 +146,10 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
     }
 
     protected boolean clientIsOffline(ReceiptHandleGroupKey groupKey) {
-        return this.consumerManager.findChannel(groupKey.getGroup(), groupKey.getChannel()) == null;
+        ClientChannelInfo clientChannelInfo=  this.consumerManager.findChannel(groupKey.getGroup(), groupKey.getChannel());
+        Channel channel=clientChannelInfo.getChannel();
+        return channel==null || !channel.isActive();
+
     }
 
     protected void scheduleRenewTask() {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -59,8 +59,7 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
     private DefaultReceiptHandleManager receiptHandleManager;
@@ -463,4 +462,20 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
         listenerArgumentCaptor.getValue().handle(ConsumerGroupEvent.CLIENT_UNREGISTER, GROUP, new ClientChannelInfo(channel, "", LanguageCode.JAVA, 0));
         assertTrue(receiptHandleManager.receiptHandleGroupMap.isEmpty());
     }
+
+    @Test
+    public void testClientOffline_channelInactive(){
+
+        Channel mockChannel=Mockito.mock(Channel.class);
+        ClientChannelInfo mockClientChannelInfo=Mockito.mock(ClientChannelInfo.class);
+        ReceiptHandleGroupKey mockReceiptHandleGroupKey=new ReceiptHandleGroupKey(mockChannel,GROUP);
+        Mockito.when(consumerManager.findChannel(GROUP,mockChannel)).thenReturn(mockClientChannelInfo);
+        Mockito.when(mockClientChannelInfo.getChannel()).thenReturn(mockChannel);
+        Mockito.when(mockChannel.isActive()).thenReturn(false);
+        assertTrue(receiptHandleManager.clientIsOffline(mockReceiptHandleGroupKey));
+
+    }
+
+
+
 }


### PR DESCRIPTION


Fixes [Bug] DefaultReceiptHandleManager#clientIsOffline The method should check Channel.isActive() to avoid resource leaks. #9805

### Brief Description

 checked Channel.isActive() in clientIsOffline

### How Did You Test This Change?

Added testClientOffline_channelInactive test case
