### PR TITLE
[ISSUE #10065] Fix inconsistent lock/unlock timeout and improve expired lock handling in ReceiptHandleGroup

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
@@ -113,34 +113,49 @@ public class ReceiptHandleGroup {
 
         public Long lock(long timeoutMs) {
             try {
+                long expiredTimeMs = ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3;
+
+                // Fast path: if the lock is already expired, force-acquire immediately
+                // instead of blocking on tryAcquire. This improves throughput when the
+                // queue has accumulated expired items.
+                Long forceResult = tryForceAcquire(expiredTimeMs);
+                if (forceResult != null) {
+                    return forceResult;
+                }
+
                 boolean result = this.semaphore.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
                 long currentTimeMs = System.currentTimeMillis();
                 if (result) {
                     this.lastLockTimeMs.set(currentTimeMs);
                     return currentTimeMs;
-                } else {
-                    // if the lock is expired, can be acquired again
-                    long expiredTimeMs = ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3;
-                    if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
-                        synchronized (this) {
-                            if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
-                                log.warn("HandleData lock expired, acquire lock success and reset lock time. " +
-                                    "MessageReceiptHandle={}, lockTime={}", messageReceiptHandle, currentTimeMs);
-                                this.lastLockTimeMs.set(currentTimeMs);
-                                return currentTimeMs;
-                            }
-                        }
-                    }
                 }
-                return null;
+
+                // Slow path: tryAcquire timed out, the lock may have expired during the wait
+                return tryForceAcquire(expiredTimeMs);
             } catch (InterruptedException e) {
                 return null;
             }
         }
 
