### PR TITLE
[ISSUE #9947] Fix TimerMessageStore.checkAndReviseMetrics throws BufferUnderflowException

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -1344,6 +1344,9 @@ public class TimerMessageStore {
                     bf.getInt();//size
                     bf.getLong();//prev pos
                     int magic = bf.getInt(); //magic
+                    if (magic == TimerLog.BLANK_MAGIC_CODE) {
+                        break;
+                    }
                     long enqueueTime = bf.getLong();
                     long delayedTime = bf.getInt() + enqueueTime;
                     long offsetPy = bf.getLong();


### PR DESCRIPTION
…eption when encountering BLANK record at end of TimerLog

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes [#9947](https://github.com/apache/rocketmq/issues/9947)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Ref #9947

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
Add unit test
