### PR TITLE
[ISSUE #10193] incorrect min offset returned from TieredMessageStore when local store returns -1

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -310,6 +310,9 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
         if (minOffsetInTieredStore < 0) {
             return minOffsetInNextStore;
         }
+        if (minOffsetInNextStore < 0) {
+            return minOffsetInTieredStore;
+        }
         return Math.min(minOffsetInNextStore, minOffsetInTieredStore);
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -238,7 +238,21 @@ public class TieredMessageStoreTest {
         Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(100L);
         Assert.assertEquals(100L, currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
 
-        Mockito.when(flatFile.getConsumeQueueMinOffset()).thenReturn(10L);
+        Assert.assertEquals(flatFile.getConsumeQueueMinOffset(),
+            currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
+
+        FlatFileStore mockFlatFileStore = Mockito.mock(FlatFileStore.class);
+        FlatMessageFile mockFlatFile = Mockito.mock(FlatMessageFile.class);
+        Mockito.when(mockFlatFileStore.getFlatFile(any(MessageQueue.class))).thenReturn(mockFlatFile);
+        Mockito.when(mockFlatFile.getConsumeQueueMinOffset()).thenReturn(10L);
+        Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(-1L);
+        try {
+            Field field = currentStore.getClass().getDeclaredField("flatFileStore");
+            field.setAccessible(true);
+            field.set(currentStore, mockFlatFileStore);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Assert.fail(e.getClass().getCanonicalName() + ": " + e.getMessage());
+        }
         Assert.assertEquals(10L, currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -238,22 +238,9 @@ public class TieredMessageStoreTest {
         Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(100L);
         Assert.assertEquals(100L, currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
 
+        Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(-1L);
         Assert.assertEquals(flatFile.getConsumeQueueMinOffset(),
             currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
-
-        FlatFileStore mockFlatFileStore = Mockito.mock(FlatFileStore.class);
-        FlatMessageFile mockFlatFile = Mockito.mock(FlatMessageFile.class);
-        Mockito.when(mockFlatFileStore.getFlatFile(any(MessageQueue.class))).thenReturn(mockFlatFile);
-        Mockito.when(mockFlatFile.getConsumeQueueMinOffset()).thenReturn(10L);
-        Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(-1L);
-        try {
-            Field field = currentStore.getClass().getDeclaredField("flatFileStore");
-            field.setAccessible(true);
-            field.set(currentStore, mockFlatFileStore);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            Assert.fail(e.getClass().getCanonicalName() + ": " + e.getMessage());
-        }
-        Assert.assertEquals(10L, currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
     }
 
     @Test


### PR DESCRIPTION
… store returns -1

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10193

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
