### PR TITLE
[ISSUE #10218] Fix resource leak in DumpCompactionLogCommand - RandomAccessFile and FileChannel never closed

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
@@ -69,9 +69,9 @@ public class DumpCompactionLogCommand implements SubCommand {
                 throw new SubCommandException("file " + fileName + " is a directory.");
             }
 
-            try {
+            try (RandomAccessFile raf = new RandomAccessFile(fileName, "rw");
+                 FileChannel fileChannel = raf.getChannel()) {
                 long fileSize = Files.size(filePath);
-                FileChannel fileChannel = new RandomAccessFile(fileName, "rw").getChannel();
                 ByteBuffer buf = fileChannel.map(MapMode.READ_WRITE, 0, fileSize);
 
                 int current = 0;


### PR DESCRIPTION
## Summary

Fixes issue #10218 - `DumpCompactionLogCommand.java` leaks `RandomAccessFile` and `FileChannel` resources.

## Bug

On line 74:
```java
FileChannel fileChannel = new RandomAccessFile(fileName, "rw").getChannel();
```

The anonymous `RandomAccessFile` instance is immediately discarded after calling `.getChannel()`, making it impossible to close later. The `FileChannel` obtained from it is also never closed. Only the `ByteBuffer` is cleaned up via `UtilAll.cleanBuffer(buf)`.

## Fix

Convert to try-with-resources:
```java
try (RandomAccessFile raf = new RandomAccessFile(fileName, "rw");
     FileChannel fileChannel = raf.getChannel()) {
    long fileSize = Files.size(filePath);
    ByteBuffer buf = fileChannel.map(MapMode.READ_WRITE, 0, fileSize);
    // ... rest of the code ...
    UtilAll.cleanBuffer(buf);
} // FileChannel and RandomAccessFile automatically closed here
```

## Why This Matters

1. **File descriptor leak**: Each run of `DumpCompactionLogCommand` leaks one file descriptor
2. **Static analysis**: Flagged by SpotBugs, SonarQube and similar tools
3. **Best practice**: try-with-resources ensures proper cleanup in all code paths including exceptions

Fixes #10218