### PR TITLE
Fix: Prevent %RETRY% topic creation on brokers not hosting subscribed topics

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AbstractSendMessageProcessor.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.broker.client.ConsumerGroupInfo;
 import org.apache.rocketmq.broker.metrics.BrokerMetricsManager;
 import org.apache.rocketmq.broker.mqtrace.ConsumeMessageContext;
 import org.apache.rocketmq.broker.mqtrace.ConsumeMessageHook;
@@ -505,10 +506,14 @@ public abstract class AbstractSendMessageProcessor implements NettyRequestProces
 
             if (null == topicConfig) {
                 if (requestHeader.getTopic().startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) {
-                    topicConfig =
-                        this.brokerController.getTopicConfigManager().createTopicInSendMessageBackMethod(
-                            requestHeader.getTopic(), 1, PermName.PERM_WRITE | PermName.PERM_READ,
-                            topicSysFlag);
+                    String consumerGroup = requestHeader.getTopic().substring(
+                        MixAll.RETRY_GROUP_TOPIC_PREFIX.length());
+                    if (isConsumerGroupSubscribedTopicOnThisBroker(consumerGroup)) {
+                        topicConfig =
+                            this.brokerController.getTopicConfigManager().createTopicInSendMessageBackMethod(
+                                requestHeader.getTopic(), 1, PermName.PERM_WRITE | PermName.PERM_READ,
+                                topicSysFlag);
+                    }
                 }
             }
 
@@ -587,6 +592,24 @@ public abstract class AbstractSendMessageProcessor implements NettyRequestProces
                 }
             }
         }
+    }
+
+    private boolean isConsumerGroupSubscribedTopicOnThisBroker(String consumerGroup) {
+        ConsumerGroupInfo consumerGroupInfo = this.brokerController.getConsumerManager()
+            .getConsumerGroupInfo(consumerGroup);
+        if (consumerGroupInfo == null) {
+            return true;
+        }
+        for (String topic : consumerGroupInfo.getSubscribeTopics()) {
+            if (topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)
+                || topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX)) {
+                continue;
+            }
+            if (this.brokerController.getTopicConfigManager().containsTopic(topic)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ClientManageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ClientManageProcessor.java
@@ -114,13 +114,28 @@ public class ClientManageProcessor implements NettyRequestProcessor {
             }
 
             isNotifyConsumerIdsChangedEnable = subscriptionGroupConfig.isNotifyConsumerIdsChangedEnable();
-            int topicSysFlag = 0;
-            if (consumerData.isUnitMode()) {
-                topicSysFlag = TopicSysFlag.buildSysFlag(false, true);
+
+            boolean shouldCreateRetryTopic = false;
+            for (SubscriptionData subscriptionData : consumerData.getSubscriptionDataSet()) {
+                String topic = subscriptionData.getTopic();
+                if (topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)
+                    || topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX)) {
+                    continue;
+                }
+                if (this.brokerController.getTopicConfigManager().containsTopic(topic)) {
+                    shouldCreateRetryTopic = true;
+                    break;
+                }
             }
