### PR TITLE
[ISSUE #10270] Make Pop RocksDB BlockCache size configurable via MessageStoreConfig

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
@@ -46,9 +46,11 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
     private WriteOptions writeOptions;
     private WriteOptions deleteOptions;
     protected ColumnFamilyHandle columnFamilyHandle;
+    private final long blockCacheSize;
 
-    public PopConsumerRocksdbStore(String filePath) {
+    public PopConsumerRocksdbStore(String filePath, long blockCacheSize) {
         super(filePath);
+        this.blockCacheSize = blockCacheSize;
     }
 
     // https://www.cnblogs.com/renjc/p/rocksdb-class-db.html
@@ -83,8 +85,8 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
             initOptions();
 
             // init column family here
-            ColumnFamilyOptions defaultOptions = RocksDBOptionsFactory.createPopCFOptions();
-            ColumnFamilyOptions popStateOptions = RocksDBOptionsFactory.createPopCFOptions();
+            ColumnFamilyOptions defaultOptions = RocksDBOptionsFactory.createPopCFOptions(blockCacheSize);
+            ColumnFamilyOptions popStateOptions = RocksDBOptionsFactory.createPopCFOptions(blockCacheSize);
             this.cfOptions.add(defaultOptions);
             this.cfOptions.add(popStateOptions);
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
@@ -47,10 +47,12 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
     private WriteOptions deleteOptions;
     protected ColumnFamilyHandle columnFamilyHandle;
     private final long blockCacheSize;
+    private final long writeBufferSize;
 
-    public PopConsumerRocksdbStore(String filePath, long blockCacheSize) {
+    public PopConsumerRocksdbStore(String filePath, long blockCacheSize, long writeBufferSize) {
         super(filePath);
         this.blockCacheSize = blockCacheSize;
+        this.writeBufferSize = writeBufferSize;
     }
 
     // https://www.cnblogs.com/renjc/p/rocksdb-class-db.html
@@ -85,8 +87,8 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
             initOptions();
 
             // init column family here
-            ColumnFamilyOptions defaultOptions = RocksDBOptionsFactory.createPopCFOptions(blockCacheSize);
-            ColumnFamilyOptions popStateOptions = RocksDBOptionsFactory.createPopCFOptions(blockCacheSize);
+            ColumnFamilyOptions defaultOptions = RocksDBOptionsFactory.createPopCFOptions(blockCacheSize, writeBufferSize);
+            ColumnFamilyOptions popStateOptions = RocksDBOptionsFactory.createPopCFOptions(blockCacheSize, writeBufferSize);
             this.cfOptions.add(defaultOptions);
             this.cfOptions.add(popStateOptions);
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -98,7 +98,8 @@ public class PopConsumerService extends ServiceThread {
         this.lastCleanupLockTime = new AtomicLong(System.currentTimeMillis());
         this.consumerLockService = new PopConsumerLockService(TimeUnit.MINUTES.toMillis(2));
         this.popConsumerStore = new PopConsumerRocksdbStore(Paths.get(
-            brokerController.getMessageStoreConfig().getStorePathRootDir(), ROCKSDB_DIRECTORY).toString());
+            brokerController.getMessageStoreConfig().getStorePathRootDir(), ROCKSDB_DIRECTORY).toString(),
+            brokerController.getMessageStoreConfig().getPopRocksdbBlockCacheSize());
         this.popConsumerCache = brokerConfig.isEnablePopBufferMerge() ? new PopConsumerCache(
             brokerController, this.popConsumerStore, this.consumerLockService, this::revive) : null;
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -99,7 +99,8 @@ public class PopConsumerService extends ServiceThread {
         this.consumerLockService = new PopConsumerLockService(TimeUnit.MINUTES.toMillis(2));
         this.popConsumerStore = new PopConsumerRocksdbStore(Paths.get(
             brokerController.getMessageStoreConfig().getStorePathRootDir(), ROCKSDB_DIRECTORY).toString(),
-            brokerController.getMessageStoreConfig().getPopRocksdbBlockCacheSize());
+            brokerController.getMessageStoreConfig().getPopRocksdbBlockCacheSize(),
+            brokerController.getMessageStoreConfig().getPopRocksdbWriteBufferSize());
         this.popConsumerCache = brokerConfig.isEnablePopBufferMerge() ? new PopConsumerCache(
             brokerController, this.popConsumerStore, this.consumerLockService, this::revive) : null;
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStoreTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStoreTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
+import org.rocksdb.util.SizeUnit;
 import org.apache.rocketmq.common.config.AbstractRocksDBStorage;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.tieredstore.util.MessageStoreUtil;
@@ -65,7 +66,7 @@ public class PopConsumerRocksdbStoreTest {
     @Test
     public void rocksdbStoreWriteDeleteTest() {
         String filePath = getRandomStorePath();
-        PopConsumerKVStore consumerStore = new PopConsumerRocksdbStore(filePath);
+        PopConsumerKVStore consumerStore = new PopConsumerRocksdbStore(filePath, 256 * SizeUnit.MB);
         Assert.assertEquals(filePath, consumerStore.getFilePath());
 
         consumerStore.start();
@@ -127,7 +128,7 @@ public class PopConsumerRocksdbStoreTest {
     @Ignore
     @SuppressWarnings("ConstantValue")
     public void tombstoneDeletionTest() throws IllegalAccessException, NoSuchFieldException {
-        PopConsumerRocksdbStore rocksdbStore = new PopConsumerRocksdbStore(getRandomStorePath());
+        PopConsumerRocksdbStore rocksdbStore = new PopConsumerRocksdbStore(getRandomStorePath(), 256 * SizeUnit.MB);
         rocksdbStore.start();
 
         int iterCount = 1000 * 1000;

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStoreTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStoreTest.java
@@ -66,7 +66,8 @@ public class PopConsumerRocksdbStoreTest {
     @Test
     public void rocksdbStoreWriteDeleteTest() {
         String filePath = getRandomStorePath();
-        PopConsumerKVStore consumerStore = new PopConsumerRocksdbStore(filePath, 256 * SizeUnit.MB);
+        PopConsumerKVStore consumerStore = new PopConsumerRocksdbStore(
+            filePath, 256 * SizeUnit.MB, 32 * SizeUnit.MB);
         Assert.assertEquals(filePath, consumerStore.getFilePath());
 
         consumerStore.start();
@@ -128,7 +129,8 @@ public class PopConsumerRocksdbStoreTest {
     @Ignore
     @SuppressWarnings("ConstantValue")
     public void tombstoneDeletionTest() throws IllegalAccessException, NoSuchFieldException {
-        PopConsumerRocksdbStore rocksdbStore = new PopConsumerRocksdbStore(getRandomStorePath(), 256 * SizeUnit.MB);
+        PopConsumerRocksdbStore rocksdbStore = new PopConsumerRocksdbStore(
+            getRandomStorePath(), 256 * SizeUnit.MB, 32 * SizeUnit.MB);
         rocksdbStore.start();
 
         int iterCount = 1000 * 1000;

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -505,6 +505,8 @@ public class MessageStoreConfig {
 
     private String rocksdbCompressionType = CompressionType.LZ4_COMPRESSION.getLibraryName();
 
+    private long popRocksdbBlockCacheSize = 256 * SizeUnit.MB;
+
     /**
      * Flush RocksDB WAL frequency, aka, flush WAL every N write ops.
      */
@@ -529,6 +531,14 @@ public class MessageStoreConfig {
 
     public void setRocksdbCompressionType(String compressionType) {
         this.rocksdbCompressionType = compressionType;
+    }
+
+    public long getPopRocksdbBlockCacheSize() {
+        return popRocksdbBlockCacheSize;
+    }
+
+    public void setPopRocksdbBlockCacheSize(long popRocksdbBlockCacheSize) {
+        this.popRocksdbBlockCacheSize = popRocksdbBlockCacheSize;
     }
 
     /**

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -507,6 +507,8 @@ public class MessageStoreConfig {
 
     private long popRocksdbBlockCacheSize = 256 * SizeUnit.MB;
 
+    private long popRocksdbWriteBufferSize = 32 * SizeUnit.MB;
+
     /**
      * Flush RocksDB WAL frequency, aka, flush WAL every N write ops.
      */
@@ -539,6 +541,14 @@ public class MessageStoreConfig {
 
     public void setPopRocksdbBlockCacheSize(long popRocksdbBlockCacheSize) {
         this.popRocksdbBlockCacheSize = popRocksdbBlockCacheSize;
+    }
+
+    public long getPopRocksdbWriteBufferSize() {
+        return popRocksdbWriteBufferSize;
+    }
+
+    public void setPopRocksdbWriteBufferSize(long popRocksdbWriteBufferSize) {
+        this.popRocksdbWriteBufferSize = popRocksdbWriteBufferSize;
     }
 
     /**

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
@@ -132,7 +132,7 @@ public class RocksDBOptionsFactory {
                 setInplaceUpdateSupport(true);
     }
 
-    public static ColumnFamilyOptions createPopCFOptions() {
+    public static ColumnFamilyOptions createPopCFOptions(long blockCacheSize) {
         BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig()
             .setFormatVersion(5)
             .setIndexType(IndexType.kBinarySearch)
@@ -145,7 +145,7 @@ public class RocksDBOptionsFactory {
             .setCacheIndexAndFilterBlocksWithHighPriority(true)
             .setPinL0FilterAndIndexBlocksInCache(false)
             .setPinTopLevelIndexAndFilter(true)
-            .setBlockCache(new LRUCache(1024 * SizeUnit.MB, 8, false))
+            .setBlockCache(new LRUCache(blockCacheSize, 8, false))
             .setWholeKeyFiltering(true);
 
         CompactionOptionsUniversal compactionOption = new CompactionOptionsUniversal()

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
@@ -132,7 +132,7 @@ public class RocksDBOptionsFactory {
                 setInplaceUpdateSupport(true);
     }
 
-    public static ColumnFamilyOptions createPopCFOptions(long blockCacheSize) {
+    public static ColumnFamilyOptions createPopCFOptions(long blockCacheSize, long writeBufferSize) {
         BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig()
             .setFormatVersion(5)
             .setIndexType(IndexType.kBinarySearch)
@@ -160,7 +160,7 @@ public class RocksDBOptionsFactory {
         //noinspection resource
         return new ColumnFamilyOptions()
             .setMaxWriteBufferNumber(4)
-            .setWriteBufferSize(128 * SizeUnit.MB)
+            .setWriteBufferSize(writeBufferSize)
             .setMinWriteBufferNumberToMerge(1)
             .setTableFormatConfig(blockBasedTableConfig)
             .setMemTableConfig(new SkipListMemTableConfig())


### PR DESCRIPTION
Add popRocksdbBlockCacheSize to MessageStoreConfig with a default of 256MB, replacing the hardcoded value in RocksDBOptionsFactory.createPopCFOptions(). This allows operators to tune Pop RocksDB memory usage based on container memory budgets.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10270

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
