### PR TITLE
[ISSUE #10430] Add unit tests for srvutil package

### DIFF
--- a/srvutil/BUILD.bazel
+++ b/srvutil/BUILD.bazel
@@ -43,8 +43,10 @@ java_library(
         ":srvutil",
         "//common",
         "//:test_deps",
-        "@maven//:org_apache_commons_commons_lang3", 
-        "@maven//:io_netty_netty_all",               
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:commons_cli_commons_cli",
+        "@maven//:io_github_aliyunmq_rocketmq_slf4j_api",
+        "@maven//:io_netty_netty_all",
     ],
 )
 

--- a/srvutil/src/test/java/org/apache/rocketmq/srvutil/ServerUtilTest.java
+++ b/srvutil/src/test/java/org/apache/rocketmq/srvutil/ServerUtilTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.srvutil;
+
+import java.util.Properties;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class ServerUtilTest {
+
+    @Test
+    public void testBuildCommandlineOptions() {
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+
+        assertThat(options.getOptions()).hasSize(2);
+
+        Option helpOption = options.getOption("h");
+        assertThat(helpOption).isNotNull();
+        assertThat(helpOption.getLongOpt()).isEqualTo("help");
+        assertThat(helpOption.isRequired()).isFalse();
+        assertThat(helpOption.hasArg()).isFalse();
+
+        Option namesrvAddrOption = options.getOption("n");
+        assertThat(namesrvAddrOption).isNotNull();
+        assertThat(namesrvAddrOption.getLongOpt()).isEqualTo("namesrvAddr");
+        assertThat(namesrvAddrOption.isRequired()).isFalse();
+        assertThat(namesrvAddrOption.hasArg()).isTrue();
+    }
+
+    @Test
+    public void testCommandLine2Properties() {
+        CommandLine commandLine = Mockito.mock(CommandLine.class);
+        Option helpOption = new Option("h", "help", false, "Print help");
+        Option namesrvAddrOption = new Option("n", "namesrvAddr", true, "Name server address list");
+
+        when(commandLine.getOptions()).thenReturn(new Option[] {helpOption, namesrvAddrOption});
+        when(commandLine.getOptionValue("help")).thenReturn(null);
+        when(commandLine.getOptionValue("namesrvAddr")).thenReturn("127.0.0.1:9876");
+
+        Properties properties = ServerUtil.commandLine2Properties(commandLine);
+
+        assertThat(properties).hasSize(1);
+        assertThat(properties.getProperty("namesrvAddr")).isEqualTo("127.0.0.1:9876");
+        assertThat(properties.getProperty("help")).isNull();
+    }
+
+    @Test
+    public void testCommandLine2PropertiesWhenOptionsNull() {
+        CommandLine commandLine = Mockito.mock(CommandLine.class);
+
+        when(commandLine.getOptions()).thenReturn(null);
+
+        Properties properties = ServerUtil.commandLine2Properties(commandLine);
+
+        assertThat(properties).isEmpty();
+    }
+}

--- a/srvutil/src/test/java/org/apache/rocketmq/srvutil/ShutdownHookThreadTest.java
+++ b/srvutil/src/test/java/org/apache/rocketmq/srvutil/ShutdownHookThreadTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.srvutil;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ShutdownHookThreadTest {
+
+    @Test
+    public void testRunShouldInvokeCallbackOnlyOnce() throws Exception {
+        Logger logger = Mockito.mock(Logger.class);
+        AtomicInteger callbackTimes = new AtomicInteger();
+        Callable<Object> callback = () -> {
+            callbackTimes.incrementAndGet();
+            return null;
+        };
+
+        ShutdownHookThread shutdownHookThread = new ShutdownHookThread(logger, callback);
+
+        shutdownHookThread.run();
+        shutdownHookThread.run();
+
+        assertThat(callbackTimes.get()).isEqualTo(1);
+        verify(logger, times(3)).info(anyString());
+    }
+
+    @Test
+    public void testRunShouldLogErrorWhenCallbackThrows() throws Exception {
+        Logger logger = Mockito.mock(Logger.class);
+        AtomicInteger callbackTimes = new AtomicInteger();
+        Callable<Object> callback = () -> {
+            callbackTimes.incrementAndGet();
+            throw new IllegalStateException("boom");
+        };
+
+        ShutdownHookThread shutdownHookThread = new ShutdownHookThread(logger, callback);
+
+        shutdownHookThread.run();
+
+        assertThat(callbackTimes.get()).isEqualTo(1);
+        verify(logger).error(eq("shutdown hook callback invoked failure."), any(IllegalStateException.class));
+    }
+}

--- a/srvutil/src/test/java/org/apache/rocketmq/srvutil/ShutdownHookThreadTest.java
+++ b/srvutil/src/test/java/org/apache/rocketmq/srvutil/ShutdownHookThreadTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("DoNotCall")
 public class ShutdownHookThreadTest {
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10430

### Brief Description

Add unit tests for `ServerUtil` and `ShutdownHookThread` in the `srvutil` package.

The added tests cover:

- command line option construction
- command line to properties conversion
- null option handling
- shutdown hook callback execution
- exception handling during callback invocation

### How Did You Test This Change?

Run unit tests locally and verified all tests pass successfully.