### PR TITLE
[ISSUE #10278] Add enableGrpcChannelReceiptHandleRenew switch to disable proxy periodic handle renewal for gRPC clients

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/MessageReceiptHandle.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/MessageReceiptHandle.java
@@ -37,6 +37,14 @@ public class MessageReceiptHandle {
     private final long consumeTimestamp;
     private String liteTopic;
     private volatile String receiptHandleStr;
+    /**
+     * Indicates whether this handle needs periodic renewal by the proxy.
+     * When true, the proxy will periodically call changeInvisibleTime to extend the handle's lifetime.
+     * When false, the handle was popped with a long invisibleTime (e.g., consumeTimeoutMinute) and
+     * only needs expiry cleanup. This flag is set at handle creation time based on the
+     * enableGrpcChannelReceiptHandleRenew config, ensuring safe transitions when the config changes.
+     */
+    private final boolean needRenew;
 
     public MessageReceiptHandle(String group, String topic, int queueId, String receiptHandleStr, String messageId,
         long queueOffset, int reconsumeTimes) {
@@ -45,6 +53,11 @@ public class MessageReceiptHandle {
 
     public MessageReceiptHandle(String group, String topic, int queueId, String receiptHandleStr, String messageId,
         long queueOffset, int reconsumeTimes, String liteTopic) {
+        this(group, topic, queueId, receiptHandleStr, messageId, queueOffset, reconsumeTimes, liteTopic, true);
+    }
+
+    public MessageReceiptHandle(String group, String topic, int queueId, String receiptHandleStr, String messageId,
+        long queueOffset, int reconsumeTimes, String liteTopic, boolean needRenew) {
         this.originalReceiptHandle = ReceiptHandle.decode(receiptHandleStr);
         this.group = group;
         this.topic = topic;
@@ -56,6 +69,7 @@ public class MessageReceiptHandle {
         this.reconsumeTimes = reconsumeTimes;
         this.consumeTimestamp = originalReceiptHandle.getRetrieveTime();
         this.liteTopic = liteTopic;
+        this.needRenew = needRenew;
     }
 
     @Override
@@ -168,5 +182,9 @@ public class MessageReceiptHandle {
 
     public void setLiteTopic(String liteTopic) {
         this.liteTopic = liteTopic;
+    }
+
+    public boolean isNeedRenew() {
+        return needRenew;
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -216,6 +216,18 @@ public class ProxyConfig implements ConfigFile {
 
     private long invisibleTimeMillisWhenClear = 1000L;
     private boolean enableProxyAutoRenew = true;
+    /**
+     * When enableProxyAutoRenew is true, this controls whether the proxy periodically renews
+     * (extends) the invisible time of receipt handles for gRPC (GrpcClientChannel) consumers
+     * via changeInvisibleTime calls to the broker.
+     * <p>
+     * When set to false, the proxy will NOT periodically renew handles for gRPC clients. Instead,
+     * it will use the consumer group's consumeTimeoutMinute as the initial invisible time during
+     * pop, and only save handles for client-disconnect cleanup (nack). This avoids the
+     * handle-mapping complexity and makes the client's original receipt handle remain valid
+     * even if the proxy crashes.
+     */
+    private boolean enableGrpcChannelReceiptHandleRenew = true;
     private int maxRenewRetryTimes = 3;
     private int renewThreadPoolNums = 2;
     private int renewMaxThreadPoolNums = 4;
@@ -1113,6 +1125,14 @@ public class ProxyConfig implements ConfigFile {
 
     public void setEnableProxyAutoRenew(boolean enableProxyAutoRenew) {
         this.enableProxyAutoRenew = enableProxyAutoRenew;
+    }
+
+    public boolean isEnableGrpcChannelReceiptHandleRenew() {
+        return enableGrpcChannelReceiptHandleRenew;
+    }
+
+    public void setEnableGrpcChannelReceiptHandleRenew(boolean enableGrpcChannelReceiptHandleRenew) {
+        this.enableGrpcChannelReceiptHandleRenew = enableGrpcChannelReceiptHandleRenew;
     }
 
     public int getMaxRenewRetryTimes() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -25,6 +25,9 @@ import apache.rocketmq.v2.Settings;
 import apache.rocketmq.v2.Subscription;
 import com.google.protobuf.util.Durations;
 import io.grpc.stub.StreamObserver;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.PopResult;
 import org.apache.rocketmq.client.consumer.PopStatus;
@@ -49,10 +52,6 @@ import org.apache.rocketmq.proxy.service.route.MessageQueueView;
 import org.apache.rocketmq.remoting.protocol.filter.FilterAPI;
 import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 public class ReceiveMessageActivity extends AbstractMessagingActivity {
     private static final String ILLEGAL_POLLING_TIME_INTRODUCED_CLIENT_VERSION = "5.0.3";
@@ -114,8 +113,12 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
 
             long actualInvisibleTime = Durations.toMillis(request.getInvisibleDuration());
             ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
-            if (proxyConfig.isEnableProxyAutoRenew() && request.getAutoRenew()) {
-                if (proxyConfig.isEnableGrpcChannelReceiptHandleRenew()) {
+            final boolean autoRenew = proxyConfig.isEnableProxyAutoRenew() && request.getAutoRenew();
+            // The handle renewal mode must match the invisible time used for this pop request.
+            // Do not re-read dynamic config after pop completes.
+            final boolean needRenew = autoRenew && proxyConfig.isEnableGrpcChannelReceiptHandleRenew();
+            if (autoRenew) {
+                if (needRenew) {
                     actualInvisibleTime = proxyConfig.getDefaultInvisibleTimeMills();
                 } else {
                     actualInvisibleTime = getConsumeTimeoutInvisibleTime(ctx, group, proxyConfig);
@@ -188,11 +191,10 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
                 );
             }
 
-            final boolean autoRenew = proxyConfig.isEnableProxyAutoRenew() && request.getAutoRenew();
             popFuture.thenAccept(popResult -> {
                 Runnable doAfterWrite = null;
                 if (autoRenew) {
-                    doAfterWrite = handleAutoRenew(ctx, request, group, topic, popResult, writer);
+                    doAfterWrite = handleAutoRenew(ctx, request, group, topic, popResult, writer, needRenew);
                 }
                 writer.writeAndComplete(ctx, request, popResult, doAfterWrite);
             }).exceptionally(t -> {
@@ -205,7 +207,7 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
     }
 
     private Runnable handleAutoRenew(ProxyContext ctx, ReceiveMessageRequest request,
-        String group, String topic, PopResult popResult, ReceiveMessageResponseStreamWriter writer
+        String group, String topic, PopResult popResult, ReceiveMessageResponseStreamWriter writer, boolean needRenew
     ) {
         if (!PopStatus.FOUND.equals(popResult.getPopStatus())) {
             return null;
@@ -219,10 +221,6 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
                 writer.processThrowableWhenWriteMessage(e, ctx, request, messageExt));
             throw e;
         }
-        // Capture the renew mode at pop time. This ensures that when the config switches dynamically,
-        // handles already created continue to be handled correctly (renewed or not) regardless of
-        // the current config state.
-        final boolean needRenew = ConfigurationManager.getProxyConfig().isEnableGrpcChannelReceiptHandleRenew();
         return () -> {
             List<MessageExt> messageExtList = popResult.getMsgFoundList();
             for (MessageExt messageExt : messageExtList) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -27,6 +27,7 @@ import com.google.protobuf.util.Durations;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.PopResult;
 import org.apache.rocketmq.client.consumer.PopStatus;
@@ -50,6 +51,7 @@ import org.apache.rocketmq.proxy.service.route.MessageQueueSelector;
 import org.apache.rocketmq.proxy.service.route.MessageQueueView;
 import org.apache.rocketmq.remoting.protocol.filter.FilterAPI;
 import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
 public class ReceiveMessageActivity extends AbstractMessagingActivity {
     private static final String ILLEGAL_POLLING_TIME_INTRODUCED_CLIENT_VERSION = "5.0.3";
@@ -107,7 +109,11 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
             long actualInvisibleTime = Durations.toMillis(request.getInvisibleDuration());
             ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
             if (proxyConfig.isEnableProxyAutoRenew() && request.getAutoRenew()) {
-                actualInvisibleTime = proxyConfig.getDefaultInvisibleTimeMills();
+                if (proxyConfig.isEnableGrpcChannelReceiptHandleRenew()) {
+                    actualInvisibleTime = proxyConfig.getDefaultInvisibleTimeMills();
+                } else {
+                    actualInvisibleTime = getConsumeTimeoutInvisibleTime(ctx, group, proxyConfig);
+                }
             } else {
                 validateInvisibleTime(actualInvisibleTime,
                     ConfigurationManager.getProxyConfig().getMinInvisibleTimeMillsForRecv());
@@ -228,6 +234,18 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
             this.messagingProcessor,
             responseObserver
         );
+    }
+
+    private long getConsumeTimeoutInvisibleTime(ProxyContext ctx, String group, ProxyConfig proxyConfig) {
+        try {
+            SubscriptionGroupConfig groupConfig = this.messagingProcessor.getSubscriptionGroupConfig(ctx, group);
+            if (groupConfig != null && groupConfig.getConsumeTimeoutMinute() > 0) {
+                return TimeUnit.MINUTES.toMillis(groupConfig.getConsumeTimeoutMinute());
+            }
+        } catch (Exception e) {
+            // fall through to default
+        }
+        return proxyConfig.getDefaultInvisibleTimeMills();
     }
 
     protected static class ReceiveMessageQueueSelector implements QueueSelector {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -245,23 +245,20 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
     }
 
     private long getConsumeTimeoutInvisibleTime(ProxyContext ctx, String group, ProxyConfig proxyConfig) {
-        long invisibleTime;
+        // Use default consumeTimeoutMinute as fallback when config is null or invalid.
+        // This is intentionally NOT defaultInvisibleTimeMills (60s) because without renewal,
+        // 60s is too short and would cause duplicate consumption.
+        long invisibleTime = DEFAULT_CONSUME_TIMEOUT_INVISIBLE_TIME_MILLIS;
         try {
             SubscriptionGroupConfig groupConfig = this.messagingProcessor.getSubscriptionGroupConfig(ctx, group);
             if (groupConfig != null && groupConfig.getConsumeTimeoutMinute() > 0) {
                 invisibleTime = TimeUnit.MINUTES.toMillis(groupConfig.getConsumeTimeoutMinute());
-            } else {
-                // Use default consumeTimeoutMinute as fallback when config is null or invalid.
-                // This is intentionally NOT defaultInvisibleTimeMills (60s) because without renewal,
-                // 60s is too short and would cause duplicate consumption.
-                invisibleTime = DEFAULT_CONSUME_TIMEOUT_INVISIBLE_TIME_MILLIS;
             }
         } catch (Exception e) {
             log.warn("Failed to get SubscriptionGroupConfig for group: {}, using default consumeTimeoutMinute (15min) "
                 + "as invisibleTime.", group, e);
             // Safe fallback: use default consumeTimeoutMinute instead of defaultInvisibleTimeMills (60s).
             // Since renewal is disabled, the handle must live long enough for the client to process it.
-            invisibleTime = DEFAULT_CONSUME_TIMEOUT_INVISIBLE_TIME_MILLIS;
         }
         // Clamp to maxInvisibleTimeMills to avoid exceeding broker's allowed range
         long maxInvisibleTime = proxyConfig.getMaxInvisibleTimeMills();

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -16,18 +16,9 @@
  */
 package org.apache.rocketmq.proxy.grpc.v2.consumer;
 
-import apache.rocketmq.v2.ClientType;
-import apache.rocketmq.v2.Code;
-import apache.rocketmq.v2.FilterExpression;
-import apache.rocketmq.v2.ReceiveMessageRequest;
-import apache.rocketmq.v2.ReceiveMessageResponse;
-import apache.rocketmq.v2.Settings;
-import apache.rocketmq.v2.Subscription;
+import apache.rocketmq.v2.*;
 import com.google.protobuf.util.Durations;
 import io.grpc.stub.StreamObserver;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.consumer.PopResult;
 import org.apache.rocketmq.client.consumer.PopStatus;
@@ -53,8 +44,17 @@ import org.apache.rocketmq.remoting.protocol.filter.FilterAPI;
 import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 public class ReceiveMessageActivity extends AbstractMessagingActivity {
     private static final String ILLEGAL_POLLING_TIME_INTRODUCED_CLIENT_VERSION = "5.0.3";
+    /**
+     * Default fallback invisibleTime when renewal is disabled and SubscriptionGroupConfig is unavailable.
+     * Uses the same default as SubscriptionGroupConfig.consumeTimeoutMinute (15 minutes).
+     */
+    private static final long DEFAULT_CONSUME_TIMEOUT_INVISIBLE_TIME_MILLIS = TimeUnit.MINUTES.toMillis(15);
 
     public ReceiveMessageActivity(MessagingProcessor messagingProcessor,
         GrpcClientSettingsManager grpcClientSettingsManager, GrpcChannelManager grpcChannelManager) {
@@ -213,6 +213,10 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
                 writer.processThrowableWhenWriteMessage(e, ctx, request, messageExt));
             throw e;
         }
+        // Capture the renew mode at pop time. This ensures that when the config switches dynamically,
+        // handles already created continue to be handled correctly (renewed or not) regardless of
+        // the current config state.
+        final boolean needRenew = ConfigurationManager.getProxyConfig().isEnableGrpcChannelReceiptHandleRenew();
         return () -> {
             List<MessageExt> messageExtList = popResult.getMsgFoundList();
             for (MessageExt messageExt : messageExtList) {
@@ -221,7 +225,7 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
                     MessageReceiptHandle messageReceiptHandle =
                         new MessageReceiptHandle(group, topic, messageExt.getQueueId(), receiptHandle, messageExt.getMsgId(),
                             messageExt.getQueueOffset(), messageExt.getReconsumeTimes(),
-                            messageExt.getProperty(MessageConst.PROPERTY_LITE_TOPIC));
+                            messageExt.getProperty(MessageConst.PROPERTY_LITE_TOPIC), needRenew);
                     messagingProcessor.addReceiptHandle(ctx, clientChannel, group, messageExt.getMsgId(), messageReceiptHandle);
                 }
             }
@@ -237,15 +241,32 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
     }
 
     private long getConsumeTimeoutInvisibleTime(ProxyContext ctx, String group, ProxyConfig proxyConfig) {
+        long invisibleTime;
         try {
             SubscriptionGroupConfig groupConfig = this.messagingProcessor.getSubscriptionGroupConfig(ctx, group);
             if (groupConfig != null && groupConfig.getConsumeTimeoutMinute() > 0) {
-                return TimeUnit.MINUTES.toMillis(groupConfig.getConsumeTimeoutMinute());
+                invisibleTime = TimeUnit.MINUTES.toMillis(groupConfig.getConsumeTimeoutMinute());
+            } else {
+                // Use default consumeTimeoutMinute as fallback when config is null or invalid.
+                // This is intentionally NOT defaultInvisibleTimeMills (60s) because without renewal,
+                // 60s is too short and would cause duplicate consumption.
+                invisibleTime = DEFAULT_CONSUME_TIMEOUT_INVISIBLE_TIME_MILLIS;
             }
         } catch (Exception e) {
-            // fall through to default
+            log.warn("Failed to get SubscriptionGroupConfig for group: {}, using default consumeTimeoutMinute (15min) "
+                + "as invisibleTime.", group, e);
+            // Safe fallback: use default consumeTimeoutMinute instead of defaultInvisibleTimeMills (60s).
+            // Since renewal is disabled, the handle must live long enough for the client to process it.
+            invisibleTime = DEFAULT_CONSUME_TIMEOUT_INVISIBLE_TIME_MILLIS;
         }
-        return proxyConfig.getDefaultInvisibleTimeMills();
+        // Clamp to maxInvisibleTimeMills to avoid exceeding broker's allowed range
+        long maxInvisibleTime = proxyConfig.getMaxInvisibleTimeMills();
+        if (maxInvisibleTime > 0 && invisibleTime > maxInvisibleTime) {
+            log.warn("Calculated invisibleTime {}ms for group {} exceeds maxInvisibleTimeMills {}ms, clamping.",
+                invisibleTime, group, maxInvisibleTime);
+            invisibleTime = maxInvisibleTime;
+        }
+        return invisibleTime;
     }
 
     protected static class ReceiveMessageQueueSelector implements QueueSelector {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -16,7 +16,13 @@
  */
 package org.apache.rocketmq.proxy.grpc.v2.consumer;
 
-import apache.rocketmq.v2.*;
+import apache.rocketmq.v2.ClientType;
+import apache.rocketmq.v2.Code;
+import apache.rocketmq.v2.FilterExpression;
+import apache.rocketmq.v2.ReceiveMessageRequest;
+import apache.rocketmq.v2.ReceiveMessageResponse;
+import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.Subscription;
 import com.google.protobuf.util.Durations;
 import io.grpc.stub.StreamObserver;
 import org.apache.commons.lang3.StringUtils;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -54,6 +54,7 @@ import org.apache.rocketmq.proxy.common.ReceiptHandleGroupKey;
 import org.apache.rocketmq.proxy.common.RenewEvent;
 import org.apache.rocketmq.proxy.common.RenewStrategyPolicy;
 import org.apache.rocketmq.proxy.common.channel.ChannelHelper;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
@@ -162,6 +163,11 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
                 ReceiptHandleGroupKey key = entry.getKey();
                 if (clientIsOffline(key)) {
                     clearGroup(key);
+                    continue;
+                }
+
+                if (!proxyConfig.isEnableGrpcChannelReceiptHandleRenew()
+                    && key.getChannel() instanceof GrpcClientChannel) {
                     continue;
                 }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -166,12 +166,21 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
                     continue;
                 }
 
+                ReceiptHandleGroup group = entry.getValue();
+
                 if (!proxyConfig.isEnableGrpcChannelReceiptHandleRenew()
                     && key.getChannel() instanceof GrpcClientChannel) {
+                    // When renew is disabled, only clean up expired handles to avoid memory leak
+                    group.scan((msgID, handleStr, v) -> {
+                        ReceiptHandle handle = ReceiptHandle.decode(v.getReceiptHandleStr());
+                        if (handle.isExpired()) {
+                            group.computeIfPresent(msgID, handleStr,
+                                messageReceiptHandle -> CompletableFuture.completedFuture(null), 0);
+                        }
+                    });
                     continue;
                 }
 
-                ReceiptHandleGroup group = entry.getValue();
                 group.scan((msgID, handleStr, v) -> {
                     long current = System.currentTimeMillis();
                     ReceiptHandle handle = ReceiptHandle.decode(v.getReceiptHandleStr());

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -54,7 +54,6 @@ import org.apache.rocketmq.proxy.common.ReceiptHandleGroupKey;
 import org.apache.rocketmq.proxy.common.RenewEvent;
 import org.apache.rocketmq.proxy.common.RenewStrategyPolicy;
 import org.apache.rocketmq.proxy.common.channel.ChannelHelper;
-import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
@@ -168,20 +167,19 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
 
                 ReceiptHandleGroup group = entry.getValue();
 
-                if (!proxyConfig.isEnableGrpcChannelReceiptHandleRenew()
-                    && key.getChannel() instanceof GrpcClientChannel) {
-                    // When renew is disabled, only clean up expired handles to avoid memory leak
-                    group.scan((msgID, handleStr, v) -> {
+                group.scan((msgID, handleStr, v) -> {
+                    // Per-handle renewal decision: handles that were created with needRenew=false
+                    // (popped when enableGrpcChannelReceiptHandleRenew was disabled) only need
+                    // expiry cleanup, NOT periodic renewal. This ensures safe transitions when
+                    // the config is dynamically switched.
+                    if (!v.isNeedRenew()) {
                         ReceiptHandle handle = ReceiptHandle.decode(v.getReceiptHandleStr());
                         if (handle.isExpired()) {
                             group.computeIfPresent(msgID, handleStr,
                                 messageReceiptHandle -> CompletableFuture.completedFuture(null), 0);
                         }
-                    });
-                    continue;
-                }
-
-                group.scan((msgID, handleStr, v) -> {
+                        return;
+                    }
                     long current = System.currentTimeMillis();
                     ReceiptHandle handle = ReceiptHandle.decode(v.getReceiptHandleStr());
                     if (handle.getNextVisibleTime() - current > proxyConfig.getRenewAheadTimeMillis()) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
@@ -49,18 +49,21 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.proxy.grpc.v2.BaseActivityTest;
 import org.apache.rocketmq.proxy.service.route.AddressableMessageQueue;
 import org.apache.rocketmq.proxy.service.route.MessageQueueView;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -72,9 +75,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import org.apache.rocketmq.proxy.config.ProxyConfig;
-import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
 public class ReceiveMessageActivityTest extends BaseActivityTest {
 
@@ -476,127 +478,197 @@ public class ReceiveMessageActivityTest extends BaseActivityTest {
     @Test
     public void testReceiveMessageWithRenewDisabledUsesConsumeTimeout() {
         ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
-        proxyConfig.setEnableProxyAutoRenew(true);
-        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+        boolean originalAutoRenew = proxyConfig.isEnableProxyAutoRenew();
+        boolean originalGrpcRenew = proxyConfig.isEnableGrpcChannelReceiptHandleRenew();
+        try {
+            proxyConfig.setEnableProxyAutoRenew(true);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
 
-        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
-        doNothing().when(receiveStreamObserver).onNext(any());
-        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+            StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+            doNothing().when(receiveStreamObserver).onNext(any());
+            when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
 
-        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
-        groupConfig.setConsumeTimeoutMinute(20);
-        when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString())).thenReturn(groupConfig);
+            SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+            groupConfig.setConsumeTimeoutMinute(20);
+            when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString())).thenReturn(groupConfig);
 
-        ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
-        when(this.messagingProcessor.popMessage(
-            any(), any(), anyString(), anyString(), anyInt(),
-            invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
-            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
+            ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+            when(this.messagingProcessor.popMessage(
+                any(), any(), anyString(), anyString(), anyInt(),
+                invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
 
-        this.receiveMessageActivity.receiveMessage(
-            createContext(),
-            ReceiveMessageRequest.newBuilder()
-                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
-                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
-                .setAutoRenew(true)
-                .setFilterExpression(FilterExpression.newBuilder()
-                    .setType(FilterType.TAG)
-                    .setExpression("*")
-                    .build())
-                .build(),
-            receiveStreamObserver
-        );
+            this.receiveMessageActivity.receiveMessage(
+                createContext(),
+                ReceiveMessageRequest.newBuilder()
+                    .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                    .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                    .setAutoRenew(true)
+                    .setFilterExpression(FilterExpression.newBuilder()
+                        .setType(FilterType.TAG)
+                        .setExpression("*")
+                        .build())
+                    .build(),
+                receiveStreamObserver
+            );
 
-        // Should use consumeTimeoutMinute (20min = 1200000ms), not defaultInvisibleTimeMills (60s)
-        assertEquals(20 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
-
-        // Restore
-        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
+            assertEquals(20 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+        } finally {
+            proxyConfig.setEnableProxyAutoRenew(originalAutoRenew);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(originalGrpcRenew);
+        }
     }
 
     @Test
     public void testReceiveMessageWithRenewDisabledFallbackOnException() {
         ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
-        proxyConfig.setEnableProxyAutoRenew(true);
-        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+        boolean originalAutoRenew = proxyConfig.isEnableProxyAutoRenew();
+        boolean originalGrpcRenew = proxyConfig.isEnableGrpcChannelReceiptHandleRenew();
+        try {
+            proxyConfig.setEnableProxyAutoRenew(true);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
 
-        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
-        doNothing().when(receiveStreamObserver).onNext(any());
-        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+            StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+            doNothing().when(receiveStreamObserver).onNext(any());
+            when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
 
-        // Simulate exception when getting subscription group config
-        when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString()))
-            .thenThrow(new RuntimeException("broker unavailable"));
+            when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString()))
+                .thenThrow(new RuntimeException("broker unavailable"));
 
-        ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
-        when(this.messagingProcessor.popMessage(
-            any(), any(), anyString(), anyString(), anyInt(),
-            invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
-            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
+            ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+            when(this.messagingProcessor.popMessage(
+                any(), any(), anyString(), anyString(), anyInt(),
+                invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
 
-        this.receiveMessageActivity.receiveMessage(
-            createContext(),
-            ReceiveMessageRequest.newBuilder()
-                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
-                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
-                .setAutoRenew(true)
-                .setFilterExpression(FilterExpression.newBuilder()
-                    .setType(FilterType.TAG)
-                    .setExpression("*")
-                    .build())
-                .build(),
-            receiveStreamObserver
-        );
+            this.receiveMessageActivity.receiveMessage(
+                createContext(),
+                ReceiveMessageRequest.newBuilder()
+                    .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                    .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                    .setAutoRenew(true)
+                    .setFilterExpression(FilterExpression.newBuilder()
+                        .setType(FilterType.TAG)
+                        .setExpression("*")
+                        .build())
+                    .build(),
+                receiveStreamObserver
+            );
 
-        // Should fallback to 15min (900000ms), NOT defaultInvisibleTimeMills (60s)
-        assertEquals(15 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+            assertEquals(15 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+        } finally {
+            proxyConfig.setEnableProxyAutoRenew(originalAutoRenew);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(originalGrpcRenew);
+        }
+    }
 
-        // Restore
-        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
+    @Test
+    public void testReceiveMessageCapturesRenewModeBeforePopCompletes() {
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        boolean originalAutoRenew = proxyConfig.isEnableProxyAutoRenew();
+        boolean originalGrpcRenew = proxyConfig.isEnableGrpcChannelReceiptHandleRenew();
+        try {
+            proxyConfig.setEnableProxyAutoRenew(true);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
+
+            StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+            doNothing().when(receiveStreamObserver).onNext(any());
+            when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+
+            CompletableFuture<PopResult> popFuture = new CompletableFuture<>();
+            ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+            when(this.messagingProcessor.popMessage(
+                any(), any(), anyString(), anyString(), anyInt(),
+                invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+                .thenReturn(popFuture);
+
+            String msgId = "msgId";
+            String popCk = "0 0 60000 0 0 broker 0 0 0";
+            MessageExt messageExt = new MessageExt();
+            messageExt.setTopic(TOPIC);
+            messageExt.setMsgId(msgId);
+            MessageAccessor.putProperty(messageExt, MessageConst.PROPERTY_POP_CK, popCk);
+            messageExt.setBody("body".getBytes());
+
+            ProxyContext ctx = createContext();
+            this.grpcChannelManager.createChannel(ctx, ctx.getClientID());
+            this.receiveMessageActivity.receiveMessage(
+                ctx,
+                ReceiveMessageRequest.newBuilder()
+                    .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                    .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                    .setAutoRenew(true)
+                    .setFilterExpression(FilterExpression.newBuilder()
+                        .setType(FilterType.TAG)
+                        .setExpression("*")
+                        .build())
+                    .build(),
+                receiveStreamObserver
+            );
+
+            assertEquals(proxyConfig.getDefaultInvisibleTimeMills(), invisibleTimeCaptor.getValue().longValue());
+
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+            popFuture.complete(new PopResult(PopStatus.FOUND, Collections.singletonList(messageExt)));
+
+            ArgumentCaptor<MessageReceiptHandle> messageReceiptHandleCaptor = ArgumentCaptor.forClass(MessageReceiptHandle.class);
+            verify(this.messagingProcessor, timeout(1000)).addReceiptHandle(
+                any(),
+                any(),
+                eq(CONSUMER_GROUP),
+                eq(msgId),
+                messageReceiptHandleCaptor.capture());
+            assertTrue(messageReceiptHandleCaptor.getValue().isNeedRenew());
+        } finally {
+            proxyConfig.setEnableProxyAutoRenew(originalAutoRenew);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(originalGrpcRenew);
+        }
     }
 
     @Test
     public void testReceiveMessageWithRenewDisabledClampsToMaxInvisibleTime() {
         ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
-        proxyConfig.setEnableProxyAutoRenew(true);
-        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+        boolean originalAutoRenew = proxyConfig.isEnableProxyAutoRenew();
+        boolean originalGrpcRenew = proxyConfig.isEnableGrpcChannelReceiptHandleRenew();
         long originalMax = proxyConfig.getMaxInvisibleTimeMills();
-        // Set maxInvisibleTimeMills to 10 min for testing
-        proxyConfig.setMaxInvisibleTimeMills(10 * 60 * 1000L);
+        try {
+            proxyConfig.setEnableProxyAutoRenew(true);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+            proxyConfig.setMaxInvisibleTimeMills(10 * 60 * 1000L);
 
-        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
-        doNothing().when(receiveStreamObserver).onNext(any());
-        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+            StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+            doNothing().when(receiveStreamObserver).onNext(any());
+            when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
 
-        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
-        groupConfig.setConsumeTimeoutMinute(30); // 30min > maxInvisibleTimeMills (10min)
-        when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString())).thenReturn(groupConfig);
+            SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+            groupConfig.setConsumeTimeoutMinute(30);
+            when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString())).thenReturn(groupConfig);
 
-        ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
-        when(this.messagingProcessor.popMessage(
-            any(), any(), anyString(), anyString(), anyInt(),
-            invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
-            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
+            ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+            when(this.messagingProcessor.popMessage(
+                any(), any(), anyString(), anyString(), anyInt(),
+                invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
 
-        this.receiveMessageActivity.receiveMessage(
-            createContext(),
-            ReceiveMessageRequest.newBuilder()
-                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
-                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
-                .setAutoRenew(true)
-                .setFilterExpression(FilterExpression.newBuilder()
-                    .setType(FilterType.TAG)
-                    .setExpression("*")
-                    .build())
-                .build(),
-            receiveStreamObserver
-        );
+            this.receiveMessageActivity.receiveMessage(
+                createContext(),
+                ReceiveMessageRequest.newBuilder()
+                    .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                    .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                    .setAutoRenew(true)
+                    .setFilterExpression(FilterExpression.newBuilder()
+                        .setType(FilterType.TAG)
+                        .setExpression("*")
+                        .build())
+                    .build(),
+                receiveStreamObserver
+            );
 
-        // Should be clamped to maxInvisibleTimeMills (10min = 600000ms)
-        assertEquals(10 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
-
-        // Restore
-        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
-        proxyConfig.setMaxInvisibleTimeMills(originalMax);
+            assertEquals(10 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+        } finally {
+            proxyConfig.setEnableProxyAutoRenew(originalAutoRenew);
+            proxyConfig.setEnableGrpcChannelReceiptHandleRenew(originalGrpcRenew);
+            proxyConfig.setMaxInvisibleTimeMills(originalMax);
+        }
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
@@ -73,6 +73,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 
 public class ReceiveMessageActivityTest extends BaseActivityTest {
 
@@ -469,5 +471,132 @@ public class ReceiveMessageActivityTest extends BaseActivityTest {
                 new ReceiveMessageActivity.ReceiveMessageQueueSelector(BROKER_NAME + i);
             assertEquals(BROKER_NAME + i, selectorBrokerName.select(ProxyContext.create(), messageQueueView).getBrokerName());
         }
+    }
+
+    @Test
+    public void testReceiveMessageWithRenewDisabledUsesConsumeTimeout() {
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        proxyConfig.setEnableProxyAutoRenew(true);
+        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+
+        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+        doNothing().when(receiveStreamObserver).onNext(any());
+        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setConsumeTimeoutMinute(20);
+        when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString())).thenReturn(groupConfig);
+
+        ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+        when(this.messagingProcessor.popMessage(
+            any(), any(), anyString(), anyString(), anyInt(),
+            invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
+
+        this.receiveMessageActivity.receiveMessage(
+            createContext(),
+            ReceiveMessageRequest.newBuilder()
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                .setAutoRenew(true)
+                .setFilterExpression(FilterExpression.newBuilder()
+                    .setType(FilterType.TAG)
+                    .setExpression("*")
+                    .build())
+                .build(),
+            receiveStreamObserver
+        );
+
+        // Should use consumeTimeoutMinute (20min = 1200000ms), not defaultInvisibleTimeMills (60s)
+        assertEquals(20 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+
+        // Restore
+        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
+    }
+
+    @Test
+    public void testReceiveMessageWithRenewDisabledFallbackOnException() {
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        proxyConfig.setEnableProxyAutoRenew(true);
+        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+
+        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+        doNothing().when(receiveStreamObserver).onNext(any());
+        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+
+        // Simulate exception when getting subscription group config
+        when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString()))
+            .thenThrow(new RuntimeException("broker unavailable"));
+
+        ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+        when(this.messagingProcessor.popMessage(
+            any(), any(), anyString(), anyString(), anyInt(),
+            invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
+
+        this.receiveMessageActivity.receiveMessage(
+            createContext(),
+            ReceiveMessageRequest.newBuilder()
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                .setAutoRenew(true)
+                .setFilterExpression(FilterExpression.newBuilder()
+                    .setType(FilterType.TAG)
+                    .setExpression("*")
+                    .build())
+                .build(),
+            receiveStreamObserver
+        );
+
+        // Should fallback to 15min (900000ms), NOT defaultInvisibleTimeMills (60s)
+        assertEquals(15 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+
+        // Restore
+        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
+    }
+
+    @Test
+    public void testReceiveMessageWithRenewDisabledClampsToMaxInvisibleTime() {
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        proxyConfig.setEnableProxyAutoRenew(true);
+        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(false);
+        long originalMax = proxyConfig.getMaxInvisibleTimeMills();
+        // Set maxInvisibleTimeMills to 10 min for testing
+        proxyConfig.setMaxInvisibleTimeMills(10 * 60 * 1000L);
+
+        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+        doNothing().when(receiveStreamObserver).onNext(any());
+        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setConsumeTimeoutMinute(30); // 30min > maxInvisibleTimeMills (10min)
+        when(this.messagingProcessor.getSubscriptionGroupConfig(any(), anyString())).thenReturn(groupConfig);
+
+        ArgumentCaptor<Long> invisibleTimeCaptor = ArgumentCaptor.forClass(Long.class);
+        when(this.messagingProcessor.popMessage(
+            any(), any(), anyString(), anyString(), anyInt(),
+            invisibleTimeCaptor.capture(), anyLong(), anyInt(), any(), anyBoolean(), any(), isNull(), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, Collections.emptyList())));
+
+        this.receiveMessageActivity.receiveMessage(
+            createContext(),
+            ReceiveMessageRequest.newBuilder()
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                .setAutoRenew(true)
+                .setFilterExpression(FilterExpression.newBuilder()
+                    .setType(FilterType.TAG)
+                    .setExpression("*")
+                    .build())
+                .build(),
+            receiveStreamObserver
+        );
+
+        // Should be clamped to maxInvisibleTimeMills (10min = 600000ms)
+        assertEquals(10 * 60 * 1000L, invisibleTimeCaptor.getValue().longValue());
+
+        // Restore
+        proxyConfig.setEnableGrpcChannelReceiptHandleRenew(true);
+        proxyConfig.setMaxInvisibleTimeMills(originalMax);
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -463,4 +463,103 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
         listenerArgumentCaptor.getValue().handle(ConsumerGroupEvent.CLIENT_UNREGISTER, GROUP, new ClientChannelInfo(channel, "", LanguageCode.JAVA, 0));
         assertTrue(receiptHandleManager.receiptHandleGroupMap.isEmpty());
     }
+
+    @Test
+    public void testNoRenewHandleSkipsRenewalAndCleansExpired() {
+        // Create a handle with needRenew=false (simulating enableGrpcChannelReceiptHandleRenew=false at pop time)
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+        long invisibleTime = 900000L; // 15min
+        String noRenewReceiptHandle = ReceiptHandle.builder()
+            .startOffset(0L)
+            .retrieveTime(System.currentTimeMillis() - invisibleTime - 1000) // already expired
+            .invisibleTime(invisibleTime)
+            .reviveQueueId(1)
+            .topicType(ReceiptHandle.NORMAL_TOPIC)
+            .brokerName(BROKER_NAME)
+            .queueId(QUEUE_ID)
+            .offset(OFFSET)
+            .commitLogOffset(0L)
+            .build().encode();
+        MessageReceiptHandle noRenewHandle = new MessageReceiptHandle(GROUP, TOPIC, QUEUE_ID, noRenewReceiptHandle,
+            MESSAGE_ID, OFFSET, RECONSUME_TIMES, null, false);
+
+        Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
+        receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, noRenewHandle);
+        Mockito.when(consumerManager.findChannel(Mockito.eq(GROUP), Mockito.eq(channel))).thenReturn(Mockito.mock(ClientChannelInfo.class));
+
+        receiptHandleManager.scheduleRenewTask();
+
+        // Should NOT call changeInvisibleTime (no renewal for needRenew=false)
+        Mockito.verify(messagingProcessor, Mockito.timeout(1000).times(0))
+            .changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyLong());
+
+        // The expired handle should be cleaned up
+        await().atMost(Duration.ofSeconds(1)).until(() -> {
+            try {
+                ReceiptHandleGroup receiptHandleGroup = receiptHandleManager.receiptHandleGroupMap.values().stream().findFirst().get();
+                return receiptHandleGroup.isEmpty();
+            } catch (Exception e) {
+                return false;
+            }
+        });
+    }
+
+    @Test
+    public void testNoRenewHandleNotExpiredStaysInMemory() {
+        // Create a handle with needRenew=false that is NOT yet expired
+        long invisibleTime = 900000L; // 15min
+        String noRenewReceiptHandle = ReceiptHandle.builder()
+            .startOffset(0L)
+            .retrieveTime(System.currentTimeMillis()) // not expired yet
+            .invisibleTime(invisibleTime)
+            .reviveQueueId(1)
+            .topicType(ReceiptHandle.NORMAL_TOPIC)
+            .brokerName(BROKER_NAME)
+            .queueId(QUEUE_ID)
+            .offset(OFFSET)
+            .commitLogOffset(0L)
+            .build().encode();
+        MessageReceiptHandle noRenewHandle = new MessageReceiptHandle(GROUP, TOPIC, QUEUE_ID, noRenewReceiptHandle,
+            MESSAGE_ID, OFFSET, RECONSUME_TIMES, null, false);
+
+        Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
+        receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, noRenewHandle);
+        Mockito.when(consumerManager.findChannel(Mockito.eq(GROUP), Mockito.eq(channel))).thenReturn(Mockito.mock(ClientChannelInfo.class));
+
+        receiptHandleManager.scheduleRenewTask();
+
+        // Should NOT call changeInvisibleTime
+        Mockito.verify(messagingProcessor, Mockito.timeout(1000).times(0))
+            .changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyLong());
+
+        // Handle should still be in memory (not expired, kept for nack on disconnect)
+        ReceiptHandleGroup receiptHandleGroup = receiptHandleManager.receiptHandleGroupMap.values().stream().findFirst().get();
+        assertEquals(false, receiptHandleGroup.isEmpty());
+    }
+
+    @Test
+    public void testTransitionNeedRenewTrueHandleStillRenewed() {
+        // Simulate a handle created when enableGrpcChannelReceiptHandleRenew=true (needRenew=true)
+        // Even if config later changes to false, this handle should still be renewed
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+        Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
+
+        // Create handle with needRenew=true (default)
+        MessageReceiptHandle needRenewHandle = new MessageReceiptHandle(GROUP, TOPIC, QUEUE_ID, receiptHandle,
+            MESSAGE_ID, OFFSET, RECONSUME_TIMES, null, true);
+        receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, needRenewHandle);
+
+        Mockito.when(consumerManager.findChannel(Mockito.eq(GROUP), Mockito.eq(channel))).thenReturn(Mockito.mock(ClientChannelInfo.class));
+        Mockito.when(metadataService.getSubscriptionGroupConfig(Mockito.any(), Mockito.eq(GROUP))).thenReturn(new SubscriptionGroupConfig());
+
+        // Even though config says no renew now, the handle has needRenew=true
+        // so it should still be renewed
+        receiptHandleManager.scheduleRenewTask();
+
+        Mockito.verify(messagingProcessor, Mockito.timeout(1000).times(1))
+            .changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class), Mockito.eq(MESSAGE_ID),
+                Mockito.eq(GROUP), Mockito.eq(TOPIC), Mockito.anyLong());
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -60,6 +60,7 @@ import org.mockito.stubbing.Answer;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
@@ -467,7 +468,6 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
     @Test
     public void testNoRenewHandleSkipsRenewalAndCleansExpired() {
         // Create a handle with needRenew=false (simulating enableGrpcChannelReceiptHandleRenew=false at pop time)
-        ProxyConfig config = ConfigurationManager.getProxyConfig();
         long invisibleTime = 900000L; // 15min
         String noRenewReceiptHandle = ReceiptHandle.builder()
             .startOffset(0L)
@@ -536,14 +536,13 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
 
         // Handle should still be in memory (not expired, kept for nack on disconnect)
         ReceiptHandleGroup receiptHandleGroup = receiptHandleManager.receiptHandleGroupMap.values().stream().findFirst().get();
-        assertEquals(false, receiptHandleGroup.isEmpty());
+        assertFalse(receiptHandleGroup.isEmpty());
     }
 
     @Test
     public void testTransitionNeedRenewTrueHandleStillRenewed() {
         // Simulate a handle created when enableGrpcChannelReceiptHandleRenew=true (needRenew=true)
         // Even if config later changes to false, this handle should still be renewed
-        ProxyConfig config = ConfigurationManager.getProxyConfig();
         Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
 
         // Create handle with needRenew=true (default)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10278

### Brief Description

This PR adds a new dynamic switch `enableGrpcChannelReceiptHandleRenew` in `ProxyConfig` to allow disabling the proxy's periodic receipt handle renewal mechanism specifically for gRPC (`GrpcClientChannel`) consumers.

**Background**: The current auto-renew approach uses a short invisible time (~60s) and periodically calls `changeInvisibleTime` to extend it. While this protects against client crashes, it has a critical flaw: if the **proxy** crashes, the client's original handle (issued with short invisible time) has already expired, and the renewed handle is lost in proxy memory. The client cannot ack through another proxy, causing unavoidable duplicate consumption.

**Changes**:
1. **`ProxyConfig.enableGrpcChannelReceiptHandleRenew`** (default `true`): New boolean switch targeting only gRPC channels. When set to `false`:
   - The proxy uses the consumer group's `consumeTimeoutMinute` (from `SubscriptionGroupConfig`) as the invisible time during pop for gRPC clients, giving the client a long-lived handle.
   - The proxy skips periodic `changeInvisibleTime` renewal calls for `GrpcClientChannel` instances only.
   - Non-gRPC channels (e.g., Remoting) continue to renew normally.
   - Handle storage and client-disconnect cleanup (nack) are preserved.

2. **`ReceiveMessageActivity`**: When `enableGrpcChannelReceiptHandleRenew=false`, resolves the invisible time from the group's `consumeTimeoutMinute` instead of the short `defaultInvisibleTimeMills`.

3. **`DefaultReceiptHandleManager`**: When `enableGrpcChannelReceiptHandleRenew=false`, the scheduled task still detects client disconnects (and nacks), but skips the periodic renewal loop only for channels that are `instanceof GrpcClientChannel`.

### How Did You Test This Change?

1. Verified compilation passes (`mvn compile -pl proxy -am`).
2. Verified no IDE errors in all modified files.
3. Existing unit tests in `DefaultReceiptHandleManagerTest` and `ReceiptHandleProcessorTest` continue to pass (they test with default `enableGrpcChannelReceiptHandleRenew=true`).
