### PR TITLE
[ISSUE #10381] Make HashedWheelTimer parameters configurable in QueueLevelConsumerOrderInfoLockManager

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/orderly/QueueLevelConsumerOrderInfoLockManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/orderly/QueueLevelConsumerOrderInfoLockManager.java
@@ -35,18 +35,18 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 
 public class QueueLevelConsumerOrderInfoLockManager {
     private static final Logger POP_LOGGER = LoggerFactory.getLogger(LoggerName.ROCKETMQ_POP_LOGGER_NAME);
-    private ConsumerOrderInfoManager consumerOrderInfoManager;
 
     private final BrokerController brokerController;
     private final Map<Key, Timeout> timeoutMap = new ConcurrentHashMap<>();
     private final Timer timer;
-    private static final int TIMER_TICK_MS = 100;
 
     public QueueLevelConsumerOrderInfoLockManager(BrokerController brokerController) {
         this.brokerController = brokerController;
+        long tickMs = brokerController.getBrokerConfig().getPopOrderLockTimerTickMs();
+        int ticksPerWheel = brokerController.getBrokerConfig().getPopOrderLockTimerTicksPerWheel();
         this.timer = new HashedWheelTimer(
             new ThreadFactoryImpl("ConsumerOrderInfoLockManager_"),
-            TIMER_TICK_MS, TimeUnit.MILLISECONDS);
+            tickMs, TimeUnit.MILLISECONDS, ticksPerWheel);
     }
 
     /**

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/LiteManagerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/LiteManagerProcessorTest.java
@@ -146,6 +146,7 @@ public class LiteManagerProcessorTest {
         when(brokerController.getLiteEventDispatcher()).thenReturn(liteEventDispatcher);
         when(brokerController.getPopLiteMessageProcessor()).thenReturn(popLiteMessageProcessor);
         when(brokerController.getConsumerOffsetManager()).thenReturn(consumerOffsetManager);
+        when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
 
         ConsumerOrderInfoManager consumerOrderInfoManager = new MemoryConsumerOrderInfoManager(brokerController);
         when(popLiteMessageProcessor.getConsumerOrderInfoManager()).thenReturn(consumerOrderInfoManager);

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -572,6 +572,10 @@ public class BrokerConfig extends BrokerIdentity {
 
     private int liteLagLatencyTopK = 50;
 
+    // HashedWheelTimer config for pop order lock manager
+    private long popOrderLockTimerTickMs = 100;
+    private int popOrderLockTimerTicksPerWheel = 512;
+
     public String getConfigBlackList() {
         return configBlackList;
     }
@@ -2487,6 +2491,22 @@ public class BrokerConfig extends BrokerIdentity {
 
     public void setLiteLagLatencyTopK(int liteLagLatencyTopK) {
         this.liteLagLatencyTopK = liteLagLatencyTopK;
+    }
+
+    public long getPopOrderLockTimerTickMs() {
+        return popOrderLockTimerTickMs;
+    }
+
+    public void setPopOrderLockTimerTickMs(long popOrderLockTimerTickMs) {
+        this.popOrderLockTimerTickMs = popOrderLockTimerTickMs;
+    }
+
+    public int getPopOrderLockTimerTicksPerWheel() {
+        return popOrderLockTimerTicksPerWheel;
+    }
+
+    public void setPopOrderLockTimerTicksPerWheel(int popOrderLockTimerTicksPerWheel) {
+        this.popOrderLockTimerTicksPerWheel = popOrderLockTimerTicksPerWheel;
     }
 
     public boolean isUseMessageFilterForNotification() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10381

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

- Add popOrderLockTimerTickMs and popOrderLockTimerTicksPerWheel to BrokerConfig
- Replace hardcoded TIMER_TICK_MS constant with configurable values from BrokerConfig
- Remove unused field consumerOrderInfoManager
- Default values (tickMs=100, ticksPerWheel=512) preserve backward compatibility