### PR TITLE
[Fix #10460]: Pre-size ProxyContext map to avoid HashMap resize on request path

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class ProxyContext {
     public static final String INNER_ACTION_PREFIX = "Inner";
-    private final Map<String, Object> value = new HashMap<>();
+    private final Map<String, Object> value = new HashMap<>(32);
 
     public static ProxyContext create() {
         return new ProxyContext();

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class ProxyContext {
     public static final String INNER_ACTION_PREFIX = "Inner";
-    private static final int DEFAULT_INITIAL_CAPACITY = 32;
+    private static final int DEFAULT_INITIAL_CAPACITY = 64;
     private final Map<String, Object> value = new HashMap<>(DEFAULT_INITIAL_CAPACITY);
 
     public static ProxyContext create() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
@@ -23,7 +23,8 @@ import java.util.Map;
 
 public class ProxyContext {
     public static final String INNER_ACTION_PREFIX = "Inner";
-    private final Map<String, Object> value = new HashMap<>(32);
+    private static final int DEFAULT_INITIAL_CAPACITY = 32;
+    private final Map<String, Object> value = new HashMap<>(DEFAULT_INITIAL_CAPACITY);
 
     public static ProxyContext create() {
         return new ProxyContext();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

  - Fixes #10460 

  ### Brief Description

  `ProxyContext` is created on every gRPC/Remoting request. Its `value` map used the default `HashMap` capacity (16, threshold 12), so adding the 10 `ContextVariable` keys plus interceptor entries triggers a 
  resize on the hot path. Pre-size the map to avoid it:

  ```java
  private static final int DEFAULT_INITIAL_CAPACITY = 64;
  private final Map<String, Object> value = new HashMap<>(DEFAULT_INITIAL_CAPACITY);
  ```
  No behavior or API change.

  How Did You Test This Change?

  Pure capacity refactor, no logic change. Existing proxy module tests pass.
