### PR TITLE
[ISSUE #10191] Fix wrong option value for namesrvAddr parsing in timer benchmark examples

### DIFF
--- a/example/src/main/java/org/apache/rocketmq/example/benchmark/timer/TimerConsumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/benchmark/timer/TimerConsumer.java
@@ -56,7 +56,7 @@ public class TimerConsumer {
             System.exit(-1);
         }
 
-        final String namesrvAddr = commandLine.hasOption('n') ? commandLine.getOptionValue('t').trim() : "localhost:9876";
+        final String namesrvAddr = commandLine.hasOption('n') ? commandLine.getOptionValue('n').trim() : "localhost:9876";
         topic = commandLine.hasOption('t') ? commandLine.getOptionValue('t').trim() : "BenchmarkTest";
         System.out.printf("namesrvAddr: %s, topic: %s%n", namesrvAddr, topic);
 

--- a/example/src/main/java/org/apache/rocketmq/example/benchmark/timer/TimerProducer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/benchmark/timer/TimerProducer.java
@@ -74,7 +74,7 @@ public class TimerProducer {
             System.exit(-1);
         }
 
-        final String namesrvAddr = commandLine.hasOption('n') ? commandLine.getOptionValue('t').trim() : "localhost:9876";
+        final String namesrvAddr = commandLine.hasOption('n') ? commandLine.getOptionValue('n').trim() : "localhost:9876";
         topic = commandLine.hasOption('t') ? commandLine.getOptionValue('t').trim() : "BenchmarkTest";
         threadCount = commandLine.hasOption("tc") ? Integer.parseInt(commandLine.getOptionValue("tc")) : 16;
         messageSize = commandLine.hasOption("ms") ? Integer.parseInt(commandLine.getOptionValue("ms")) : 1024;


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10191 

### Brief Description

The `namesrvAddr` should be parsed from the `-n` option value.


### How Did You Test This Change?

Local test.
