### PR TITLE
[ISSUE #10171] Support custom JAVA_HOME on Linux in runbroker.sh and runserver.sh

### DIFF
--- a/distribution/bin/runbroker.sh
+++ b/distribution/bin/runbroker.sh
@@ -26,12 +26,11 @@ error_exit ()
 
 find_java_home()
 {
+    if [ -n "$JAVA_HOME" ]; then
+        return
+    fi
     case "`uname`" in
         Darwin)
-          if [ -n "$JAVA_HOME" ]; then
-            JAVA_HOME=$JAVA_HOME
-            return
-          fi
             JAVA_HOME=$(/usr/libexec/java_home)
         ;;
         *)

--- a/distribution/bin/runserver.sh
+++ b/distribution/bin/runserver.sh
@@ -26,12 +26,11 @@ error_exit ()
 
 find_java_home()
 {
+    if [ -n "$JAVA_HOME" ]; then
+        return
+    fi
     case "`uname`" in
         Darwin)
-          if [ -n "$JAVA_HOME" ]; then
-              JAVA_HOME=$JAVA_HOME
-              return
-          fi
             JAVA_HOME=$(/usr/libexec/java_home)
         ;;
         *)

--- a/distribution/bin/tools.sh
+++ b/distribution/bin/tools.sh
@@ -27,7 +27,6 @@ error_exit ()
 find_java_home()
 {
     if [ -n "$JAVA_HOME" ]; then
-        JAVA_HOME=$JAVA_HOME
         return
     fi
     case "`uname`" in


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10171 

### Brief Description

Support custom `JAVA_HOME` on Linux in `runbroker.sh` and `runserver.sh`, consistent with the existing fix in `tools.sh`.

