### PR TITLE
[ISSUE #9945] Use UniqueKey as the TimerDelKey value when no namespace is appended

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
@@ -288,7 +288,7 @@ public class Timeline {
             }
             int separatorIndex = deleteKey.indexOf(DELETE_KEY_SPLIT);
             if (separatorIndex == -1) {
-                throw new IllegalArgumentException("Invalid deleteKey format");
+                return deleteKey;
             }
             return deleteKey.substring(separatorIndex + 1);
         }


### PR DESCRIPTION
#9945