### PR TITLE
[ISSUE #10253] fix stale wildcardGroupMap entries caused by incorrect parsing during LiteTopic wildcard unregistration

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImpl.java
@@ -400,7 +400,7 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
 
     private void unmarkWildcardGroupIfNecessary(String lmqName) {
         if (!LiteUtil.isLiteTopicQueue(lmqName)) { // must be topic@group
-            String[] topicAtGroup = StringUtils.split(lmqName);
+            String[] topicAtGroup = StringUtils.split(lmqName, "@");
             if (null == topicAtGroup || topicAtGroup.length != 2) {
                 return;
             }

--- a/broker/src/test/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImplTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImplTest.java
@@ -308,6 +308,34 @@ public class LiteSubscriptionRegistryImplTest {
     }
 
     /**
+     * Test removeCompleteSubscription cleans wildcard group metadata
+     */
+    @Test
+    public void testRemoveCompleteSubscription_WildcardGroupMetadataCleanup() {
+        String clientId = "testClient";
+        String group = "testGroup";
+        String topic = "testTopic";
+        Set<String> lmqNameAll = new HashSet<>();
+        lmqNameAll.add("lmq1");
+
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setGroupName(group);
+        groupConfig.setWildcardLiteGroup(true);
+        when(mockSubscriptionGroupManager.findSubscriptionGroupConfig(group)).thenReturn(groupConfig);
+
+        registry.addCompleteSubscription(clientId, group, topic, lmqNameAll, 1L);
+
+        assertTrue(registry.wildcardGroupMap.containsKey(topic));
+        assertTrue(registry.wildcardGroupMap.get(topic).contains(group));
+
+        registry.removeCompleteSubscription(clientId);
+
+        assertFalse(registry.wildcardGroupMap.containsKey(topic));
+        assertNull(registry.getLiteSubscription(clientId));
+        assertEquals(0, registry.getActiveSubscriptionNum());
+    }
+
+    /**
      * Test addCompleteSubscription updates complete subscription
      */
     @Test


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10253

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
