### PR TITLE
[ISSUE #10425] Revert split registration dataVersion change

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -647,6 +647,9 @@ public class TopicConfigManager extends ConfigManager {
         topicConfigWrapper.setTopicConfigTable(topicConfigTable);
         topicConfigWrapper.setTopicQueueMappingInfoMap(topicQueueMappingInfoMap);
         topicConfigWrapper.setDataVersion(this.getDataVersion());
+        if (this.brokerController.getBrokerConfig().isEnableSplitRegistration()) {
+            this.getDataVersion().nextVersion();
+        }
         return topicConfigWrapper;
     }
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicConfigManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicConfigManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.common.attribute.LongRangeAttribute;
 import org.apache.rocketmq.common.constant.PermName;
 import org.apache.rocketmq.common.utils.QueueTypeUtils;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
+import org.apache.rocketmq.remoting.protocol.body.TopicConfigAndMappingSerializeWrapper;
 import org.apache.rocketmq.store.DefaultMessageStore;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Assert;
@@ -399,5 +400,18 @@ public class TopicConfigManagerTest {
         Assert.assertTrue(result.containsKey(String.format("topic%05d", ThreadLocalRandom.current().nextInt(beginIndex, endIndex))));
         Assert.assertFalse(result.containsKey(String.format("topic%05d", beginIndex - 1)));
         Assert.assertFalse(result.containsKey(String.format("topic%05d", endIndex + 1)));
+    }
+
+    @Test
+    public void testBuildSerializeWrapperUpdatesDataVersionWhenSplitRegistrationEnabled() {
+        brokerController.getBrokerConfig().setEnableSplitRegistration(true);
+        long counterBefore = topicConfigManager.getDataVersion().getCounter().get();
+
+        TopicConfigAndMappingSerializeWrapper wrapper =
+            topicConfigManager.buildSerializeWrapper(topicConfigManager.getTopicConfigTable());
+
+        long counterAfter = topicConfigManager.getDataVersion().getCounter().get();
+        Assert.assertEquals(counterBefore + 1, counterAfter);
+        Assert.assertEquals(counterAfter, wrapper.getDataVersion().getCounter().get());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

- Fixes #10425

### Brief Description

This reverts #9521 and restores the topic config `DataVersion` advancement when `enableSplitRegistration` is enabled.

With split broker registration, a broker sends topic configs to the name server in multiple registration requests. The name server records the broker `DataVersion` after each request and uses it to decide whether existing topic route data should be updated. If all split requests carry the same `DataVersion`, later batches can be treated as unchanged for topics that already exist under the broker.

Restoring the per-wrapper `DataVersion` advancement keeps each split registration batch visible as a distinct update. This PR also adds a focused regression test for `TopicConfigManager#buildSerializeWrapper`.

### How Did You Test This Change?

- `/usr/local/bin/mvn -pl broker -am -Dtest=TopicConfigManagerTest -DfailIfNoTests=false -DskipITs -DskipCheckStyle test`
