### PR TITLE
[BUG] Add logging to empty catch block in DefaultRecallMessageTraceHook

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/trace/hook/DefaultRecallMessageTraceHook.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/hook/DefaultRecallMessageTraceHook.java
@@ -18,6 +18,8 @@
 package org.apache.rocketmq.client.trace.hook;
 
 import org.apache.rocketmq.client.trace.TraceBean;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.client.trace.TraceContext;
 import org.apache.rocketmq.client.trace.TraceDispatcher;
 import org.apache.rocketmq.client.trace.TraceType;
@@ -33,7 +35,7 @@ import org.apache.rocketmq.remoting.protocol.header.RecallMessageRequestHeader;
 import java.util.ArrayList;
 
 public class DefaultRecallMessageTraceHook implements RPCHook {
-
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultRecallMessageTraceHook.class);
     private static final String RECALL_TRACE_ENABLE_KEY = "com.rocketmq.recall.default.trace.enable";
     private boolean enableDefaultTrace = Boolean.parseBoolean(System.getProperty(RECALL_TRACE_ENABLE_KEY, "false"));
     private TraceDispatcher traceDispatcher;
@@ -80,6 +82,7 @@ public class DefaultRecallMessageTraceHook implements RPCHook {
 
             traceDispatcher.append(traceContext);
         } catch (Exception e) {
+            LOG.error("Failed to append recall trace context", e);
         }
     }
 }


### PR DESCRIPTION
The catch block in doAfterResponse() was silently swallowing exceptions without any logging, making debugging impossible. Added LOG.error() to properly log exceptions when recall trace context fails to append.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
