### PR TITLE
[ISSUE #10225] Optimize HandleData locking mechanism to avoid unnecessary blocking

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
@@ -113,22 +113,40 @@ public class ReceiptHandleGroup {
 
         public Long lock(long timeoutMs) {
             try {
-                boolean result = this.semaphore.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
+                long expiredTimeMs = ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3;
                 long currentTimeMs = System.currentTimeMillis();
+                // Try non-blocking acquire first
+                if (this.semaphore.tryAcquire()) {
+                    this.lastLockTimeMs.set(currentTimeMs);
+                    return currentTimeMs;
+                }
+                // Check if lock is already expired before blocking
+                if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+                    synchronized (this) {
+                        if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+                            log.warn("HandleData lock expired, acquire lock success without blocking " +
+                                "and reset lock time. MessageReceiptHandle={}, lockTime={}",
+                                messageReceiptHandle, currentTimeMs);
+                            this.lastLockTimeMs.set(currentTimeMs);
+                            return currentTimeMs;
+                        }
+                    }
+                }
+                // Try blocking acquire with timeout
+                boolean result = this.semaphore.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
+                currentTimeMs = System.currentTimeMillis();
                 if (result) {
                     this.lastLockTimeMs.set(currentTimeMs);
                     return currentTimeMs;
-                } else {
-                    // if the lock is expired, can be acquired again
-                    long expiredTimeMs = ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3;
-                    if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
-                        synchronized (this) {
-                            if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
-                                log.warn("HandleData lock expired, acquire lock success and reset lock time. " +
-                                    "MessageReceiptHandle={}, lockTime={}", messageReceiptHandle, currentTimeMs);
-                                this.lastLockTimeMs.set(currentTimeMs);
-                                return currentTimeMs;
-                            }
+                }
+                // Recheck expiration after timeout
+                if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+                    synchronized (this) {
+                        if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+                            log.warn("HandleData lock expired, acquire lock success and reset lock time. "
+                                + "MessageReceiptHandle={}, lockTime={}", messageReceiptHandle, currentTimeMs);
+                            this.lastLockTimeMs.set(currentTimeMs);
+                            return currentTimeMs;
                         }
                     }
                 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
@@ -113,7 +113,6 @@ public class ReceiptHandleGroup {
 
         public Long lock(long timeoutMs) {
             try {
-                long expiredTimeMs = ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3;
                 long currentTimeMs = System.currentTimeMillis();
                 // Try non-blocking acquire first
                 if (this.semaphore.tryAcquire()) {
@@ -121,6 +120,7 @@ public class ReceiptHandleGroup {
                     return currentTimeMs;
                 }
                 // Check if lock is already expired before blocking
+                long expiredTimeMs = ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3;
                 if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
                     synchronized (this) {
                         if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
@@ -21,12 +21,14 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.common.consumer.ReceiptHandle;
 import org.apache.rocketmq.common.message.MessageClientIDSetter;
 import org.apache.rocketmq.common.utils.FutureUtils;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.InitConfigTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -311,5 +313,36 @@ public class ReceiptHandleGroupTest extends InitConfigTest {
 
     private MessageReceiptHandle createMessageReceiptHandle(String handle, String msgID) {
         return new MessageReceiptHandle(GROUP, TOPIC, 0, handle, msgID, 0, 0);
+    }
+
+    @Test
+    public void testAcquireExpiredLock() throws InterruptedException {
+        final long lockTimeoutMs = 100L;
+        ConfigurationManager.getProxyConfig().setLockTimeoutMsInHandleGroup(lockTimeoutMs);
+
+        String handle = ReceiptHandle.builder()
+            .startOffset(0L)
+            .retrieveTime(System.currentTimeMillis())
+            .invisibleTime(3000)
+            .reviveQueueId(1)
+            .topicType(ReceiptHandle.NORMAL_TOPIC)
+            .brokerName("brokerName")
+            .queueId(1)
+            .offset(1L)
+            .commitLogOffset(0L)
+            .build().encode();
+        receiptHandleGroup.put(msgID, createMessageReceiptHandle(handle, msgID));
+
+        // Simulate a slow task via a never-completing future
+        CompletableFuture<MessageReceiptHandle> slowFuture = new CompletableFuture<>();
+        receiptHandleGroup.computeIfPresent(msgID, handle, h -> slowFuture);
+        // Then make the lock expired
+        TimeUnit.MILLISECONDS.sleep(3 * lockTimeoutMs);
+
+        // Another caller can acquire this expired lock without blocking
+        long startTime = System.currentTimeMillis();
+        receiptHandleGroup.remove(msgID, handle);
+        long elapsed = System.currentTimeMillis() - startTime;
+        assertTrue(elapsed < lockTimeoutMs);
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
@@ -320,17 +320,7 @@ public class ReceiptHandleGroupTest extends InitConfigTest {
         final long lockTimeoutMs = 100L;
         ConfigurationManager.getProxyConfig().setLockTimeoutMsInHandleGroup(lockTimeoutMs);
 
-        String handle = ReceiptHandle.builder()
-            .startOffset(0L)
-            .retrieveTime(System.currentTimeMillis())
-            .invisibleTime(3000)
-            .reviveQueueId(1)
-            .topicType(ReceiptHandle.NORMAL_TOPIC)
-            .brokerName("brokerName")
-            .queueId(1)
-            .offset(1L)
-            .commitLogOffset(0L)
-            .build().encode();
+        String handle = createHandle();
         receiptHandleGroup.put(msgID, createMessageReceiptHandle(handle, msgID));
 
         // Simulate a slow task via a never-completing future


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10225 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Add a non-blocking tryAcquire() as the fast path, and check the expiration condition before falling through to the blocking tryAcquire(timeout, unit)

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

Add a unit test to cover diff.
