### PR TITLE
[ISSUE #10405] Fix orderly consumer retry message routed to wrong broker via TBW102 fallback

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
@@ -404,8 +404,12 @@ public class ConsumeMessageOrderlyService implements ConsumeMessageService {
     }
 
     private boolean trySendToTopicBroker(Message retryMsg, MessageExt originalMsg) {
-        Set<MessageQueue> mqs = this.defaultMQPushConsumerImpl.getRebalanceImpl()
-            .getTopicSubscribeInfoTable().get(originalMsg.getTopic());
+        java.util.concurrent.ConcurrentMap<String, Set<MessageQueue>> table =
+            this.defaultMQPushConsumerImpl.getRebalanceImpl().getTopicSubscribeInfoTable();
+        if (table == null) {
+            return false;
+        }
+        Set<MessageQueue> mqs = table.get(originalMsg.getTopic());
         if (mqs == null || mqs.isEmpty()) {
             return false;
         }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
@@ -19,7 +19,9 @@ package org.apache.rocketmq.client.impl.consumer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -390,12 +392,42 @@ public class ConsumeMessageOrderlyService implements ConsumeMessageService {
             MessageAccessor.clearProperty(newMsg, MessageConst.PROPERTY_TRANSACTION_PREPARED);
             newMsg.setDelayTimeLevel(3 + msg.getReconsumeTimes());
 
-            this.defaultMQPushConsumerImpl.getmQClientFactory().getDefaultMQProducer().send(newMsg);
+            if (!trySendToTopicBroker(newMsg, msg)) {
+                this.defaultMQPushConsumerImpl.getmQClientFactory().getDefaultMQProducer().send(newMsg);
+            }
             return true;
         } catch (Exception e) {
             log.error("sendMessageBack exception, group: " + this.consumerGroup + " msg: " + msg.toString(), e);
         }
 
+        return false;
+    }
+
+    private boolean trySendToTopicBroker(Message retryMsg, MessageExt originalMsg) {
+        Set<MessageQueue> mqs = this.defaultMQPushConsumerImpl.getRebalanceImpl()
+            .getTopicSubscribeInfoTable().get(originalMsg.getTopic());
+        if (mqs == null || mqs.isEmpty()) {
+            return false;
+        }
+
+        Set<String> brokerNames = new LinkedHashSet<>();
+        String originalBroker = originalMsg.getBrokerName();
+        if (originalBroker != null) {
+            brokerNames.add(originalBroker);
+        }
+        for (MessageQueue mq : mqs) {
+            brokerNames.add(mq.getBrokerName());
+        }
+
+        for (String brokerName : brokerNames) {
+            try {
+                MessageQueue retryMQ = new MessageQueue(retryMsg.getTopic(), brokerName, 0);
+                this.defaultMQPushConsumerImpl.getmQClientFactory().getDefaultMQProducer().send(retryMsg, retryMQ);
+                return true;
+            } catch (Exception e) {
+                log.warn("Failed to send retry message to broker {}, trying next", brokerName, e);
+            }
+        }
         return false;
     }
 

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopOrderlyService.java
@@ -318,8 +318,12 @@ public class ConsumeMessagePopOrderlyService implements ConsumeMessageService {
     }
 
     private boolean trySendToTopicBroker(Message retryMsg, MessageExt originalMsg) {
-        Set<MessageQueue> mqs = this.defaultMQPushConsumerImpl.getRebalanceImpl()
-            .getTopicSubscribeInfoTable().get(originalMsg.getTopic());
+        java.util.concurrent.ConcurrentMap<String, Set<MessageQueue>> table =
+            this.defaultMQPushConsumerImpl.getRebalanceImpl().getTopicSubscribeInfoTable();
+        if (table == null) {
+            return false;
+        }
+        Set<MessageQueue> mqs = table.get(originalMsg.getTopic());
         if (mqs == null || mqs.isEmpty()) {
             return false;
         }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopOrderlyService.java
@@ -18,7 +18,9 @@ package org.apache.rocketmq.client.impl.consumer;
 
 import io.netty.util.internal.ConcurrentSet;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -304,12 +306,42 @@ public class ConsumeMessagePopOrderlyService implements ConsumeMessageService {
             MessageAccessor.setMaxReconsumeTimes(newMsg, String.valueOf(getMaxReconsumeTimes()));
             newMsg.setDelayTimeLevel(3 + msg.getReconsumeTimes());
 
-            this.defaultMQPushConsumerImpl.getmQClientFactory().getDefaultMQProducer().send(newMsg);
+            if (!trySendToTopicBroker(newMsg, msg)) {
+                this.defaultMQPushConsumerImpl.getmQClientFactory().getDefaultMQProducer().send(newMsg);
+            }
             return true;
         } catch (Exception e) {
             log.error("sendMessageBack exception, group: " + this.consumerGroup + " msg: " + msg.toString(), e);
         }
 
+        return false;
+    }
+
+    private boolean trySendToTopicBroker(Message retryMsg, MessageExt originalMsg) {
+        Set<MessageQueue> mqs = this.defaultMQPushConsumerImpl.getRebalanceImpl()
+            .getTopicSubscribeInfoTable().get(originalMsg.getTopic());
+        if (mqs == null || mqs.isEmpty()) {
+            return false;
+        }
+
+        Set<String> brokerNames = new LinkedHashSet<>();
+        String originalBroker = originalMsg.getBrokerName();
+        if (originalBroker != null) {
+            brokerNames.add(originalBroker);
+        }
+        for (MessageQueue mq : mqs) {
+            brokerNames.add(mq.getBrokerName());
+        }
+
+        for (String brokerName : brokerNames) {
+            try {
+                MessageQueue retryMQ = new MessageQueue(retryMsg.getTopic(), brokerName, 0);
+                this.defaultMQPushConsumerImpl.getmQClientFactory().getDefaultMQProducer().send(retryMsg, retryMQ);
+                return true;
+            } catch (Exception e) {
+                log.warn("Failed to send retry message to broker {}, trying next", brokerName, e);
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
## Summary

- Fix `ConsumeMessageOrderlyService.sendMessageBack()` and `ConsumeMessagePopOrderlyService.sendMessageBack()` to route retry messages to brokers that actually host the original topic, instead of falling back to TBW102 which routes to all brokers in the cluster.

## Root Cause

When an orderly consumer's reconsume times reach `maxReconsumeTimes`, `sendMessageBack()` sends the retry message via `getDefaultMQProducer().send(newMsg)` — a normal producer send. Since the `%RETRY%` topic doesn't exist yet, the producer falls back to TBW102 (a system topic present on ALL brokers) for broker selection. This causes the `%RETRY%` topic to be auto-created on brokers that don't host the original topic.

**Contrast with concurrent consumers**: `ConsumeMessageConcurrentlyService` uses `consumerSendMsgBack` which targets `msg.getBrokerName()` directly — no TBW102 fallback.

## Fix

Added `trySendToTopicBroker()` to both orderly service classes. It uses the consumer's existing `topicSubscribeInfoTable` (route info for the original topic) to select candidate brokers:

1. **Prefer original broker** — the broker where the message was consumed
2. **Failover to other brokers hosting the topic** — if the original broker is down
3. **Final fallback to default send** — only when route info is unavailable (should not happen in practice)

## Impact

| Scenario | Before | After |
|---|---|---|
| Original broker alive | May route to any broker (TBW102) | Routes to original broker ✓ |
| Original broker down | Routes to any broker | Failover to other brokers hosting the topic ✓ |
| All topic brokers down | Routes to any broker | Same (fallback) |

No behavioral change for brokers that DO host the original topic. Backward compatible.

## Test plan

- [ ] Verify `trySendToTopicBroker` prefers the original broker when available
- [ ] Verify failover to another broker when original broker send fails
- [ ] Verify fallback to default send when route info is empty
- [ ] Integration test: proxy cluster mode with multi-broker, orderly consumer hitting maxReconsumeTimes — `%RETRY%` should only appear on brokers hosting the original topic

Closes #10405

🤖 Generated with [Claude Code](https://claude.com/claude-code)