### PR TITLE
[ISSUE #10107] Fix fastjson2 integer overflow when parsing AtomicLong

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,7 @@ maven_install(
     artifacts = [
         "junit:junit:4.13.2",
         "com.alibaba:fastjson:1.2.76",
-        "com.alibaba.fastjson2:fastjson2:2.0.43",
+        "com.alibaba.fastjson2:fastjson2:2.0.59",
         "org.hamcrest:hamcrest-library:1.3",
         "io.netty:netty-all:4.1.65.Final",
         "org.assertj:assertj-core:3.22.0",
@@ -112,7 +112,7 @@ maven_install(
         "com.alipay.sofa:hessian:3.3.6",
         "io.netty:netty-tcnative-boringssl-static:2.0.48.Final",
         "org.mockito:mockito-junit-jupiter:4.11.0",
-        "com.alibaba.fastjson2:fastjson2:2.0.43",
+        "com.alibaba.fastjson2:fastjson2:2.0.59",
         "org.junit.jupiter:junit-jupiter-api:5.9.1",
     ],
     fetch_sources = True,

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
         <fastjson.version>1.2.83</fastjson.version>
-        <fastjson2.version>2.0.43</fastjson2.version>
+        <fastjson2.version>2.0.59</fastjson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <jna.version>4.2.2</jna.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/DataVersionTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/DataVersionTest.java
@@ -17,9 +17,15 @@
 
 package org.apache.rocketmq.remoting.protocol;
 
-import java.util.concurrent.atomic.AtomicLong;
-import org.junit.Assert;
+import com.alibaba.fastjson2.JSON;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DataVersionTest {
 
@@ -28,7 +34,7 @@ public class DataVersionTest {
         DataVersion dataVersion = new DataVersion();
         DataVersion other = new DataVersion();
         other.setTimestamp(dataVersion.getTimestamp());
-        Assert.assertTrue(dataVersion.equals(other));
+        assertEquals(dataVersion, other);
     }
 
     @Test
@@ -37,7 +43,7 @@ public class DataVersionTest {
         DataVersion other = new DataVersion();
         other.setCounter(new AtomicLong(1L));
         other.setTimestamp(dataVersion.getTimestamp());
-        Assert.assertFalse(dataVersion.equals(other));
+        assertNotEquals(dataVersion, other);
     }
 
     @Test
@@ -46,7 +52,7 @@ public class DataVersionTest {
         DataVersion other = new DataVersion();
         other.setCounter(null);
         other.setTimestamp(dataVersion.getTimestamp());
-        Assert.assertFalse(dataVersion.equals(other));
+        assertNotEquals(dataVersion, other);
     }
 
     @Test
@@ -55,7 +61,7 @@ public class DataVersionTest {
         dataVersion.setCounter(null);
         DataVersion other = new DataVersion();
         other.setTimestamp(dataVersion.getTimestamp());
-        Assert.assertFalse(dataVersion.equals(other));
+        assertNotEquals(dataVersion, other);
     }
 
     @Test
@@ -65,13 +71,25 @@ public class DataVersionTest {
         DataVersion other = new DataVersion();
         other.setCounter(null);
         other.setTimestamp(dataVersion.getTimestamp());
-        Assert.assertTrue(dataVersion.equals(other));
+        assertEquals(dataVersion, other);
     }
 
     @Test
     public void testEncode() {
         DataVersion dataVersion = new DataVersion();
-        Assert.assertTrue(dataVersion.encode().length > 0);
-        Assert.assertNotNull(dataVersion.toJson());
+        assertTrue(dataVersion.encode().length > 0);
+        assertNotNull(dataVersion.toJson());
+    }
+
+    @Test
+    public void testJsonSerializationAndDeserialization() {
+        DataVersion expected = new DataVersion();
+        expected.setCounter(new AtomicLong(Long.MAX_VALUE));
+        expected.setTimestamp(expected.getTimestamp());
+        String jsonStr = expected.toJson();
+        assertNotNull(jsonStr);
+        DataVersion actual = JSON.parseObject(jsonStr, DataVersion.class);
+        assertNotNull(actual);
+        assertEquals(expected.getTimestamp(), actual.getTimestamp());
     }
 }


### PR DESCRIPTION

Fixes #10107 .
