### PR TITLE
[Bug] Fix resource leak: properly close RandomAccessFile and FileChannel using try-with-resources

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
@@ -69,9 +69,9 @@ public class DumpCompactionLogCommand implements SubCommand {
                 throw new SubCommandException("file " + fileName + " is a directory.");
             }
 
-            try {
+            try (RandomAccessFile raf = new RandomAccessFile(fileName, "rw");
+                 FileChannel fileChannel = raf.getChannel()) {
                 long fileSize = Files.size(filePath);
-                FileChannel fileChannel = new RandomAccessFile(fileName, "rw").getChannel();
                 ByteBuffer buf = fileChannel.map(MapMode.READ_WRITE, 0, fileSize);
 
                 int current = 0;

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java
@@ -69,10 +69,10 @@ public class DumpCompactionLogCommand implements SubCommand {
                 throw new SubCommandException("file " + fileName + " is a directory.");
             }
 
-            try (RandomAccessFile raf = new RandomAccessFile(fileName, "rw");
+            try (RandomAccessFile raf = new RandomAccessFile(fileName, "r");
                  FileChannel fileChannel = raf.getChannel()) {
                 long fileSize = Files.size(filePath);
-                ByteBuffer buf = fileChannel.map(MapMode.READ_WRITE, 0, fileSize);
+                ByteBuffer buf = fileChannel.map(MapMode.READ_ONLY, 0, fileSize);
 
                 int current = 0;
                 while (current < fileSize) {


### PR DESCRIPTION
## Bug Description

In `DumpCompactionLogCommand.java`, a `RandomAccessFile` is created to obtain a `FileChannel`, but neither the `RandomAccessFile` nor the `FileChannel` is ever closed. This causes a file descriptor leak.

**Issue:** #10218

```java
// Before (buggy):
FileChannel fileChannel = new RandomAccessFile(fileName, "rw").getChannel();
ByteBuffer buf = fileChannel.map(MapMode.READ_WRITE, 0, fileSize);
// ...
UtilAll.cleanBuffer(buf);
// fileChannel and RandomAccessFile are never closed
```

## Fix

Use try-with-resources to ensure both `RandomAccessFile` and `FileChannel` are properly closed:

```java
try (RandomAccessFile raf = new RandomAccessFile(fileName, "rw");
     FileChannel fileChannel = raf.getChannel()) {
    // ...
}
```

This follows the recommended Java practice for resource management.