### PR TITLE
[ISSUE #10193] Fix incorrect min offset when next store returns -1

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -310,6 +310,9 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
         if (minOffsetInTieredStore < 0) {
             return minOffsetInNextStore;
         }
+        if (minOffsetInNextStore < 0) {
+            return minOffsetInTieredStore;
+        }
         return Math.min(minOffsetInNextStore, minOffsetInTieredStore);
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -240,6 +240,12 @@ public class TieredMessageStoreTest {
 
         Mockito.when(flatFile.getConsumeQueueMinOffset()).thenReturn(10L);
         Assert.assertEquals(10L, currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
+
+        // When local store returns -1 (no valid offset), tiered store offset should be used
+        long tieredOffset = flatFile.getConsumeQueueMinOffset();
+        Assert.assertTrue("tiered offset should be valid for this test", tieredOffset >= 0);
+        Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(-1L);
+        Assert.assertEquals(tieredOffset, currentStore.getMinOffsetInQueue(mq.getTopic(), mq.getQueueId()));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10193

### Brief Description

`TieredMessageStore.getMinOffsetInQueue()` merges the min offset from the next store and tiered store using `Math.min()`. However, when the next store has no valid data, it returns -1 as a sentinel value. This -1 is not a real offset but still participates in the `Math.min(-1, tieredOffset)` comparison, which always returns -1 and silently discards a valid tiered store offset.

The fix adds a guard for `minOffsetInNextStore < 0` before the `Math.min` call, mirroring the existing `minOffsetInTieredStore < 0` guard above it. When the next store is invalid, the tiered store offset is returned directly.

### How Did You Test This Change?

Added a test case in `TieredMessageStoreTest.testGetMinOffsetInQueue()`: set the next store to return -1 while the tiered store holds a valid offset, and verify the tiered offset is returned instead of -1. All 111 tieredstore module tests pass.