### PR TITLE
[ISSUE #10073] Fix StoreCheckpoint logicsMsgTimestamp to reflect flushed consume queue storetime

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -709,7 +709,7 @@ public class ConsumeQueue implements ConsumeQueueInterface {
                     this.messageStore.getMessageStoreConfig().isEnableDLegerCommitLog()) {
                     this.messageStore.getStoreCheckpoint().setPhysicMsgTimestamp(request.getStoreTimestamp());
                 }
-                this.messageStore.getStoreCheckpoint().setLogicsMsgTempTimestamp(request.getStoreTimestamp());
+                this.messageStore.getStoreCheckpoint().setTmpLogicsMsgTimestamp(request.getStoreTimestamp());
                 if (MultiDispatchUtils.checkMultiDispatchQueue(this.messageStore.getMessageStoreConfig(), request)) {
                     multiDispatchLmqQueue(request, maxRetries);
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -709,7 +709,7 @@ public class ConsumeQueue implements ConsumeQueueInterface {
                     this.messageStore.getMessageStoreConfig().isEnableDLegerCommitLog()) {
                     this.messageStore.getStoreCheckpoint().setPhysicMsgTimestamp(request.getStoreTimestamp());
                 }
-                this.messageStore.getStoreCheckpoint().setLogicsMsgTimestamp(request.getStoreTimestamp());
+                this.messageStore.getStoreCheckpoint().setLogicsMsgTempTimestamp(request.getStoreTimestamp());
                 if (MultiDispatchUtils.checkMultiDispatchQueue(this.messageStore.getMessageStoreConfig(), request)) {
                     multiDispatchLmqQueue(request, maxRetries);
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/StoreCheckpoint.java
+++ b/store/src/main/java/org/apache/rocketmq/store/StoreCheckpoint.java
@@ -33,6 +33,7 @@ public class StoreCheckpoint {
     private final RandomAccessFile randomAccessFile;
     private final FileChannel fileChannel;
     private final MappedByteBuffer mappedByteBuffer;
+    private volatile long logicsMsgTempTimestamp = 0;
     private volatile long physicMsgTimestamp = 0;
     private volatile long logicsMsgTimestamp = 0;
     private volatile long indexMsgTimestamp = 0;
@@ -110,6 +111,14 @@ public class StoreCheckpoint {
 
     public void setLogicsMsgTimestamp(long logicsMsgTimestamp) {
         this.logicsMsgTimestamp = logicsMsgTimestamp;
+    }
+
+    public long getLogicsMsgTempTimestamp() {
+        return logicsMsgTempTimestamp;
+    }
+
+    public void setLogicsMsgTempTimestamp(long logicsMsgTempTimestamp) {
+        this.logicsMsgTempTimestamp = logicsMsgTempTimestamp;
     }
 
     public long getConfirmPhyOffset() {

--- a/store/src/main/java/org/apache/rocketmq/store/StoreCheckpoint.java
+++ b/store/src/main/java/org/apache/rocketmq/store/StoreCheckpoint.java
@@ -33,7 +33,7 @@ public class StoreCheckpoint {
     private final RandomAccessFile randomAccessFile;
     private final FileChannel fileChannel;
     private final MappedByteBuffer mappedByteBuffer;
-    private volatile long logicsMsgTempTimestamp = 0;
+    private volatile long tmpLogicsMsgTimestamp = 0;
     private volatile long physicMsgTimestamp = 0;
     private volatile long logicsMsgTimestamp = 0;
     private volatile long indexMsgTimestamp = 0;
@@ -113,12 +113,12 @@ public class StoreCheckpoint {
         this.logicsMsgTimestamp = logicsMsgTimestamp;
     }
 
-    public long getLogicsMsgTempTimestamp() {
-        return logicsMsgTempTimestamp;
+    public long getTmpLogicsMsgTimestamp() {
+        return tmpLogicsMsgTimestamp;
     }
 
-    public void setLogicsMsgTempTimestamp(long logicsMsgTempTimestamp) {
-        this.logicsMsgTempTimestamp = logicsMsgTempTimestamp;
+    public void setTmpLogicsMsgTimestamp(long tmpLogicsMsgTimestamp) {
+        this.tmpLogicsMsgTimestamp = tmpLogicsMsgTimestamp;
     }
 
     public long getConfirmPhyOffset() {

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -536,7 +536,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
                 if (BrokerRole.SLAVE == this.messageStore.getMessageStoreConfig().getBrokerRole()) {
                     this.messageStore.getStoreCheckpoint().setPhysicMsgTimestamp(request.getStoreTimestamp());
                 }
-                this.messageStore.getStoreCheckpoint().setLogicsMsgTempTimestamp(request.getStoreTimestamp());
+                this.messageStore.getStoreCheckpoint().setTmpLogicsMsgTimestamp(request.getStoreTimestamp());
                 return;
             } else {
                 // XXX: warn and notify me

--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -536,7 +536,7 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
                 if (BrokerRole.SLAVE == this.messageStore.getMessageStoreConfig().getBrokerRole()) {
                     this.messageStore.getStoreCheckpoint().setPhysicMsgTimestamp(request.getStoreTimestamp());
                 }
-                this.messageStore.getStoreCheckpoint().setLogicsMsgTimestamp(request.getStoreTimestamp());
+                this.messageStore.getStoreCheckpoint().setLogicsMsgTempTimestamp(request.getStoreTimestamp());
                 return;
             } else {
                 // XXX: warn and notify me

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -648,15 +648,17 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
             if (currentTimeMillis >= (this.lastFlushTimestamp + flushConsumeQueueThoroughInterval)) {
                 this.lastFlushTimestamp = currentTimeMillis;
                 flushConsumeQueueLeastPages = 0;
-                logicsMsgTimestamp = messageStore.getStoreCheckpoint().getLogicsMsgTimestamp();
+                logicsMsgTimestamp = messageStore.getStoreCheckpoint().getLogicsMsgTempTimestamp();
             }
 
+            boolean flushOK = true;
             for (ConcurrentMap<Integer, ConsumeQueueInterface> maps : consumeQueueTable.values()) {
                 for (ConsumeQueueInterface cq : maps.values()) {
                     boolean result = false;
                     for (int i = 0; i < retryTimes && !result; i++) {
                         result = flush(cq, flushConsumeQueueLeastPages);
                     }
+                    flushOK &= result;
                 }
             }
 
@@ -664,7 +666,7 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
                 messageStore.getCompactionStore().flush(flushConsumeQueueLeastPages);
             }
 
-            if (0 == flushConsumeQueueLeastPages) {
+            if (flushOK && 0 == flushConsumeQueueLeastPages) {
                 if (logicsMsgTimestamp > 0) {
                     messageStore.getStoreCheckpoint().setLogicsMsgTimestamp(logicsMsgTimestamp);
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -648,7 +648,7 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
             if (currentTimeMillis >= (this.lastFlushTimestamp + flushConsumeQueueThoroughInterval)) {
                 this.lastFlushTimestamp = currentTimeMillis;
                 flushConsumeQueueLeastPages = 0;
-                logicsMsgTimestamp = messageStore.getStoreCheckpoint().getLogicsMsgTempTimestamp();
+                logicsMsgTimestamp = messageStore.getStoreCheckpoint().getTmpLogicsMsgTimestamp();
             }
 
             boolean flushOK = true;


### PR DESCRIPTION
…logicsMsgTempTimestamp for in-memory storetime

Change-Id: I6085bf6efaef84168ece31d080481717465f2b13

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10073 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
