### PR TITLE
[ISSUE #10035] Fix: avoid extra padding when message end position is already page-al…

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
+++ b/store/src/main/java/org/apache/rocketmq/store/logfile/DefaultMappedFile.java
@@ -389,6 +389,9 @@ public class DefaultMappedFile extends AbstractMappedFile {
                         int endpos = currentPos + msgLen;
                         // alignment end position
                         int extraAppendSize = UNSAFE_PAGE_SIZE - endpos % UNSAFE_PAGE_SIZE;
+                        if (extraAppendSize == UNSAFE_PAGE_SIZE) {
+                            extraAppendSize = 0;
+                        }
                         int actualAppendSize = msgLen + extraAppendSize;
 
                         this.fileChannel.position(currentPos);


### PR DESCRIPTION
…igned

Change-Id: I3e7fad9c4b194b20015414bcceb830760df68fea

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10035

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
