### PR TITLE
Fix thread name prefix for fileRecyclingExecutor

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
@@ -75,7 +75,7 @@ public class MessageStoreExecutor {
             Math.max(4, Runtime.getRuntime().availableProcessors()),
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.fileRecyclingThreadPoolQueue,
-            new ThreadFactoryImpl("BufferFetchExecutor_"));
+            new ThreadFactoryImpl("FileRecyclingExecutor_"));
     }
 
     private void shutdownExecutor(ExecutorService executor) {


### PR DESCRIPTION
Fixes #9959. Corrects thread name prefix from BufferFetchExecutor_ to FileRecyclingExecutor_ for fileRecyclingExecutor in MessageStoreExecutor.