### PR TITLE
docs: fix broker container reference and producer typos

### DIFF
--- a/docs/cn/BrokerContainer.md
+++ b/docs/cn/BrokerContainer.md
@@ -51,7 +51,7 @@ BrokerContainer中的所有broker共享同一个传输层，就像RocketMQ客户
 
 BrokerContainer配置文件内容主要是Netty网络层参数（由于传输层共享），BrokerContainer的监听端口、namesrv配置，以及最重要的brokerConfigPaths参数，brokerConfigPaths是指需要向BrokerContainer内添加的brokerConfig路径，多个config间用“:”分隔，不指定则只启动BrokerConainer，具体broker可通过mqadmin工具添加
 
-broker-container.conf（distribution/conf/container/broker-container.conf）:
+broker-container.conf（可参考 distribution/conf/container/2container-2m-2s/broker-container1.conf）:
 
 ```
 #配置端口，用于接收mqadmin命令

--- a/docs/en/client/java/API_Reference_DefaultMQProducer.md
+++ b/docs/en/client/java/API_Reference_DefaultMQProducer.md
@@ -6,12 +6,12 @@
 extends ClientConfig 
 implements MQProducer`
 
->`DefaultMQProducer` is the entry point for an application to post messages, out of the box, ca  quickly create a producer with a no-argument construction. it is mainly responsible for message sending, support synchronous、asynchronous、one-way send. All of these send methods support batch send.  The parameters of the sender can be adjusted through the getter/setter methods , provided by this class. `DefaultMQProducer` has multi send method and each method is slightly different. Make  sure you know the usage before you use it . Blow is a producer example . [see more examples](https://github.com/apache/rocketmq/blob/master/example/src/main/java/org/apache/rocketmq/example/).
+>`DefaultMQProducer` is the entry point for an application to post messages. Out of the box, you can quickly create a producer with a no-argument constructor. It is mainly responsible for message sending and supports synchronous, asynchronous, and one-way sends. All of these send methods support batch sends. The parameters of the sender can be adjusted through the getter/setter methods provided by this class. `DefaultMQProducer` has multiple send methods, and each method is slightly different. Make sure you know the usage before you use it. Below is a producer example. [See more examples](https://github.com/apache/rocketmq/blob/master/example/src/main/java/org/apache/rocketmq/example/).
 
 ``` java 
 public class Producer {
     public static void main(String[] args) throws MQClientException {
-        // create a produce with producer_group_name
+        // create a producer with producer_group_name
         DefaultMQProducer producer = new DefaultMQProducer("ProducerGroupName");
 
         // start the producer
@@ -55,7 +55,7 @@ public class Producer {
 |int|retryTimesWhenSendAsyncFailed|Maximum number of internal attempts to send a message in asynchronous mode|
 |boolean|retryAnotherBrokerWhenNotStoreOK|Whether to retry another broker if an internal send fails|
 |int|maxMessageSize| Maximum length of message body                                   |
-|TraceDispatcher|traceDispatcher| Message trackers. Use rcpHook to track messages              |
+|TraceDispatcher|traceDispatcher| Message trackers. Use rpcHook to track messages              |
 
 ### construction method 
 
@@ -68,4 +68,3 @@ public class Producer {
 |DefaultMQProducer(RPCHook rpcHook)|creates a producer with  a rpc hook.|
 |DefaultMQProducer(final String producerGroup, RPCHook rpcHook)|creates a producer with  a rpc hook and producer group.|
 |DefaultMQProducer(final String producerGroup, RPCHook rpcHook, boolean enableMsgTrace,final String customizedTraceTopic)|all of above.|
-


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10451

### Brief Description

Fix two documentation issues:

- Update the BrokerContainer doc to reference an existing sample config: `distribution/conf/container/2container-2m-2s/broker-container1.conf`.
- Fix obvious typos in the English `DefaultMQProducer` API reference, including `ca quickly`, `Blow is`, `create a produce`, and `rcpHook`.

### How Did You Test This Change?

- `git diff --check HEAD~1..HEAD`
- `rg -n "ca  quickly|Blow is|rcpHook|distribution/conf/container/broker-container\.conf|create a produce with" docs/cn/BrokerContainer.md docs/en/client/java/API_Reference_DefaultMQProducer.md || true`
- `test -f distribution/conf/container/2container-2m-2s/broker-container1.conf`

Documentation-only change.
