### PR TITLE
[ISSUE #10410] Fix RocksDBOptionsFactoryTest compile failure

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerOuterAPITest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerOuterAPITest.java
@@ -44,6 +44,7 @@ import org.apache.rocketmq.common.BrokerIdentity;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.common.SemaphoreReleaseOnlyOnce;
 import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
@@ -334,12 +335,7 @@ public class BrokerOuterAPITest {
 
     @Test
     public void testPullMessageFromSpecificBrokerAsync_brokerReturn_pullStatusCode() throws Exception {
-        Channel channel = Mockito.mock(Channel.class);
-        when(channel.isActive()).thenReturn(true);
-        NettyRemotingClient mockClient = PowerMockito.spy(new NettyRemotingClient(new NettyClientConfig()));
-        DefaultChannelPromise promise = PowerMockito.spy(new DefaultChannelPromise(PowerMockito.mock(Channel.class), new DefaultEventExecutor()));
-        PowerMockito.when(mockClient, "getAndCreateChannelAsync", any()).thenReturn(promise);
-        when(promise.channel()).thenReturn(channel);
+        NettyRemotingClient mockClient = Mockito.mock(NettyRemotingClient.class);
         BrokerOuterAPI api = new BrokerOuterAPI(new NettyClientConfig(), new AuthConfig());
         Field field = BrokerOuterAPI.class.getDeclaredField("remotingClient");
         field.setAccessible(true);
@@ -348,14 +344,12 @@ public class BrokerOuterAPITest {
         int[] respCodes = new int[] {ResponseCode.SUCCESS, ResponseCode.PULL_NOT_FOUND, ResponseCode.PULL_RETRY_IMMEDIATELY, ResponseCode.PULL_OFFSET_MOVED};
         PullStatus[] respStatus = new PullStatus[] {PullStatus.FOUND, PullStatus.NO_NEW_MSG, PullStatus.NO_MATCHED_MSG, PullStatus.OFFSET_ILLEGAL};
         for (int i = 0; i < respCodes.length; i++) {
-            CompletableFuture<ResponseFuture> future = new CompletableFuture<>();
-            doReturn(future).when(mockClient).invokeImpl(any(Channel.class), any(RemotingCommand.class), anyLong());
             RemotingCommand response = mockPullMessageResponse(respCodes[i]);
-            ResponseFuture responseFuture = new ResponseFuture(channel, 0, null, 1000,
-                    resp -> { }, new SemaphoreReleaseOnlyOnce(new Semaphore(1)));
-            responseFuture.setResponseCommand(response);
-            promise.trySuccess(null);
-            future.complete(responseFuture);
+            Mockito.doAnswer(invocation -> {
+                InvokeCallback callback = invocation.getArgument(3);
+                callback.operationSucceed(response);
+                return null;
+            }).when(mockClient).invokeAsync(anyString(), any(RemotingCommand.class), anyLong(), any(InvokeCallback.class));
 
             Triple<PullResult, String, Boolean> rst = api.pullMessageFromSpecificBrokerAsync("", "", "", "", 1, 1, 1, 3000L).join();
             Assert.assertEquals(respStatus[i], rst.getLeft().getPullStatus());

--- a/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/consumer/DefaultLitePullConsumerTest.java
@@ -75,7 +75,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -727,7 +726,7 @@ public class DefaultLitePullConsumerTest {
         field.setAccessible(true);
         field.set(litePullConsumerImpl, offsetStore);
 
-        when(mQClientFactory.getMQClientAPIImpl().pullMessage(anyString(), any(PullMessageRequestHeader.class),
+        when(mQClientAPIImpl.pullMessage(anyString(), any(PullMessageRequestHeader.class),
             anyLong(), any(CommunicationMode.class), nullable(PullCallback.class)))
             .thenAnswer(new Answer<PullResult>() {
                 @Override
@@ -746,9 +745,11 @@ public class DefaultLitePullConsumerTest {
                 }
             });
 
-        doAnswer(x -> new FindBrokerResult("127.0.0.1:10911", false)).when(mQClientFactory).findBrokerAddressInSubscribe(anyString(), anyLong(), anyBoolean());
+        doReturn(new FindBrokerResult("127.0.0.1:10911", false))
+            .when(mQClientFactory).findBrokerAddressInSubscribe(anyString(), anyLong(), anyBoolean());
 
-        doReturn(Collections.singletonList(mQClientFactory.getClientId())).when(mQClientFactory).findConsumerIdList(anyString(), anyString());
+        String clientId = mQClientFactory.getClientId();
+        doReturn(Collections.singletonList(clientId)).when(mQClientFactory).findConsumerIdList(anyString(), anyString());
 
         doReturn(123L).when(offsetStore).readOffset(any(MessageQueue.class), any(ReadOffsetType.class));
     }
@@ -787,7 +788,7 @@ public class DefaultLitePullConsumerTest {
         field.setAccessible(true);
         field.set(litePullConsumerImpl, offsetStore);
 
-        when(mQClientFactory.getMQClientAPIImpl().pullMessage(anyString(), any(PullMessageRequestHeader.class),
+        when(mQClientAPIImpl.pullMessage(anyString(), any(PullMessageRequestHeader.class),
             anyLong(), any(CommunicationMode.class), nullable(PullCallback.class)))
             .thenAnswer(new Answer<PullResult>() {
                 @Override
@@ -807,7 +808,8 @@ public class DefaultLitePullConsumerTest {
                 }
             });
 
-        when(mQClientFactory.findBrokerAddressInSubscribe(anyString(), anyLong(), anyBoolean())).thenReturn(new FindBrokerResult("127.0.0.1:10911", false));
+        doReturn(new FindBrokerResult("127.0.0.1:10911", false))
+            .when(mQClientFactory).findBrokerAddressInSubscribe(anyString(), anyLong(), anyBoolean());
 
         doReturn(123L).when(offsetStore).readOffset(any(MessageQueue.class), any(ReadOffsetType.class));
     }

--- a/store/src/test/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactoryTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/rocksdb/RocksDBOptionsFactoryTest.java
@@ -52,8 +52,7 @@ public class RocksDBOptionsFactoryTest {
         MessageStore messageStore = mock(MessageStore.class);
         when(messageStore.getMessageStoreConfig()).thenReturn(config);
 
-        ConsumeQueueCompactionFilterFactory compactionFilterFactory = new ConsumeQueueCompactionFilterFactory(() -> 0);
-        try (ColumnFamilyOptions options = RocksDBOptionsFactory.createCQCFOptions(messageStore, compactionFilterFactory);
+        try (ColumnFamilyOptions options = RocksDBOptionsFactory.createCQCFOptions(messageStore);
             CompactionOptionsUniversal compactionOptions = options.compactionOptionsUniversal()) {
             Assert.assertEquals(50, compactionOptions.maxSizeAmplificationPercent());
         }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10410
Fixes #10412
Fixes #10413

### Brief Description

`RocksDBOptionsFactoryTest` referenced a non-existent `ConsumeQueueCompactionFilterFactory` and called a non-existent overload of `RocksDBOptionsFactory.createCQCFOptions`, causing `rocketmq-store` test compilation to fail. This PR updates the test to call the current `createCQCFOptions(MessageStore)` API directly.

It also stabilizes `BrokerOuterAPITest.testPullMessageFromSpecificBrokerAsync_brokerReturn_pullStatusCode` by mocking the `invokeAsync` callback directly for each broker response code. The previous test reused a completed Netty `DefaultChannelPromise` and repeatedly re-stubbed the same spy in a loop, making it sensitive to listener scheduling on macOS CI.

Finally, it stabilizes `DefaultLitePullConsumerTest.testSubscribe_BroadcastPollMessageSuccess` by stubbing the injected `MQClientAPIImpl` mock directly and avoiding spy calls while preparing Mockito stubs.

### How Did You Test This Change?

- `git diff --check`
- `mvn -pl store -am -DskipTests test-compile`
- `mvn -pl common,remoting,store -Dtest=org.apache.rocketmq.store.rocksdb.RocksDBOptionsFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl broker -am -DskipTests test-compile`
- `mvn -pl broker -am -Djacoco.skip=true -DargLine='--add-exports=java.xml/jdk.xml.internal=ALL-UNNAMED' -Dtest=org.apache.rocketmq.broker.BrokerOuterAPITest#testPullMessageFromSpecificBrokerAsync_brokerReturn_pullStatusCode -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl client -am -Djacoco.skip=true -Dtest=org.apache.rocketmq.client.consumer.DefaultLitePullConsumerTest#testSubscribe_BroadcastPollMessageSuccess -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl client -am -Djacoco.skip=true -Dtest=org.apache.rocketmq.client.consumer.DefaultLitePullConsumerTest -Dsurefire.failIfNoSpecifiedTests=false test`
