### PR TITLE
[DOCS] Add missing setNamesrvAddr in Chinese Example_Delay.md

### DIFF
--- a/docs/cn/Example_Delay.md
+++ b/docs/cn/Example_Delay.md
@@ -15,6 +15,8 @@ public class ScheduledMessageConsumer {
     public static void main(String[] args) throws Exception {
         // Instantiate message consumer
         DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("ExampleConsumer");
+        // 设置NameServer地址
+        consumer.setNamesrvAddr("localhost:9876");
         // Subscribe topics
         consumer.subscribe("TestTopic", "*");
         // Register message listener
@@ -46,6 +48,8 @@ public class ScheduledMessageProducer {
     public static void main(String[] args) throws Exception {
         // Instantiate a producer to send scheduled messages
         DefaultMQProducer producer = new DefaultMQProducer("ExampleProducerGroup");
+        // 设置NameServer地址
+        producer.setNamesrvAddr("localhost:9876");
         // Launch producer
         producer.start();
         int totalMessagesToSend = 100;


### PR DESCRIPTION
Add the missing setNamesrvAddr() calls in consumer and producer setup code examples to align with the English version and other Chinese example files.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
