### PR TITLE
[ISSUE # 10086]  Fix timer engine switch to persist correct config key

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -3466,13 +3466,13 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             if (MessageConst.TIMER_ENGINE_ROCKSDB_TIMELINE.equals(engineType)) {
                 if (this.brokerController.getTimerMessageRocksDBStore() == null) {
                     response.setCode(ResponseCode.INVALID_PARAMETER);
-                    response.setRemark("timerUseRocksDB muse be configured true when broker start");
+                    response.setRemark("timerRocksDBEnable must be configured true when broker start");
                     return response;
                 }
                 result = this.brokerController.getTimerMessageRocksDBStore().restart();
                 if (result) {
                     properties.put("timerStopEnqueue", Boolean.TRUE.toString());
-                    properties.put("timerUseRocksDB", Boolean.TRUE.toString());
+                    properties.put("timerRocksDBEnable", Boolean.TRUE.toString());
                     properties.put("timerRocksDBStopScan", Boolean.FALSE.toString());
                 }
             } else {


### PR DESCRIPTION
Motivation
switchTimerEngine writes timerUseRocksDB to the broker configuration, but the actual config key is timerRocksDBEnable. As a result, the switch isn’t persisted and may revert after restart.There’s also a typo in the error message.

Changes
- Persist timerRocksDBEnable instead of timerUseRocksDB
- Fix typo in error message (muse → must) and reference correct key name

Impact
Ensures engine switch is persisted correctly and improves user-facing guidance.

Test Plan
- Manual: switch to RocksDB engine, verify timerRocksDBEnable=true is written to config; restart broker and confirm RocksDB engine remains enabled.