### PR TITLE
docs: fix broker IP typo in startup examples

### DIFF
--- a/docs/cn/Debug_In_Idea.md
+++ b/docs/cn/Debug_In_Idea.md
@@ -32,7 +32,7 @@ namesrvAddr = 127.0.0.1:9876
 ![Idea_config_broker.png](image/Idea_config_broker.png)
 4. 运行Broker，观察到如下日志则启动成功
 ```shell
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 ### Step3: 发送或消费消息

--- a/docs/cn/Deployment.md
+++ b/docs/cn/Deployment.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### 验证broker是否启动成功，比如，broker的ip是192.168.1.2 然后名字是broker-a
 $ tail -f ~/logs/rocketmqlogs/Broker.log 
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 我们可以在 Broker.log 中看到“The broker[brokerName,ip:port] boot success..”，这表明 broker 已成功启动。
@@ -167,4 +167,3 @@ RocketMQ 5.0 开始支持自动主从切换的模式，可参考以下文档
 [部署文档](controller/deploy.md)
 
 [设计思想](controller/design.md)
-

--- a/docs/cn/operation.md
+++ b/docs/cn/operation.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### 验证Broker是否启动成功，例如Broker的IP为：192.168.1.2，且名称为broker-a
 $ tail -f ~/logs/rocketmqlogs/broker.log 
-The broker[broker-a, 192.169.1.2:10911] boot success...
+The broker[broker-a, 192.168.1.2:10911] boot success...
 ```
 
 #### 1.2 多Master模式

--- a/docs/en/Debug_In_Idea.md
+++ b/docs/en/Debug_In_Idea.md
@@ -32,7 +32,7 @@ namesrvAddr = 127.0.0.1:9876
 ![Idea_config_broker.png](../cn/image/Idea_config_broker.png)
 4. Run the Broker and if the following log is observed, it indicates successful startup.
 ```shell
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 ### Step3: Send or Consume Messages

--- a/docs/en/Deployment.md
+++ b/docs/en/Deployment.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### Then verify that the broker is started successfully, for example, the IP of broker is 192.168.1.2 and the name is broker-a
 $ tail -f ~/logs/rocketmqlogs/Broker.log 
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 We can see 'The broker[brokerName,ip:port] boot success..' in Broker.log that indicates the broker has been started successfully.

--- a/docs/en/operation.md
+++ b/docs/en/operation.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### check whether Broker is successfully started, eg: Broker's IP is 192.168.1.2, Broker's name is broker-a
 $ tail -f ~/logs/rocketmqlogs/broker.log 
-The broker[broker-a, 192.169.1.2:10911] boot success...
+The broker[broker-a, 192.168.1.2:10911] boot success...
 ```
 
 #### 1.2 Multi Master mode


### PR DESCRIPTION
### Which Issue(s) This PR References

Refs #10451

### Brief Description

Fix broker startup log examples that used `192.169.1.2` while the surrounding text describes the broker IP as `192.168.1.2`.

This keeps the English and Chinese operation, deployment, and IDEA debugging docs consistent with the README examples.

### How Did You Test This Change?

- `git diff --check HEAD~1..HEAD`
- `rg -n "192\.169\.1\.2" docs/en docs/cn || true`

Documentation-only change.
