### PR TITLE
[CLIENT] Add synchronized to registerAdminExt for thread safety

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -1158,7 +1158,7 @@ public class MQClientInstance {
         this.unregisterClient(group, null);
     }
 
-    public boolean registerAdminExt(final String group, final MQAdminExtInner admin) {
+    public synchronized boolean registerAdminExt(final String group, final MQAdminExtInner admin) {
         if (null == group || null == admin) {
             return false;
         }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
@@ -74,7 +74,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -228,6 +232,45 @@ public class MQClientInstanceTest {
         mqClientInstance.unregisterAdminExt(group);
         flag = mqClientInstance.registerAdminExt(group, mock(MQAdminExtInner.class));
         assertThat(flag).isTrue();
+    }
+
+    @Test
+    public void testRegisterAdminExtConcurrently() throws Exception {
+        final int threadCount = 10;
+        final String testGroup = "ConcurrentAdminGroup";
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final AtomicInteger successCount = new AtomicInteger(0);
+        final AtomicInteger failCount = new AtomicInteger(0);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    boolean result = mqClientInstance.registerAdminExt(testGroup, mock(MQAdminExtInner.class));
+                    if (result) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertEquals(1, successCount.get());
+        assertEquals(threadCount - 1, failCount.get());
+
+        mqClientInstance.unregisterAdminExt(testGroup);
     }
 
     @Test


### PR DESCRIPTION
Brief Description
This PR enhances thread safety in MQClientInstance by adding the synchronized keyword to the registerAdminExt() method. This change ensures consistency with the existing registerConsumer() and registerProducer() methods, which are already synchronized. Additionally, a concurrent test case has been added to verify the thread safety of the registration methods.

Changes:

Add synchronized keyword to registerAdminExt() method
Add concurrent test case to verify thread safety
How Did You Test This Change?
Unit Test: Added a concurrent test case that simulates multiple threads calling registerAdminExt() simultaneously
Verification: The test verifies that concurrent registration operations are thread-safe and do not cause race conditions
Consistency Check: Confirmed that all three registration methods (registerConsumer(), registerProducer(), and registerAdminExt()) now have consistent synchronization behavior