+        private Long tryForceAcquire(long expiredTimeMs) {
+            long currentTimeMs = System.currentTimeMillis();
+            if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+                synchronized (this) {
+                    currentTimeMs = System.currentTimeMillis();
+                    if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+                        log.warn("HandleData lock expired, acquire lock success and reset lock time. "
+                            + "MessageReceiptHandle={}, lockTime={}", messageReceiptHandle, currentTimeMs);
+                        this.lastLockTimeMs.set(currentTimeMs);
+                        return currentTimeMs;
+                    }
+                }
+            }
+            return null;
+        }
+
         public void unlock(long lockTimeMs) {
             // if the lock is expired, we don't need to unlock it
-            if (System.currentTimeMillis() - lockTimeMs > ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 2) {
+            if (System.currentTimeMillis() - lockTimeMs > ConfigurationManager.getProxyConfig().getLockTimeoutMsInHandleGroup() * 3) {
                 log.warn("HandleData lock expired, unlock fail. MessageReceiptHandle={}, lockTime={}, now={}",
                     messageReceiptHandle, lockTimeMs, System.currentTimeMillis());
                 return;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroup.java
@@ -138,8 +138,12 @@ public class ReceiptHandleGroup {
         }
 
         private Long tryForceAcquire(long expiredTimeMs) {
+            long lastLock = this.lastLockTimeMs.get();
+            if (lastLock < 0) {
+                return null;
+            }
             long currentTimeMs = System.currentTimeMillis();
-            if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {
+            if (currentTimeMs - lastLock > expiredTimeMs) {
                 synchronized (this) {
                     currentTimeMs = System.currentTimeMillis();
                     if (currentTimeMs - this.lastLockTimeMs.get() > expiredTimeMs) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.common.consumer.ReceiptHandle;
 import org.apache.rocketmq.common.message.MessageClientIDSetter;
 import org.apache.rocketmq.common.utils.FutureUtils;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.InitConfigTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -307,6 +309,60 @@ public class ReceiptHandleGroupTest extends InitConfigTest {
         await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertEquals(1, count.get()));
         assertEquals(handle1, removeHandleRef.get().getReceiptHandleStr());
         assertTrue(receiptHandleGroup.isEmpty());
+    }
+
+    @Test
+    public void testUnlockReleasesWithinAlignedThreshold() throws Exception {
+        // T=200ms → 2T=400ms, 3T=600ms, deadlock window=[400,600) is 200ms wide
+        ConfigurationManager.getProxyConfig().setLockTimeoutMsInHandleGroup(200);
+
+        String handle = createHandle();
+        ReceiptHandleGroup.HandleData handleData =
+            new ReceiptHandleGroup.HandleData(createMessageReceiptHandle(handle, msgID));
+
+        // Thread A acquires the lock
+        Long lockTime = handleData.lock(200);
+        assertNotNull(lockTime);
+
+        // Wait until elapsed is in [2T, 3T) — the old deadlock window.
+        // Before the fix, unlock() used *2 so it would skip release here,
+        // leaking the semaphore permit.
+        Thread.sleep(450);
+
+        handleData.unlock(lockTime);
+
+        // Use a short tryAcquire timeout (10ms) so that even after the wait,
+        // total elapsed stays well below 3T (600ms). This ensures we're testing
+        // the unlock release path, not accidentally relying on force-acquire.
+        Long lockTime2 = handleData.lock(10);
+        assertNotNull("Lock should succeed after aligned unlock", lockTime2);
+        handleData.unlock(lockTime2);
+    }
+
+    @Test
+    public void testLockForceAcquiresBeforeTryAcquire() throws Exception {
+        ConfigurationManager.getProxyConfig().setLockTimeoutMsInHandleGroup(100);
+
+        String handle = createHandle();
+        ReceiptHandleGroup.HandleData handleData =
+            new ReceiptHandleGroup.HandleData(createMessageReceiptHandle(handle, msgID));
+
+        // Acquire the lock and never release (simulate a stuck holder)
+        Long lockTime = handleData.lock(100);
+        assertNotNull(lockTime);
+
+        // Wait until the lock is fully expired (> 3T = 300ms)
+        Thread.sleep(350);
+
+        // With the pre-check, lock() should detect the expiry before calling
+        // tryAcquire and force-acquire immediately — no blocking wait
+        long start = System.currentTimeMillis();
+        Long lockTime2 = handleData.lock(100);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertNotNull("Expired lock should be force-acquired", lockTime2);
+        assertTrue("Expected fast force-acquire but took " + elapsed + "ms", elapsed < 50);
+        handleData.unlock(lockTime2);
     }
 
     private MessageReceiptHandle createMessageReceiptHandle(String handle, String msgID) {


### PR DESCRIPTION
## Summary

`ReceiptHandleGroup.HandleData` uses different timeout multipliers for `lock()` (`*3`) and `unlock()` (`*2`), creating a **deadlock window of duration T** in the range `[2T, 3T)`:

1. Thread A holds the lock longer than `2T` (e.g., slow network I/O)
2. Thread A calls `unlock()` — since elapsed > `T*2`, it skips `semaphore.release()`, leaking the permit
3. Thread B calls `lock()` — `tryAcquire()` fails (0 permits), and force-acquire requires elapsed > `T*3`, which isn't met yet
4. All operations on the affected `HandleData` throw `ProxyException(INTERNAL_SERVER_ERROR)` until `3T` elapses

With the default `lockTimeoutMsInHandleGroup = 3000ms`, this is a **3-second window** where the semaphore is stuck.

## Changes

- **Align `unlock()` threshold from `*2` to `*3`** to match `lock()`'s force-acquire threshold, eliminating the gap
- **Check lock expiry before `tryAcquire()`** so that expired locks are force-acquired immediately without blocking for the full timeout (addresses the second point in the issue)
- **Extract `tryForceAcquire()`** to deduplicate the double-checked locking block between the fast path and slow path
- **Add two tests** covering the aligned threshold behavior and the pre-check fast path, verified to fail on the old code

## Test plan

- [x] `testUnlockReleasesWithinAlignedThreshold` — verifies semaphore is properly released when elapsed is in `[2T, 3T)` (failed with old `*2` threshold)
- [x] `testLockForceAcquiresBeforeTryAcquire` — verifies expired lock is force-acquired in <50ms instead of blocking for the full timeout (old code: 111ms; new code: <5ms)
- [x] All 7 existing `ReceiptHandleGroupTest` tests pass (no regression)

Fixes #10065