### PR TITLE
[ISSUE #10157] Fix tiered metadata leak after topic delete (#10158)

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
@@ -152,6 +152,7 @@ public class DefaultMetadataStore extends ConfigManager implements MetadataStore
     @Override
     public void deleteTopic(String topic) {
         topicMetadataTable.remove(topic);
+        queueMetadataTable.remove(topic);
         persist();
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

- Fixes #10157

### Brief Description
topicinfo will leak after topic delete in tiered storage
<img width="2472" height="1422" alt="image" src="https://github.com/user-attachments/assets/fd93bd6a-61c6-4c8c-a3bf-1b7df737491f" />


### How Did You Test This Change?

I fixed the metadata leakage issue that occurred when deleting a topic with tiered storage enabled. To verify the fix:

1. Created a topic with tiered storage enabled.
2. Deleted the topic
3. there is no topicinfo in queueMetaTable
