### PR TITLE
[ISSUE #10244] Trigger MemoryConsumerOrderInfoManager autoClean periodically

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -719,6 +719,17 @@ public class BrokerController {
             @Override
             public void run() {
                 try {
+                    BrokerController.this.popLiteMessageProcessor.cleanConsumerOrderInfo();
+                } catch (Throwable e) {
+                    LOG.error("BrokerController: failed to clean pop lite consumer order info", e);
+                }
+            }
+        }, 5, 5, TimeUnit.MINUTES);
+
+        this.scheduledExecutorService.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                try {
                     BrokerController.this.protectBroker();
                 } catch (Throwable e) {
                     LOG.error("BrokerController: failed to protectBroker", e);

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopLiteMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopLiteMessageProcessor.java
@@ -438,9 +438,6 @@ public class PopLiteMessageProcessor implements NettyRequestProcessor {
     }
 
     public class PopLiteLockManager extends ServiceThread {
-        private static final long AUTO_CLEAN_INTERVAL = 5 * 60 * 1000;
-        private long lastCleanTime = System.currentTimeMillis();
-
         @Override
         public String getServiceName() {
             if (brokerController.getBrokerConfig().isInBrokerContainer()) {
@@ -455,10 +452,6 @@ public class PopLiteMessageProcessor implements NettyRequestProcessor {
                 try {
                     waitForRunning(60000);
                     lockService.removeTimeout();
-                    if (System.currentTimeMillis() - lastCleanTime >= AUTO_CLEAN_INTERVAL) {
-                        ((MemoryConsumerOrderInfoManager) consumerOrderInfoManager).autoClean();
-                        lastCleanTime = System.currentTimeMillis();
-                    }
                 } catch (Exception ignored) {
                 }
             }
@@ -475,6 +468,10 @@ public class PopLiteMessageProcessor implements NettyRequestProcessor {
 
     public ConsumerOrderInfoManager getConsumerOrderInfoManager() {
         return consumerOrderInfoManager;
+    }
+
+    public void cleanConsumerOrderInfo() {
+        ((MemoryConsumerOrderInfoManager) consumerOrderInfoManager).autoClean();
     }
 
     public void startPopLiteLockManager() {

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/orderly/ConsumerOrderInfoManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/orderly/ConsumerOrderInfoManagerTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.broker.offset.MemoryConsumerOrderInfoManager;
 import org.apache.rocketmq.broker.subscription.SubscriptionGroupManager;
 import org.apache.rocketmq.broker.topic.TopicConfigManager;
 import org.apache.rocketmq.common.BrokerConfig;
@@ -454,6 +455,36 @@ public class ConsumerOrderInfoManagerTest {
                 break;
             }
         }
+    }
+
+    @Test
+    public void testMemoryConsumerOrderInfoManagerAutoCleanGroupNotExist() {
+        BrokerConfig brokerConfig = new BrokerConfig();
+        BrokerController brokerController = mock(BrokerController.class);
+        TopicConfigManager topicConfigManager = mock(TopicConfigManager.class);
+        SubscriptionGroupManager subscriptionGroupManager = mock(SubscriptionGroupManager.class);
+        when(brokerController.getBrokerConfig()).thenReturn(brokerConfig);
+        when(brokerController.getTopicConfigManager()).thenReturn(topicConfigManager);
+        when(brokerController.getSubscriptionGroupManager()).thenReturn(subscriptionGroupManager);
+        when(topicConfigManager.selectTopicConfig(eq(TOPIC))).thenReturn(new TopicConfig(TOPIC));
+        when(subscriptionGroupManager.containsSubscriptionGroup(GROUP)).thenReturn(false);
+
+        MemoryConsumerOrderInfoManager memoryConsumerOrderInfoManager =
+            new MemoryConsumerOrderInfoManager(brokerController);
+        memoryConsumerOrderInfoManager.update(null, false,
+            TOPIC,
+            GROUP,
+            QUEUE_ID_0,
+            popTime,
+            1,
+            Lists.newArrayList(2L, 3L, 4L),
+            new StringBuilder());
+
+        assertEquals(1, memoryConsumerOrderInfoManager.getTable().size());
+
+        memoryConsumerOrderInfoManager.autoClean();
+
+        assertEquals(0, memoryConsumerOrderInfoManager.getTable().size());
     }
 
     private void assertEncodeAndDecode() {


### PR DESCRIPTION
### Summary

This PR fixes the missing periodic cleanup for `MemoryConsumerOrderInfoManager`.

Previously, the cleanup logic already existed in `autoClean()`, including the case where the subscription group no longer exists, but it was not triggered periodically for the in-memory manager path.

### Changes

- schedule periodic cleanup for memory consumer order info in broker periodic tasks
- expose a cleanup entry from `PopLiteMessageProcessor`
- keep `PopLiteLockManager` focused on lock timeout cleanup
- add unit coverage for the missing-group cleanup case

### Why

The issue is not in the cleanup rule itself, but in the missing trigger path for `MemoryConsumerOrderInfoManager.autoClean()`.

### Tests

- `git diff --check`
- `mvn -pl broker -am -Dmaven.repo.local=/tmp/rocketmq-m2 -Dtest=ConsumerOrderInfoManagerTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false compiler:compile compiler:testCompile surefire:test`
