### PR TITLE
[ISSUE #10082] Missing PROPERTY_TIMER_DELAY_MS property check in delay message type validation

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.common.attribute.TopicMessageType;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.filter.ExpressionType;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -160,21 +161,8 @@ public class GrpcConverter {
         }
 
         // message_type
-        String isTrans = messageExt.getProperty(MessageConst.PROPERTY_TRANSACTION_PREPARED);
-        String isTransValue = "true";
-        if (isTransValue.equals(isTrans)) {
-            systemPropertiesBuilder.setMessageType(MessageType.TRANSACTION);
-        } else if (messageExt.getProperty(MessageConst.PROPERTY_DELAY_TIME_LEVEL) != null
-            || messageExt.getProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS) != null
-            || messageExt.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC) != null) {
-            systemPropertiesBuilder.setMessageType(MessageType.DELAY);
-        } else if (messageExt.getProperty(MessageConst.PROPERTY_SHARDING_KEY) != null) {
-            systemPropertiesBuilder.setMessageType(MessageType.FIFO);
-        } else if (messageExt.getProperty(MessageConst.PROPERTY_LITE_TOPIC) != null) {
-            systemPropertiesBuilder.setMessageType(MessageType.LITE);
-        } else {
-            systemPropertiesBuilder.setMessageType(MessageType.NORMAL);
-        }
+        TopicMessageType topicMessageType = TopicMessageType.parseFromMessageProperty(messageExt.getProperties());
+        systemPropertiesBuilder.setMessageType(convertToGrpcMessageType(topicMessageType));
 
         // born_timestamp (millis)
         long bornTimestamp = messageExt.getBornTimestamp();
@@ -270,5 +258,25 @@ public class GrpcConverter {
             .setResourceNamespace(NamespaceUtil.getNamespaceFromResource(resourceNameWithNamespace))
             .setName(NamespaceUtil.withoutNamespace(resourceNameWithNamespace))
             .build();
+    }
+
+    protected MessageType convertToGrpcMessageType(TopicMessageType topicMessageType) {
+        switch (topicMessageType) {
+            case TRANSACTION:
+                return MessageType.TRANSACTION;
+            case DELAY:
+                return MessageType.DELAY;
+            case FIFO:
+                return MessageType.FIFO;
+            case PRIORITY:
+                return MessageType.PRIORITY;
+            case LITE:
+                return MessageType.LITE;
+            case NORMAL:
+                return MessageType.NORMAL;
+            case UNSPECIFIED:
+            default:
+                return MessageType.NORMAL;
+        }
     }
 }


### PR DESCRIPTION
Change-Id: I1820986a5389b2209528a34a2201afe483898b7b

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10082

### Brief Description

Refactored message type detection logic - Replaced the hardcoded if-else logic with TopicMessageType.parseFromMessageProperty() to ensure consistency across the codebase
Added type conversion method - Introduced convertToGrpcMessageType() to convert TopicMessageType enum to gRPC MessageType
Fixed missing property check - Now correctly handles all 4 delay-related properties:
PROPERTY_DELAY_TIME_LEVEL
PROPERTY_TIMER_DELIVER_MS
PROPERTY_TIMER_DELAY_SEC
PROPERTY_TIMER_DELAY_MS

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
