### PR TITLE
[ISSUE #10302] Support SNI multi-domain certificate for Proxy TLS

### DIFF
--- a/distribution/conf/rmq-proxy.json
+++ b/distribution/conf/rmq-proxy.json
@@ -1,3 +1,14 @@
 {
-  "rocketMQClusterName": "DefaultCluster"
+  "rocketMQClusterName": "DefaultCluster",
+  "proxyMode": "LOCAL",
+  "grpcServerPort": 8081,
+  "tlsTestModeEnable": false,
+  "tlsKeyPath": "/home/wuxingcan.wxc/rocketmq/.claude/worktrees/sni-multi-domain/distribution/conf/tls/server.key",
+  "tlsCertPath": "/home/wuxingcan.wxc/rocketmq/.claude/worktrees/sni-multi-domain/distribution/conf/tls/server.crt",
+  "tlsDomainConfigs": {
+    "*.example.com": {
+      "certPath": "/home/wuxingcan.wxc/rocketmq/.claude/worktrees/sni-multi-domain/distribution/conf/tls/example.crt",
+      "keyPath": "/home/wuxingcan.wxc/rocketmq/.claude/worktrees/sni-multi-domain/distribution/conf/tls/example.key"
+    }
+  }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/ProxyStartup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/ProxyStartup.java
@@ -79,8 +79,7 @@ public class ProxyStartup {
             MessagingProcessor messagingProcessor = createMessagingProcessor();
 
             // tls cert update
-            TlsSniManager tlsSniManager = new TlsSniManager();
-            tlsSniManager.initialize(ConfigurationManager.getProxyConfig());
+            TlsSniManager tlsSniManager = TlsSniManager.getInstance();
             TlsCertificateManager tlsCertificateManager = new TlsCertificateManager(tlsSniManager);
             PROXY_START_AND_SHUTDOWN.appendStartAndShutdown(tlsCertificateManager);
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/ProxyStartup.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/ProxyStartup.java
@@ -45,6 +45,7 @@ import org.apache.rocketmq.proxy.processor.DefaultMessagingProcessor;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
 import org.apache.rocketmq.proxy.remoting.RemotingProtocolServer;
 import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.srvutil.ServerUtil;
 
@@ -78,7 +79,9 @@ public class ProxyStartup {
             MessagingProcessor messagingProcessor = createMessagingProcessor();
 
             // tls cert update
-            TlsCertificateManager tlsCertificateManager = new TlsCertificateManager();
+            TlsSniManager tlsSniManager = new TlsSniManager();
+            tlsSniManager.initialize(ConfigurationManager.getProxyConfig());
+            TlsCertificateManager tlsCertificateManager = new TlsCertificateManager(tlsSniManager);
             PROXY_START_AND_SHUTDOWN.appendStartAndShutdown(tlsCertificateManager);
 
             // create grpcServer

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -84,6 +84,8 @@ public class ProxyConfig implements ConfigFile {
     private String tlsKeyPassword = "";
     private String tlsCertPath = ConfigurationManager.getProxyHome() + "/conf/tls/rocketmq.crt";
     private int tlsCertWatchIntervalMs = 60 * 60 * 1000; // 1 hour
+    private Map<String, TlsDomainConfig> tlsDomainConfigs = new HashMap<>();
+    private boolean tlsWildcardMatchMultiLevel = false;
     /**
      * gRPC
      */
@@ -527,6 +529,22 @@ public class ProxyConfig implements ConfigFile {
 
     public void setTlsCertPath(String tlsCertPath) {
         this.tlsCertPath = tlsCertPath;
+    }
+
+    public Map<String, TlsDomainConfig> getTlsDomainConfigs() {
+        return tlsDomainConfigs;
+    }
+
+    public void setTlsDomainConfigs(Map<String, TlsDomainConfig> tlsDomainConfigs) {
+        this.tlsDomainConfigs = tlsDomainConfigs;
+    }
+
+    public boolean isTlsWildcardMatchMultiLevel() {
+        return tlsWildcardMatchMultiLevel;
+    }
+
+    public void setTlsWildcardMatchMultiLevel(boolean tlsWildcardMatchMultiLevel) {
+        this.tlsWildcardMatchMultiLevel = tlsWildcardMatchMultiLevel;
     }
 
     public int getGrpcBossLoopNum() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/TlsDomainConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/TlsDomainConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.config;
+
+public class TlsDomainConfig {
+    private String certPath;
+    private String keyPath;
+    private String keyPassword;
+
+    public TlsDomainConfig() {
+    }
+
+    public String getCertPath() {
+        return certPath;
+    }
+
+    public void setCertPath(String certPath) {
+        this.certPath = certPath;
+    }
+
+    public String getKeyPath() {
+        return keyPath;
+    }
+
+    public void setKeyPath(String keyPath) {
+        this.keyPath = keyPath;
+    }
+
+    public String getKeyPassword() {
+        return keyPassword;
+    }
+
+    public void setKeyPassword(String keyPassword) {
+        this.keyPassword = keyPassword;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
@@ -77,9 +77,9 @@ public class GrpcServer implements StartAndShutdown {
         @Override
         public void onTlsContextReload() {
             try {
-                ProxyAndTlsProtocolNegotiator.loadSslContext();
+                ProxyAndTlsProtocolNegotiator.loadAllSslContexts();
                 log.info("SslContext reloaded for grpc server");
-            } catch (CertificateException | IOException e) {
+            } catch (Exception e) {
                 log.error("Failed to reload SslContext for server", e);
             }
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
@@ -74,12 +74,10 @@ public class GrpcServer implements StartAndShutdown {
     class GrpcTlsReloadHandler implements TlsCertificateManager.TlsContextReloadListener {
         @Override
         public void onTlsContextReload() {
-            try {
-                ProxyAndTlsProtocolNegotiator.loadAllSslContexts();
-                log.info("SslContext reloaded for grpc server");
-            } catch (Exception e) {
-                log.error("Failed to reload SslContext for server", e);
-            }
+            // TlsCertificateManager's FileWatchListeners already reload the specific changed
+            // domain via TlsSniManager directly. Since TlsSniManager is a singleton, new
+            // connections automatically pick up the latest context without additional reload.
+            log.info("TLS certificate change detected, contexts already reloaded by TlsSniManager");
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
@@ -25,8 +25,6 @@ import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
 
-import java.io.IOException;
-import java.security.cert.CertificateException;
 import java.util.concurrent.TimeUnit;
 
 public class GrpcServer implements StartAndShutdown {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -17,6 +17,9 @@
 package org.apache.rocketmq.proxy.grpc;
 
 import io.grpc.Attributes;
+import io.grpc.InternalChannelz;
+import io.grpc.SecurityLevel;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiationEvent;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiator;
@@ -42,6 +45,8 @@ import io.grpc.netty.shaded.io.netty.util.AsyncMapping;
 import io.grpc.netty.shaded.io.netty.util.AsciiString;
 import io.grpc.netty.shaded.io.netty.util.CharsetUtil;
 
+import javax.net.ssl.SSLSession;
+
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -65,6 +70,7 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     private static final String HA_PROXY_HANDLER = "HAProxyHandler";
     private static final String TLS_MODE_HANDLER = "TlsModeHandler";
     private static final String SNI_HANDLER = "SniHandler";
+    private static final String GRPC_SNI_COMPLETE_HANDLER = "GrpcSniCompleteHandler";
     /**
      * the length of the ssl record header (in bytes)
      */
@@ -260,17 +266,27 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
         private void addSniHandler(ChannelHandlerContext ctx) {
             TlsSniManager sniManager = getTlsSniManager();
             AsyncMapping<String, SslContext> sslContextMapping = (hostname, promise) -> {
-                SslContext sslCtx = sniManager.getSslContext(hostname);
-                if (sslCtx != null) {
-                    promise.setSuccess(sslCtx);
-                } else {
-                    promise.setSuccess(sniManager.getDefaultContext());
+                try {
+                    SslContext sslCtx = sniManager.getSslContext(hostname != null ? hostname.toLowerCase(java.util.Locale.ROOT) : null);
+                    if (sslCtx == null) {
+                        sslCtx = sniManager.getDefaultContext();
+                    }
+                    if (sslCtx == null) {
+                        promise.setFailure(new javax.net.ssl.SSLException("No SslContext available for SNI hostname: " + hostname));
+                    } else {
+                        promise.setSuccess(sslCtx);
+                    }
+                } catch (Exception e) {
+                    promise.setFailure(e);
                 }
                 return promise;
             };
+            // Pipeline order after this call:
+            //   TlsModeHandler -> SniHandler (becomes SslHandler after SNI) -> GrpcSniCompleteHandler -> ...
+            // GrpcSniCompleteHandler is AFTER SniHandler so it receives SslHandshakeCompletionEvent (inbound, head→tail)
             ctx.pipeline()
                 .addAfter(ctx.name(), SNI_HANDLER, new SniHandler(sslContextMapping))
-                .addAfter(ctx.name(), null, new GrpcSniHandshakeCompleteHandler());
+                .addAfter(SNI_HANDLER, GRPC_SNI_COMPLETE_HANDLER, new GrpcSniHandshakeCompleteHandler(grpcHandler, pne));
         }
 
         private void addPlaintextHandler(ChannelHandlerContext ctx) {
@@ -290,24 +306,76 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     }
 
     /**
-     * Fires ProtocolNegotiationEvent after SNI-based TLS handshake completes.
-     * This connects the gRPC handler (GrpcHttp2ConnectionHandler) into the pipeline
-     * so that ALPN negotiation and HTTP/2 framing can proceed.
+     * Placed AFTER the SniHandler/SslHandler in the pipeline.
+     * Receives SslHandshakeCompletionEvent (inbound, fires head→tail), then:
+     *  - verifies ALPN negotiated "h2" (warns and continues if no ALPN, to support test mode)
+     *  - builds enriched Attributes + InternalChannelz.Security from the SSL session
+     *  - replaces itself with grpcHandler
+     *  - calls grpcHandler.handleProtocolNegotiationCompleted to wire up gRPC HTTP/2
      */
-    private class GrpcSniHandshakeCompleteHandler extends ChannelInboundHandlerAdapter {
+    private static class GrpcSniHandshakeCompleteHandler extends ChannelInboundHandlerAdapter {
+
+        private final GrpcHttp2ConnectionHandler grpcHandler;
+        private ProtocolNegotiationEvent pne;
+
+        GrpcSniHandshakeCompleteHandler(GrpcHttp2ConnectionHandler grpcHandler, ProtocolNegotiationEvent pne) {
+            this.grpcHandler = grpcHandler;
+            this.pne = pne;
+        }
+
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof ProtocolNegotiationEvent) {
+                // Accumulate upstream attributes (e.g. HA proxy)
+                pne = (ProtocolNegotiationEvent) evt;
+                return;
+            }
             if (evt instanceof SslHandshakeCompletionEvent) {
                 SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
-                if (event.isSuccess()) {
-                    ctx.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
-                } else {
-                    ctx.fireExceptionCaught(event.cause());
+                try {
+                    if (!event.isSuccess()) {
+                        log.warn("SNI TLS handshake failed", event.cause());
+                        ctx.fireExceptionCaught(event.cause());
+                        ctx.pipeline().remove(this);
+                        return;
+                    }
+                    SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
+                    if (sslHandler == null) {
+                        Exception ex = new javax.net.ssl.SSLException("SslHandler not found in pipeline after SNI handshake");
+                        ctx.fireExceptionCaught(ex);
+                        ctx.pipeline().remove(this);
+                        return;
+                    }
+                    // ALPN check: gRPC requires "h2"; in test/permissive mode ALPN may be absent
+                    String protocol = sslHandler.applicationProtocol();
+                    if (protocol != null && !protocol.isEmpty() && !"h2".equals(protocol)) {
+                        Exception ex = new javax.net.ssl.SSLException(
+                            "Failed protocol negotiation: expected h2 but got " + protocol);
+                        ctx.fireExceptionCaught(ex);
+                        ctx.pipeline().remove(this);
+                        return;
+                    }
+
+                    // Build enriched Attributes and Security from SSL session
+                    SSLSession sslSession = sslHandler.engine().getSession();
+                    InternalChannelz.Security security = new InternalChannelz.Security(
+                        new InternalChannelz.Tls(sslSession));
+                    Attributes attrs = InternalProtocolNegotiationEvent.getAttributes(pne).toBuilder()
+                        .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+                        .set(io.grpc.Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)
+                        .build();
+
+                    // Replace this handler with grpcHandler, then complete negotiation
+                    ctx.pipeline().replace(this, null, grpcHandler);
+                    grpcHandler.handleProtocolNegotiationCompleted(attrs, security);
+                } catch (Exception e) {
+                    log.error("Error completing SNI TLS handshake", e);
+                    ctx.fireExceptionCaught(e);
+                    ctx.pipeline().remove(this);
                 }
-            } else {
-                super.userEventTriggered(ctx, evt);
+                return;
             }
-            ctx.pipeline().remove(this);
+            super.userEventTriggered(ctx, evt);
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -18,7 +18,6 @@ package org.apache.rocketmq.proxy.grpc;
 
 import io.grpc.Attributes;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcHttp2ConnectionHandler;
-import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiationEvent;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiator;
 import io.grpc.netty.shaded.io.grpc.netty.InternalProtocolNegotiators;
@@ -35,22 +34,14 @@ import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyTLV;
-import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
-import io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler;
-import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
-
-import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import io.grpc.netty.shaded.io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SniHandler;
 import io.grpc.netty.shaded.io.netty.util.AsciiString;
 import io.grpc.netty.shaded.io.netty.util.CharsetUtil;
+import io.grpc.netty.shaded.io.netty.util.GlobalEventExecutor;
+import io.grpc.netty.shaded.io.netty.util.concurrent.Promise;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.cert.CertificateException;
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -63,6 +54,7 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.proxy.grpc.constant.AttributeKeys;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.common.TlsMode;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 
@@ -72,18 +64,19 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     private static final String HA_PROXY_DECODER = "HAProxyDecoder";
     private static final String HA_PROXY_HANDLER = "HAProxyHandler";
     private static final String TLS_MODE_HANDLER = "TlsModeHandler";
+    private static final String SNI_HANDLER = "SniHandler";
     /**
      * the length of the ssl record header (in bytes)
      */
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    private static SslContext sslContext;
+    private static volatile TlsSniManager tlsSniManager;
 
     public ProxyAndTlsProtocolNegotiator() {
         try {
-            loadSslContext();
-            log.info("SslContext created for proxy server");
-        } catch (IOException | CertificateException e) {
+            loadAllSslContexts();
+            log.info("SslContext created for proxy server with SNI support");
+        } catch (Exception e) {
             log.error("SslContext init error", e);
             throw new RuntimeException(e);
         }
@@ -103,39 +96,24 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     public void close() {
     }
 
-    public static void loadSslContext() throws CertificateException, IOException {
-        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
-        SslProvider provider;
-        if (OpenSsl.isAvailable()) {
-            provider = SslProvider.OPENSSL;
-            log.info("Using OpenSSL provider");
-        } else {
-            provider = SslProvider.JDK;
-            log.info("Using JDK SSL provider");
-        }
-        if (proxyConfig.isTlsTestModeEnable()) {
-            SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
-            sslContext = GrpcSslContexts.forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
-                .sslProvider(provider)
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .clientAuth(ClientAuth.NONE)
-                .build();
-        } else {
-            String tlsCertPath = ConfigurationManager.getProxyConfig().getTlsCertPath();
-            String tlsKeyPath = ConfigurationManager.getProxyConfig().getTlsKeyPath();
-            String tlsKeyPassword = ConfigurationManager.getProxyConfig().getTlsKeyPassword();
-            try (InputStream serverKeyInputStream = Files.newInputStream(
-                Paths.get(tlsKeyPath));
-                 InputStream serverCertificateStream = Files.newInputStream(
-                     Paths.get(tlsCertPath))) {
-                sslContext = GrpcSslContexts.forServer(serverCertificateStream,
-                        serverKeyInputStream,
-                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
-                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                    .clientAuth(ClientAuth.NONE)
-                    .build();
+    private static TlsSniManager getTlsSniManager() {
+        if (tlsSniManager == null) {
+            synchronized (ProxyAndTlsProtocolNegotiator.class) {
+                if (tlsSniManager == null) {
+                    tlsSniManager = new TlsSniManager();
+                    tlsSniManager.initialize(ConfigurationManager.getProxyConfig());
+                }
             }
         }
+        return tlsSniManager;
+    }
+
+    public static void loadAllSslContexts() {
+        getTlsSniManager();
+    }
+
+    public static TlsSniManager getManager() {
+        return getTlsSniManager();
     }
 
     private class ProxyAndTlsProtocolHandler extends ByteToMessageDecoder {
@@ -199,12 +177,6 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
             ctx.pipeline().remove(this);
         }
 
-        /**
-         * The definition of key refers to the implementation of nginx
-         * <a href="https://nginx.org/en/docs/http/ngx_http_core_module.html#var_proxy_protocol_addr">ngx_http_core_module</a>
-         *
-         * @param msg
-         */
         private void handleWithMessage(HAProxyMessage msg) {
             try {
                 Attributes.Builder builder = InternalProtocolNegotiationEvent.getAttributes(pne).toBuilder();
@@ -254,14 +226,10 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
 
         private ProtocolNegotiationEvent pne = InternalProtocolNegotiationEvent.getDefault();
 
-        private final ChannelHandler ssl;
-        private final ChannelHandler plaintext;
+        private final GrpcHttp2ConnectionHandler grpcHandler;
 
         public TlsModeHandler(GrpcHttp2ConnectionHandler grpcHandler) {
-            this.ssl = InternalProtocolNegotiators.serverTls(sslContext)
-                .newHandler(grpcHandler);
-            this.plaintext = InternalProtocolNegotiators.serverPlaintext()
-                .newHandler(grpcHandler);
+            this.grpcHandler = grpcHandler;
         }
 
         @Override
@@ -269,18 +237,17 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
             try {
                 TlsMode tlsMode = TlsSystemConfig.tlsMode;
                 if (TlsMode.ENFORCING.equals(tlsMode)) {
-                    ctx.pipeline().addAfter(ctx.name(), null, this.ssl);
+                    addSniHandler(ctx);
                 } else if (TlsMode.DISABLED.equals(tlsMode)) {
-                    ctx.pipeline().addAfter(ctx.name(), null, this.plaintext);
+                    addPlaintextHandler(ctx);
                 } else {
-                    // in SslHandler.isEncrypted, it needs at least 5 bytes to judge is encrypted or not
                     if (in.readableBytes() < SSL_RECORD_HEADER_LENGTH) {
                         return;
                     }
                     if (SslHandler.isEncrypted(in)) {
-                        ctx.pipeline().addAfter(ctx.name(), null, this.ssl);
+                        addSniHandler(ctx);
                     } else {
-                        ctx.pipeline().addAfter(ctx.name(), null, this.plaintext);
+                        addPlaintextHandler(ctx);
                     }
                 }
                 ctx.fireUserEventTriggered(pne);
@@ -289,6 +256,25 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
                 log.error("process ssl protocol negotiator failed.", e);
                 throw e;
             }
+        }
+
+        private void addSniHandler(ChannelHandlerContext ctx) {
+            TlsSniManager sniManager = getTlsSniManager();
+            SniHandler sniHandler = new SniHandler((hostname, promise) -> {
+                SslContext sslCtx = sniManager.getSslContext(hostname);
+                if (sslCtx != null) {
+                    promise.setSuccess(sslCtx);
+                } else {
+                    promise.setSuccess(sniManager.getDefaultContext());
+                }
+            }, GlobalEventExecutor.INSTANCE);
+            ctx.pipeline().addAfter(ctx.name(), SNI_HANDLER, sniHandler);
+        }
+
+        private void addPlaintextHandler(ChannelHandlerContext ctx) {
+            ChannelHandler plaintext = InternalProtocolNegotiators.serverPlaintext()
+                .newHandler(grpcHandler);
+            ctx.pipeline().addAfter(ctx.name(), null, plaintext);
         }
 
         @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -78,7 +78,9 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
 
     public ProxyAndTlsProtocolNegotiator() {
         try {
-            loadAllSslContexts();
+            // Ensure TlsSniManager is initialized with all configured domain contexts.
+            // No need to call loadAllSslContexts() here — getInstance() triggers initialize().
+            getTlsSniManager();
             log.info("SslContext created for proxy server with SNI support");
         } catch (Exception e) {
             log.error("SslContext init error", e);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -37,10 +37,9 @@ import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SniHandler;
+import io.grpc.netty.shaded.io.netty.util.AsyncMapping;
 import io.grpc.netty.shaded.io.netty.util.AsciiString;
 import io.grpc.netty.shaded.io.netty.util.CharsetUtil;
-import io.grpc.netty.shaded.io.netty.util.GlobalEventExecutor;
-import io.grpc.netty.shaded.io.netty.util.concurrent.Promise;
 
 import java.util.List;
 
@@ -109,7 +108,16 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     }
 
     public static void loadAllSslContexts() {
-        getTlsSniManager();
+        TlsSniManager manager = getTlsSniManager();
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        if (proxyConfig.getTlsDomainConfigs() != null && !proxyConfig.getTlsDomainConfigs().isEmpty()) {
+            manager.reloadDefaultContext();
+            for (String domain : proxyConfig.getTlsDomainConfigs().keySet()) {
+                manager.reloadDomainContext(domain);
+            }
+        } else {
+            manager.reloadDefaultContext();
+        }
     }
 
     public static TlsSniManager getManager() {
@@ -260,15 +268,16 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
 
         private void addSniHandler(ChannelHandlerContext ctx) {
             TlsSniManager sniManager = getTlsSniManager();
-            SniHandler sniHandler = new SniHandler((hostname, promise) -> {
+            AsyncMapping<String, SslContext> sslContextMapping = (hostname, promise) -> {
                 SslContext sslCtx = sniManager.getSslContext(hostname);
                 if (sslCtx != null) {
                     promise.setSuccess(sslCtx);
                 } else {
                     promise.setSuccess(sniManager.getDefaultContext());
                 }
-            }, GlobalEventExecutor.INSTANCE);
-            ctx.pipeline().addAfter(ctx.name(), SNI_HANDLER, sniHandler);
+                return promise;
+            };
+            ctx.pipeline().addAfter(ctx.name(), SNI_HANDLER, new SniHandler(sslContextMapping));
         }
 
         private void addPlaintextHandler(ChannelHandlerContext ctx) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -35,6 +35,7 @@ import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyMessageDecoder
 import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.grpc.netty.shaded.io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SniHandler;
 import io.grpc.netty.shaded.io.netty.util.AsyncMapping;
@@ -69,8 +70,6 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
      */
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-    private static volatile TlsSniManager tlsSniManager;
-
     public ProxyAndTlsProtocolNegotiator() {
         try {
             loadAllSslContexts();
@@ -96,15 +95,7 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     }
 
     private static TlsSniManager getTlsSniManager() {
-        if (tlsSniManager == null) {
-            synchronized (ProxyAndTlsProtocolNegotiator.class) {
-                if (tlsSniManager == null) {
-                    tlsSniManager = new TlsSniManager();
-                    tlsSniManager.initialize(ConfigurationManager.getProxyConfig());
-                }
-            }
-        }
-        return tlsSniManager;
+        return TlsSniManager.getInstance();
     }
 
     public static void loadAllSslContexts() {
@@ -277,7 +268,9 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
                 }
                 return promise;
             };
-            ctx.pipeline().addAfter(ctx.name(), SNI_HANDLER, new SniHandler(sslContextMapping));
+            ctx.pipeline()
+                .addAfter(ctx.name(), SNI_HANDLER, new SniHandler(sslContextMapping))
+                .addAfter(ctx.name(), null, new GrpcSniHandshakeCompleteHandler());
         }
 
         private void addPlaintextHandler(ChannelHandlerContext ctx) {
@@ -293,6 +286,28 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
             } else {
                 super.userEventTriggered(ctx, evt);
             }
+        }
+    }
+
+    /**
+     * Fires ProtocolNegotiationEvent after SNI-based TLS handshake completes.
+     * This connects the gRPC handler (GrpcHttp2ConnectionHandler) into the pipeline
+     * so that ALPN negotiation and HTTP/2 framing can proceed.
+     */
+    private class GrpcSniHandshakeCompleteHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof SslHandshakeCompletionEvent) {
+                SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
+                if (event.isSuccess()) {
+                    ctx.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
+                } else {
+                    ctx.fireExceptionCaught(event.cause());
+                }
+            } else {
+                super.userEventTriggered(ctx, evt);
+            }
+            ctx.pipeline().remove(this);
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
@@ -72,16 +72,8 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
             try {
                 ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
                 if (proxyConfig.getTlsDomainConfigs() != null && !proxyConfig.getTlsDomainConfigs().isEmpty()) {
-                    // SNI mode: reload all domain contexts
-                    if (tlsSniManager == null) {
-                        tlsSniManager = new TlsSniManager();
-                        tlsSniManager.initialize(proxyConfig);
-                    } else {
-                        tlsSniManager.reloadDefaultContext();
-                        for (String domain : proxyConfig.getTlsDomainConfigs().keySet()) {
-                            tlsSniManager.reloadDomainContext(domain);
-                        }
-                    }
+                    // SNI mode: use shared TlsSniManager singleton
+                    tlsSniManager = TlsSniManager.getInstance();
 
                     TlsContextProvider.getInstance().setSniLookup(
                         new TlsContextProvider.SniContextLookup() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
@@ -87,12 +87,12 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
                         new TlsContextProvider.SniContextLookup() {
                             @Override
                             public SslContext lookup(String sniHostname) {
-                                return tlsSniManager.getSslContext(sniHostname);
+                                return tlsSniManager.getStdSslContext(sniHostname);
                             }
 
                             @Override
                             public SslContext getDefaultContext() {
-                                return tlsSniManager.getDefaultContext();
+                                return tlsSniManager.getStdDefaultContext();
                             }
                         }
                     );

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
@@ -19,23 +19,25 @@ package org.apache.rocketmq.proxy.remoting;
 
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.common.ProxyException;
 import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.proxy.remoting.protocol.ProtocolNegotiationHandler;
 import org.apache.rocketmq.proxy.remoting.protocol.http2proxy.Http2ProtocolProxyHandler;
 import org.apache.rocketmq.proxy.remoting.protocol.remoting.RemotingProtocolHandler;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.ChannelEventListener;
 import org.apache.rocketmq.remoting.common.TlsMode;
 import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
 import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.netty.TlsContextProvider;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
-
-import java.io.IOException;
-import java.security.cert.CertificateException;
 
 /**
  * support remoting and http2 protocol at one port
@@ -47,6 +49,7 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
 
     private final RemotingProtocolHandler remotingProtocolHandler;
     protected Http2ProtocolProxyHandler http2ProtocolProxyHandler;
+    private TlsSniManager tlsSniManager;
 
     public MultiProtocolRemotingServer(NettyServerConfig nettyServerConfig, ChannelEventListener channelEventListener) {
         super(nettyServerConfig, channelEventListener);
@@ -67,12 +70,47 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
 
         if (tlsMode != TlsMode.DISABLED) {
             try {
-                sslContext = MultiProtocolTlsHelper.buildSslContext();
-                log.info("SslContext created for multi protocol remoting server");
-            } catch (CertificateException | IOException e) {
+                ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+                if (proxyConfig.getTlsDomainConfigs() != null && !proxyConfig.getTlsDomainConfigs().isEmpty()) {
+                    // SNI mode: reload all domain contexts
+                    if (tlsSniManager == null) {
+                        tlsSniManager = new TlsSniManager();
+                        tlsSniManager.initialize(proxyConfig);
+                    } else {
+                        tlsSniManager.reloadDefaultContext();
+                        for (String domain : proxyConfig.getTlsDomainConfigs().keySet()) {
+                            tlsSniManager.reloadDomainContext(domain);
+                        }
+                    }
+
+                    TlsContextProvider.getInstance().setSniLookup(
+                        new TlsContextProvider.SniContextLookup() {
+                            @Override
+                            public SslContext lookup(String sniHostname) {
+                                return tlsSniManager.getSslContext(sniHostname);
+                            }
+
+                            @Override
+                            public SslContext getDefaultContext() {
+                                return tlsSniManager.getDefaultContext();
+                            }
+                        }
+                    );
+                    log.info("SNI-enabled SslContext created/reloaded for multi protocol remoting server");
+                } else {
+                    // Single cert mode: backward compatible
+                    sslContext = MultiProtocolTlsHelper.buildSslContext();
+                    TlsContextProvider.getInstance().setSingleContext(sslContext);
+                    log.info("Single SslContext created/reloaded for multi protocol remoting server");
+                }
+            } catch (Exception e) {
                 throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR, "Failed to create SslContext for server", e);
             }
         }
+    }
+
+    public TlsSniManager getTlsSniManager() {
+        return tlsSniManager;
     }
 
     @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
@@ -27,7 +27,6 @@ import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 import org.apache.rocketmq.srvutil.FileWatchService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
@@ -21,35 +21,69 @@ import org.apache.rocketmq.common.utils.StartAndShutdown;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 import org.apache.rocketmq.srvutil.FileWatchService;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TlsCertificateManager implements StartAndShutdown {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
-    private final FileWatchService fileWatchService;
     private final List<TlsContextReloadListener> reloadListeners = new ArrayList<>();
+    private final List<DomainReloadListener> domainReloadListeners = new ArrayList<>();
+    private final List<FileWatchService> fileWatchServices = new ArrayList<>();
+    private final TlsSniManager tlsSniManager;
 
-    public TlsCertificateManager() {
+    public TlsCertificateManager(TlsSniManager tlsSniManager) {
+        this.tlsSniManager = tlsSniManager;
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+        int watchInterval = config.getTlsCertWatchIntervalMs();
+
+        // Watch default cert/key pair
         try {
-            this.fileWatchService = new FileWatchService(
-                new String[] {
-                    ConfigurationManager.getProxyConfig().getTlsCertPath(),
-                    ConfigurationManager.getProxyConfig().getTlsKeyPath()
-                },
-                new CertKeyFileWatchListener(),
-                ConfigurationManager.getProxyConfig().getTlsCertWatchIntervalMs()
+            String defaultCertPath = config.getTlsCertPath();
+            String defaultKeyPath = config.getTlsKeyPath();
+            FileWatchService defaultWatchService = new FileWatchService(
+                new String[] {defaultCertPath, defaultKeyPath},
+                new DefaultCertKeyFileWatchListener(),
+                watchInterval
             );
+            fileWatchServices.add(defaultWatchService);
+            log.info("Watching default TLS cert/key: {}, {}", defaultCertPath, defaultKeyPath);
         } catch (Exception e) {
-            log.error("Failed to initialize TLS certificate watch service", e);
+            log.error("Failed to initialize default TLS certificate watch service", e);
             throw new RuntimeException("Failed to initialize TLS certificate manager", e);
+        }
+
+        // Watch domain-specific cert/key pairs
+        Map<String, TlsDomainConfig> domainConfigs = config.getTlsDomainConfigs();
+        if (domainConfigs != null && !domainConfigs.isEmpty()) {
+            for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
+                String domainPattern = entry.getKey();
+                TlsDomainConfig domainConfig = entry.getValue();
+                try {
+                    FileWatchService domainWatchService = new FileWatchService(
+                        new String[] {domainConfig.getCertPath(), domainConfig.getKeyPath()},
+                        new DomainCertKeyFileWatchListener(domainPattern),
+                        watchInterval
+                    );
+                    fileWatchServices.add(domainWatchService);
+                    log.info("Watching domain TLS cert/key: {}, {} for pattern: {}",
+                        domainConfig.getCertPath(), domainConfig.getKeyPath(), domainPattern);
+                } catch (Exception e) {
+                    log.error("Failed to initialize domain TLS certificate watch service for: {}", domainPattern, e);
+                }
+            }
         }
     }
 
-    public FileWatchService getFileWatchService() {
-        return this.fileWatchService;
+    public List<FileWatchService> getFileWatchServices() {
+        return this.fileWatchServices;
     }
 
     public void registerReloadListener(TlsContextReloadListener listener) {
@@ -64,40 +98,54 @@ public class TlsCertificateManager implements StartAndShutdown {
         }
     }
 
+    public void registerDomainReloadListener(DomainReloadListener listener) {
+        if (listener != null) {
+            this.domainReloadListeners.add(listener);
+        }
+    }
+
+    public void unregisterDomainReloadListener(DomainReloadListener listener) {
+        if (listener != null) {
+            this.domainReloadListeners.remove(listener);
+        }
+    }
+
     public List<TlsContextReloadListener> getReloadListeners() {
         return this.reloadListeners;
     }
 
     @Override
     public void start() throws Exception {
-        this.fileWatchService.start();
-        log.info("TLS certificate manager started successfully, start watching: {} {}",
-            ConfigurationManager.getProxyConfig().getTlsCertPath(),
-            ConfigurationManager.getProxyConfig().getTlsKeyPath()
-        );
+        for (FileWatchService service : fileWatchServices) {
+            service.start();
+        }
+        log.info("TLS certificate manager started successfully, watching {} file groups", fileWatchServices.size());
     }
 
     @Override
     public void shutdown() throws Exception {
-        this.fileWatchService.shutdown();
+        for (FileWatchService service : fileWatchServices) {
+            service.shutdown();
+        }
         log.info("TLS certificate manager shutdown successfully");
     }
 
-    private class CertKeyFileWatchListener implements FileWatchService.Listener {
+    private class DefaultCertKeyFileWatchListener implements FileWatchService.Listener {
         private boolean certChanged = false;
         private boolean keyChanged = false;
 
         @Override
         public void onChanged(String path) {
-            log.info("File changed: {}", path);
-            if (path.equals(TlsSystemConfig.tlsServerCertPath)) {
+            log.info("Default TLS file changed: {}", path);
+            if (path.equals(TlsSystemConfig.tlsServerCertPath) || path.equals(ConfigurationManager.getProxyConfig().getTlsCertPath())) {
                 certChanged = true;
-            } else if (path.equals(TlsSystemConfig.tlsServerKeyPath)) {
+            } else if (path.equals(TlsSystemConfig.tlsServerKeyPath) || path.equals(ConfigurationManager.getProxyConfig().getTlsKeyPath())) {
                 keyChanged = true;
             }
 
             if (certChanged && keyChanged) {
-                log.info("The certificate and private key changed, reload the ssl context");
+                log.info("The default certificate and private key changed, reload the default ssl context");
+                tlsSniManager.reloadDefaultContext();
                 notifyContextReload();
                 certChanged = false;
                 keyChanged = false;
@@ -115,8 +163,55 @@ public class TlsCertificateManager implements StartAndShutdown {
         }
     }
 
+    private class DomainCertKeyFileWatchListener implements FileWatchService.Listener {
+        private final String domainPattern;
+        private boolean certChanged = false;
+        private boolean keyChanged = false;
+
+        DomainCertKeyFileWatchListener(String domainPattern) {
+            this.domainPattern = domainPattern;
+        }
+
+        @Override
+        public void onChanged(String path) {
+            log.info("Domain TLS file changed: {} for pattern: {}", path, domainPattern);
+            TlsDomainConfig config = ConfigurationManager.getProxyConfig().getTlsDomainConfigs().get(domainPattern);
+            if (config == null) {
+                return;
+            }
+            if (path.equals(config.getCertPath())) {
+                certChanged = true;
+            } else if (path.equals(config.getKeyPath())) {
+                keyChanged = true;
+            }
+
+            if (certChanged && keyChanged) {
+                log.info("The certificate and private key changed for domain: {}, reload the ssl context", domainPattern);
+                tlsSniManager.reloadDomainContext(domainPattern);
+                notifyDomainReload(domainPattern);
+                certChanged = false;
+                keyChanged = false;
+            }
+        }
+
+        private void notifyDomainReload(String domainPattern) {
+            for (DomainReloadListener listener : domainReloadListeners) {
+                try {
+                    listener.onDomainTlsContextReload(domainPattern);
+                } catch (Throwable e) {
+                    log.error("Failed to notify domain TLS context reload to listener: " + listener, e);
+                }
+            }
+        }
+    }
+
     // Interface for listeners interested in TLS context reload events
     public interface TlsContextReloadListener {
         void onTlsContextReload();
+    }
+
+    // Interface for listeners interested in domain-specific TLS context reload events
+    public interface DomainReloadListener {
+        void onDomainTlsContextReload(String domainPattern);
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
+import io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
+import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.grpc.netty.shaded.io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.CertificateException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TlsSniManager {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+
+    private volatile SslContext defaultContext;
+    private volatile Map<String, SslContext> domainContexts = new ConcurrentHashMap<>();
+    private Map<String, TlsDomainConfig> domainConfigs;
+    private boolean tlsTestModeEnable;
+    private String tlsKeyPassword;
+    private boolean wildcardMatchMultiLevel;
+
+    /**
+     * Get the matching SslContext for the given SNI hostname.
+     * Supports wildcard matching (e.g. *.example.com matches foo.example.com).
+     * When wildcardMatchMultiLevel is true, a.b.example.com also matches *.example.com.
+     * Returns defaultContext when no match is found.
+     */
+    public SslContext getSslContext(String sniHostname) {
+        if (StringUtils.isBlank(sniHostname)) {
+            return defaultContext;
+        }
+
+        // Exact match first
+        SslContext ctx = domainContexts.get(sniHostname);
+        if (ctx != null) {
+            return ctx;
+        }
+
+        // Wildcard match: foo.example.com matches *.example.com
+        for (Map.Entry<String, SslContext> entry : domainContexts.entrySet()) {
+            String domainPattern = entry.getKey();
+            if (domainPattern.startsWith("*.")) {
+                String suffix = domainPattern.substring(1);
+                if (sniHostname.endsWith(suffix) && sniHostname.length() > suffix.length()) {
+                    String remaining = sniHostname.substring(0, sniHostname.length() - suffix.length());
+                    if (wildcardMatchMultiLevel || !remaining.contains(".")) {
+                        return entry.getValue();
+                    }
+                }
+            }
+        }
+
+        // Bare domain matches wildcard: rocketmq.com matches *.rocketmq.com
+        for (Map.Entry<String, SslContext> entry : domainContexts.entrySet()) {
+            String domainPattern = entry.getKey();
+            if (domainPattern.startsWith("*.")) {
+                String bareDomain = domainPattern.substring(2);
+                if (sniHostname.equals(bareDomain)) {
+                    return entry.getValue();
+                }
+            }
+        }
+
+        return defaultContext;
+    }
+
+    public SslContext getDefaultContext() {
+        return defaultContext;
+    }
+
+    public Map<String, TlsDomainConfig> getDomainConfigs() {
+        return domainConfigs;
+    }
+
+    /**
+     * Rebuild SslContext for a specific domain (used for hot reload).
+     */
+    public void reloadDomainContext(String domainPattern) {
+        TlsDomainConfig config = domainConfigs.get(domainPattern);
+        if (config == null) {
+            log.warn("Cannot reload domain context, config not found: {}", domainPattern);
+            return;
+        }
+        try {
+            SslContext newCtx = buildSslContext(config, tlsTestModeEnable);
+            domainContexts.put(domainPattern, newCtx);
+            log.info("Reloaded SslContext for domain: {}", domainPattern);
+        } catch (Exception e) {
+            log.error("Failed to reload SslContext for domain: {}", domainPattern, e);
+        }
+    }
+
+    /**
+     * Reload the default context.
+     */
+    public void reloadDefaultContext() {
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        try {
+            defaultContext = buildDefaultSslContext(proxyConfig);
+            log.info("Reloaded default SslContext");
+        } catch (Exception e) {
+            log.error("Failed to reload default SslContext", e);
+        }
+    }
+
+    /**
+     * Initialize all domain SslContexts from ProxyConfig.
+     */
+    public void initialize(ProxyConfig config) {
+        this.tlsTestModeEnable = config.isTlsTestModeEnable();
+        this.tlsKeyPassword = config.getTlsKeyPassword();
+        this.domainConfigs = config.getTlsDomainConfigs();
+        this.wildcardMatchMultiLevel = config.isTlsWildcardMatchMultiLevel();
+
+        try {
+            defaultContext = buildDefaultSslContext(config);
+            log.info("Initialized default SslContext");
+        } catch (Exception e) {
+            log.error("Failed to initialize default SslContext", e);
+            throw new RuntimeException("Failed to initialize TlsSniManager", e);
+        }
+
+        if (domainConfigs != null && !domainConfigs.isEmpty()) {
+            for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
+                String domainPattern = entry.getKey();
+                TlsDomainConfig domainConfig = entry.getValue();
+                try {
+                    SslContext ctx = buildSslContext(domainConfig, tlsTestModeEnable);
+                    domainContexts.put(domainPattern, ctx);
+                    log.info("Initialized SslContext for domain: {}", domainPattern);
+                } catch (Exception e) {
+                    log.error("Failed to initialize SslContext for domain: {}", domainPattern, e);
+                    throw new RuntimeException("Failed to initialize TlsSniManager for domain: " + domainPattern, e);
+                }
+            }
+        }
+    }
+
+    private SslContext buildDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
+        SslProvider provider = OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
+        if (config.isTlsTestModeEnable()) {
+            SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
+            return GrpcSslContexts.forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
+                .sslProvider(provider)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(ClientAuth.NONE)
+                .build();
+        } else {
+            String tlsCertPath = config.getTlsCertPath();
+            String tlsKeyPath = config.getTlsKeyPath();
+            String tlsKeyPassword = config.getTlsKeyPassword();
+            try (InputStream serverKeyInputStream = Files.newInputStream(Paths.get(tlsKeyPath));
+                 InputStream serverCertificateStream = Files.newInputStream(Paths.get(tlsCertPath))) {
+                return GrpcSslContexts.forServer(serverCertificateStream,
+                        serverKeyInputStream,
+                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .clientAuth(ClientAuth.NONE)
+                    .build();
+            }
+        }
+    }
+
+    private SslContext buildSslContext(TlsDomainConfig config, boolean testMode) throws CertificateException, IOException {
+        SslProvider provider = OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
+        if (testMode) {
+            SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
+            return GrpcSslContexts.forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
+                .sslProvider(provider)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(ClientAuth.NONE)
+                .build();
+        } else {
+            String tlsCertPath = config.getCertPath();
+            String tlsKeyPath = config.getKeyPath();
+            String tlsKeyPassword = StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : this.tlsKeyPassword;
+            try (InputStream serverKeyInputStream = Files.newInputStream(Paths.get(tlsKeyPath));
+                 InputStream serverCertificateStream = Files.newInputStream(Paths.get(tlsCertPath))) {
+                return GrpcSslContexts.forServer(serverCertificateStream,
+                        serverKeyInputStream,
+                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .clientAuth(ClientAuth.NONE)
+                    .build();
+            }
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
@@ -154,10 +154,24 @@ public class TlsSniManager {
         try {
             io.netty.handler.ssl.SslContext stdCtx = buildStdSslContext(config, tlsTestModeEnable);
             SslContext shadedCtx = buildShadedSslContext(config, tlsTestModeEnable);
-            // For exact domains, release old context to avoid native SSL resource leaks
+            // Release old context to avoid native SSL resource leaks
             if (!domainPattern.startsWith("*.")) {
                 releaseQuietly(stdExactContexts.get(domainPattern));
                 releaseQuietly(shadedExactContexts.get(domainPattern));
+            } else {
+                // For wildcard patterns, find and release old contexts before replacement
+                for (WildcardSslContext<io.netty.handler.ssl.SslContext> wc : stdWildcardContexts) {
+                    if (wc.domainPattern.equals(domainPattern)) {
+                        releaseQuietly(wc.context);
+                        break;
+                    }
+                }
+                for (WildcardSslContext<SslContext> wc : shadedWildcardContexts) {
+                    if (wc.domainPattern.equals(domainPattern)) {
+                        releaseQuietly(wc.context);
+                        break;
+                    }
+                }
             }
             addDomainContexts(domainPattern, stdCtx, shadedCtx);
             log.info("Reloaded SslContext for domain: {}", domainPattern);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
@@ -35,34 +35,64 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Manages multiple SslContext instances for SNI-based certificate selection.
  * Maintains both standard Netty SslContext (for remoting server) and
  * gRPC-shaded SslContext (for gRPC server) from the same certificate configs.
+ *
+ * This class is a singleton — all components should access it via {@link #getInstance()}.
+ * Wildcard domains are matched in deterministic longest-pattern-first order.
  */
 public class TlsSniManager {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
+    private static volatile TlsSniManager instance;
+
     // Standard Netty SslContext (for remoting server)
     private volatile io.netty.handler.ssl.SslContext defaultStdContext;
-    private volatile Map<String, io.netty.handler.ssl.SslContext> stdDomainContexts = new ConcurrentHashMap<>();
+    private final Map<String, io.netty.handler.ssl.SslContext> stdExactContexts = new ConcurrentHashMap<>();
+    private final CopyOnWriteArrayList<WildcardSslContext<io.netty.handler.ssl.SslContext>> stdWildcardContexts = new CopyOnWriteArrayList<>();
 
     // gRPC-shaded Netty SslContext (for gRPC server)
     private volatile SslContext defaultShadedContext;
-    private volatile Map<String, SslContext> shadedDomainContexts = new ConcurrentHashMap<>();
+    private final Map<String, SslContext> shadedExactContexts = new ConcurrentHashMap<>();
+    private final CopyOnWriteArrayList<WildcardSslContext<SslContext>> shadedWildcardContexts = new CopyOnWriteArrayList<>();
 
     private Map<String, TlsDomainConfig> domainConfigs;
-    private boolean tlsTestModeEnable;
-    private String tlsKeyPassword;
-    private boolean wildcardMatchMultiLevel;
+    private volatile boolean tlsTestModeEnable;
+    private volatile String tlsKeyPassword;
+    private volatile boolean wildcardMatchMultiLevel;
+
+    public static TlsSniManager getInstance() {
+        TlsSniManager local = instance;
+        if (local == null) {
+            synchronized (TlsSniManager.class) {
+                local = instance;
+                if (local == null) {
+                    local = new TlsSniManager();
+                    local.initialize(ConfigurationManager.getProxyConfig());
+                    instance = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    // For testing — reset singleton state
+    public static void resetInstance() {
+        instance = null;
+    }
 
     // --- Standard Netty SslContext accessors ---
 
     public io.netty.handler.ssl.SslContext getStdSslContext(String sniHostname) {
-        return lookupContext(sniHostname, stdDomainContexts, defaultStdContext);
+        return lookupContext(sniHostname, stdExactContexts, stdWildcardContexts, defaultStdContext);
     }
 
     public io.netty.handler.ssl.SslContext getStdDefaultContext() {
@@ -72,7 +102,7 @@ public class TlsSniManager {
     // --- gRPC-shaded SslContext accessors ---
 
     public SslContext getSslContext(String sniHostname) {
-        return lookupContext(sniHostname, shadedDomainContexts, defaultShadedContext);
+        return lookupContext(sniHostname, shadedExactContexts, shadedWildcardContexts, defaultShadedContext);
     }
 
     public SslContext getDefaultContext() {
@@ -85,39 +115,24 @@ public class TlsSniManager {
         return domainConfigs;
     }
 
-    private <T> T lookupContext(String sniHostname, Map<String, T> domainContexts, T defaultCtx) {
+    private <T> T lookupContext(String sniHostname,
+            Map<String, T> exactContexts,
+            List<WildcardSslContext<T>> wildcardContexts,
+            T defaultCtx) {
         if (StringUtils.isBlank(sniHostname)) {
             return defaultCtx;
         }
 
         // Exact match first
-        T ctx = domainContexts.get(sniHostname);
+        T ctx = exactContexts.get(sniHostname);
         if (ctx != null) {
             return ctx;
         }
 
-        // Wildcard match: foo.example.com matches *.example.com
-        for (Map.Entry<String, T> entry : domainContexts.entrySet()) {
-            String domainPattern = entry.getKey();
-            if (domainPattern.startsWith("*.")) {
-                String suffix = domainPattern.substring(1);
-                if (sniHostname.endsWith(suffix) && sniHostname.length() > suffix.length()) {
-                    String remaining = sniHostname.substring(0, sniHostname.length() - suffix.length());
-                    if (wildcardMatchMultiLevel || !remaining.contains(".")) {
-                        return entry.getValue();
-                    }
-                }
-            }
-        }
-
-        // Bare domain matches wildcard: rocketmq.com matches *.rocketmq.com
-        for (Map.Entry<String, T> entry : domainContexts.entrySet()) {
-            String domainPattern = entry.getKey();
-            if (domainPattern.startsWith("*.")) {
-                String bareDomain = domainPattern.substring(2);
-                if (sniHostname.equals(bareDomain)) {
-                    return entry.getValue();
-                }
+        // Wildcard match: patterns are sorted longest-first for deterministic matching
+        for (WildcardSslContext<T> wc : wildcardContexts) {
+            if (wc.matches(sniHostname, wildcardMatchMultiLevel)) {
+                return wc.context;
             }
         }
 
@@ -135,9 +150,8 @@ public class TlsSniManager {
         }
         try {
             io.netty.handler.ssl.SslContext stdCtx = buildStdSslContext(config, tlsTestModeEnable);
-            stdDomainContexts.put(domainPattern, stdCtx);
             SslContext shadedCtx = buildShadedSslContext(config, tlsTestModeEnable);
-            shadedDomainContexts.put(domainPattern, shadedCtx);
+            addDomainContexts(domainPattern, stdCtx, shadedCtx);
             log.info("Reloaded SslContext for domain: {}", domainPattern);
         } catch (Exception e) {
             log.error("Failed to reload SslContext for domain: {}", domainPattern, e);
@@ -179,14 +193,26 @@ public class TlsSniManager {
         }
 
         if (domainConfigs != null && !domainConfigs.isEmpty()) {
-            for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
-                String domainPattern = entry.getKey();
-                TlsDomainConfig domainConfig = entry.getValue();
+            // Sort domain patterns: exact match first (no wildcard), then wildcard patterns longest-first
+            List<String> sortedPatterns = new ArrayList<>(domainConfigs.keySet());
+            sortedPatterns.sort((a, b) -> {
+                boolean aWildcard = a.startsWith("*.");
+                boolean bWildcard = b.startsWith("*.");
+                if (aWildcard != bWildcard) {
+                    return aWildcard ? 1 : -1; // exact first
+                }
+                if (aWildcard) {
+                    return b.length() - a.length(); // longer wildcard first
+                }
+                return 0;
+            });
+
+            for (String domainPattern : sortedPatterns) {
+                TlsDomainConfig domainConfig = domainConfigs.get(domainPattern);
                 try {
                     io.netty.handler.ssl.SslContext stdCtx = buildStdSslContext(domainConfig, tlsTestModeEnable);
-                    stdDomainContexts.put(domainPattern, stdCtx);
                     SslContext shadedCtx = buildShadedSslContext(domainConfig, tlsTestModeEnable);
-                    shadedDomainContexts.put(domainPattern, shadedCtx);
+                    addDomainContexts(domainPattern, stdCtx, shadedCtx);
                     log.info("Initialized SslContext for domain: {}", domainPattern);
                 } catch (Exception e) {
                     log.error("Failed to initialize SslContext for domain: {}", domainPattern, e);
@@ -196,35 +222,42 @@ public class TlsSniManager {
         }
     }
 
-    // --- Standard Netty SslContext builders ---
-
-    private io.netty.handler.ssl.SslContext buildStdDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
-        io.netty.handler.ssl.SslProvider provider = io.netty.handler.ssl.OpenSsl.isAvailable()
-            ? io.netty.handler.ssl.SslProvider.OPENSSL : io.netty.handler.ssl.SslProvider.JDK;
-        if (config.isTlsTestModeEnable()) {
-            io.netty.handler.ssl.util.SelfSignedCertificate ssc = new io.netty.handler.ssl.util.SelfSignedCertificate();
-            return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(provider)
-                .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
-                .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
-                .build();
+    private void addDomainContexts(String domainPattern,
+            io.netty.handler.ssl.SslContext stdCtx,
+            SslContext shadedCtx) {
+        if (domainPattern.startsWith("*.")) {
+            stdWildcardContexts.add(new WildcardSslContext<>(domainPattern, stdCtx));
+            shadedWildcardContexts.add(new WildcardSslContext<>(domainPattern, shadedCtx));
         } else {
-            String tlsCertPath = config.getTlsCertPath();
-            String tlsKeyPath = config.getTlsKeyPath();
-            String tlsKeyPassword = config.getTlsKeyPassword();
-            try (InputStream keyIn = Files.newInputStream(Paths.get(tlsKeyPath));
-                 InputStream certIn = Files.newInputStream(Paths.get(tlsCertPath))) {
-                return SslContextBuilder.forServer(certIn, keyIn,
-                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
-                    .sslProvider(provider)
-                    .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
-                    .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
-                    .build();
-            }
+            stdExactContexts.put(domainPattern, stdCtx);
+            shadedExactContexts.put(domainPattern, shadedCtx);
         }
     }
 
+    // --- Standard Netty SslContext builders ---
+
+    private io.netty.handler.ssl.SslContext buildStdDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
+        return buildStdSslContextInternal(
+            config.isTlsTestModeEnable() ? null : config.getTlsCertPath(),
+            config.isTlsTestModeEnable() ? null : config.getTlsKeyPath(),
+            config.isTlsTestModeEnable() ? null : config.getTlsKeyPassword(),
+            config.isTlsTestModeEnable()
+        );
+    }
+
     private io.netty.handler.ssl.SslContext buildStdSslContext(TlsDomainConfig config, boolean testMode) throws CertificateException, IOException {
+        String keyPassword = StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : this.tlsKeyPassword;
+        return buildStdSslContextInternal(
+            testMode ? null : config.getCertPath(),
+            testMode ? null : config.getKeyPath(),
+            testMode ? null : keyPassword,
+            testMode
+        );
+    }
+
+    private io.netty.handler.ssl.SslContext buildStdSslContextInternal(
+            String certPath, String keyPath, String keyPassword, boolean testMode)
+            throws CertificateException, IOException {
         io.netty.handler.ssl.SslProvider provider = io.netty.handler.ssl.OpenSsl.isAvailable()
             ? io.netty.handler.ssl.SslProvider.OPENSSL : io.netty.handler.ssl.SslProvider.JDK;
         if (testMode) {
@@ -235,13 +268,10 @@ public class TlsSniManager {
                 .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
                 .build();
         } else {
-            String tlsCertPath = config.getCertPath();
-            String tlsKeyPath = config.getKeyPath();
-            String tlsKeyPassword = StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : this.tlsKeyPassword;
-            try (InputStream keyIn = Files.newInputStream(Paths.get(tlsKeyPath));
-                 InputStream certIn = Files.newInputStream(Paths.get(tlsCertPath))) {
+            try (InputStream keyIn = Files.newInputStream(Paths.get(keyPath));
+                 InputStream certIn = Files.newInputStream(Paths.get(certPath))) {
                 return SslContextBuilder.forServer(certIn, keyIn,
-                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
+                        StringUtils.isNotBlank(keyPassword) ? keyPassword : null)
                     .sslProvider(provider)
                     .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
                     .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
@@ -253,31 +283,27 @@ public class TlsSniManager {
     // --- gRPC-shaded Netty SslContext builders ---
 
     private SslContext buildShadedDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
-        SslProvider provider = io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
-        if (config.isTlsTestModeEnable()) {
-            SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
-            return GrpcSslContexts.forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
-                .sslProvider(provider)
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
-                .build();
-        } else {
-            String tlsCertPath = config.getTlsCertPath();
-            String tlsKeyPath = config.getTlsKeyPath();
-            String tlsKeyPassword = config.getTlsKeyPassword();
-            try (InputStream serverKeyInputStream = Files.newInputStream(Paths.get(tlsKeyPath));
-                 InputStream serverCertificateStream = Files.newInputStream(Paths.get(tlsCertPath))) {
-                return GrpcSslContexts.forServer(serverCertificateStream,
-                        serverKeyInputStream,
-                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
-                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                    .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
-                    .build();
-            }
-        }
+        return buildShadedSslContextInternal(
+            config.isTlsTestModeEnable() ? null : config.getTlsCertPath(),
+            config.isTlsTestModeEnable() ? null : config.getTlsKeyPath(),
+            config.isTlsTestModeEnable() ? null : config.getTlsKeyPassword(),
+            config.isTlsTestModeEnable()
+        );
     }
 
     private SslContext buildShadedSslContext(TlsDomainConfig config, boolean testMode) throws CertificateException, IOException {
+        String keyPassword = StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : this.tlsKeyPassword;
+        return buildShadedSslContextInternal(
+            testMode ? null : config.getCertPath(),
+            testMode ? null : config.getKeyPath(),
+            testMode ? null : keyPassword,
+            testMode
+        );
+    }
+
+    private SslContext buildShadedSslContextInternal(
+            String certPath, String keyPath, String keyPassword, boolean testMode)
+            throws CertificateException, IOException {
         SslProvider provider = io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
         if (testMode) {
             SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
@@ -287,18 +313,46 @@ public class TlsSniManager {
                 .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                 .build();
         } else {
-            String tlsCertPath = config.getCertPath();
-            String tlsKeyPath = config.getKeyPath();
-            String tlsKeyPassword = StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : this.tlsKeyPassword;
-            try (InputStream serverKeyInputStream = Files.newInputStream(Paths.get(tlsKeyPath));
-                 InputStream serverCertificateStream = Files.newInputStream(Paths.get(tlsCertPath))) {
+            try (InputStream serverKeyInputStream = Files.newInputStream(Paths.get(keyPath));
+                 InputStream serverCertificateStream = Files.newInputStream(Paths.get(certPath))) {
                 return GrpcSslContexts.forServer(serverCertificateStream,
                         serverKeyInputStream,
-                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
+                        StringUtils.isNotBlank(keyPassword) ? keyPassword : null)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                     .build();
             }
+        }
+    }
+
+    /**
+     * Holds a wildcard domain pattern and its associated SslContext.
+     */
+    private static class WildcardSslContext<T> {
+        final String domainPattern;
+        final T context;
+
+        WildcardSslContext(String domainPattern, T context) {
+            this.domainPattern = domainPattern;
+            this.context = context;
+        }
+
+        /**
+         * Check if a hostname matches this wildcard pattern.
+         * RFC 6125: *.example.com matches foo.example.com but not a.b.example.com
+         * (unless multiLevel matching is enabled).
+         */
+        boolean matches(String hostname, boolean multiLevel) {
+            if (!domainPattern.startsWith("*.")) {
+                return false;
+            }
+            String suffix = domainPattern.substring(1); // ".example.com"
+            if (!hostname.endsWith(suffix) || hostname.length() <= suffix.length()) {
+                return false;
+            }
+            String remaining = hostname.substring(0, hostname.length() - suffix.length());
+            // For single-level wildcard matching, the remaining part must not contain "."
+            return multiLevel || !remaining.contains(".");
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
@@ -17,12 +17,11 @@
 package org.apache.rocketmq.proxy.service.cert;
 
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
-import io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
 import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.grpc.netty.shaded.io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.handler.ssl.SslContextBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
@@ -39,35 +38,66 @@ import java.security.cert.CertificateException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Manages multiple SslContext instances for SNI-based certificate selection.
+ * Maintains both standard Netty SslContext (for remoting server) and
+ * gRPC-shaded SslContext (for gRPC server) from the same certificate configs.
+ */
 public class TlsSniManager {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
-    private volatile SslContext defaultContext;
-    private volatile Map<String, SslContext> domainContexts = new ConcurrentHashMap<>();
+    // Standard Netty SslContext (for remoting server)
+    private volatile io.netty.handler.ssl.SslContext defaultStdContext;
+    private volatile Map<String, io.netty.handler.ssl.SslContext> stdDomainContexts = new ConcurrentHashMap<>();
+
+    // gRPC-shaded Netty SslContext (for gRPC server)
+    private volatile SslContext defaultShadedContext;
+    private volatile Map<String, SslContext> shadedDomainContexts = new ConcurrentHashMap<>();
+
     private Map<String, TlsDomainConfig> domainConfigs;
     private boolean tlsTestModeEnable;
     private String tlsKeyPassword;
     private boolean wildcardMatchMultiLevel;
 
-    /**
-     * Get the matching SslContext for the given SNI hostname.
-     * Supports wildcard matching (e.g. *.example.com matches foo.example.com).
-     * When wildcardMatchMultiLevel is true, a.b.example.com also matches *.example.com.
-     * Returns defaultContext when no match is found.
-     */
+    // --- Standard Netty SslContext accessors ---
+
+    public io.netty.handler.ssl.SslContext getStdSslContext(String sniHostname) {
+        return lookupContext(sniHostname, stdDomainContexts, defaultStdContext);
+    }
+
+    public io.netty.handler.ssl.SslContext getStdDefaultContext() {
+        return defaultStdContext;
+    }
+
+    // --- gRPC-shaded SslContext accessors ---
+
     public SslContext getSslContext(String sniHostname) {
+        return lookupContext(sniHostname, shadedDomainContexts, defaultShadedContext);
+    }
+
+    public SslContext getDefaultContext() {
+        return defaultShadedContext;
+    }
+
+    // --- Common ---
+
+    public Map<String, TlsDomainConfig> getDomainConfigs() {
+        return domainConfigs;
+    }
+
+    private <T> T lookupContext(String sniHostname, Map<String, T> domainContexts, T defaultCtx) {
         if (StringUtils.isBlank(sniHostname)) {
-            return defaultContext;
+            return defaultCtx;
         }
 
         // Exact match first
-        SslContext ctx = domainContexts.get(sniHostname);
+        T ctx = domainContexts.get(sniHostname);
         if (ctx != null) {
             return ctx;
         }
 
         // Wildcard match: foo.example.com matches *.example.com
-        for (Map.Entry<String, SslContext> entry : domainContexts.entrySet()) {
+        for (Map.Entry<String, T> entry : domainContexts.entrySet()) {
             String domainPattern = entry.getKey();
             if (domainPattern.startsWith("*.")) {
                 String suffix = domainPattern.substring(1);
@@ -81,7 +111,7 @@ public class TlsSniManager {
         }
 
         // Bare domain matches wildcard: rocketmq.com matches *.rocketmq.com
-        for (Map.Entry<String, SslContext> entry : domainContexts.entrySet()) {
+        for (Map.Entry<String, T> entry : domainContexts.entrySet()) {
             String domainPattern = entry.getKey();
             if (domainPattern.startsWith("*.")) {
                 String bareDomain = domainPattern.substring(2);
@@ -91,15 +121,7 @@ public class TlsSniManager {
             }
         }
 
-        return defaultContext;
-    }
-
-    public SslContext getDefaultContext() {
-        return defaultContext;
-    }
-
-    public Map<String, TlsDomainConfig> getDomainConfigs() {
-        return domainConfigs;
+        return defaultCtx;
     }
 
     /**
@@ -112,11 +134,14 @@ public class TlsSniManager {
             return;
         }
         try {
-            SslContext newCtx = buildSslContext(config, tlsTestModeEnable);
-            domainContexts.put(domainPattern, newCtx);
+            io.netty.handler.ssl.SslContext stdCtx = buildStdSslContext(config, tlsTestModeEnable);
+            stdDomainContexts.put(domainPattern, stdCtx);
+            SslContext shadedCtx = buildShadedSslContext(config, tlsTestModeEnable);
+            shadedDomainContexts.put(domainPattern, shadedCtx);
             log.info("Reloaded SslContext for domain: {}", domainPattern);
         } catch (Exception e) {
             log.error("Failed to reload SslContext for domain: {}", domainPattern, e);
+            throw new RuntimeException("Failed to reload SslContext for domain: " + domainPattern, e);
         }
     }
 
@@ -126,10 +151,12 @@ public class TlsSniManager {
     public void reloadDefaultContext() {
         ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
         try {
-            defaultContext = buildDefaultSslContext(proxyConfig);
+            defaultStdContext = buildStdDefaultSslContext(proxyConfig);
+            defaultShadedContext = buildShadedDefaultSslContext(proxyConfig);
             log.info("Reloaded default SslContext");
         } catch (Exception e) {
             log.error("Failed to reload default SslContext", e);
+            throw new RuntimeException("Failed to reload default SslContext", e);
         }
     }
 
@@ -143,8 +170,9 @@ public class TlsSniManager {
         this.wildcardMatchMultiLevel = config.isTlsWildcardMatchMultiLevel();
 
         try {
-            defaultContext = buildDefaultSslContext(config);
-            log.info("Initialized default SslContext");
+            defaultStdContext = buildStdDefaultSslContext(config);
+            defaultShadedContext = buildShadedDefaultSslContext(config);
+            log.info("Initialized default SslContext (standard + gRPC-shaded)");
         } catch (Exception e) {
             log.error("Failed to initialize default SslContext", e);
             throw new RuntimeException("Failed to initialize TlsSniManager", e);
@@ -155,8 +183,10 @@ public class TlsSniManager {
                 String domainPattern = entry.getKey();
                 TlsDomainConfig domainConfig = entry.getValue();
                 try {
-                    SslContext ctx = buildSslContext(domainConfig, tlsTestModeEnable);
-                    domainContexts.put(domainPattern, ctx);
+                    io.netty.handler.ssl.SslContext stdCtx = buildStdSslContext(domainConfig, tlsTestModeEnable);
+                    stdDomainContexts.put(domainPattern, stdCtx);
+                    SslContext shadedCtx = buildShadedSslContext(domainConfig, tlsTestModeEnable);
+                    shadedDomainContexts.put(domainPattern, shadedCtx);
                     log.info("Initialized SslContext for domain: {}", domainPattern);
                 } catch (Exception e) {
                     log.error("Failed to initialize SslContext for domain: {}", domainPattern, e);
@@ -166,14 +196,70 @@ public class TlsSniManager {
         }
     }
 
-    private SslContext buildDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
-        SslProvider provider = OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
+    // --- Standard Netty SslContext builders ---
+
+    private io.netty.handler.ssl.SslContext buildStdDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
+        io.netty.handler.ssl.SslProvider provider = io.netty.handler.ssl.OpenSsl.isAvailable()
+            ? io.netty.handler.ssl.SslProvider.OPENSSL : io.netty.handler.ssl.SslProvider.JDK;
+        if (config.isTlsTestModeEnable()) {
+            io.netty.handler.ssl.util.SelfSignedCertificate ssc = new io.netty.handler.ssl.util.SelfSignedCertificate();
+            return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                .sslProvider(provider)
+                .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
+                .build();
+        } else {
+            String tlsCertPath = config.getTlsCertPath();
+            String tlsKeyPath = config.getTlsKeyPath();
+            String tlsKeyPassword = config.getTlsKeyPassword();
+            try (InputStream keyIn = Files.newInputStream(Paths.get(tlsKeyPath));
+                 InputStream certIn = Files.newInputStream(Paths.get(tlsCertPath))) {
+                return SslContextBuilder.forServer(certIn, keyIn,
+                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
+                    .sslProvider(provider)
+                    .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                    .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
+                    .build();
+            }
+        }
+    }
+
+    private io.netty.handler.ssl.SslContext buildStdSslContext(TlsDomainConfig config, boolean testMode) throws CertificateException, IOException {
+        io.netty.handler.ssl.SslProvider provider = io.netty.handler.ssl.OpenSsl.isAvailable()
+            ? io.netty.handler.ssl.SslProvider.OPENSSL : io.netty.handler.ssl.SslProvider.JDK;
+        if (testMode) {
+            io.netty.handler.ssl.util.SelfSignedCertificate ssc = new io.netty.handler.ssl.util.SelfSignedCertificate();
+            return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                .sslProvider(provider)
+                .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
+                .build();
+        } else {
+            String tlsCertPath = config.getCertPath();
+            String tlsKeyPath = config.getKeyPath();
+            String tlsKeyPassword = StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : this.tlsKeyPassword;
+            try (InputStream keyIn = Files.newInputStream(Paths.get(tlsKeyPath));
+                 InputStream certIn = Files.newInputStream(Paths.get(tlsCertPath))) {
+                return SslContextBuilder.forServer(certIn, keyIn,
+                        StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
+                    .sslProvider(provider)
+                    .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
+                    .clientAuth(io.netty.handler.ssl.ClientAuth.NONE)
+                    .build();
+            }
+        }
+    }
+
+    // --- gRPC-shaded Netty SslContext builders ---
+
+    private SslContext buildShadedDefaultSslContext(ProxyConfig config) throws CertificateException, IOException {
+        SslProvider provider = io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
         if (config.isTlsTestModeEnable()) {
             SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
             return GrpcSslContexts.forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
                 .sslProvider(provider)
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .clientAuth(ClientAuth.NONE)
+                .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                 .build();
         } else {
             String tlsCertPath = config.getTlsCertPath();
@@ -185,20 +271,20 @@ public class TlsSniManager {
                         serverKeyInputStream,
                         StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                    .clientAuth(ClientAuth.NONE)
+                    .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                     .build();
             }
         }
     }
 
-    private SslContext buildSslContext(TlsDomainConfig config, boolean testMode) throws CertificateException, IOException {
-        SslProvider provider = OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
+    private SslContext buildShadedSslContext(TlsDomainConfig config, boolean testMode) throws CertificateException, IOException {
+        SslProvider provider = io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
         if (testMode) {
             SelfSignedCertificate selfSignedCertificate = new SelfSignedCertificate();
             return GrpcSslContexts.forServer(selfSignedCertificate.certificate(), selfSignedCertificate.privateKey())
                 .sslProvider(provider)
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .clientAuth(ClientAuth.NONE)
+                .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                 .build();
         } else {
             String tlsCertPath = config.getCertPath();
@@ -210,7 +296,7 @@ public class TlsSniManager {
                         serverKeyInputStream,
                         StringUtils.isNotBlank(tlsKeyPassword) ? tlsKeyPassword : null)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                    .clientAuth(ClientAuth.NONE)
+                    .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                     .build();
             }
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
@@ -123,15 +123,18 @@ public class TlsSniManager {
             return defaultCtx;
         }
 
+        // Normalize to lowercase — DNS is case-insensitive per RFC 4343
+        String hostname = sniHostname.toLowerCase(java.util.Locale.ROOT);
+
         // Exact match first
-        T ctx = exactContexts.get(sniHostname);
+        T ctx = exactContexts.get(hostname);
         if (ctx != null) {
             return ctx;
         }
 
         // Wildcard match: patterns are sorted longest-first for deterministic matching
         for (WildcardSslContext<T> wc : wildcardContexts) {
-            if (wc.matches(sniHostname, wildcardMatchMultiLevel)) {
+            if (wc.matches(hostname, wildcardMatchMultiLevel)) {
                 return wc.context;
             }
         }
@@ -151,6 +154,11 @@ public class TlsSniManager {
         try {
             io.netty.handler.ssl.SslContext stdCtx = buildStdSslContext(config, tlsTestModeEnable);
             SslContext shadedCtx = buildShadedSslContext(config, tlsTestModeEnable);
+            // For exact domains, release old context to avoid native SSL resource leaks
+            if (!domainPattern.startsWith("*.")) {
+                releaseQuietly(stdExactContexts.get(domainPattern));
+                releaseQuietly(shadedExactContexts.get(domainPattern));
+            }
             addDomainContexts(domainPattern, stdCtx, shadedCtx);
             log.info("Reloaded SslContext for domain: {}", domainPattern);
         } catch (Exception e) {
@@ -165,8 +173,12 @@ public class TlsSniManager {
     public void reloadDefaultContext() {
         ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
         try {
+            io.netty.handler.ssl.SslContext oldStd = defaultStdContext;
+            SslContext oldShaded = defaultShadedContext;
             defaultStdContext = buildStdDefaultSslContext(proxyConfig);
             defaultShadedContext = buildShadedDefaultSslContext(proxyConfig);
+            releaseQuietly(oldStd);
+            releaseQuietly(oldShaded);
             log.info("Reloaded default SslContext");
         } catch (Exception e) {
             log.error("Failed to reload default SslContext", e);
@@ -226,6 +238,9 @@ public class TlsSniManager {
             io.netty.handler.ssl.SslContext stdCtx,
             SslContext shadedCtx) {
         if (domainPattern.startsWith("*.")) {
+            // Remove existing entries for this pattern before adding to ensure reload replaces old context
+            stdWildcardContexts.removeIf(wc -> wc.domainPattern.equals(domainPattern));
+            shadedWildcardContexts.removeIf(wc -> wc.domainPattern.equals(domainPattern));
             stdWildcardContexts.add(new WildcardSslContext<>(domainPattern, stdCtx));
             shadedWildcardContexts.add(new WildcardSslContext<>(domainPattern, shadedCtx));
         } else {
@@ -318,9 +333,20 @@ public class TlsSniManager {
                 return GrpcSslContexts.forServer(serverCertificateStream,
                         serverKeyInputStream,
                         StringUtils.isNotBlank(keyPassword) ? keyPassword : null)
+                    .sslProvider(provider)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .clientAuth(io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth.NONE)
                     .build();
+            }
+        }
+    }
+
+    private static void releaseQuietly(Object ctx) {
+        if (ctx != null) {
+            try {
+                io.netty.util.ReferenceCountUtil.release(ctx);
+            } catch (Exception e) {
+                log.warn("Failed to release SslContext", e);
             }
         }
     }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
@@ -66,20 +66,20 @@ public class ProxyAndTlsProtocolNegotiatorTest {
     @Test
     public void testLoadSslContextWithUnencryptedKey() throws Exception {
         configureTls("server.key", "server.pem", "");
-        ProxyAndTlsProtocolNegotiator.loadSslContext();
+        ProxyAndTlsProtocolNegotiator.loadAllSslContexts();
     }
 
     @Test
     public void testLoadSslContextWithEncryptedKey() throws Exception {
         // "1234" is the password of certs/client.key, inherited from remoting module test resources
         configureTls("client.key", "client.pem", "1234");
-        ProxyAndTlsProtocolNegotiator.loadSslContext();
+        ProxyAndTlsProtocolNegotiator.loadAllSslContexts();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = RuntimeException.class)
     public void testLoadSslContextWithWrongPassword() throws Exception {
         configureTls("client.key", "client.pem", "wrong_password");
-        ProxyAndTlsProtocolNegotiator.loadSslContext();
+        ProxyAndTlsProtocolNegotiator.loadAllSslContexts();
     }
 
     private void configureTls(String keyFile, String certFile, String password) throws IOException {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiatorTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,6 +42,7 @@ public class ProxyAndTlsProtocolNegotiatorTest {
 
     @Before
     public void setUp() throws Exception {
+        TlsSniManager.resetInstance();
         ConfigurationManager.initConfig();
         ConfigurationManager.getProxyConfig().setTlsTestModeEnable(true);
         negotiator = new ProxyAndTlsProtocolNegotiator();

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManagerTest.java
@@ -18,12 +18,8 @@ package org.apache.rocketmq.proxy.service.cert;
 
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
-import org.apache.rocketmq.proxy.config.TlsDomainConfig;
-import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
-import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 import org.apache.rocketmq.srvutil.FileWatchService;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,10 +30,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.util.HashMap;
+import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -250,7 +246,7 @@ public class TlsCertificateManagerTest {
     public void testInnerCertKeyFileWatchListener() throws Exception {
         Class<?> innerClass = null;
         for (Class<?> clazz : TlsCertificateManager.class.getDeclaredClasses()) {
-            if (clazz.getSimpleName().equals("CertKeyFileWatchListener")) {
+            if (clazz.getSimpleName().equals("DefaultCertKeyFileWatchListener")) {
                 innerClass = clazz;
                 break;
             }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManagerTest.java
@@ -18,6 +18,9 @@ package org.apache.rocketmq.proxy.service.cert;
 
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
+import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 import org.apache.rocketmq.srvutil.FileWatchService;
 import org.junit.After;
@@ -31,10 +34,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -54,6 +57,7 @@ public class TlsCertificateManagerTest {
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
 
+    private TlsSniManager tlsSniManager;
     private TlsCertificateManager manager;
 
     @Mock
@@ -85,29 +89,22 @@ public class TlsCertificateManagerTest {
         TlsSystemConfig.tlsServerCertPath = certFile.getAbsolutePath();
         TlsSystemConfig.tlsServerKeyPath = keyFile.getAbsolutePath();
 
-        // Create the TlsCertificateManager
-        manager = new TlsCertificateManager();
+        // Create TlsSniManager and TlsCertificateManager
+        tlsSniManager = new TlsSniManager();
+        manager = new TlsCertificateManager(tlsSniManager);
 
-        // Extract the file watch listener using reflection
+        // Extract the file watch listener from the first watch service
         fileWatchListener = extractFileWatchListener(manager);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        // Restore the original config
-        if (configField != null && originalConfig != null) {
-            configField.set(null, originalConfig);
-        }
-    }
-
     private FileWatchService.Listener extractFileWatchListener(TlsCertificateManager manager) throws Exception {
-        Field fileWatchServiceField = TlsCertificateManager.class.getDeclaredField("fileWatchService");
-        fileWatchServiceField.setAccessible(true);
-        FileWatchService fileWatchService = (FileWatchService) fileWatchServiceField.get(manager);
+        Field fileWatchServicesField = TlsCertificateManager.class.getDeclaredField("fileWatchServices");
+        fileWatchServicesField.setAccessible(true);
+        List<FileWatchService> fileWatchServices = (List<FileWatchService>) fileWatchServicesField.get(manager);
 
         Field listenerField = FileWatchService.class.getDeclaredField("listener");
         listenerField.setAccessible(true);
-        return (FileWatchService.Listener) listenerField.get(fileWatchService);
+        return (FileWatchService.Listener) listenerField.get(fileWatchServices.get(0));
     }
 
     @Test
@@ -120,11 +117,14 @@ public class TlsCertificateManagerTest {
     public void testStartAndShutdown() throws Exception {
         TlsCertificateManager managerSpy = spy(manager);
 
-        Field watchServiceField = TlsCertificateManager.class.getDeclaredField("fileWatchService");
-        watchServiceField.setAccessible(true);
-        FileWatchService watchService = (FileWatchService) watchServiceField.get(managerSpy);
+        Field watchServicesField = TlsCertificateManager.class.getDeclaredField("fileWatchServices");
+        watchServicesField.setAccessible(true);
+        List<FileWatchService> watchServices = (List<FileWatchService>) watchServicesField.get(managerSpy);
+
+        // Spy on the first watch service
+        FileWatchService watchService = watchServices.get(0);
         FileWatchService watchServiceSpy = spy(watchService);
-        watchServiceField.set(managerSpy, watchServiceSpy);
+        watchServices.set(0, watchServiceSpy);
 
         managerSpy.start();
         verify(watchServiceSpy).start();

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class TlsSniManagerTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    private TlsSniManager sniManager;
+
+    private File defaultCertFile;
+    private File defaultKeyFile;
+    private File firstCertFile;
+    private File firstKeyFile;
+    private File secondCertFile;
+    private File secondKeyFile;
+
+    @Before
+    public void setUp() throws Exception {
+        defaultCertFile = tempDir.newFile("default.crt");
+        defaultKeyFile = tempDir.newFile("default.key");
+        try (FileWriter w = new FileWriter(defaultCertFile)) { w.write("default cert"); }
+        try (FileWriter w = new FileWriter(defaultKeyFile)) { w.write("default key"); }
+
+        firstCertFile = tempDir.newFile("example.crt");
+        firstKeyFile = tempDir.newFile("example.key");
+        try (FileWriter w = new FileWriter(firstCertFile)) { w.write("example cert"); }
+        try (FileWriter w = new FileWriter(firstKeyFile)) { w.write("example key"); }
+
+        secondCertFile = tempDir.newFile("sample.crt");
+        secondKeyFile = tempDir.newFile("sample.key");
+        try (FileWriter w = new FileWriter(secondCertFile)) { w.write("sample cert"); }
+        try (FileWriter w = new FileWriter(secondKeyFile)) { w.write("sample key"); }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testInitializeWithTestMode() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        assertNotNull(sniManager.getDefaultContext());
+        assertNotNull(sniManager.getSslContext("test.example.com"));
+    }
+
+    @Test
+    public void testWildcardMatch_FirstDomain() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext("foo.example.com");
+        assertNotNull(ctx);
+    }
+
+    @Test
+    public void testWildcardMatch_SecondDomain() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext("mq.sample.org");
+        assertNotNull(ctx);
+    }
+
+    @Test
+    public void testExactMatch() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext("example.com");
+        assertNotNull(ctx);
+    }
+
+    @Test
+    public void testNoMatchFallbackToDefault() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext("unknown.other.com");
+        assertNotNull(ctx);
+        assertSame(sniManager.getDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testNullSniFallbackToDefault() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext(null);
+        assertNotNull(ctx);
+        assertSame(sniManager.getDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testEmptySniFallbackToDefault() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext("");
+        assertNotNull(ctx);
+        assertSame(sniManager.getDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testMultiLevelSubdomainNoMatchByDefault() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        // a.b.example.com should NOT match *.example.com by default
+        SslContext ctx = sniManager.getSslContext("a.b.example.com");
+        assertNotNull(ctx);
+        assertSame(sniManager.getDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testMultiLevelSubdomainMatchWhenEnabled() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfigWithMultiLevel());
+
+        // a.b.example.com SHOULD match *.example.com when tlsWildcardMatchMultiLevel is true
+        SslContext ctx = sniManager.getSslContext("a.b.example.com");
+        assertNotNull(ctx);
+        // Should NOT be the default context
+        org.junit.Assert.assertNotSame(sniManager.getDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testReloadDomainContext() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext before = sniManager.getSslContext("foo.example.com");
+        sniManager.reloadDomainContext("*.example.com");
+        SslContext after = sniManager.getSslContext("foo.example.com");
+        assertNotNull(before);
+        assertNotNull(after);
+    }
+
+    @Test
+    public void testReloadDefaultContext() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext before = sniManager.getDefaultContext();
+        sniManager.reloadDefaultContext();
+        SslContext after = sniManager.getDefaultContext();
+        assertNotNull(before);
+        assertNotNull(after);
+    }
+
+    @Test
+    public void testDomainConfigsNotEmpty() {
+        sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        Map<String, TlsDomainConfig> configs = sniManager.getDomainConfigs();
+        assertNotNull(configs);
+        assertEquals(2, configs.size());
+        assertTrue(configs.containsKey("*.example.com"));
+        assertTrue(configs.containsKey("*.sample.org"));
+    }
+
+    private org.apache.rocketmq.proxy.config.ProxyConfig createTestModeProxyConfig() {
+        org.apache.rocketmq.proxy.config.ProxyConfig config = new org.apache.rocketmq.proxy.config.ProxyConfig();
+        config.setTlsTestModeEnable(true);
+
+        Map<String, TlsDomainConfig> domainConfigs = new HashMap<>();
+        TlsDomainConfig firstConfig = new TlsDomainConfig();
+        firstConfig.setCertPath(firstCertFile.getAbsolutePath());
+        firstConfig.setKeyPath(firstKeyFile.getAbsolutePath());
+        domainConfigs.put("*.example.com", firstConfig);
+
+        TlsDomainConfig secondConfig = new TlsDomainConfig();
+        secondConfig.setCertPath(secondCertFile.getAbsolutePath());
+        secondConfig.setKeyPath(secondKeyFile.getAbsolutePath());
+        domainConfigs.put("*.sample.org", secondConfig);
+
+        config.setTlsDomainConfigs(domainConfigs);
+
+        return config;
+    }
+
+    private org.apache.rocketmq.proxy.config.ProxyConfig createTestModeProxyConfigWithMultiLevel() {
+        org.apache.rocketmq.proxy.config.ProxyConfig config = createTestModeProxyConfig();
+        config.setTlsWildcardMatchMultiLevel(true);
+        return config;
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.proxy.service.cert;
 
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -50,6 +51,10 @@ public class TlsSniManagerTest {
 
     @Before
     public void setUp() throws Exception {
+        ConfigurationManager.initEnv();
+        ConfigurationManager.initConfig();
+        ConfigurationManager.getProxyConfig().setTlsTestModeEnable(true);
+
         defaultCertFile = tempDir.newFile("default.crt");
         defaultKeyFile = tempDir.newFile("default.key");
         try (FileWriter w = new FileWriter(defaultCertFile)) { w.write("default cert"); }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
@@ -265,4 +265,103 @@ public class TlsSniManagerTest {
 
         return config;
     }
+
+    @Test
+    public void testStdSslContext_WildcardMatch() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        io.netty.handler.ssl.SslContext ctx = sniManager.getStdSslContext("foo.example.com");
+        assertNotNull(ctx);
+        org.junit.Assert.assertNotSame(sniManager.getStdDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testStdSslContext_FallbackToDefault() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        io.netty.handler.ssl.SslContext ctx = sniManager.getStdSslContext("unknown.other.com");
+        assertNotNull(ctx);
+        assertSame(sniManager.getStdDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testStdDefaultContext_NotNull() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        assertNotNull(sniManager.getStdDefaultContext());
+    }
+
+    @Test
+    public void testReloadDomainContext_ActuallyReplaces() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext before = sniManager.getSslContext("foo.example.com");
+        sniManager.reloadDomainContext("*.example.com");
+        SslContext after = sniManager.getSslContext("foo.example.com");
+
+        assertNotNull(before);
+        assertNotNull(after);
+        org.junit.Assert.assertNotSame("reloadDomainContext should produce a new SslContext", before, after);
+    }
+
+    @Test
+    public void testReloadDefaultContext_ActuallyReplaces() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext before = sniManager.getDefaultContext();
+        sniManager.reloadDefaultContext();
+        SslContext after = sniManager.getDefaultContext();
+
+        assertNotNull(before);
+        assertNotNull(after);
+        org.junit.Assert.assertNotSame("reloadDefaultContext should produce a new SslContext", before, after);
+    }
+
+    @Test
+    public void testWildcardMatch_CaseInsensitive() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfig());
+
+        SslContext ctx = sniManager.getSslContext("FOO.EXAMPLE.COM");
+        assertNotNull(ctx);
+        org.junit.Assert.assertNotSame(sniManager.getDefaultContext(), ctx);
+    }
+
+    @Test
+    public void testExactMatchTakesPriorityOverWildcard() {
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfigWithExactAndWildcard());
+
+        SslContext exact = sniManager.getSslContext("exact.example.com");
+        SslContext wildcard = sniManager.getSslContext("other.example.com");
+
+        assertNotNull(exact);
+        assertNotNull(wildcard);
+        org.junit.Assert.assertNotSame(exact, wildcard);
+    }
+
+    private org.apache.rocketmq.proxy.config.ProxyConfig createTestModeProxyConfigWithExactAndWildcard() {
+        org.apache.rocketmq.proxy.config.ProxyConfig config = new org.apache.rocketmq.proxy.config.ProxyConfig();
+        config.setTlsTestModeEnable(true);
+
+        Map<String, TlsDomainConfig> domainConfigs = new HashMap<>();
+
+        TlsDomainConfig wildcardConfig = new TlsDomainConfig();
+        wildcardConfig.setCertPath(firstCertFile.getAbsolutePath());
+        wildcardConfig.setKeyPath(firstKeyFile.getAbsolutePath());
+        domainConfigs.put("*.example.com", wildcardConfig);
+
+        TlsDomainConfig exactConfig = new TlsDomainConfig();
+        exactConfig.setCertPath(secondCertFile.getAbsolutePath());
+        exactConfig.setKeyPath(secondKeyFile.getAbsolutePath());
+        domainConfigs.put("exact.example.com", exactConfig);
+
+        config.setTlsDomainConfigs(domainConfigs);
+        return config;
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
@@ -40,8 +40,6 @@ public class TlsSniManagerTest {
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
 
-    private TlsSniManager sniManager;
-
     private File defaultCertFile;
     private File defaultKeyFile;
     private File firstCertFile;
@@ -51,6 +49,7 @@ public class TlsSniManagerTest {
 
     @Before
     public void setUp() throws Exception {
+        TlsSniManager.resetInstance();
         ConfigurationManager.initEnv();
         ConfigurationManager.initConfig();
         ConfigurationManager.getProxyConfig().setTlsTestModeEnable(true);
@@ -73,11 +72,12 @@ public class TlsSniManagerTest {
 
     @After
     public void tearDown() throws Exception {
+        TlsSniManager.resetInstance();
     }
 
     @Test
     public void testInitializeWithTestMode() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         assertNotNull(sniManager.getDefaultContext());
@@ -86,7 +86,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testWildcardMatch_FirstDomain() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext ctx = sniManager.getSslContext("foo.example.com");
@@ -95,7 +95,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testWildcardMatch_SecondDomain() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext ctx = sniManager.getSslContext("mq.sample.org");
@@ -104,7 +104,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testExactMatch() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext ctx = sniManager.getSslContext("example.com");
@@ -113,7 +113,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testNoMatchFallbackToDefault() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext ctx = sniManager.getSslContext("unknown.other.com");
@@ -123,7 +123,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testNullSniFallbackToDefault() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext ctx = sniManager.getSslContext(null);
@@ -133,7 +133,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testEmptySniFallbackToDefault() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext ctx = sniManager.getSslContext("");
@@ -143,7 +143,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testMultiLevelSubdomainNoMatchByDefault() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         // a.b.example.com should NOT match *.example.com by default
@@ -154,7 +154,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testMultiLevelSubdomainMatchWhenEnabled() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfigWithMultiLevel());
 
         // a.b.example.com SHOULD match *.example.com when tlsWildcardMatchMultiLevel is true
@@ -166,7 +166,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testReloadDomainContext() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext before = sniManager.getSslContext("foo.example.com");
@@ -178,7 +178,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testReloadDefaultContext() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         SslContext before = sniManager.getDefaultContext();
@@ -190,7 +190,7 @@ public class TlsSniManagerTest {
 
     @Test
     public void testDomainConfigsNotEmpty() {
-        sniManager = new TlsSniManager();
+        TlsSniManager sniManager = new TlsSniManager();
         sniManager.initialize(createTestModeProxyConfig());
 
         Map<String, TlsDomainConfig> configs = sniManager.getDomainConfigs();
@@ -198,6 +198,26 @@ public class TlsSniManagerTest {
         assertEquals(2, configs.size());
         assertTrue(configs.containsKey("*.example.com"));
         assertTrue(configs.containsKey("*.sample.org"));
+    }
+
+    @Test
+    public void testSingleton() {
+        TlsSniManager s1 = TlsSniManager.getInstance();
+        TlsSniManager s2 = TlsSniManager.getInstance();
+        assertSame(s1, s2);
+    }
+
+    @Test
+    public void testWildcardMatchOrderDeterministic() {
+        // Longer wildcard should match before shorter wildcard
+        TlsSniManager sniManager = new TlsSniManager();
+        sniManager.initialize(createTestModeProxyConfigWithOverlappingWildcards());
+
+        // foo.sub.example.com should match *.sub.example.com (longer), not *.example.com (shorter)
+        SslContext ctx = sniManager.getSslContext("foo.sub.example.com");
+        assertNotNull(ctx);
+        // Verify it's NOT the default context
+        org.junit.Assert.assertNotSame(sniManager.getDefaultContext(), ctx);
     }
 
     private org.apache.rocketmq.proxy.config.ProxyConfig createTestModeProxyConfig() {
@@ -223,6 +243,26 @@ public class TlsSniManagerTest {
     private org.apache.rocketmq.proxy.config.ProxyConfig createTestModeProxyConfigWithMultiLevel() {
         org.apache.rocketmq.proxy.config.ProxyConfig config = createTestModeProxyConfig();
         config.setTlsWildcardMatchMultiLevel(true);
+        return config;
+    }
+
+    private org.apache.rocketmq.proxy.config.ProxyConfig createTestModeProxyConfigWithOverlappingWildcards() {
+        org.apache.rocketmq.proxy.config.ProxyConfig config = new org.apache.rocketmq.proxy.config.ProxyConfig();
+        config.setTlsTestModeEnable(true);
+
+        Map<String, TlsDomainConfig> domainConfigs = new HashMap<>();
+        TlsDomainConfig broadConfig = new TlsDomainConfig();
+        broadConfig.setCertPath(firstCertFile.getAbsolutePath());
+        broadConfig.setKeyPath(firstKeyFile.getAbsolutePath());
+        domainConfigs.put("*.example.com", broadConfig);
+
+        TlsDomainConfig specificConfig = new TlsDomainConfig();
+        specificConfig.setCertPath(secondCertFile.getAbsolutePath());
+        specificConfig.setKeyPath(secondKeyFile.getAbsolutePath());
+        domainConfigs.put("*.sub.example.com", specificConfig);
+
+        config.setTlsDomainConfigs(domainConfigs);
+
         return config;
     }
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -52,11 +52,12 @@ import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
-import io.netty.util.GlobalEventExecutor;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.AsyncMapping;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.Pair;
@@ -512,11 +513,21 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                     case ENFORCING:
                         SslContext defaultCtx = TlsContextProvider.getInstance().getDefaultContext();
                         if (null != defaultCtx) {
-                            SniContextProvider sniProvider = TlsContextProvider.getInstance().getSniLookup();
-                            if (sniProvider != null) {
+                            final TlsContextProvider.SniContextLookup sniLookup = TlsContextProvider.getInstance().getSniLookup();
+                            if (sniLookup != null) {
                                 ctx.pipeline()
                                     .addAfter(getDefaultEventExecutorGroup(), TLS_MODE_HANDLER, TLS_HANDLER_NAME,
-                                        new SniHandler(sniProvider, GlobalEventExecutor.INSTANCE))
+                                        new SniHandler(new AsyncMapping<String, SslContext>() {
+                                            @Override
+                                            public Promise<SslContext> map(String hostname, Promise<SslContext> promise) {
+                                                SslContext selected = sniLookup.lookup(hostname);
+                                                if (selected == null) {
+                                                    selected = sniLookup.getDefaultContext();
+                                                }
+                                                promise.setSuccess(selected);
+                                                return promise;
+                                            }
+                                        }, 10))
                                     .addAfter(getDefaultEventExecutorGroup(), TLS_HANDLER_NAME, FILE_REGION_ENCODER_NAME, new FileRegionEncoder());
                             } else {
                                 ctx.pipeline()

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -45,11 +45,14 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.handler.codec.haproxy.HAProxyTLV;
+import io.netty.handler.ssl.SniHandler;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
+import io.netty.util.GlobalEventExecutor;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
@@ -507,10 +510,19 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                         throw new UnsupportedOperationException("The NettyRemotingServer in SSL disabled mode doesn't support ssl client");
                     case PERMISSIVE:
                     case ENFORCING:
-                        if (null != sslContext) {
-                            ctx.pipeline()
-                                .addAfter(getDefaultEventExecutorGroup(), TLS_MODE_HANDLER, TLS_HANDLER_NAME, sslContext.newHandler(ctx.channel().alloc()))
-                                .addAfter(getDefaultEventExecutorGroup(), TLS_HANDLER_NAME, FILE_REGION_ENCODER_NAME, new FileRegionEncoder());
+                        SslContext defaultCtx = TlsContextProvider.getInstance().getDefaultContext();
+                        if (null != defaultCtx) {
+                            SniContextProvider sniProvider = TlsContextProvider.getInstance().getSniLookup();
+                            if (sniProvider != null) {
+                                ctx.pipeline()
+                                    .addAfter(getDefaultEventExecutorGroup(), TLS_MODE_HANDLER, TLS_HANDLER_NAME,
+                                        new SniHandler(sniProvider, GlobalEventExecutor.INSTANCE))
+                                    .addAfter(getDefaultEventExecutorGroup(), TLS_HANDLER_NAME, FILE_REGION_ENCODER_NAME, new FileRegionEncoder());
+                            } else {
+                                ctx.pipeline()
+                                    .addAfter(getDefaultEventExecutorGroup(), TLS_MODE_HANDLER, TLS_HANDLER_NAME, defaultCtx.newHandler(ctx.channel().alloc()))
+                                    .addAfter(getDefaultEventExecutorGroup(), TLS_HANDLER_NAME, FILE_REGION_ENCODER_NAME, new FileRegionEncoder());
+                            }
                             log.info("Handlers prepended to channel pipeline to establish SSL connection");
                         } else {
                             ctx.close();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -521,11 +521,22 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                                         new SniHandler(new AsyncMapping<String, SslContext>() {
                                             @Override
                                             public Promise<SslContext> map(String hostname, Promise<SslContext> promise) {
-                                                SslContext selected = sniLookup.lookup(hostname);
-                                                if (selected == null) {
-                                                    selected = sniLookup.getDefaultContext();
+                                                try {
+                                                    String normalizedHost = hostname != null
+                                                        ? hostname.toLowerCase(java.util.Locale.ROOT) : null;
+                                                    SslContext selected = sniLookup.lookup(normalizedHost);
+                                                    if (selected == null) {
+                                                        selected = sniLookup.getDefaultContext();
+                                                    }
+                                                    if (selected == null) {
+                                                        promise.setFailure(new javax.net.ssl.SSLException(
+                                                            "No SslContext available for SNI hostname: " + hostname));
+                                                    } else {
+                                                        promise.setSuccess(selected);
+                                                    }
+                                                } catch (Exception e) {
+                                                    promise.setFailure(e);
                                                 }
-                                                promise.setSuccess(selected);
                                                 return promise;
                                             }
                                         }))

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -527,7 +527,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
                                                 promise.setSuccess(selected);
                                                 return promise;
                                             }
-                                        }, 10))
+                                        }))
                                     .addAfter(getDefaultEventExecutorGroup(), TLS_HANDLER_NAME, FILE_REGION_ENCODER_NAME, new FileRegionEncoder());
                             } else {
                                 ctx.pipeline()

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -188,6 +188,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         if (tlsMode != TlsMode.DISABLED) {
             try {
                 sslContext = TlsHelper.buildSslContext(false);
+                TlsContextProvider.getInstance().setSingleContext(sslContext);
                 log.info("SslContext created for server");
             } catch (CertificateException | IOException e) {
                 log.error("Failed to create SslContext for server", e);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/TlsContextProvider.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/TlsContextProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.netty;
+
+import io.netty.handler.ssl.SslContext;
+
+/**
+ * Holder for SslContext used by remoting server's TlsModeHandler.
+ * Proxy module initializes this with either a single SslContext or a TlsSniManager-backed provider.
+ */
+public class TlsContextProvider {
+
+    private static volatile TlsContextProvider instance = new TlsContextProvider();
+
+    private volatile SslContext singleContext;
+    private volatile SniContextLookup sniLookup;
+
+    public static TlsContextProvider getInstance() {
+        return instance;
+    }
+
+    public static void setInstance(TlsContextProvider provider) {
+        instance = provider;
+    }
+
+    /**
+     * Set a single SslContext (backward compatible mode).
+     */
+    public void setSingleContext(SslContext ctx) {
+        this.singleContext = ctx;
+        this.sniLookup = null;
+    }
+
+    /**
+     * Set an SNI-aware context lookup.
+     */
+    public void setSniLookup(SniContextLookup lookup) {
+        this.sniLookup = lookup;
+        this.singleContext = null;
+    }
+
+    /**
+     * Get the SslContext for a given SNI hostname. Returns singleContext when no SNI lookup is configured.
+     */
+    public SslContext getSslContext(String sniHostname) {
+        if (sniLookup != null) {
+            SslContext ctx = sniLookup.lookup(sniHostname);
+            if (ctx != null) {
+                return ctx;
+            }
+        }
+        return singleContext;
+    }
+
+    /**
+     * Get the default SslContext for fallback.
+     */
+    public SslContext getDefaultContext() {
+        if (sniLookup != null) {
+            return sniLookup.getDefaultContext();
+        }
+        return singleContext;
+    }
+
+    /**
+     * Returns the SniContextLookup if configured, null otherwise.
+     */
+    public SniContextLookup getSniLookup() {
+        return sniLookup;
+    }
+
+    /**
+     * Interface for SNI-aware context lookup, implemented in proxy module.
+     */
+    public interface SniContextLookup {
+        SslContext lookup(String sniHostname);
+        SslContext getDefaultContext();
+    }
+}

--- a/test/src/test/java/org/apache/rocketmq/test/base/IntegrationTestBase.java
+++ b/test/src/test/java/org/apache/rocketmq/test/base/IntegrationTestBase.java
@@ -205,8 +205,7 @@ public class IntegrationTestBase {
             }
             startAndShutdown.appendStartAndShutdown(messagingProcessor);
 
-            TlsSniManager tlsSniManager = new TlsSniManager();
-            tlsSniManager.initialize(ConfigurationManager.getProxyConfig());
+            TlsSniManager tlsSniManager = TlsSniManager.getInstance();
             TlsCertificateManager tlsCertificateManager = new TlsCertificateManager(tlsSniManager);
             startAndShutdown.appendStartAndShutdown(tlsCertificateManager);
 

--- a/test/src/test/java/org/apache/rocketmq/test/base/IntegrationTestBase.java
+++ b/test/src/test/java/org/apache/rocketmq/test/base/IntegrationTestBase.java
@@ -53,6 +53,7 @@ import org.apache.rocketmq.proxy.grpc.v2.GrpcMessagingApplication;
 import org.apache.rocketmq.proxy.processor.DefaultMessagingProcessor;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
 import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyServerConfig;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
@@ -204,7 +205,9 @@ public class IntegrationTestBase {
             }
             startAndShutdown.appendStartAndShutdown(messagingProcessor);
 
-            TlsCertificateManager tlsCertificateManager = new TlsCertificateManager();
+            TlsSniManager tlsSniManager = new TlsSniManager();
+            tlsSniManager.initialize(ConfigurationManager.getProxyConfig());
+            TlsCertificateManager tlsCertificateManager = new TlsCertificateManager(tlsSniManager);
             startAndShutdown.appendStartAndShutdown(tlsCertificateManager);
 
             GrpcMessagingApplication application = GrpcMessagingApplication.create(messagingProcessor);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10302

### Brief Description

Introduce **SNI (Server Name Indication)** support to allow RocketMQ Proxy to serve multiple TLS domains with independent certificates on the same port.

**Key changes:**

| File | Change |
|---|---|
| `proxy/.../config/TlsDomainConfig.java` | **New** — per-domain TLS config POJO |
| `proxy/.../config/ProxyConfig.java` | Add `tlsDomainConfigs` map field + getters/setters |
| `proxy/.../service/cert/TlsSniManager.java` | **New** — multi-domain SslContext manager with wildcard matching |
| `proxy/.../service/cert/TlsCertificateManager.java` | Extended for multi-domain file watching |
| `proxy/.../grpc/ProxyAndTlsProtocolNegotiator.java` | Use `SniHandler` + `TlsSniManager` for gRPC SNI |
| `proxy/.../grpc/GrpcServer.java` | Update reload handler to use renamed method |
| `proxy/.../remoting/MultiProtocolRemotingServer.java` | Wire up `TlsContextProvider` with SNI lookup |
| `proxy/.../ProxyStartup.java` | Initialize `TlsSniManager` before `TlsCertificateManager` |
| `remoting/.../netty/TlsContextProvider.java` | **New** — SslContext holder bridge (remoting ↔ proxy) |
| `remoting/.../netty/NettyRemotingServer.java` | `TlsModeHandler` uses `SniHandler` via `TlsContextProvider` |

**Backward compatibility:** When `tlsDomainConfigs` is not configured, behavior is identical to the existing single-cert model.

### How Did You Test This Change?

- Added unit tests in `TlsSniManagerTest` for wildcard matching, exact match, null/empty fallback, multi-level subdomain rejection, and domain context reload
- Updated `TlsCertificateManagerTest` for the new multi-domain constructor

CI will run `mvn -B package` to verify compilation and all existing tests pass.