### PR TITLE
[ISSUE #10079] FlushConsumeQueueService: always flush store checkpoint after CQ flush

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/ConsumeQueueStore.java
@@ -651,14 +651,12 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
                 logicsMsgTimestamp = messageStore.getStoreCheckpoint().getTmpLogicsMsgTimestamp();
             }
 
-            boolean flushOK = true;
             for (ConcurrentMap<Integer, ConsumeQueueInterface> maps : consumeQueueTable.values()) {
                 for (ConsumeQueueInterface cq : maps.values()) {
                     boolean result = false;
                     for (int i = 0; i < retryTimes && !result; i++) {
                         result = flush(cq, flushConsumeQueueLeastPages);
                     }
-                    flushOK &= result;
                 }
             }
 
@@ -666,7 +664,7 @@ public class ConsumeQueueStore extends AbstractConsumeQueueStore {
                 messageStore.getCompactionStore().flush(flushConsumeQueueLeastPages);
             }
 
-            if (flushOK && 0 == flushConsumeQueueLeastPages) {
+            if (0 == flushConsumeQueueLeastPages) {
                 if (logicsMsgTimestamp > 0) {
                     messageStore.getStoreCheckpoint().setLogicsMsgTimestamp(logicsMsgTimestamp);
                 }


### PR DESCRIPTION
…h, remove conditional check

Change-Id: I57c0922bb81c2d43359867e82a92fdf2deab7ad7

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10079

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
