### PR TITLE
[ISSUE #10344] Parameterize RocksDB CQ size amplification

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -505,6 +505,8 @@ public class MessageStoreConfig {
 
     private String rocksdbCompressionType = CompressionType.LZ4_COMPRESSION.getLibraryName();
 
+    private int rocksdbMaxSizeAmplificationPercent = 25;
+
     private long popRocksdbBlockCacheSize = 256 * SizeUnit.MB;
 
     private long popRocksdbWriteBufferSize = 32 * SizeUnit.MB;
@@ -533,6 +535,14 @@ public class MessageStoreConfig {
 
     public void setRocksdbCompressionType(String compressionType) {
         this.rocksdbCompressionType = compressionType;
+    }
+
+    public int getRocksdbMaxSizeAmplificationPercent() {
+        return rocksdbMaxSizeAmplificationPercent;
+    }
+
+    public void setRocksdbMaxSizeAmplificationPercent(int rocksdbMaxSizeAmplificationPercent) {
+        this.rocksdbMaxSizeAmplificationPercent = rocksdbMaxSizeAmplificationPercent;
     }
 
     public long getPopRocksdbBlockCacheSize() {

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactory.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.store.rocksdb;
 
 import org.apache.rocketmq.common.config.ConfigHelper;
 import org.apache.rocketmq.store.MessageStore;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
@@ -58,19 +59,18 @@ public class RocksDBOptionsFactory {
                 setBlockCache(new LRUCache(1024 * SizeUnit.MB, 8, false)).
                 setWholeKeyFiltering(true);
 
+        MessageStoreConfig messageStoreConfig = messageStore.getMessageStoreConfig();
         ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-        CompactionOptionsUniversal compactionOption = new CompactionOptionsUniversal();
-        compactionOption.setSizeRatio(100).
-                setMaxSizeAmplificationPercent(25).
+        CompactionOptionsUniversal compactionOption = new CompactionOptionsUniversal().
+                setSizeRatio(100).
+                setMaxSizeAmplificationPercent(messageStoreConfig.getRocksdbMaxSizeAmplificationPercent()).
                 setAllowTrivialMove(true).
                 setMinMergeWidth(2).
                 setMaxMergeWidth(Integer.MAX_VALUE).
                 setStopStyle(CompactionStopStyle.CompactionStopStyleTotalSize).
                 setCompressionSizePercent(-1);
-        String bottomMostCompressionTypeOpt = messageStore.getMessageStoreConfig()
-            .getBottomMostCompressionTypeForConsumeQueueStore();
-        String compressionTypeOpt = messageStore.getMessageStoreConfig()
-            .getRocksdbCompressionType();
+        String bottomMostCompressionTypeOpt = messageStoreConfig.getBottomMostCompressionTypeForConsumeQueueStore();
+        String compressionTypeOpt = messageStoreConfig.getRocksdbCompressionType();
         CompressionType bottomMostCompressionType = CompressionType.getCompressionType(bottomMostCompressionTypeOpt);
         CompressionType compressionType = CompressionType.getCompressionType(compressionTypeOpt);
         return columnFamilyOptions.setMaxWriteBufferNumber(4).

--- a/store/src/test/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactoryTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactoryTest.java
@@ -17,12 +17,25 @@
 
 package org.apache.rocketmq.store.rocksdb;
 
+import org.apache.rocketmq.store.MessageStore;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionOptionsUniversal;
 import org.rocksdb.CompressionType;
+import org.rocksdb.RocksDB;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RocksDBOptionsFactoryTest {
+
+    @BeforeClass
+    public static void loadRocksDB() {
+        RocksDB.loadLibrary();
+    }
 
     @Test
     public void testBottomMostCompressionType() {
@@ -31,4 +44,19 @@ public class RocksDBOptionsFactoryTest {
             CompressionType.getCompressionType(config.getBottomMostCompressionTypeForConsumeQueueStore()));
         Assert.assertEquals(CompressionType.LZ4_COMPRESSION, CompressionType.getCompressionType("lz4"));
     }
+
+    @Test
+    public void testConsumeQueueUniversalCompactionMaxSizeAmplificationPercent() {
+        MessageStoreConfig config = new MessageStoreConfig();
+        config.setRocksdbMaxSizeAmplificationPercent(50);
+        MessageStore messageStore = mock(MessageStore.class);
+        when(messageStore.getMessageStoreConfig()).thenReturn(config);
+
+        ConsumeQueueCompactionFilterFactory compactionFilterFactory = new ConsumeQueueCompactionFilterFactory(() -> 0);
+        try (ColumnFamilyOptions options = RocksDBOptionsFactory.createCQCFOptions(messageStore, compactionFilterFactory);
+            CompactionOptionsUniversal compactionOptions = options.compactionOptionsUniversal()) {
+            Assert.assertEquals(50, compactionOptions.maxSizeAmplificationPercent());
+        }
+    }
+
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

### Summary
- Add `rocksdbMaxSizeAmplificationPercent` to `MessageStoreConfig`, defaulting to the current value `25`.
- Apply the value only when building RocksDB ConsumeQueue universal compaction options.
- Add a focused unit test for the CQ compaction option.

### Motivation
This lets operators tune RocksDB ConsumeQueue universal compaction space amplification without changing defaults or affecting other RocksDB users.

### Test Plan
- `/usr/local/bin/mvn -pl store -DskipITs -Dtest=RocksDBOptionsFactoryTest test`
