### PR TITLE
[ISSUE #10276] Fix PopConsumerService changeInvisibilityDuration losing CK record when visibilityTimeout collision

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -530,11 +530,9 @@ public class PopConsumerService extends ServiceThread {
         // If the new CK has the same key as the old CK (same visibilityTimeout),
         // the write already overwrites the old record in RocksDB, skip delete
         // to avoid removing the newly written record.
-        if (!skipWrite && ckRecord.getVisibilityTimeout() == ackRecord.getVisibilityTimeout()) {
-            return;
+        if (skipWrite || ckRecord.getVisibilityTimeout() != ackRecord.getVisibilityTimeout()) {
+            this.popConsumerStore.deleteRecords(Collections.singletonList(ackRecord));
         }
-
-        this.popConsumerStore.deleteRecords(Collections.singletonList(ackRecord));
     }
 
     // Use broker escape bridge to support remote read

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -511,8 +511,10 @@ public class PopConsumerService extends ServiceThread {
 
         // No need to generate new records when the group does not exist,
         // because these retry messages will not be consumed by anyone.
-        if (brokerConfig.isPopReviveSkipIfGroupAbsent() &&
-            !brokerController.getSubscriptionGroupManager().containsSubscriptionGroup(groupId)) {
+        boolean skipWrite = brokerConfig.isPopReviveSkipIfGroupAbsent() &&
+            !brokerController.getSubscriptionGroupManager().containsSubscriptionGroup(groupId);
+
+        if (skipWrite) {
             log.info("PopConsumerService change invisibility skip, time={}, " +
                 "groupId={}, topicId={}, queueId={}, offset={}", popTime, groupId, topicId, queueId, offset);
         } else {
@@ -523,6 +525,13 @@ public class PopConsumerService extends ServiceThread {
             if (popConsumerCache.deleteRecords(Collections.singletonList(ackRecord)).isEmpty()) {
                 return;
             }
+        }
+
+        // If the new CK has the same key as the old CK (same visibilityTimeout),
+        // the write already overwrites the old record in RocksDB, skip delete
+        // to avoid removing the newly written record.
+        if (!skipWrite && ckRecord.getVisibilityTimeout() == ackRecord.getVisibilityTimeout()) {
+            return;
         }
 
         this.popConsumerStore.deleteRecords(Collections.singletonList(ackRecord));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10276

### Brief Description

In `PopConsumerService.changeInvisibilityDuration`, the RocksDB key is composed of `visibilityTimeout + groupId + topicId + queueId + offset`, where `visibilityTimeout = popTime + invisibleTime`.

When the new CK's `changedPopTime + changedInvisibleTime` equals the old CK's `popTime + invisibleTime`, both records produce the same RocksDB key. The current code first writes the new CK (which overwrites the old record at the same key), then deletes using the old CK's key — which inadvertently removes the newly written record, causing the message to never be retried.

**Fix:** Added a check before the delete operation. If the write was performed and the new CK has the same `visibilityTimeout` as the old one (same key), the delete is skipped since the write already replaced the old value in place.

### How Did You Test This Change?

- Verified compilation passes successfully
- Verified no new lint or compilation errors in the modified file
- Logic analysis confirms correctness for all scenarios:
  1. Keys differ → write new CK + delete old CK (normal path)
  2. Keys same → write overwrites old record, skip delete (fix path)
  3. Group absent (skipWrite) → skip write + delete old CK (unchanged behavior)
