### PR TITLE
Upgraded Netty to 4.1.130.Final to remediate CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <commons-cli.version>1.5.0</commons-cli.version>
-        <netty.version>4.1.119.Final</netty.version>
+        <netty.version>4.1.130.Final</netty.version>
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk15on.version>1.69</bcpkix-jdk15on.version>
         <fastjson.version>1.2.83</fastjson.version>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

#10089

### Brief Description

Upgraded Netty to 4.1.130.Final to remediate CVE-2025-55163, CVE-2025-59419, CVE-2025-58057, CVE-2025-67735 and CVE-2025-58056

### How Did You Test This Change?

Local build passes