### PR TITLE
[ISSUE #10455] docs: fix inaccurate documentation examples and typos

### DIFF
--- a/distribution/conf/container/2container-2m-2s/broker-container1.conf
+++ b/distribution/conf/container/2container-2m-2s/broker-container1.conf
@@ -20,5 +20,5 @@ namesrvAddr=172.22.144.49:9876
 #或指定自动获取namesrv
 fetchNamesrvAddrByAddressServer=false
 #指定要向BrokerContainer内添加的brokerConfig路径，多个config间用“:”分隔；
-#不指定则只启动BrokerConainer，具体broker可通过mqadmin工具添加
+#不指定则只启动BrokerContainer，具体broker可通过mqadmin工具添加
 brokerConfigPaths=/root/2container-2m-2s/broker-a-in-container1.conf:/root/2container-2m-2s/broker-b-in-container1.conf

--- a/distribution/conf/container/2container-2m-2s/broker-container2.conf
+++ b/distribution/conf/container/2container-2m-2s/broker-container2.conf
@@ -20,5 +20,5 @@ namesrvAddr=172.22.144.49:9876
 #或指定自动获取namesrv
 fetchNamesrvAddrByAddressServer=false
 #指定要向BrokerContainer内添加的brokerConfig路径，多个config间用“:”分隔；
-#不指定则只启动BrokerConainer，具体broker可通过mqadmin工具添加
+#不指定则只启动BrokerContainer，具体broker可通过mqadmin工具添加
 brokerConfigPaths=/root/2container-2m-2s/broker-a-in-container2.conf:/root/2container-2m-2s/broker-b-in-container2.conf

--- a/docs/cn/BrokerContainer.md
+++ b/docs/cn/BrokerContainer.md
@@ -49,9 +49,9 @@ BrokerContainer中的所有broker共享同一个传输层，就像RocketMQ客户
 
 像Broker启动利用BrokerStartup一样，使用BrokerContainerStartup来启动BrokerContainer。我们可以通过两种方式向BrokerContainer中增加broker，一种是通过启动时通过在配置文件中指定
 
-BrokerContainer配置文件内容主要是Netty网络层参数（由于传输层共享），BrokerContainer的监听端口、namesrv配置，以及最重要的brokerConfigPaths参数，brokerConfigPaths是指需要向BrokerContainer内添加的brokerConfig路径，多个config间用“:”分隔，不指定则只启动BrokerConainer，具体broker可通过mqadmin工具添加
+BrokerContainer配置文件内容主要是Netty网络层参数（由于传输层共享），BrokerContainer的监听端口、namesrv配置，以及最重要的brokerConfigPaths参数，brokerConfigPaths是指需要向BrokerContainer内添加的brokerConfig路径，多个config间用“:”分隔，不指定则只启动BrokerContainer，具体broker可通过mqadmin工具添加
 
-broker-container.conf（distribution/conf/container/broker-container.conf）:
+broker-container.conf（可参考 distribution/conf/container/2container-2m-2s/broker-container1.conf）:
 
 ```
 #配置端口，用于接收mqadmin命令
@@ -61,14 +61,14 @@ namesrvAddr=127.0.0.1:9876
 #或指定自动获取namesrv
 fetchNamesrvAddrByAddressServer=true
 #指定要向BrokerContainer内添加的brokerConfig路径，多个config间用“:”分隔；
-#不指定则只启动BrokerConainer，具体broker可通过mqadmin工具添加
+#不指定则只启动BrokerContainer，具体broker可通过mqadmin工具添加
 brokerConfigPaths=/home/admin/broker-a.conf:/home/admin/broker-b.conf
 ```
 broker的配置和以前一样，但在BrokerContainer模式下broker配置文件中下Netty网络层参数和nameserver参数不生效，均使用BrokerContainer的配置参数。
 
 完成配置文件后，可以以如下命令启动
 ```
-sh mqbrokercontainer -c broker-container.conf
+sh mqbrokercontainer -c distribution/conf/container/2container-2m-2s/broker-container1.conf
 ```
 mqbrokercontainer脚本路径为distribution/bin/mqbrokercontainer。
 

--- a/docs/cn/Debug_In_Idea.md
+++ b/docs/cn/Debug_In_Idea.md
@@ -32,7 +32,7 @@ namesrvAddr = 127.0.0.1:9876
 ![Idea_config_broker.png](image/Idea_config_broker.png)
 4. 运行Broker，观察到如下日志则启动成功
 ```shell
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 ### Step3: 发送或消费消息

--- a/docs/cn/Deployment.md
+++ b/docs/cn/Deployment.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### 验证broker是否启动成功，比如，broker的ip是192.168.1.2 然后名字是broker-a
 $ tail -f ~/logs/rocketmqlogs/Broker.log 
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 我们可以在 Broker.log 中看到“The broker[brokerName,ip:port] boot success..”，这表明 broker 已成功启动。

--- a/docs/cn/FAQ.md
+++ b/docs/cn/FAQ.md
@@ -6,7 +6,7 @@
 
 1. **为什么我们要使用RocketMQ而不是选择其他的产品？**
 
-   请参考[为什么要选择RocketMQ](http://rocketmq.apache.org/docs/motivation/)
+   请参考[为什么要选择RocketMQ](https://rocketmq.apache.org/docs/motivation/)
 
 2. **我是否需要安装其他的软件才能使用RocketMQ，例如zookeeper？**
 

--- a/docs/cn/client/java/API_Reference_DefaultMQProducer.md
+++ b/docs/cn/client/java/API_Reference_DefaultMQProducer.md
@@ -54,7 +54,7 @@ public class Producer {
 |int|retryTimesWhenSendAsyncFailed|异步模式下内部尝试发送消息的最大次数|
 |boolean|retryAnotherBrokerWhenNotStoreOK|是否在内部发送失败时重试另一个broker|
 |int|maxMessageSize|消息体的最大长度|
-|TraceDispatcher|traceDispatcher|基于RPCHooK实现的消息轨迹插件|
+|TraceDispatcher|traceDispatcher|基于RPCHook实现的消息轨迹插件|
 
 ### 构造方法摘要
 
@@ -443,7 +443,7 @@ public class Producer {
 
 	- 异常描述：
 
-		MQClientException - 生产者状态非Running；没有找到broker；broker返回失败；网络异常等客户端异常客户端异常。<br>
+		MQClientException - 生产者状态非Running；没有找到broker；broker返回失败；网络异常等客户端异常。<br>
 		InterruptedException - 线程中断。
 
 8. searchOffset
@@ -678,7 +678,7 @@ public class Producer {
 
 	`public void send(Message msg, MessageQueue mq, SendCallback sendCallback)`
 
-	向指定的消息队列异步发送单条消息，异步发送调用后直接返回，并在在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
+	向指定的消息队列异步发送单条消息，异步发送调用后直接返回，并在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
 	异步发送时，在成功发送前，其内部会尝试重新发送消息的最大次数（参见*retryTimesWhenSendAsyncFailed*属性）。
 
 	- 入参描述：
@@ -703,7 +703,7 @@ public class Producer {
 
 	`public void send(Message msg, MessageQueue mq, SendCallback sendCallback, long timeout)`
 
-	向指定的消息队列异步发送单条消息，异步发送调用后直接返回，并在在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
+	向指定的消息队列异步发送单条消息，异步发送调用后直接返回，并在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
 	若在指定时间内消息未发送成功，回调方法会收到*RemotingTooMuchRequestException*异常。
 	异步发送时，在成功发送前，其内部会尝试重新发送消息的最大次数（参见*retryTimesWhenSendAsyncFailed*属性）。
 
@@ -789,7 +789,7 @@ public class Producer {
 
 	`public void send(Message msg, MessageQueueSelector selector, Object arg, SendCallback sendCallback)`
 
-	向通过`MessageQueueSelector`计算出的队列异步发送单条消息，异步发送调用后直接返回，并在在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
+	向通过`MessageQueueSelector`计算出的队列异步发送单条消息，异步发送调用后直接返回，并在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
 	异步发送时，在成功发送前，其内部会尝试重新发送消息的最大次数（参见*retryTimesWhenSendAsyncFailed*属性）。
 
 	可以通过自实现`MessageQueueSelector`接口，将某一类消息发送至固定的队列。比如：将同一个订单的状态变更消息投递至固定的队列。
@@ -817,7 +817,7 @@ public class Producer {
 
 	`public void send(Message msg, MessageQueueSelector selector, Object arg, SendCallback sendCallback, long timeout)`
 
-	向通过`MessageQueueSelector`计算出的队列异步发送单条消息，异步发送调用后直接返回，并在在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
+	向通过`MessageQueueSelector`计算出的队列异步发送单条消息，异步发送调用后直接返回，并在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
 	异步发送时，在成功发送前，其内部会尝试重新发送消息的最大次数（参见*retryTimesWhenSendAsyncFailed*属性）。
 
 	可以通过自实现`MessageQueueSelector`接口，将某一类消息发送至固定的队列。比如：将同一个订单的状态变更消息投递至固定的队列。
@@ -846,7 +846,7 @@ public class Producer {
 
 	`public void send(Message msg, SendCallback sendCallback)`
 
-	异步发送单条消息，异步发送调用后直接返回，并在在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
+	异步发送单条消息，异步发送调用后直接返回，并在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
 	异步发送时，在成功发送前，其内部会尝试重新发送消息的最大次数（参见*retryTimesWhenSendAsyncFailed*属性）。
 
 	- 入参描述：
@@ -870,7 +870,7 @@ public class Producer {
 
 	`public void send(Message msg, SendCallback sendCallback, long timeout)`
 
-	异步发送单条消息，异步发送调用后直接返回，并在在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
+	异步发送单条消息，异步发送调用后直接返回，并在发送成功或者异常时回调`sendCallback`，所以异步发送时`sendCallback`参数不能为null，否则在回调时会抛出`NullPointerException`。
 	异步发送时，在成功发送前，其内部会尝试重新发送消息的最大次数（参见*retryTimesWhenSendAsyncFailed*属性）。
 
 	- 入参描述：

--- a/docs/cn/design.md
+++ b/docs/cn/design.md
@@ -86,7 +86,7 @@ RocketMQ的RPC通信采用Netty组件作为底层通信库，同样也遵循了R
 
 ![](image/rocketmq_design_6.png)
 
-从上面的框图中可以大致了解RocketMQ中NettyRemotingServer的Reactor 多线程模型。一个 Reactor 主线程（eventLoopGroupBoss，即为上面的1）负责监听 TCP网络连接请求，建立好连接，创建SocketChannel，并注册到selector上。RocketMQ的源码中会自动根据OS的类型选择NIO和Epoll，也可以通过参数配置），然后监听真正的网络数据。拿到网络数据后，再丢给Worker线程池（eventLoopGroupSelector，即为上面的“N”，源码中默认设置为3），在真正执行业务逻辑之前需要进行SSL验证、编解码、空闲检查、网络连接管理，这些工作交给defaultEventExecutorGroup（即为上面的“M1”，源码中默认设置为8）去做。而处理业务操作放在业务线程池中执行，根据 RomotingCommand 的业务请求码code去processorTable这个本地缓存变量中找到对应的 processor，然后封装成task任务后，提交给对应的业务processor处理线程池来执行（sendMessageExecutor，以发送消息为例，即为上面的 “M2”）。从入口到业务逻辑的几个步骤中线程池一直再增加，这跟每一步逻辑复杂性相关，越复杂，需要的并发通道越宽。
+从上面的框图中可以大致了解RocketMQ中NettyRemotingServer的Reactor 多线程模型。一个 Reactor 主线程（eventLoopGroupBoss，即为上面的1）负责监听 TCP网络连接请求，建立好连接，创建SocketChannel，并注册到selector上。RocketMQ的源码中会自动根据OS的类型选择NIO和Epoll，也可以通过参数配置），然后监听真正的网络数据。拿到网络数据后，再丢给Worker线程池（eventLoopGroupSelector，即为上面的“N”，源码中默认设置为3），在真正执行业务逻辑之前需要进行SSL验证、编解码、空闲检查、网络连接管理，这些工作交给defaultEventExecutorGroup（即为上面的“M1”，源码中默认设置为8）去做。而处理业务操作放在业务线程池中执行，根据 RemotingCommand 的业务请求码code去processorTable这个本地缓存变量中找到对应的 processor，然后封装成task任务后，提交给对应的业务processor处理线程池来执行（sendMessageExecutor，以发送消息为例，即为上面的 “M2”）。从入口到业务逻辑的几个步骤中线程池一直在增加，这跟每一步逻辑复杂性相关，越复杂，需要的并发通道越宽。
 
 线程数 | 线程名 | 线程具体说明
  --- | --- | --- 
@@ -108,7 +108,7 @@ RocketMQ分布式消息队列的消息过滤方式有别于其它MQ中间件，�
 ### 4 负载均衡
 RocketMQ中的负载均衡都在Client端完成，具体来说的话，主要可以分为Producer端发送消息时候的负载均衡和Consumer端订阅消息的负载均衡。
 #### 4.1 Producer的负载均衡
-Producer端在发送消息的时候，会先根据Topic找到指定的TopicPublishInfo，在获取了TopicPublishInfo路由信息后，RocketMQ的客户端在默认方式下selectOneMessageQueue()方法会从TopicPublishInfo中的messageQueueList中选择一个队列（MessageQueue）进行发送消息。具体的容错策略均在MQFaultStrategy这个类中定义。这里有一个sendLatencyFaultEnable开关变量，如果开启，在随机递增取模的基础上，再过滤掉not available的Broker代理。所谓的"latencyFaultTolerance"，是指对之前失败的，按一定的时间做退避。例如，如果上次请求的latency超过550L ms，就退避30000L ms；超过1000L，就退避60000L；如果关闭，采用随机递增取模的方式选择一个队列（MessageQueue）来发送消息，latencyFaultTolerance机制是实现消息发送高可用的核心关键所在。
+Producer端在发送消息的时候，会先根据Topic找到指定的TopicPublishInfo，在获取了TopicPublishInfo路由信息后，RocketMQ的客户端在默认方式下selectOneMessageQueue()方法会从TopicPublishInfo中的messageQueueList中选择一个队列（MessageQueue）进行发送消息。具体的容错策略均在MQFaultStrategy这个类中定义。这里有一个sendLatencyFaultEnable开关变量，如果开启，在随机递增取模的基础上，再过滤掉not available的Broker代理。所谓的"latencyFaultTolerance"，是指对之前失败的，按一定的时间做退避。例如，如果上次请求的latency超过550ms，就退避30000ms；超过1000ms，就退避60000ms；如果关闭，采用随机递增取模的方式选择一个队列（MessageQueue）来发送消息，latencyFaultTolerance机制是实现消息发送高可用的核心关键所在。
 #### 4.2 Consumer的负载均衡
 在RocketMQ中，Consumer端的两种消费模式（Push/Pull）都是基于拉模式来获取消息的，而在Push模式只是对pull模式的一种封装，其本质实现为消息拉取线程在从服务器拉取到一批消息后，然后提交到消息消费线程池后，又“马不停蹄”的继续向服务器再次尝试拉取消息。如果未拉取到消息，则延迟一下又继续拉取。在两种基于拉模式的消费方式（Push/Pull）中，均需要Consumer端知道从Broker端的哪一个消息队列中去获取消息。因此，有必要在Consumer端来做负载均衡，即Broker端中多个MessageQueue分配给同一个ConsumerGroup中的哪些Consumer消费。
 
@@ -196,7 +196,7 @@ RocketMQ将Op消息写入到全局一个特定的Topic中通过源码中的方�
 
 如果在RocketMQ事务消息的二阶段过程中失败了，例如在做Commit操作时，出现网络问题导致Commit失败，那么需要通过一定的策略使这条消息最终被Commit。RocketMQ采用了一种补偿机制，称为“回查”。Broker端对未确定状态的消息发起回查，将消息发送到对应的Producer端（同一个Group的Producer），由Producer根据消息来检查本地事务的状态，进而执行Commit或者Rollback。Broker端通过对比Half消息和Op消息进行事务消息的回查并且推进CheckPoint（记录那些事务消息的状态是确定的）。
 
-值得注意的是，rocketmq并不会无休止的的信息事务状态回查，默认回查15次，如果15次回查还是无法得知事务状态，rocketmq默认回滚该消息。
+值得注意的是，rocketmq并不会无休止地对消息事务状态回查，默认回查15次，如果15次回查还是无法得知事务状态，rocketmq默认回滚该消息。
 ### 6 消息查询
 RocketMQ支持按照下面两种维度（“按照Message Id查询消息”、“按照Message Key查询消息”）进行消息查询。
 #### 6.1   按照MessageId查询消息

--- a/docs/cn/operation.md
+++ b/docs/cn/operation.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### 验证Broker是否启动成功，例如Broker的IP为：192.168.1.2，且名称为broker-a
 $ tail -f ~/logs/rocketmqlogs/broker.log 
-The broker[broker-a, 192.169.1.2:10911] boot success...
+The broker[broker-a, 192.168.1.2:10911] boot success...
 ```
 
 #### 1.2 多Master模式

--- a/docs/en/Debug_In_Idea.md
+++ b/docs/en/Debug_In_Idea.md
@@ -32,7 +32,7 @@ namesrvAddr = 127.0.0.1:9876
 ![Idea_config_broker.png](../cn/image/Idea_config_broker.png)
 4. Run the Broker and if the following log is observed, it indicates successful startup.
 ```shell
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 ### Step3: Send or Consume Messages

--- a/docs/en/Deployment.md
+++ b/docs/en/Deployment.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### Then verify that the broker is started successfully, for example, the IP of broker is 192.168.1.2 and the name is broker-a
 $ tail -f ~/logs/rocketmqlogs/Broker.log 
-The broker[broker-a,192.169.1.2:10911] boot success...
+The broker[broker-a,192.168.1.2:10911] boot success...
 ```
 
 We can see 'The broker[brokerName,ip:port] boot success..' in Broker.log that indicates the broker has been started successfully.

--- a/docs/en/FAQ.md
+++ b/docs/en/FAQ.md
@@ -6,7 +6,7 @@ The following questions are frequently asked with regard to the RocketMQ project
 
 1. Why did we create rocketmq project instead of selecting other products?
 
-   Please refer to [Why RocketMQ](http://rocketmq.apache.org/docs/motivation)
+   Please refer to [Why RocketMQ](https://rocketmq.apache.org/docs/motivation)
 
 2. Do I have to install other software, such as zookeeper, to use RocketMQ?
 

--- a/docs/en/client/java/API_Reference_DefaultMQProducer.md
+++ b/docs/en/client/java/API_Reference_DefaultMQProducer.md
@@ -6,12 +6,12 @@
 extends ClientConfig 
 implements MQProducer`
 
->`DefaultMQProducer` is the entry point for an application to post messages, out of the box, ca  quickly create a producer with a no-argument construction. it is mainly responsible for message sending, support synchronous、asynchronous、one-way send. All of these send methods support batch send.  The parameters of the sender can be adjusted through the getter/setter methods , provided by this class. `DefaultMQProducer` has multi send method and each method is slightly different. Make  sure you know the usage before you use it . Blow is a producer example . [see more examples](https://github.com/apache/rocketmq/blob/master/example/src/main/java/org/apache/rocketmq/example/).
+>`DefaultMQProducer` is the entry point for an application to post messages. Out of the box, you can quickly create a producer with a no-argument constructor. It is mainly responsible for message sending and supports synchronous, asynchronous, and one-way sends. All of these send methods support batch sends. The parameters of the sender can be adjusted through the getter/setter methods provided by this class. `DefaultMQProducer` has multiple send methods, and each method is slightly different. Make sure you know the usage before you use it. Below is a producer example. [See more examples](https://github.com/apache/rocketmq/blob/master/example/src/main/java/org/apache/rocketmq/example/).
 
 ``` java 
 public class Producer {
     public static void main(String[] args) throws MQClientException {
-        // create a produce with producer_group_name
+        // create a producer with producer_group_name
         DefaultMQProducer producer = new DefaultMQProducer("ProducerGroupName");
 
         // start the producer
@@ -55,7 +55,7 @@ public class Producer {
 |int|retryTimesWhenSendAsyncFailed|Maximum number of internal attempts to send a message in asynchronous mode|
 |boolean|retryAnotherBrokerWhenNotStoreOK|Whether to retry another broker if an internal send fails|
 |int|maxMessageSize| Maximum length of message body                                   |
-|TraceDispatcher|traceDispatcher| Message trackers. Use rcpHook to track messages              |
+|TraceDispatcher|traceDispatcher| Message trackers. Use rpcHook to track messages              |
 
 ### construction method 
 

--- a/docs/en/controller/persistent_unique_broker_id.md
+++ b/docs/en/controller/persistent_unique_broker_id.md
@@ -100,7 +100,7 @@ After successful registration, all subsequent requests and state records for the
 
 ## Upgrade plan
 
-To upgrade to version 4.x, follow the 5.0 upgrade documentation process.
+To upgrade from version 4.x, follow the 5.0 upgrade documentation process.
 For upgrading from the non-persistent BrokerId version in 5.0.0 or 5.1.0 to the persistent BrokerId version 5.1.1 or above, follow the following steps:
 
 ### Upgrade Controller

--- a/docs/en/operation.md
+++ b/docs/en/operation.md
@@ -27,7 +27,7 @@ $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### check whether Broker is successfully started, eg: Broker's IP is 192.168.1.2, Broker's name is broker-a
 $ tail -f ~/logs/rocketmqlogs/broker.log 
-The broker[broker-a, 192.169.1.2:10911] boot success...
+The broker[broker-a, 192.168.1.2:10911] boot success...
 ```
 
 #### 1.2 Multi Master mode


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10455

### Brief Description

This PR fixes several documentation inaccuracies in the English and Chinese developer guides:

1. **Broker startup log IP mismatch** — Six docs (operation, deployment, and IDEA debugging guides in both en/cn) showed sample log output with `192.169.1.2` while the surrounding text uses `192.168.1.2`. Corrected for consistency.

2. **BrokerContainer config path** — `docs/cn/BrokerContainer.md` referenced a non-existent `distribution/conf/container/broker-container.conf`. Updated to point to the existing sample at `distribution/conf/container/2container-2m-2s/broker-container1.conf`, fixed the startup command accordingly, and corrected the `BrokerConainer` → `BrokerContainer` typo in the doc and sample config comments.

3. **DefaultMQProducer API reference typos**
   - **English**: fixed `ca quickly`, `Blow is`, `create a produce`, `rcpHook`, and improved the class introduction paragraph.
   - **Chinese**: fixed `RPCHooK` → `RPCHook`, removed duplicate `客户端异常`, and corrected `并在在` → `并在` in async send descriptions.

4. **Other fixes** — FAQ links upgraded from `http://` to `https://`; corrected `upgrade to version 4.x` → `upgrade from version 4.x` in the persistent broker ID upgrade guide; fixed typos in `docs/cn/design.md` (e.g. `RomotingCommand`, `550L ms`, `无休止的的信息`).

Documentation-only change; no code behavior affected.

### How Did You Test This Change?

Documentation-only change. Verified with:

- `rg -n "192\.169\.1\.2" docs/` — no matches
- `rg -n "ca quickly|Blow is|rcpHook|RPCHooK|BrokerConainer|并在在" docs/ distribution/` — no matches
- `rg -n "distribution/conf/container/broker-container\.conf" docs/` — no matches
- `test -f distribution/conf/container/2container-2m-2s/broker-container1.conf` — sample config exists