### PR TITLE
[Bug] Fix potential NPE in EscapeBridge when topicPublishInfo is null

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/failover/EscapeBridge.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/failover/EscapeBridge.java
@@ -185,6 +185,11 @@ public class EscapeBridge {
                 messageExt.setWaitStoreMsgOK(false);
 
                 final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
+                if (null == topicPublishInfo || !topicPublishInfo.ok()) {
+                    LOG.warn("asyncPutMessage: no route info of topic {} when escaping message, msgId={}",
+                        messageExt.getTopic(), messageExt.getMsgId());
+                    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
+                }
                 final String producerGroup = getProducerGroup(messageExt);
 
                 final MessageQueue mqSelected = topicPublishInfo.selectOneMessageQueue();
@@ -250,6 +255,11 @@ public class EscapeBridge {
                 messageExt.setWaitStoreMsgOK(false);
 
                 final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
+                if (null == topicPublishInfo || !topicPublishInfo.ok()) {
+                    LOG.warn("asyncRemotePutMessageToSpecificQueue: no route info of topic {} when escaping message, msgId={}",
+                        messageExt.getTopic(), messageExt.getMsgId());
+                    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
+                }
                 List<MessageQueue> mqs = topicPublishInfo.getMessageQueueList();
 
                 if (null == mqs || mqs.isEmpty()) {


### PR DESCRIPTION
## Bug Description

In `EscapeBridge.java`, the methods `asyncPutMessage()` and `asyncRemotePutMessageToSpecificQueue()` call `tryToFindTopicPublishInfo()` but do not check for a null return value before dereferencing.

**Issue:** #10216

### Location 1 - `asyncPutMessage()`:
```java
final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
final MessageQueue mqSelected = topicPublishInfo.selectOneMessageQueue(); // NPE if null
```

### Location 2 - `asyncRemotePutMessageToSpecificQueue()`:
```java
final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
List<MessageQueue> mqs = topicPublishInfo.getMessageQueueList(); // NPE if null
```

## Fix

Add null checks consistent with the existing pattern in `putMessageToRemoteBroker()`:

```java
if (null == topicPublishInfo || !topicPublishInfo.ok()) {
    LOG.warn("asyncPutMessage: no route info of topic {}...", ...);
    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
}
```

This prevents NPE when a slave broker acting as master attempts to escape a message for a topic whose route information is not yet available.