### PR TITLE
[ISSUE #10341] Fix Bazel CI build failure caused by Maven Central rate limiting

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -16,7 +16,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Cache Bazel repository
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: bazel-repo-${{ runner.os }}-${{ hashFiles('WORKSPACE') }}
+          restore-keys: |
+            bazel-repo-${{ runner.os }}-
       - name: Build
         run: bazel build --config=remote //...
       - name: Run Tests

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -115,10 +115,10 @@ maven_install(
         "com.alibaba.fastjson2:fastjson2:2.0.59",
         "org.junit.jupiter:junit-jupiter-api:5.9.1",
     ],
-    fetch_sources = True,
+    fetch_sources = False,
     repositories = [
-        # Private repositories are supported through HTTP Basic auth
         "https://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
     ],
 )
 


### PR DESCRIPTION
## Summary
- Disable `fetch_sources` to halve Maven download requests and avoid HTTP 429 rate limiting
- Add `repo.maven.apache.org` as fallback mirror repository
- Add `actions/cache` for Bazel repository cache to avoid redundant downloads across CI runs
- Upgrade `actions/checkout` from v2 to v4

## Test plan
- [x] Verify Bazel CI workflow passes without 429 errors
- [x] Confirm build and test targets still compile successfully

Closes #10341

🤖 Generated with [Claude Code](https://claude.com/claude-code)