### PR TITLE
[refactor] Use Collections.emptyMap() instead of new HashMap<>() for better code quality

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.subscription;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -416,11 +417,11 @@ public class SubscriptionGroupManager extends ConfigManager {
     private Map<String, String> current(String groupName) {
         SubscriptionGroupConfig subscriptionGroupConfig = this.subscriptionGroupTable.get(groupName);
         if (subscriptionGroupConfig == null) {
-            return new HashMap<>();
+            return Collections.emptyMap();
         } else {
             Map<String, String> attributes = subscriptionGroupConfig.getAttributes();
             if (attributes == null) {
-                return new HashMap<>();
+                return Collections.emptyMap();
             } else {
                 return attributes;
             }

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.broker.topic;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -750,11 +751,11 @@ public class TopicConfigManager extends ConfigManager {
     private Map<String, String> current(String topic) {
         TopicConfig topicConfig = getTopicConfig(topic);
         if (topicConfig == null) {
-            return new HashMap<>();
+            return Collections.emptyMap();
         } else {
             Map<String, String> attributes = topicConfig.getAttributes();
             if (attributes == null) {
-                return new HashMap<>();
+                return Collections.emptyMap();
             } else {
                 return attributes;
             }


### PR DESCRIPTION
Replace empty map instantiations with Collections.emptyMap() which is:
- More readable and intentional
- Immutable and safer
- Slightly more performant

Signed-off-by: Senrian