### PR TITLE
[ISSUE #10419] Fix NPE when class filter route data is missing

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapper.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapper.java
@@ -299,10 +299,12 @@ public class PullAPIWrapper {
         ConcurrentMap<String, TopicRouteData> topicRouteTable = this.mQClientFactory.getTopicRouteTable();
         if (topicRouteTable != null) {
             TopicRouteData topicRouteData = topicRouteTable.get(topic);
-            List<String> list = topicRouteData.getFilterServerTable().get(brokerAddr);
+            if (topicRouteData != null && topicRouteData.getFilterServerTable() != null) {
+                List<String> list = topicRouteData.getFilterServerTable().get(brokerAddr);
 
-            if (list != null && !list.isEmpty()) {
-                return list.get(randomNum() % list.size());
+                if (list != null && !list.isEmpty()) {
+                    return list.get(randomNum() % list.size());
+                }
             }
         }
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapperTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapperTest.java
@@ -60,6 +60,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -151,6 +152,29 @@ public class PullAPIWrapperTest {
                 eq(defaultTimeout),
                 any(CommunicationMode.class),
                 any(PullCallback.class));
+    }
+
+    @Test
+    public void testPullKernelImplWithMissingTopicRouteDataForClassFilter() {
+        when(mQClientFactory.getTopicRouteTable()).thenReturn(new ConcurrentHashMap<>());
+
+        MQClientException actual = assertThrows(MQClientException.class, () -> pullAPIWrapper.pullKernelImpl(
+            createMessageQueue(),
+            "",
+            "",
+            1L,
+            1L,
+            1,
+            1,
+            PullSysFlag.buildSysFlag(false, false, false, true),
+            1L,
+            System.currentTimeMillis(),
+            defaultTimeout,
+            CommunicationMode.SYNC,
+            null
+        ));
+
+        assertTrue(actual.getMessage().contains("Find Filter Server Failed"));
     }
 
     @Test

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapperTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapperTest.java
@@ -158,6 +158,45 @@ public class PullAPIWrapperTest {
     public void testPullKernelImplWithMissingTopicRouteDataForClassFilter() {
         when(mQClientFactory.getTopicRouteTable()).thenReturn(new ConcurrentHashMap<>());
 
+        assertFindFilterServerFailed();
+    }
+
+    @Test
+    public void testPullKernelImplWithMissingFilterServerTableForClassFilter() {
+        TopicRouteData topicRouteData = new TopicRouteData();
+        topicRouteData.setFilterServerTable(null);
+        ConcurrentMap<String, TopicRouteData> topicRouteTable = new ConcurrentHashMap<>();
+        topicRouteTable.put(defaultTopic, topicRouteData);
+        when(mQClientFactory.getTopicRouteTable()).thenReturn(topicRouteTable);
+
+        assertFindFilterServerFailed();
+    }
+
+    @Test
+    public void testPullKernelImplWithMissingBrokerFilterServerForClassFilter() {
+        TopicRouteData topicRouteData = new TopicRouteData();
+        topicRouteData.setFilterServerTable(new HashMap<>());
+        ConcurrentMap<String, TopicRouteData> topicRouteTable = new ConcurrentHashMap<>();
+        topicRouteTable.put(defaultTopic, topicRouteData);
+        when(mQClientFactory.getTopicRouteTable()).thenReturn(topicRouteTable);
+
+        assertFindFilterServerFailed();
+    }
+
+    @Test
+    public void testPullKernelImplWithEmptyFilterServerListForClassFilter() {
+        TopicRouteData topicRouteData = new TopicRouteData();
+        HashMap<String, List<String>> filterServerTable = new HashMap<>();
+        filterServerTable.put(defaultBrokerAddr, new ArrayList<>());
+        topicRouteData.setFilterServerTable(filterServerTable);
+        ConcurrentMap<String, TopicRouteData> topicRouteTable = new ConcurrentHashMap<>();
+        topicRouteTable.put(defaultTopic, topicRouteData);
+        when(mQClientFactory.getTopicRouteTable()).thenReturn(topicRouteTable);
+
+        assertFindFilterServerFailed();
+    }
+
+    private void assertFindFilterServerFailed() {
         MQClientException actual = assertThrows(MQClientException.class, () -> pullAPIWrapper.pullKernelImpl(
             createMessageQueue(),
             "",


### PR DESCRIPTION

### Which Issue(s) This PR Fixes
- Fixes #10419

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->


### Brief Description



This PR avoids a potential `NullPointerException` in `PullAPIWrapper#computePullFromWhichFilterServer` when class filter is enabled but the local topic route table does not contain route data for the target topic.

Instead of dereferencing a missing `TopicRouteData`, the code falls through to the existing `MQClientException` path.



### How Did You Test This Change?
- Added a targeted unit test for missing topic route data.
- Ran:
```bash
mvn -pl client -Dtest=org.apache.rocketmq.client.impl.consumer.PullAPIWrapperTest -Djacoco.skip=true test
```
The test passed with `Tests run: 8, Failures: 0, Errors: 0, Skipped: 0`.

