### PR TITLE
fix: validate message batch input

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageBatch.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageBatch.java
@@ -40,8 +40,9 @@ public class MessageBatch extends Message implements Iterable<Message> {
     }
 
     public static MessageBatch generateFromList(Collection<? extends Message> messages) {
-        assert messages != null;
-        assert messages.size() > 0;
+        if (messages == null || messages.isEmpty()) {
+            throw new IllegalArgumentException("messages must not be null or empty");
+        }
         List<Message> messageList = new ArrayList<>(messages.size());
         Message first = null;
         for (Message message : messages) {

--- a/common/src/test/java/org/apache/rocketmq/common/MessageBatchTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageBatchTest.java
@@ -41,6 +41,16 @@ public class MessageBatchTest {
         MessageBatch.generateFromList(messages);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerate_NullMessages() throws Exception {
+        MessageBatch.generateFromList(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerate_EmptyMessages() throws Exception {
+        MessageBatch.generateFromList(new ArrayList<>());
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testGenerate_DiffTopic() throws Exception {
         List<Message> messages = generateMessages();


### PR DESCRIPTION
## What is the purpose of the change

Fixes #10458

`MessageBatch.generateFromList` used Java `assert` statements to validate null and empty input. That made invalid input behavior depend on assertion settings, producing `AssertionError` when assertions are enabled or later `NullPointerException` when they are disabled.

This PR replaces the assertions with explicit `IllegalArgumentException` validation.

## Brief changelog

- Validate null and empty message collections explicitly in `MessageBatch.generateFromList`
- Add unit coverage for null and empty message collection inputs

## Verifying this change

- `mvn -pl common -Dtest=MessageBatchTest -Dspotbugs.skip=true test`

## Note

A full `mvn -pl common -Dtest=MessageBatchTest test` run failed before surefire in this local environment because SpotBugs hit `java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release` on the current JDK. The targeted test command above was used to verify the change.
