### PR TITLE
Fix consumerOffset deserialization compatibility

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
@@ -48,10 +48,10 @@ public class ConsumerOffsetManager extends ConfigManager {
     protected ConcurrentMap<String/* topic@group */, ConcurrentMap<Integer, Long>> offsetTable =
         new ConcurrentHashMap<>(512);
 
-    protected final ConcurrentMap<String, ConcurrentMap<Integer, Long>> resetOffsetTable =
+    protected final transient ConcurrentMap<String, ConcurrentMap<Integer, Long>> resetOffsetTable =
         new ConcurrentHashMap<>(512);
 
-    private final ConcurrentMap<String/* topic@group */, ConcurrentMap<Integer, Long>> pullOffsetTable =
+    private final transient ConcurrentMap<String/* topic@group */, ConcurrentMap<Integer, Long>> pullOffsetTable =
         new ConcurrentHashMap<>(512);
 
     protected transient BrokerController brokerController;

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -511,8 +511,10 @@ public class PopConsumerService extends ServiceThread {
 
         // No need to generate new records when the group does not exist,
         // because these retry messages will not be consumed by anyone.
-        if (brokerConfig.isPopReviveSkipIfGroupAbsent() &&
-            !brokerController.getSubscriptionGroupManager().containsSubscriptionGroup(groupId)) {
+        boolean skipWrite = brokerConfig.isPopReviveSkipIfGroupAbsent() &&
+            !brokerController.getSubscriptionGroupManager().containsSubscriptionGroup(groupId);
+
+        if (skipWrite) {
             log.info("PopConsumerService change invisibility skip, time={}, " +
                 "groupId={}, topicId={}, queueId={}, offset={}", popTime, groupId, topicId, queueId, offset);
         } else {
@@ -525,7 +527,12 @@ public class PopConsumerService extends ServiceThread {
             }
         }
 
-        this.popConsumerStore.deleteRecords(Collections.singletonList(ackRecord));
+        // If the new CK has the same key as the old CK (same visibilityTimeout),
+        // the write already overwrites the old record in RocksDB, skip delete
+        // to avoid removing the newly written record.
+        if (skipWrite || ckRecord.getVisibilityTimeout() != ackRecord.getVisibilityTimeout()) {
+            this.popConsumerStore.deleteRecords(Collections.singletonList(ackRecord));
+        }
     }
 
     // Use broker escape bridge to support remote read

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSerializable.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSerializable.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.remoting.protocol;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
 
 import java.nio.charset.Charset;
@@ -44,7 +45,7 @@ public abstract class RemotingSerializable {
         if (data == null) {
             return null;
         }
-        return JSON.parseObject(data, classOfT);
+        return JSON.parseObject(data, classOfT, JSONReader.Feature.AllowUnQuotedFieldNames);
     }
 
     public static <T> List<T> decodeList(final byte[] data, Class<T> classOfT) {
@@ -55,7 +56,7 @@ public abstract class RemotingSerializable {
     }
 
     public static <T> T fromJson(String json, Class<T> classOfT) {
-        return JSON.parseObject(json, classOfT);
+        return JSON.parseObject(json, classOfT, JSONReader.Feature.AllowUnQuotedFieldNames);
     }
 
     public byte[] encode() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSerializable.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSerializable.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.remoting.protocol;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
 
@@ -45,7 +46,11 @@ public abstract class RemotingSerializable {
         if (data == null) {
             return null;
         }
-        return JSON.parseObject(data, classOfT, JSONReader.Feature.AllowUnQuotedFieldNames);
+        try {
+            return JSON.parseObject(data, classOfT, JSONReader.Feature.AllowUnQuotedFieldNames);
+        } catch (JSONException e) {
+            return JSON.toJavaObject(JSON.parseObject(data, JSONReader.Feature.AllowUnQuotedFieldNames), classOfT);
+        }
     }
 
     public static <T> List<T> decodeList(final byte[] data, Class<T> classOfT) {
@@ -56,7 +61,11 @@ public abstract class RemotingSerializable {
     }
 
     public static <T> T fromJson(String json, Class<T> classOfT) {
-        return JSON.parseObject(json, classOfT, JSONReader.Feature.AllowUnQuotedFieldNames);
+        try {
+            return JSON.parseObject(json, classOfT, JSONReader.Feature.AllowUnQuotedFieldNames);
+        } catch (JSONException e) {
+            return JSON.toJavaObject(JSON.parseObject(json, JSONReader.Feature.AllowUnQuotedFieldNames), classOfT);
+        }
     }
 
     public byte[] encode() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerOffsetSerializeWrapper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerOffsetSerializeWrapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.remoting.protocol.body;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
@@ -25,6 +26,13 @@ import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
 public class ConsumerOffsetSerializeWrapper extends RemotingSerializable {
     private ConcurrentMap<String/* topic@group */, ConcurrentMap<Integer, Long>> offsetTable =
         new ConcurrentHashMap<>(512);
+
+    private ConcurrentMap<String/* topic@group */, ConcurrentMap<Integer, Long>> pullOffsetTable =
+        new ConcurrentHashMap<>(512);
+
+    private ConcurrentMap<String, List<String>> groupTopicMap =
+        new ConcurrentHashMap<>(512);
+
     private DataVersion dataVersion;
 
     public ConcurrentMap<String, ConcurrentMap<Integer, Long>> getOffsetTable() {
@@ -33,6 +41,14 @@ public class ConsumerOffsetSerializeWrapper extends RemotingSerializable {
 
     public void setOffsetTable(ConcurrentMap<String, ConcurrentMap<Integer, Long>> offsetTable) {
         this.offsetTable = offsetTable;
+    }
+
+    public ConcurrentMap<String, ConcurrentMap<Integer, Long>> getPullOffsetTable() {
+        return pullOffsetTable;
+    }
+
+    public ConcurrentMap<String, List<String>> getGroupTopicMap() {
+        return groupTopicMap;
     }
 
     public DataVersion getDataVersion() {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
@@ -135,8 +135,8 @@ public class RemotingSerializableTest {
         Map topicOffsets = (Map) offsetTable.get("TopicTest@gid-test");
         assertNotNull(topicOffsets);
 
-        assertEquals(123L, ((Number) topicOffsets.get("0")).longValue());
-        assertEquals(456L, ((Number) topicOffsets.get("1")).longValue());
+        assertEquals(123L, ((Number) topicOffsets.get(0)).longValue());
+        assertEquals(456L, ((Number) topicOffsets.get(1)).longValue());
     }
 
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
@@ -20,6 +20,8 @@ import com.alibaba.fastjson2.JSONWriter;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+
+import org.apache.rocketmq.remoting.protocol.body.ConsumerOffsetSerializeWrapper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -126,13 +129,14 @@ public class RemotingSerializableTest {
     @Test
     public void testDecodeUnquotedFieldNames() {
         // Simulate consumerOffset format serialized by 5.4.x version (unquoted numeric keys)
-        String jsonWithUnquotedKeys = "{\"offsetTable\":{\"TopicTest@gid-test\":{0:123,1:456}}}";
-        Map<String, Map<Integer, Long>> result = RemotingSerializable.fromJson(jsonWithUnquotedKeys, Map.class);
+        String jsonWithUnquotedKeys = "{\"dataVersion\":{\"counter\":736456,\"stateVersion\":0,\"timestamp\":1778062479960},\"groupTopicMap\":{\"gid-test-rocketmq-tx\":[\"%RETRY%gid-test-rocketmq-tx\",\"TopicTest-tx-high\"]},\"offsetTable\":{\"TopicTest@gid-test\":{0:123,1:456}},\"pullOffsetTable\":{\"TopicTest-high@gid-test-rocketmq\":{0:4953634646,1:4953403208}}}";
+
+        ConsumerOffsetSerializeWrapper result = RemotingSerializable.fromJson(jsonWithUnquotedKeys, ConsumerOffsetSerializeWrapper.class);
         assertNotNull(result);
-        Map offsetTable = (Map) result.get("offsetTable");
+        ConcurrentMap<String, ConcurrentMap<Integer, Long>> offsetTable = result.getOffsetTable();
         assertNotNull(offsetTable);
 
-        Map topicOffsets = (Map) offsetTable.get("TopicTest@gid-test");
+        Map topicOffsets = offsetTable.get("TopicTest@gid-test");
         assertNotNull(topicOffsets);
 
         assertEquals(123L, ((Number) topicOffsets.get(0)).longValue());

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class RemotingSerializableTest {
     @Test
@@ -121,6 +123,22 @@ public class RemotingSerializableTest {
             Assert.fail("Should not throw");
         }
     }
+    @Test
+    public void testDecodeUnquotedFieldNames() {
+        // 模拟 5.4.x 版本序列化的 consumerOffset 格式（数字 key 无引号）
+        String jsonWithUnquotedKeys = "{\"offsetTable\":{\"TopicTest@gid-test\":{0:123,1:456}}}";
+        Map<String, Map<Integer, Long>> result = RemotingSerializable.fromJson(jsonWithUnquotedKeys, Map.class);
+        assertNotNull(result);
+        Map offsetTable = (Map) result.get("offsetTable");
+        assertNotNull(offsetTable);
+
+        Map topicOffsets = (Map) offsetTable.get("TopicTest@gid-test");
+        assertNotNull(topicOffsets);
+
+        assertEquals(123L, ((Number) topicOffsets.get("0")).longValue());
+        assertEquals(456L, ((Number) topicOffsets.get("1")).longValue());
+    }
+
 }
 
 class Sample {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
@@ -125,7 +125,7 @@ public class RemotingSerializableTest {
     }
     @Test
     public void testDecodeUnquotedFieldNames() {
-        // 模拟 5.4.x 版本序列化的 consumerOffset 格式（数字 key 无引号）
+        // Simulate consumerOffset format serialized by 5.4.x version (unquoted numeric keys)
         String jsonWithUnquotedKeys = "{\"offsetTable\":{\"TopicTest@gid-test\":{0:123,1:456}}}";
         Map<String, Map<Integer, Long>> result = RemotingSerializable.fromJson(jsonWithUnquotedKeys, Map.class);
         assertNotNull(result);

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/body/ConsumerOffsetSerializeWrapperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/body/ConsumerOffsetSerializeWrapperTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.remoting.protocol.body;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ConsumerOffsetSerializeWrapperTest {
+
+    @Test
+    public void testDecodeWithUnknownFields() {
+        String consumerOffsetJson = "{" +
+            "\"dataVersion\":{\"counter\":736456,\"stateVersion\":0,\"timestamp\":1778062479960}," +
+            "\"groupTopicMap\":{" +
+            "\"gid-test-rocketmq\":[\"TopicTest-high\",\"%RETRY%gid-test-rocketmq\"]" +
+            "}," +
+            "\"offsetTable\":{" +
+            "\"TopicTest-high@gid-test\":{0:4954824657,1:4954593219,2:80629020}," +
+            "\"TopicTest@gid\":{0:123}" +
+            "}," +
+            "\"pullOffsetTable\":{" +
+            "\"TopicTest-high@gid-test\":{0:4953634646,1:4953403208}" +
+            "}" +
+            "}";
+
+        ConsumerOffsetSerializeWrapper result = RemotingSerializable.decode(
+            consumerOffsetJson.getBytes(StandardCharsets.UTF_8),
+            ConsumerOffsetSerializeWrapper.class
+        );
+
+        assertNotNull(result);
+        assertNotNull(result.getOffsetTable());
+        assertNotNull(result.getDataVersion());
+
+        Map<String, ConcurrentMap<Integer, Long>> offsetTable = result.getOffsetTable();
+        assertNotNull(offsetTable.get("TopicTest-high@gid-test"));
+        assertEquals(4954824657L, offsetTable.get("TopicTest-high@gid-test").get(0).longValue());
+        assertEquals(4954593219L, offsetTable.get("TopicTest-high@gid-test").get(1).longValue());
+    }
+}


### PR DESCRIPTION
between 5.4.x and 5.5.x

When upgrading from 5.4.x to 5.5.x

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10284

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
