### PR TITLE
[DOCS] Fix typo in Example_Batch.md ListSplitter

### DIFF
--- a/docs/en/Example_Batch.md
+++ b/docs/en/Example_Batch.md
@@ -53,7 +53,7 @@ public class ListSplitter implements Iterator<List<Message>> {
         int tmpSize = calcMessageSize(currMessage); 
         while(tmpSize > SIZE_LIMIT) {
             currIndex += 1;
-            Message message = messages.get(curIndex); 
+            Message message = messages.get(currIndex); 
             tmpSize = calcMessageSize(message);
         }
         return currIndex; 


### PR DESCRIPTION
Fix variable name typo: 'curIndex' -> 'currIndex' in the getStartIndex() method. All other references in the same method use 'currIndex', making this a clear copy-paste error.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
