### PR TITLE
[ISSUE #10216] Fix potential NPE in EscapeBridge when topicPublishInfo is null

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/failover/EscapeBridge.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/failover/EscapeBridge.java
@@ -185,6 +185,11 @@ public class EscapeBridge {
                 messageExt.setWaitStoreMsgOK(false);
 
                 final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
+                if (null == topicPublishInfo || !topicPublishInfo.ok()) {
+                    LOG.warn("asyncPutMessage: no route info of topic {} when escaping message, msgId={}",
+                        messageExt.getTopic(), messageExt.getMsgId());
+                    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
+                }
                 final String producerGroup = getProducerGroup(messageExt);
 
                 final MessageQueue mqSelected = topicPublishInfo.selectOneMessageQueue();
@@ -250,6 +255,11 @@ public class EscapeBridge {
                 messageExt.setWaitStoreMsgOK(false);
 
                 final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
+                if (null == topicPublishInfo || !topicPublishInfo.ok()) {
+                    LOG.warn("asyncRemotePutMessageToSpecificQueue: no route info of topic {} when escaping message, msgId={}",
+                        messageExt.getTopic(), messageExt.getMsgId());
+                    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
+                }
                 List<MessageQueue> mqs = topicPublishInfo.getMessageQueueList();
 
                 if (null == mqs || mqs.isEmpty()) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/failover/EscapeBridgeTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/failover/EscapeBridgeTest.java
@@ -421,6 +421,66 @@ public class EscapeBridgeTest {
         return result;
     }
 
+    @Test
+    public void testAsyncPutMessageWhenTopicPublishInfoIsNull() {
+        when(brokerController.peekMasterBroker()).thenReturn(null);
+        when(topicRouteInfoManager.tryToFindTopicPublishInfo(anyString())).thenReturn(null);
+
+        messageExtBrokerInner = new MessageExtBrokerInner();
+        messageExtBrokerInner.setTopic(TEST_TOPIC);
+        messageExtBrokerInner.setBody("test".getBytes(StandardCharsets.UTF_8));
+
+        CompletableFuture<PutMessageResult> future = escapeBridge.asyncPutMessage(messageExtBrokerInner);
+        PutMessageResult result = future.join();
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, result.getPutMessageStatus());
+    }
+
+    @Test
+    public void testAsyncPutMessageWhenTopicPublishInfoNotOk() {
+        when(brokerController.peekMasterBroker()).thenReturn(null);
+        TopicPublishInfo emptyInfo = new TopicPublishInfo();
+        when(topicRouteInfoManager.tryToFindTopicPublishInfo(anyString())).thenReturn(emptyInfo);
+
+        messageExtBrokerInner = new MessageExtBrokerInner();
+        messageExtBrokerInner.setTopic(TEST_TOPIC);
+        messageExtBrokerInner.setBody("test".getBytes(StandardCharsets.UTF_8));
+
+        CompletableFuture<PutMessageResult> future = escapeBridge.asyncPutMessage(messageExtBrokerInner);
+        PutMessageResult result = future.join();
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, result.getPutMessageStatus());
+    }
+
+    @Test
+    public void testAsyncRemotePutMessageToSpecificQueueWhenTopicPublishInfoIsNull() {
+        when(topicRouteInfoManager.tryToFindTopicPublishInfo(anyString())).thenReturn(null);
+
+        messageExtBrokerInner = new MessageExtBrokerInner();
+        messageExtBrokerInner.setTopic(TEST_TOPIC);
+        messageExtBrokerInner.setBody("test".getBytes(StandardCharsets.UTF_8));
+
+        CompletableFuture<PutMessageResult> future = escapeBridge.asyncRemotePutMessageToSpecificQueue(messageExtBrokerInner);
+        PutMessageResult result = future.join();
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, result.getPutMessageStatus());
+    }
+
+    @Test
+    public void testAsyncRemotePutMessageToSpecificQueueWhenTopicPublishInfoNotOk() {
+        TopicPublishInfo emptyInfo = new TopicPublishInfo();
+        when(topicRouteInfoManager.tryToFindTopicPublishInfo(anyString())).thenReturn(emptyInfo);
+
+        messageExtBrokerInner = new MessageExtBrokerInner();
+        messageExtBrokerInner.setTopic(TEST_TOPIC);
+        messageExtBrokerInner.setBody("test".getBytes(StandardCharsets.UTF_8));
+
+        CompletableFuture<PutMessageResult> future = escapeBridge.asyncRemotePutMessageToSpecificQueue(messageExtBrokerInner);
+        PutMessageResult result = future.join();
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, result.getPutMessageStatus());
+    }
+
     private TopicPublishInfo mockTopicPublishInfo(String... brokerNames) {
         TopicPublishInfo topicPublishInfo = new TopicPublishInfo();
         for (String brokerName : brokerNames) {


### PR DESCRIPTION
## Problem

`EscapeBridge.asyncPutMessage()` and `asyncRemotePutMessageToSpecificQueue()` dereference the return value of `tryToFindTopicPublishInfo()` without null checks, causing NullPointerException when topic route information is unavailable.

## Root Cause

`tryToFindTopicPublishInfo()` can return null when the topic route is not yet available (e.g., during broker startup or after nameserver disconnection). The `putMessageToRemoteBroker()` method in the same class already handles this correctly with a null/validity check, but `asyncPutMessage()` and `asyncRemotePutMessageToSpecificQueue()` were missing this guard.

## Fix

- **`asyncPutMessage()`**: Add `null == topicPublishInfo || !topicPublishInfo.ok()` check before calling `selectOneMessageQueue()`, returning `PUT_TO_REMOTE_BROKER_FAIL` with a warning log, consistent with `putMessageToRemoteBroker()`.
- **`asyncRemotePutMessageToSpecificQueue()`**: Add the same null/validity check before calling `getMessageQueueList()`.

## Tests Added

| Change Point | Test |
|-------------|------|
| Null check in `asyncPutMessage()` | `testAsyncPutMessageWhenTopicPublishInfoIsNull()` — verifies PUT_TO_REMOTE_BROKER_FAIL when info is null |
| Validity check in `asyncPutMessage()` | `testAsyncPutMessageWhenTopicPublishInfoNotOk()` — verifies same result when info has no queues |
| Null check in `asyncRemotePutMessageToSpecificQueue()` | `testAsyncRemotePutMessageToSpecificQueueWhenTopicPublishInfoIsNull()` — verifies safe handling |
| Validity check in `asyncRemotePutMessageToSpecificQueue()` | `testAsyncRemotePutMessageToSpecificQueueWhenTopicPublishInfoNotOk()` — verifies same result |

## Impact

Only affects the escape bridge failover path when slave acts as master. Normal message put operations are unaffected. The fix makes error handling consistent across all methods in `EscapeBridge`.

Fixes #10216