### PR TITLE
[ISSUE #10207] Fix potential NPE in HA connections when remote address is null

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/DefaultHAConnection.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.store.ha;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -61,7 +62,8 @@ public class DefaultHAConnection implements HAConnection {
     public DefaultHAConnection(final DefaultHAService haService, final SocketChannel socketChannel) throws IOException {
         this.haService = haService;
         this.socketChannel = socketChannel;
-        this.clientAddress = this.socketChannel.socket().getRemoteSocketAddress().toString();
+        SocketAddress remoteAddress = this.socketChannel.socket().getRemoteSocketAddress();
+        this.clientAddress = remoteAddress != null ? remoteAddress.toString() : "";
         this.socketChannel.configureBlocking(false);
         this.socketChannel.socket().setSoLinger(false, -1);
         this.socketChannel.socket().setTcpNoDelay(true);

--- a/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/autoswitch/AutoSwitchHAConnection.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.store.ha.autoswitch;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -106,7 +107,8 @@ public class AutoSwitchHAConnection implements HAConnection {
         this.haService = haService;
         this.socketChannel = socketChannel;
         this.epochCache = epochCache;
-        this.clientAddress = this.socketChannel.socket().getRemoteSocketAddress().toString();
+        SocketAddress remoteAddress = this.socketChannel.socket().getRemoteSocketAddress();
+        this.clientAddress = remoteAddress != null ? remoteAddress.toString() : "";
         this.socketChannel.configureBlocking(false);
         this.socketChannel.socket().setSoLinger(false, -1);
         this.socketChannel.socket().setTcpNoDelay(true);

--- a/store/src/test/java/org/apache/rocketmq/store/ha/DefaultHAConnectionTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/ha/DefaultHAConnectionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.ha;
+
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.store.DefaultMessageStore;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultHAConnectionTest {
+
+    private SocketChannel socketChannel;
+    private DefaultHAConnection connection;
+
+    @After
+    public void tearDown() throws Exception {
+        if (socketChannel != null && socketChannel.isOpen()) {
+            socketChannel.close();
+        }
+    }
+
+    @Test
+    public void testConstructorWithNullRemoteAddress() throws Exception {
+        DefaultHAService haService = mock(DefaultHAService.class);
+        DefaultMessageStore messageStore = mock(DefaultMessageStore.class);
+        MessageStoreConfig storeConfig = new MessageStoreConfig();
+        when(haService.getDefaultMessageStore()).thenReturn(messageStore);
+        when(messageStore.getMessageStoreConfig()).thenReturn(storeConfig);
+        when(haService.getConnectionCount()).thenReturn(new AtomicInteger(0));
+
+        // SocketChannel.open() creates a non-connected channel,
+        // so getRemoteSocketAddress() returns null
+        socketChannel = SocketChannel.open();
+        connection = new DefaultHAConnection(haService, socketChannel);
+
+        assertNotNull(connection);
+        assertEquals("", connection.getClientAddress());
+    }
+}


### PR DESCRIPTION
## Problem

In `DefaultHAConnection` and `AutoSwitchHAConnection`, `.toString()` is called directly on the return value of `getRemoteSocketAddress()` without a null check:

```java
this.clientAddress = this.socketChannel.socket().getRemoteSocketAddress().toString();
```

`Socket.getRemoteSocketAddress()` returns `null` if the socket is not connected. Under network instability (e.g., slave connects and immediately disconnects before the HA connection constructor completes), this throws `NullPointerException`.

## Root Cause

No null check on the return value of `getRemoteSocketAddress()` before calling `.toString()`.

## Fix

Extract the `SocketAddress` into a local variable and check for null before calling `.toString()`:

```java
SocketAddress remoteAddress = this.socketChannel.socket().getRemoteSocketAddress();
this.clientAddress = remoteAddress != null ? remoteAddress.toString() : "";
```

Applied to both:
- `DefaultHAConnection.java:64`
- `AutoSwitchHAConnection.java:109`

## Tests Added

- `testConstructorWithNullRemoteAddress` — Creates a `DefaultHAConnection` with a non-connected `SocketChannel` (where `getRemoteSocketAddress()` returns null). Verifies no NPE is thrown and `clientAddress` is set to empty string.

## Impact

- Defensive null check only, no behavioral change for normal connected sockets
- Prevents NPE crash during HA connection setup under network instability

Fixes #10207