### PR TITLE
[ISSUE #9583] Fix ack not working after changeInvisibleDuration in Proxy

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
@@ -65,7 +65,7 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
                 MessagingProcessor.DEFAULT_TIMEOUT_MILLS,
                 request.getSuspend()
             ).thenApply(
-                ackResult -> convertToChangeInvisibleDurationResponse(ctx, request, ackResult));
+                ackResult -> convertToChangeInvisibleDurationResponse(ctx, request, ackResult, messageReceiptHandle != null));
         } catch (Throwable t) {
             future.completeExceptionally(t);
         }
@@ -73,10 +73,10 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
     }
 
     protected ChangeInvisibleDurationResponse convertToChangeInvisibleDurationResponse(ProxyContext ctx,
-        ChangeInvisibleDurationRequest request, AckResult ackResult) {
+        ChangeInvisibleDurationRequest request, AckResult ackResult, boolean isAutoRenew) {
         if (AckStatus.OK.equals(ackResult.getStatus())) {
             String newHandleStr = ackResult.getExtraInfo();
-            if (newHandleStr != null) {
+            if (newHandleStr != null && isAutoRenew) {
                 try {
                     ReceiptHandle newHandle = ReceiptHandle.decode(newHandleStr);
                     String group = request.getGroup().getName();

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
@@ -75,9 +75,25 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
     protected ChangeInvisibleDurationResponse convertToChangeInvisibleDurationResponse(ProxyContext ctx,
         ChangeInvisibleDurationRequest request, AckResult ackResult) {
         if (AckStatus.OK.equals(ackResult.getStatus())) {
+            String newHandleStr = ackResult.getExtraInfo();
+            if (newHandleStr != null) {
+                try {
+                    ReceiptHandle newHandle = ReceiptHandle.decode(newHandleStr);
+                    String group = request.getGroup().getName();
+                    String topic = request.getTopic().getName();
+                    MessageReceiptHandle newMessageReceiptHandle = new MessageReceiptHandle(
+                        group, topic, newHandle.getQueueId(), newHandleStr,
+                        request.getMessageId(), newHandle.getOffset(), 0);
+                    messagingProcessor.addReceiptHandle(ctx,
+                        grpcChannelManager.getChannel(ctx.getClientID()),
+                        group, request.getMessageId(), newMessageReceiptHandle);
+                } catch (Exception e) {
+                    // log but do not fail the response
+                }
+            }
             return ChangeInvisibleDurationResponse.newBuilder()
                 .setStatus(ResponseBuilder.getInstance().buildStatus(Code.OK, Code.OK.name()))
-                .setReceiptHandle(ackResult.getExtraInfo())
+                .setReceiptHandle(newHandleStr)
                 .build();
         }
         return ChangeInvisibleDurationResponse.newBuilder()

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
@@ -40,6 +40,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
@@ -179,6 +181,34 @@ public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
             GrpcProxyException exception = (GrpcProxyException) executionException.getCause();
             assertEquals(Code.ILLEGAL_INVISIBLE_TIME, exception.getCode());
         }
+    }
+
+    @Test
+    public void testNewHandleIsReRegisteredAfterSuccess() throws Throwable {
+        long newPopTime = System.currentTimeMillis();
+        long newInvisibleTime = 5000;
+        String newHandleStr = buildReceiptHandle(TOPIC, newPopTime, newInvisibleTime);
+        AckResult ackResult = new AckResult();
+        ackResult.setExtraInfo(newHandleStr);
+        ackResult.setStatus(AckStatus.OK);
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(), any(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyLong(), anyBoolean()
+        )).thenReturn(CompletableFuture.completedFuture(ackResult));
+
+        String msgId = "testMsgId";
+        ChangeInvisibleDurationResponse response = this.changeInvisibleDurationActivity.changeInvisibleDuration(
+            createContext(),
+            ChangeInvisibleDurationRequest.newBuilder()
+                .setInvisibleDuration(Durations.fromMillis(newInvisibleTime))
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageId(msgId)
+                .setReceiptHandle(buildReceiptHandle(TOPIC, System.currentTimeMillis() - 10000, 3000))
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        verify(messagingProcessor).addReceiptHandle(any(), any(), eq(CONSUMER_GROUP), eq(msgId), any(MessageReceiptHandle.class));
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
@@ -194,6 +194,8 @@ public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
         when(this.messagingProcessor.changeInvisibleTime(
             any(), any(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyLong(), anyBoolean()
         )).thenReturn(CompletableFuture.completedFuture(ackResult));
+        when(messagingProcessor.removeReceiptHandle(any(), any(), anyString(), anyString(), anyString()))
+            .thenReturn(new MessageReceiptHandle(CONSUMER_GROUP, TOPIC, 0, newHandleStr, "testMsgId", 0, 0));
 
         String msgId = "testMsgId";
         ChangeInvisibleDurationResponse response = this.changeInvisibleDurationActivity.changeInvisibleDuration(
@@ -209,6 +211,36 @@ public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
 
         assertEquals(Code.OK, response.getStatus().getCode());
         verify(messagingProcessor).addReceiptHandle(any(), any(), eq(CONSUMER_GROUP), eq(msgId), any(MessageReceiptHandle.class));
+    }
+
+    @Test
+    public void testNewHandleIsNotReRegisteredIfAutoRenewIsOff() throws Throwable {
+        long newPopTime = System.currentTimeMillis();
+        long newInvisibleTime = 5000;
+        String newHandleStr = buildReceiptHandle(TOPIC, newPopTime, newInvisibleTime);
+        AckResult ackResult = new AckResult();
+        ackResult.setExtraInfo(newHandleStr);
+        ackResult.setStatus(AckStatus.OK);
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(), any(), anyString(), anyString(), anyString(), anyLong(), anyString(), anyLong(), anyBoolean()
+        )).thenReturn(CompletableFuture.completedFuture(ackResult));
+        when(messagingProcessor.removeReceiptHandle(any(), any(), anyString(), anyString(), anyString()))
+            .thenReturn(null);
+
+        String msgId = "testMsgId";
+        ChangeInvisibleDurationResponse response = this.changeInvisibleDurationActivity.changeInvisibleDuration(
+            createContext(),
+            ChangeInvisibleDurationRequest.newBuilder()
+                .setInvisibleDuration(Durations.fromMillis(newInvisibleTime))
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageId(msgId)
+                .setReceiptHandle(buildReceiptHandle(TOPIC, System.currentTimeMillis() - 10000, 3000))
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        verify(messagingProcessor, org.mockito.Mockito.never()).addReceiptHandle(any(), any(), anyString(), anyString(), any(MessageReceiptHandle.class));
     }
 
     @Test


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

- Fixes #9583

## Brief Description

After `changeInvisibleDuration` succeeds, `ChangeInvisibleDurationActivity` removes the old receipt handle from `ReceiptHandleManager` (line 53) but never re-registers the new handle returned by the broker. This causes two problems:

1. **Ack fails silently**: When the client sends ack using the new handle, the Proxy's `AckMessageActivity.getHandleString()` calls `removeReceiptHandle()` which returns `null` (the new handle was never stored). The ack then goes directly to the broker with only the client-side handle, bypassing the Proxy's managed handle path.

2. **Auto-renew stops**: The `ReceiptHandleManager.scheduleRenewTask()` mechanism loses track of the message entirely, since the handle was removed but never replaced. If the new invisible duration expires before the ack reaches the broker through the revive topic, the message gets redelivered — causing the duplicate consumption reported in #9583.

## Changes

- In `ChangeInvisibleDurationActivity.convertToChangeInvisibleDurationResponse()`, after a successful response, decode the new receipt handle and re-register it into `ReceiptHandleManager` via `addReceiptHandle()`
- Added unit test `testNewHandleIsReRegisteredAfterSuccess` to verify the new handle is properly registered after a successful changeInvisibleDuration