### PR TITLE
[ISSUE #9983] Prohibit CallerRunsPolicy in NettyRemotingServer to prevent blocking IO threads

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -344,13 +344,25 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             executorThis = this.publicExecutor;
         }
 
+        rejectCallerRunsPolicy(executorThis);
         Pair<NettyRequestProcessor, ExecutorService> pair = new Pair<>(processor, executorThis);
         this.processorTable.put(requestCode, pair);
     }
 
     @Override
     public void registerDefaultProcessor(NettyRequestProcessor processor, ExecutorService executor) {
+        rejectCallerRunsPolicy(executor);
         this.defaultRequestProcessorPair = new Pair<>(processor, executor);
+    }
+
+    private static void rejectCallerRunsPolicy(ExecutorService executor) {
+        if (executor instanceof ThreadPoolExecutor) {
+            if (((ThreadPoolExecutor) executor).getRejectedExecutionHandler()
+                instanceof ThreadPoolExecutor.CallerRunsPolicy) {
+                throw new IllegalArgumentException(
+                    "CallerRunsPolicy is not allowed in NettyRemotingServer as it may block Netty IO threads");
+            }
+        }
     }
 
     @Override
@@ -665,12 +677,14 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                 executorThis = NettyRemotingServer.this.publicExecutor;
             }
 
+            rejectCallerRunsPolicy(executorThis);
             Pair<NettyRequestProcessor, ExecutorService> pair = new Pair<>(processor, executorThis);
             this.processorTable.put(requestCode, pair);
         }
 
         @Override
         public void registerDefaultProcessor(final NettyRequestProcessor processor, final ExecutorService executor) {
+            rejectCallerRunsPolicy(executor);
             this.defaultRequestProcessorPair = new Pair<>(processor, executor);
         }
 

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
@@ -23,6 +23,11 @@ import io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +36,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -59,5 +65,58 @@ public class NettyRemotingServerTest {
         content.writeBytes("xxxx".getBytes(StandardCharsets.UTF_8));
         HAProxyTLV haProxyTLV = new HAProxyTLV((byte) 0xE1, content);
         nettyRemotingServer.handleHAProxyTLV(haProxyTLV, channel);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterProcessorRejectsCallerRunsPolicy() {
+        NettyRequestProcessor processor = mock(NettyRequestProcessor.class);
+        ExecutorService executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1), new ThreadPoolExecutor.CallerRunsPolicy());
+        try {
+            nettyRemotingServer.registerProcessor(0, processor, executor);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterDefaultProcessorRejectsCallerRunsPolicy() {
+        NettyRequestProcessor processor = mock(NettyRequestProcessor.class);
+        ExecutorService executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1), new ThreadPoolExecutor.CallerRunsPolicy());
+        try {
+            nettyRemotingServer.registerDefaultProcessor(processor, executor);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegisterProcessorAllowsNonCallerRunsPolicy() {
+        NettyRequestProcessor processor = mock(NettyRequestProcessor.class);
+        ExecutorService executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1), new ThreadPoolExecutor.AbortPolicy());
+        try {
+            nettyRemotingServer.registerProcessor(0, processor, executor);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegisterProcessorAllowsNullExecutor() {
+        NettyRequestProcessor processor = mock(NettyRequestProcessor.class);
+        nettyRemotingServer.registerProcessor(0, processor, null);
+    }
+
+    @Test
+    public void testRegisterProcessorAllowsFixedThreadPool() {
+        NettyRequestProcessor processor = mock(NettyRequestProcessor.class);
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        try {
+            nettyRemotingServer.registerProcessor(0, processor, executor);
+        } finally {
+            executor.shutdown();
+        }
     }
 }


### PR DESCRIPTION
## Problem

When a custom `ExecutorService` with `CallerRunsPolicy` is registered via `registerProcessor` or `registerDefaultProcessor`, and the thread pool becomes exhausted, the rejected task is executed on the caller thread — which is the **Netty IO EventLoop thread**. This blocks the IO thread from processing other requests/heartbeats, causing severe performance degradation or node unavailability.

## Root Cause

No validation exists on the `RejectedExecutionHandler` of the provided executor in `registerProcessor` / `registerDefaultProcessor`. Users can silently misconfigure a `ThreadPoolExecutor` with `CallerRunsPolicy`, leading to IO thread blocking under high concurrency.

## Fix

Added a `rejectCallerRunsPolicy` validation method that checks if the executor is a `ThreadPoolExecutor` with `CallerRunsPolicy` and throws `IllegalArgumentException` for fast-fail. The check is applied to:

- `NettyRemotingServer#registerProcessor`
- `NettyRemotingServer#registerDefaultProcessor`
- `SubRemotingServer#registerProcessor`
- `SubRemotingServer#registerDefaultProcessor`

## Tests Added

- `testRegisterProcessorRejectsCallerRunsPolicy` — Verifies `registerProcessor` throws `IllegalArgumentException` when CallerRunsPolicy is used
- `testRegisterDefaultProcessorRejectsCallerRunsPolicy` — Verifies `registerDefaultProcessor` throws `IllegalArgumentException` when CallerRunsPolicy is used
- `testRegisterProcessorAllowsNonCallerRunsPolicy` — Verifies AbortPolicy (default) is accepted without error
- `testRegisterProcessorAllowsNullExecutor` — Verifies null executor (falls back to publicExecutor) works correctly
- `testRegisterProcessorAllowsFixedThreadPool` — Verifies standard FixedThreadPool is accepted

## Impact

- **Scope**: Only affects registration-time validation, no runtime overhead
- **Behavioral change**: Executors with CallerRunsPolicy will now be rejected at registration time instead of silently causing IO thread blocking at runtime

Fixes #9983