### PR TITLE
Fix CID_DefaultHeartBeatSyncerTopic not created when autoCreateSubscriptionGroup is false.

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/AdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/AdminService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.proxy.service.admin;
 
 import java.util.List;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
 public interface AdminService {
 
@@ -26,6 +27,8 @@ public interface AdminService {
 
     boolean createTopicOnTopicBrokerIfNotExist(String createTopic, String sampleTopic, int wQueueNum,
         int rQueueNum, boolean examineTopic, int retryCheckCount);
+
+    boolean createSubscriptionGroupIfNotExist(String clusterName, SubscriptionGroupConfig config, int retryTimes);
 
     boolean createTopicOnBroker(String topic, int wQueueNum, int rQueueNum, List<BrokerData> curBrokerDataList,
         List<BrokerData> sampleBrokerDataList, boolean examineTopic, int retryCheckCount) throws Exception;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
@@ -21,18 +21,20 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.rocketmq.client.impl.mqclient.MQClientAPIExt;
+import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.constant.PermName;
-import org.apache.rocketmq.remoting.protocol.route.BrokerData;
-import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
-import org.apache.rocketmq.client.impl.mqclient.MQClientAPIExt;
-import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
 import org.apache.rocketmq.proxy.service.route.TopicRouteHelper;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
 public class DefaultAdminService implements AdminService {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
@@ -88,6 +90,47 @@ public class DefaultAdminService implements AdminService {
             log.error("create topic {} failed.", createTopic, e);
         }
         return false;
+    }
+
+    @Override
+    public boolean createSubscriptionGroupIfNotExist(String clusterName, SubscriptionGroupConfig config,
+        int retryTimes) {
+        try {
+            ClusterInfo clusterInfo = this.getClient().getBrokerClusterInfo(Duration.ofSeconds(3).toMillis());
+            if (clusterInfo == null || clusterInfo.getClusterAddrTable() == null) {
+                log.error("createSubscriptionGroupIfNotExist failed, cluster info is empty");
+                return false;
+            }
+
+            Set<String> brokerNames = clusterInfo.getClusterAddrTable().get(clusterName);
+            if (brokerNames == null || brokerNames.isEmpty()) {
+                log.error("createSubscriptionGroupIfNotExist failed, cluster {} is empty", clusterName);
+                return false;
+            }
+
+            boolean allSuccess = true;
+            for (String brokerName : brokerNames) {
+                BrokerData brokerData = clusterInfo.getBrokerAddrTable().get(brokerName);
+                if (brokerData == null || brokerData.getBrokerAddrs() == null) {
+                    continue;
+                }
+
+                String masterAddr = brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
+                if (masterAddr != null) {
+                    try {
+                        this.getClient().createSubscriptionGroup(masterAddr, config, Duration.ofSeconds(3).toMillis());
+                        log.info("create subscription group {} on broker {} success", config.getGroupName(), masterAddr);
+                    } catch (Exception e) {
+                        log.error("create subscription group {} on broker {} failed", config.getGroupName(), masterAddr, e);
+                        allSuccess = false;
+                    }
+                }
+            }
+            return allSuccess;
+        } catch (Exception e) {
+            log.error("createSubscriptionGroupIfNotExist failed, clusterName: {}", clusterName, e);
+            return false;
+        }
     }
 
     @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/AbstractSystemMessageSyncer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/AbstractSystemMessageSyncer.java
@@ -46,6 +46,7 @@ import org.apache.rocketmq.remoting.protocol.heartbeat.MessageModel;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
 public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, MessageListenerConcurrently {
     protected static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
@@ -55,7 +56,8 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
     protected final RPCHook rpcHook;
     protected DefaultMQPushConsumer defaultMQPushConsumer;
 
-    public AbstractSystemMessageSyncer(TopicRouteService topicRouteService, AdminService adminService, MQClientAPIFactory mqClientAPIFactory, RPCHook rpcHook) {
+    public AbstractSystemMessageSyncer(TopicRouteService topicRouteService, AdminService adminService,
+        MQClientAPIFactory mqClientAPIFactory, RPCHook rpcHook) {
         this.topicRouteService = topicRouteService;
         this.adminService = adminService;
         this.mqClientAPIFactory = mqClientAPIFactory;
@@ -142,6 +144,7 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
     @Override
     public void start() throws Exception {
         this.createSysTopic();
+        this.createSysConsumerGroup();
         RPCHook rpcHook = this.getRpcHook();
         this.defaultMQPushConsumer = new DefaultMQPushConsumer(this.getSystemMessageConsumerId(), rpcHook);
 
@@ -172,6 +175,28 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
         );
         if (!createSuccess) {
             throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR, "create system broadcast topic " + this.getBroadcastTopicName() + " failed on cluster " + clusterName);
+        }
+    }
+
+    protected void createSysConsumerGroup() {
+        String clusterName = this.getBroadcastTopicClusterName();
+        if (StringUtils.isEmpty(clusterName)) {
+            throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR, "system topic cluster cannot be empty");
+        }
+
+        SubscriptionGroupConfig config = new SubscriptionGroupConfig();
+        config.setGroupName(this.getSystemMessageConsumerId());
+        config.setConsumeBroadcastEnable(true);
+        config.setConsumeEnable(true);
+
+        boolean createSuccess = this.adminService.createSubscriptionGroupIfNotExist(
+            clusterName,
+            config,
+            3
+        );
+
+        if (!createSuccess) {
+            throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR, "create system broadcast consumer group " + this.getSystemMessageConsumerId() + " failed on cluster " + clusterName);
         }
     }
 


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

The HeartbeatSyncer in Proxy relies on the Broker to automatically create the internal consumer group (CID_DefaultHeartBeatSyncerTopic). If autoCreateSubscriptionGroup is set to false on the Broker, the Syncer fails to start because the group does not exist.

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
