### PR TITLE
[ISSUE #10183] When the lock is not locked successfully, there is an exception when trying to release the lock

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
@@ -430,8 +430,10 @@ public class ProcessQueue {
     }
 
     public void fillProcessQueueInfo(final ProcessQueueInfo info) {
+        boolean lockAcquired = false;
         try {
             this.treeMapLock.readLock().lockInterruptibly();
+            lockAcquired = true;
 
             if (!this.msgTreeMap.isEmpty()) {
                 info.setCachedMsgMinOffset(this.msgTreeMap.firstKey());
@@ -454,8 +456,11 @@ public class ProcessQueue {
             info.setLastPullTimestamp(this.lastPullTimestamp);
             info.setLastConsumeTimestamp(this.lastConsumeTimestamp);
         } catch (Exception e) {
+            log.error("fillProcessQueueInfo exception", e);
         } finally {
-            this.treeMapLock.readLock().unlock();
+            if (lockAcquired) {
+                this.treeMapLock.readLock().unlock();
+            }
         }
     }
 


### PR DESCRIPTION
…ion when trying to release the lock.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10185

### Brief Description

When the lock is not locked successfully, there is an **IllegalMonitorStateException** when trying to release the lock.

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