-            String newTopic = MixAll.getRetryTopic(consumerData.getGroupName());
-            this.brokerController.getTopicConfigManager().createTopicInSendMessageBackMethod(newTopic, subscriptionGroupConfig.getRetryQueueNums(),
-                PermName.PERM_WRITE | PermName.PERM_READ, hasOrderTopicSub, topicSysFlag);
+            if (shouldCreateRetryTopic) {
+                int topicSysFlag = 0;
+                if (consumerData.isUnitMode()) {
+                    topicSysFlag = TopicSysFlag.buildSysFlag(false, true);
+                }
+                String newTopic = MixAll.getRetryTopic(consumerData.getGroupName());
+                this.brokerController.getTopicConfigManager().createTopicInSendMessageBackMethod(newTopic, subscriptionGroupConfig.getRetryQueueNums(),
+                    PermName.PERM_WRITE | PermName.PERM_READ, hasOrderTopicSub, topicSysFlag);
+            }
 
             boolean changed = this.brokerController.getConsumerManager().registerConsumer(
                 consumerData.getGroupName(),
@@ -176,12 +191,27 @@ public class ClientManageProcessor implements NettyRequestProcessor {
                 continue;
             }
             isNotifyConsumerIdsChangedEnable = subscriptionGroupConfig.isNotifyConsumerIdsChangedEnable();
-            int topicSysFlag = 0;
-            if (consumerData.isUnitMode()) {
-                topicSysFlag = TopicSysFlag.buildSysFlag(false, true);
+
+            boolean shouldCreateRetryTopic = false;
+            for (SubscriptionData subscriptionData : consumerData.getSubscriptionDataSet()) {
+                String topic = subscriptionData.getTopic();
+                if (topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)
+                    || topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX)) {
+                    continue;
+                }
+                if (this.brokerController.getTopicConfigManager().containsTopic(topic)) {
+                    shouldCreateRetryTopic = true;
+                    break;
+                }
             }
-            String newTopic = MixAll.getRetryTopic(consumerData.getGroupName());
-            this.brokerController.getTopicConfigManager().createTopicInSendMessageBackMethod(newTopic, subscriptionGroupConfig.getRetryQueueNums(), PermName.PERM_WRITE | PermName.PERM_READ, hasOrderTopicSub, topicSysFlag);
+            if (shouldCreateRetryTopic) {
+                int topicSysFlag = 0;
+                if (consumerData.isUnitMode()) {
+                    topicSysFlag = TopicSysFlag.buildSysFlag(false, true);
+                }
+                String newTopic = MixAll.getRetryTopic(consumerData.getGroupName());
+                this.brokerController.getTopicConfigManager().createTopicInSendMessageBackMethod(newTopic, subscriptionGroupConfig.getRetryQueueNums(), PermName.PERM_WRITE | PermName.PERM_READ, hasOrderTopicSub, topicSysFlag);
+            }
             boolean changed = false;
             if (heartbeatData.isWithoutSub()) {
                 changed = this.brokerController.getConsumerManager().registerConsumerWithoutSub(consumerData.getGroupName(), clientChannelInfo, consumerData.getConsumeType(), consumerData.getMessageModel(), consumerData.getConsumeFromWhere(), isNotifyConsumerIdsChangedEnable);


### PR DESCRIPTION
## Summary

Fix for [#10405](https://github.com/apache/rocketmq/issues/10405): When orderly consumer consume message fails and reaches `maxReconsumeTimes`, the `%RETRY%` topic is unconditionally created on all brokers, including those that don't host the original topic.

## Root Cause

Two code paths create `%RETRY%` topic without checking if the broker actually hosts any of the consumer's subscribed topics:

1. **`ClientManageProcessor.java`** (heartbeat path) — `registerConsumer()` unconditionally creates `%RETRY%<group>` for every consumer heartbeat
2. **`AbstractSendMessageProcessor.java`** (msgCheck fallback) — Creates retry topic without broker-topic validation

## Fix

Added guard conditions in both paths:

1. **ClientManageProcessor** — Before creating `%RETRY%` topic, iterate through the consumer's subscription set and verify at least one subscribed topic (excluding `%RETRY%`/`%DLQ%` system topics) exists on this broker via `containsTopic()`. Only create `%RETRY%` if the check passes.

2. **AbstractSendMessageProcessor** — In the `msgCheck` fallback path, extract the consumer group from the retry topic name and perform the same validation before creating the topic.

## Impact

- Reduces unnecessary topic metadata bloat across brokers
- Prevents confusing `%RETRY%` routes on brokers that have no relevant data
- No behavioral change for brokers that DO host subscribed topics
- Backward compatible — existing retry flow continues to work normally

Closes #10405