### PR TITLE
Upgraded GRPC to 1.79 to remediate CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-io.version>2.14.0</commons-io.version>
         <guava.version>32.0.1-jre</guava.version>
-        <gson.version>2.9.0</gson.version>
+        <gson.version>2.12.1</gson.version>
         <openmessaging.version>0.3.1-alpha</openmessaging.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <commons-codec.version>1.13</commons-codec.version>
@@ -128,7 +128,8 @@
         <extra-enforcer-rules.version>1.0-beta-4</extra-enforcer-rules.version>
         <concurrentlinkedhashmap-lru.version>1.4.2</concurrentlinkedhashmap-lru.version>
         <rocketmq-proto.version>2.1.1</rocketmq-proto.version>
-        <grpc.version>1.53.0</grpc.version>
+        <grpc.version>1.79.0</grpc.version>
+        <googe.error_prone_annotations.version>2.45.0</googe.error_prone_annotations.version>
         <protobuf.version>3.20.1</protobuf.version>
         <disruptor.version>1.2.10</disruptor.version>
         <org.relection.version>0.9.11</org.relection.version>
@@ -1120,6 +1121,11 @@
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>1.3.5</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${googe.error_prone_annotations.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
+            <version>2.12.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10099 

### Brief Description

Upgraded GRPC to 1.79 to remediate CVE-2023-32731, CVE-2023-32732 and CVE-2025-55163

### How Did You Test This Change?

Local build passes