### PR TITLE
[ISSUE #10038] Fix checkCommitLogOffsetOnRecover to skip validation for BLANK_MAGIC_…

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -795,7 +795,7 @@ public class CommitLog implements Swappable {
                 int size = dispatchRequest.getMsgSize();
                 if (dispatchRequest.isSuccess()) {
                     // Check commitlog offset validity if enabled
-                    if (checkCommitLogOffsetOnRecover) {
+                    if (size > 0 && checkCommitLogOffsetOnRecover) {
                         if (dispatchRequest.getCommitLogOffset() < mappedFile.getFileFromOffset()
                             || dispatchRequest.getCommitLogOffset() > mappedFile.getFileFromOffset() + mappedFile.getFileSize()) {
                             log.warn("found illegal commitlog offset {} in {}, current pos={}, it will be truncated.",


### PR DESCRIPTION
…CODE messages

Change-Id: If1913db5155fe4135f2dbd1b58417b3afc6748c1

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10038

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
