### PR TITLE
[ISSUE #10247] Remove duplicate remove call in InvocationChannel

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationChannel.java
@@ -41,7 +41,6 @@ public class InvocationChannel extends SimpleChannel {
             if (null != context) {
                 context.handle(responseCommand);
             }
-            inFlightRequestMap.remove(responseCommand.getOpaque());
         }
         return super.writeAndFlush(msg);
     }


### PR DESCRIPTION
Remove redundant second inFlightRequestMap.remove() call in writeAndFlush(). The remove was already called once at line 41 to retrieve the context. The duplicate remove at line 46 had no effect and was unnecessary.

Fixes: #10247

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
