### PR TITLE
[ISSUE #9926] Avoid redundant list allocation in parsePublishMessageQueues

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
@@ -157,9 +157,14 @@ public class MQAdminImpl {
     }
 
     public List<MessageQueue> parsePublishMessageQueues(List<MessageQueue> messageQueueList) {
-        List<MessageQueue> resultQueues = new ArrayList<>();
+        String namespace = this.mQClientFactory.getClientConfig().getNamespace();
+        if (namespace == null || namespace.isEmpty()) {
+            return messageQueueList;
+        }
+
+        List<MessageQueue> resultQueues = new ArrayList<>(messageQueueList.size());
         for (MessageQueue queue : messageQueueList) {
-            String userTopic = NamespaceUtil.withoutNamespace(queue.getTopic(), this.mQClientFactory.getClientConfig().getNamespace());
+            String userTopic = NamespaceUtil.withoutNamespace(queue.getTopic(), namespace);
             resultQueues.add(new MessageQueue(userTopic, queue.getBrokerName(), queue.getQueueId()));
         }
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/MQAdminImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/MQAdminImplTest.java
@@ -44,6 +44,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +52,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -213,6 +215,34 @@ public class MQAdminImplTest {
         result.setBrokerDatas(createBrokerData());
         result.setQueueDatas(createQueueData());
         return result;
+    }
+
+    @Test
+    public void assertParsePublishMessageQueuesReturnsOriginalListWhenNoNamespace() {
+        ClientConfig clientConfig = mock(ClientConfig.class);
+        when(clientConfig.getNamespace()).thenReturn(null);
+        when(mQClientFactory.getClientConfig()).thenReturn(clientConfig);
+        MQAdminImpl adminNoNs = new MQAdminImpl(mQClientFactory);
+
+        List<MessageQueue> original = new ArrayList<>();
+        original.add(new MessageQueue("TopicA", "broker-0", 0));
+        original.add(new MessageQueue("TopicA", "broker-0", 1));
+
+        List<MessageQueue> result = adminNoNs.parsePublishMessageQueues(original);
+        assertSame(original, result);
+    }
+
+    @Test
+    public void assertParsePublishMessageQueuesStripsNamespace() {
+        List<MessageQueue> original = new ArrayList<>();
+        original.add(new MessageQueue("namespace%TopicA", "broker-0", 0));
+        original.add(new MessageQueue("namespace%TopicA", "broker-0", 1));
+
+        List<MessageQueue> result = mqAdminImpl.parsePublishMessageQueues(original);
+        assertEquals(2, result.size());
+        for (MessageQueue mq : result) {
+            assertEquals("TopicA", mq.getTopic());
+        }
     }
 
     private List<BrokerData> createBrokerData() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #9926

### Brief Description

`MQAdminImpl.parsePublishMessageQueues()` is called on every message send (hot path). Under high throughput (50K+ TPS), it creates significant GC pressure by allocating a new `ArrayList` and N new `MessageQueue` objects per call — even when namespace is empty (the common case for most users), where the copied data is identical to the original.

**Changes:**
1. When namespace is null or empty, return the original list directly (zero allocation)
2. When namespace stripping is needed, pre-allocate `ArrayList` with exact capacity to avoid internal array resizing
3. Cache the namespace string to avoid repeated `getNamespace()` calls in the loop

**Impact:** Eliminates per-message object allocation on the send path for the majority of users who don't use namespaces. For users with namespaces, reduces allocation by pre-sizing the list.

### How Did You Test This Change?

- Added unit test `assertParsePublishMessageQueuesReturnsOriginalListWhenNoNamespace` — verifies same list instance is returned when namespace is empty
- Added unit test `assertParsePublishMessageQueuesStripsNamespace` — verifies namespace stripping still works correctly
- Ran full client module test suite: 566 tests passed, 0 failures