### PR TITLE
[ISSUE #10208] Fix resource leak in IOTinyUtils.copyFile

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/IOTinyUtils.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/IOTinyUtils.java
@@ -86,19 +86,11 @@ public class IOTinyUtils {
             throw new RuntimeException("failed to create target file.");
         }
 
-        FileChannel sc = null;
-        FileChannel tc = null;
-        try {
-            tc = new FileOutputStream(tf).getChannel();
-            sc = new FileInputStream(sf).getChannel();
+        try (FileInputStream fis = new FileInputStream(sf);
+             FileOutputStream fos = new FileOutputStream(tf);
+             FileChannel sc = fis.getChannel();
+             FileChannel tc = fos.getChannel()) {
             sc.transferTo(0, sc.size(), tc);
-        } finally {
-            if (null != sc) {
-                sc.close();
-            }
-            if (null != tc) {
-                tc.close();
-            }
         }
     }
 


### PR DESCRIPTION
## Problem

In `IOTinyUtils.copyFile()`, `FileOutputStream` and `FileInputStream` are created inline:

```java
tc = new FileOutputStream(tf).getChannel();
sc = new FileInputStream(sf).getChannel();
```

The underlying stream references are lost. If `new FileInputStream(sf)` throws an exception (e.g., file locked), the already-created `FileOutputStream` and its channel will never be closed, leaking a file descriptor. The `finally` block only closes the `FileChannel` variables, which may be null at that point.

## Root Cause

Stream objects are not stored in variables and therefore cannot be closed in the `finally` block if an exception occurs between their creation.

## Fix

Refactored to use try-with-resources, which ensures all four resources (`FileInputStream`, `FileOutputStream`, and their channels) are properly closed in all cases:

```java
try (FileInputStream fis = new FileInputStream(sf);
     FileOutputStream fos = new FileOutputStream(tf);
     FileChannel sc = fis.getChannel();
     FileChannel tc = fos.getChannel()) {
    sc.transferTo(0, sc.size(), tc);
}
```

## Tests Added

No new tests needed — existing `IOTinyUtilsTest.testCopyFile()` covers the normal path and passes with the refactored code. The fix is a pure resource management improvement.

## Impact

- **No behavioral change** for normal operation
- Fixes potential file descriptor leak on exception paths
- Reduces code from 14 lines to 5 lines with cleaner resource management

Fixes #10208