### PR TITLE
[ISSUE #9926] Optimize memory allocation in parsePublishMessageQueues

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
@@ -157,9 +157,14 @@ public class MQAdminImpl {
     }
 
     public List<MessageQueue> parsePublishMessageQueues(List<MessageQueue> messageQueueList) {
-        List<MessageQueue> resultQueues = new ArrayList<>();
+        String namespace = this.mQClientFactory.getClientConfig().getNamespace();
+        if (StringUtils.isEmpty(namespace)) {
+            return messageQueueList;
+        }
+
+        List<MessageQueue> resultQueues = new ArrayList<>(messageQueueList.size());
         for (MessageQueue queue : messageQueueList) {
-            String userTopic = NamespaceUtil.withoutNamespace(queue.getTopic(), this.mQClientFactory.getClientConfig().getNamespace());
+            String userTopic = NamespaceUtil.withoutNamespace(queue.getTopic(), namespace);
             resultQueues.add(new MessageQueue(userTopic, queue.getBrokerName(), queue.getQueueId()));
         }
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/MQAdminImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/MQAdminImplTest.java
@@ -44,6 +44,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +52,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -198,6 +200,65 @@ public class MQAdminImplTest {
         assertNotNull(queryResult);
         assertEquals(1, queryResult.getMessageList().size());
         assertEquals(defaultTopic, queryResult.getMessageList().get(0).getTopic());
+    }
+
+    @Test
+    public void testParsePublishMessageQueuesReturnsOriginalListWhenNamespaceEmpty() {
+        ClientConfig clientConfig = mock(ClientConfig.class);
+        when(clientConfig.getNamespace()).thenReturn("");
+        MQClientInstance emptyNsFactory = mock(MQClientInstance.class);
+        when(emptyNsFactory.getClientConfig()).thenReturn(clientConfig);
+        MQAdminImpl adminWithEmptyNs = new MQAdminImpl(emptyNsFactory);
+
+        List<MessageQueue> input = new ArrayList<>();
+        input.add(new MessageQueue("topic1", "broker1", 0));
+        input.add(new MessageQueue("topic2", "broker2", 1));
+
+        List<MessageQueue> result = adminWithEmptyNs.parsePublishMessageQueues(input);
+        assertSame(input, result);
+    }
+
+    @Test
+    public void testParsePublishMessageQueuesReturnsOriginalListWhenNamespaceNull() {
+        ClientConfig clientConfig = mock(ClientConfig.class);
+        when(clientConfig.getNamespace()).thenReturn(null);
+        MQClientInstance nullNsFactory = mock(MQClientInstance.class);
+        when(nullNsFactory.getClientConfig()).thenReturn(clientConfig);
+        MQAdminImpl adminWithNullNs = new MQAdminImpl(nullNsFactory);
+
+        List<MessageQueue> input = new ArrayList<>();
+        input.add(new MessageQueue("topic1", "broker1", 0));
+
+        List<MessageQueue> result = adminWithNullNs.parsePublishMessageQueues(input);
+        assertSame(input, result);
+    }
+
+    @Test
+    public void testParsePublishMessageQueuesStripsNamespace() {
+        List<MessageQueue> input = new ArrayList<>();
+        input.add(new MessageQueue("namespace%topic1", defaultBroker, 0));
+        input.add(new MessageQueue("namespace%topic2", defaultBroker, 1));
+
+        List<MessageQueue> result = mqAdminImpl.parsePublishMessageQueues(input);
+        assertEquals(2, result.size());
+        assertEquals("topic1", result.get(0).getTopic());
+        assertEquals("topic2", result.get(1).getTopic());
+        assertEquals(defaultBroker, result.get(0).getBrokerName());
+    }
+
+    @Test
+    public void testParsePublishMessageQueuesPreservesOrderAndSize() {
+        List<MessageQueue> input = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            input.add(new MessageQueue("namespace%topic" + i, defaultBroker, i));
+        }
+
+        List<MessageQueue> result = mqAdminImpl.parsePublishMessageQueues(input);
+        assertEquals(100, result.size());
+        for (int i = 0; i < 100; i++) {
+            assertEquals("topic" + i, result.get(i).getTopic());
+            assertEquals(i, result.get(i).getQueueId());
+        }
     }
 
     private String buildMsgId() {


### PR DESCRIPTION
## Problem

Under high throughput workloads (e.g., 50K LMQ tps), `parsePublishMessageQueues` causes massive memory allocation due to:
1. Creating a new `ArrayList` (with default capacity 10) for every call, even when namespace is empty
2. Repeated `getNamespace()` calls per queue element
3. Unnecessary `ArrayList` growth/copy when the list size exceeds initial capacity

Profiling by the issue reporter showed this method as a significant source of memory allocation overhead.

## Root Cause

The method unconditionally creates a new list and copies all queues with namespace stripping, even when no namespace is configured (the most common deployment scenario). The `ArrayList` is also created with default capacity instead of being pre-sized.

## Fix

1. **Early return when namespace is empty**: Return the original `messageQueueList` directly, avoiding all allocation
2. **Pre-allocate ArrayList**: Use `new ArrayList<>(messageQueueList.size())` to avoid internal array resizing
3. **Cache namespace**: Extract `getNamespace()` call outside the loop to avoid repeated method invocations

## Tests Added

- `testParsePublishMessageQueuesReturnsOriginalListWhenNamespaceEmpty` — Verifies same list instance is returned when namespace is empty string
- `testParsePublishMessageQueuesReturnsOriginalListWhenNamespaceNull` — Verifies same list instance is returned when namespace is null
- `testParsePublishMessageQueuesStripsNamespace` — Verifies namespace is correctly stripped when present
- `testParsePublishMessageQueuesPreservesOrderAndSize` — Verifies correct behavior with 100 queues

## Impact

- **Zero allocation** in the common case (no namespace configured)
- **No behavioral change** when namespace is configured, only reduced memory allocation
- Hot path optimization for high-throughput producers

Fixes #9926