### PR TITLE
[ISSUE #10071] Fix PopLiteLongPollingService#cleanUnusedResource

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLiteLongPollingService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLiteLongPollingService.java
@@ -26,7 +26,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.ServiceThread;
 import org.apache.rocketmq.common.constant.LoggerName;
-import org.apache.rocketmq.common.lite.LiteSubscription;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.remoting.netty.NettyRemotingAbstract;
@@ -126,7 +125,7 @@ public class PopLiteLongPollingService extends ServiceThread {
                 }
 
                 // clean unused
-                if (lastCleanTime == 0 || System.currentTimeMillis() - lastCleanTime > 5 * 60 * 1000) {
+                if (lastCleanTime == 0 || System.currentTimeMillis() - lastCleanTime > 3 * 60 * 1000) {
                     cleanUnusedResource();
                 }
             } catch (Throwable e) {
@@ -247,10 +246,8 @@ public class PopLiteLongPollingService extends ServiceThread {
     private void cleanUnusedResource() {
         try {
             pollingMap.entrySet().removeIf(entry -> {
-                String clientId = entry.getKey(); // see getPollingKey()
-                LiteSubscription subscription = brokerController.getLiteSubscriptionRegistry().getLiteSubscription(clientId);
-                if (null == subscription || CollectionUtils.isEmpty(subscription.getLiteTopicSet())) {
-                    LOGGER.info("clean polling structure of {}", clientId);
+                if (CollectionUtils.isEmpty(entry.getValue())) {
+                    LOGGER.info("clean polling structure of {}", entry.getKey()); // see getPollingKey()
                     return true;
                 }
                 return false;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10071

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Problem: The cleanUnusedResource method was cleaning up client long polling requests without returning results to clients, causing client errors.

Solution:
1. Simplified the cleanUnusedResource method to only remove entries with empty request queues
2. Changed cleanup interval from 5 minutes to 3 minutes

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
