### PR TITLE
forbid windows sync directory

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/MixAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MixAll.java
@@ -249,7 +249,9 @@ public class MixAll {
         if (!Files.isDirectory(dir)) {
             throw new NotDirectoryException(dir.toString());
         }
-
+        if (isWindows()) {
+            return;
+        }
         try (FileChannel fc = FileChannel.open(dir, StandardOpenOption.READ)) {
             fc.force(true);
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #9899

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Windows does not support fsync diretory.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
