### PR TITLE
Upgraded LZ4 and migrated to newer group id

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>zstd-jni</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <rocketmq-shaded-slf4j-api-bridge.version>1.0.0</rocketmq-shaded-slf4j-api-bridge.version>
         <commons-validator.version>1.7</commons-validator.version>
         <zstd-jni.version>1.5.2-2</zstd-jni.version>
-        <lz4-java.version>1.8.0</lz4-java.version>
+        <lz4-java.version>1.10.3</lz4-java.version>
         <opentracing.version>0.33.0</opentracing.version>
         <jaeger.version>1.8.1</jaeger.version>
         <dleger.version>0.3.2</dleger.version>
@@ -791,7 +791,7 @@
                 <version>${zstd-jni.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.lz4</groupId>
+                <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
                 <version>${lz4-java.version}</version>
             </dependency>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10091

### Brief Description

Upgraded LZ4 to the newer community Group ID to remediate CVE-2025-12183 and CVE-2025-66566

### How Did You Test This Change?

Local build