### PR TITLE
Upgrade Protobuf Java to remediate CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <concurrentlinkedhashmap-lru.version>1.4.2</concurrentlinkedhashmap-lru.version>
         <rocketmq-proto.version>2.1.1</rocketmq-proto.version>
         <grpc.version>1.53.0</grpc.version>
-        <protobuf.version>3.20.1</protobuf.version>
+        <protobuf.version>3.25.8</protobuf.version>
         <disruptor.version>1.2.10</disruptor.version>
         <org.relection.version>0.9.11</org.relection.version>
         <caffeine.version>2.9.3</caffeine.version>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10097 

### Brief Description

Upgraded Protobuf Java to 3.25.8 to remediate CVE-2022-3509, CVE-2022-3510 and CVE-2024-7254

### How Did You Test This Change?

Local build