### PR TITLE
[Bug] Fix TOCTOU race condition in MQClientInstance.brokerVersionTable access

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -654,10 +654,8 @@ public class MQClientInstance {
     private boolean sendHeartbeatToBroker(long id, String brokerName, String addr, HeartbeatData heartbeatData) {
         try {
             int version = this.mQClientAPIImpl.sendHeartbeat(addr, heartbeatData, clientConfig.getMqClientApiTimeout());
-            if (!this.brokerVersionTable.containsKey(brokerName)) {
-                this.brokerVersionTable.put(brokerName, new ConcurrentHashMap<>(4));
-            }
-            this.brokerVersionTable.get(brokerName).put(addr, version);
+            this.brokerVersionTable.computeIfAbsent(brokerName, k -> new ConcurrentHashMap<>(4))
+                    .put(addr, version);
             long times = this.sendHeartbeatTimesTotal.getAndIncrement();
             if (times % 20 == 0) {
                 log.info("send heart beat to broker[{} {} {}] success", brokerName, id, addr);
@@ -734,10 +732,8 @@ public class MQClientInstance {
                 log.info("sendHeartbeatToAllBrokerV2 normal brokerName: {} subChange: {} brokerAddrHeartbeatFingerprintTable: {}", brokerName, heartbeatV2Result.isSubChange(), JSON.toJSONString(brokerAddrHeartbeatFingerprintTable));
             }
             version = heartbeatV2Result.getVersion();
-            if (!this.brokerVersionTable.containsKey(brokerName)) {
-                this.brokerVersionTable.put(brokerName, new ConcurrentHashMap<>(4));
-            }
-            this.brokerVersionTable.get(brokerName).put(addr, version);
+            this.brokerVersionTable.computeIfAbsent(brokerName, k -> new ConcurrentHashMap<>(4))
+                    .put(addr, version);
             long times = this.sendHeartbeatTimesTotal.getAndIncrement();
             if (times % 20 == 0) {
                 log.info("send heart beat to broker[{} {} {}] success", brokerName, id, addr);
@@ -1301,9 +1297,11 @@ public class MQClientInstance {
     }
 
     private int findBrokerVersion(String brokerName, String brokerAddr) {
-        if (this.brokerVersionTable.containsKey(brokerName)) {
-            if (this.brokerVersionTable.get(brokerName).containsKey(brokerAddr)) {
-                return this.brokerVersionTable.get(brokerName).get(brokerAddr);
+        ConcurrentHashMap<String, Integer> brokerVersions = this.brokerVersionTable.get(brokerName);
+        if (brokerVersions != null) {
+            Integer version = brokerVersions.get(brokerAddr);
+            if (version != null) {
+                return version;
             }
         }
         //To do need to fresh the version


### PR DESCRIPTION
## Bug Description

Issue: #10214

In `MQClientInstance.java`, `brokerVersionTable` (a `ConcurrentHashMap`) is accessed using a non-atomic check-then-act pattern that can cause NullPointerException under concurrent access.

### Locations Fixed

1. **sendHeartbeatToBroker()** - Race between containsKey() and get()
2. **sendHeartbeatToBrokerV2()** - Same issue
3. **findBrokerVersion()** - Triple get() calls with potential NPE

### Fix Pattern

Use `computeIfAbsent` for atomic get-or-create:
```java
// Before (race condition):
if (!this.brokerVersionTable.containsKey(brokerName)) {
    this.brokerVersionTable.put(brokerName, new ConcurrentHashMap<>(4));
}
this.brokerVersionTable.get(brokerName).put(addr, version);

// After (thread-safe):
this.brokerVersionTable.computeIfAbsent(brokerName, k -> new ConcurrentHashMap<>(4))
        .put(addr, version);
```

For findBrokerVersion(), use a local variable to avoid NPE if entry is removed between calls.