### PR TITLE
[refactor] Use isEmpty() instead of size() == 0 in PopBufferMergeService

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopBufferMergeService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopBufferMergeService.java
@@ -109,7 +109,7 @@ public class PopBufferMergeService extends ServiceThread {
 
                 this.waitForRunning(interval);
 
-                if (!this.serving && this.buffer.size() == 0 && getOffsetTotalSize() == 0) {
+                if (!this.serving && this.buffer.isEmpty() && getOffsetTotalSize() == 0) {
                     this.serving = true;
                 }
             } catch (Throwable e) {


### PR DESCRIPTION
Use isEmpty() method for better readability and performance.

Signed-off-by: Senrian <senrian@github.com>