### PR TITLE
[ISSUE #10195] Ensure RocksDB compatibility in slave-master synchronization

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -323,7 +323,7 @@ public class SubscriptionGroupManager extends ConfigManager {
         int maxGroupNum) {
         // [groupSeq, groupSeq + maxGroupNum)
         int beginIndex = groupSeq;
-        if (StringUtils.isBlank(dataVersion) || !Objects.equals(DataVersion.fromJson(dataVersion, DataVersion.class), this.dataVersion)) {
+        if (beginIndex != 0 && (StringUtils.isBlank(dataVersion) || !Objects.equals(DataVersion.fromJson(dataVersion, DataVersion.class), getDataVersion()))) {
             beginIndex = 0;
             log.info("get sub subscription group table from {} due to {}", beginIndex,
                 StringUtils.isBlank(dataVersion) ? "DataVersion Empty" : "DataVersion Changed");

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -725,7 +725,7 @@ public class TopicConfigManager extends ConfigManager {
         int maxTopicNum) {
         // [topicSeq, topicSeq + maxTopicNum)
         int beginIndex = topicSeq;
-        if (StringUtils.isBlank(dataVersion) || !Objects.equals(DataVersion.fromJson(dataVersion, DataVersion.class), this.dataVersion)) {
+        if (beginIndex != 0 && (StringUtils.isBlank(dataVersion) || !Objects.equals(DataVersion.fromJson(dataVersion, DataVersion.class), getDataVersion()))) {
             beginIndex = 0;
             log.info("get sub topic config table from {} due to {}", beginIndex,
                 StringUtils.isBlank(dataVersion) ? "DataVersion Empty" : "DataVersion Changed");


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10195

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
When enable rocksdb engine，slave can't sync all topics and subscription from master.
Because the below logic uses wrong DataVersion:
<img width="1633" height="755" alt="image" src="https://github.com/user-attachments/assets/9931af1f-92eb-4253-b483-076e7bda7b29" />

The returned to client's DataVersion is from rocksdb，but TopicConfigManager#subTopicConfigTable use the DataVersion from TopicConfigManager:
![2](https://github.com/user-attachments/assets/56d40b8a-5dc8-4b44-bde0-31126f72790e)
The two DataVersion are not equals！So `beginIndex` will be reseted to 0 every time.


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

1 Use command to check the topic: `./mqadmin rocksDBConfigToJson -p ../data/config -t topics`
2 Watch the slave's log:
![r](https://github.com/user-attachments/assets/2a178b23-53e6-457a-a465-a83fe8d7538f)

