### PR TITLE
[ISSUE #10462] Tiered Storage: memory backpressure, concurrency hardening and bug fixes

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java
@@ -122,6 +122,17 @@ public class MessageStoreConfig {
     private double readAheadCacheSizeThresholdRate = 0.3;
 
     private int tieredStoreMaxPendingLimit = 10000;
+    /**
+     * Minimum fraction of max heap that must remain free for dispatch to proceed.
+     * Actual threshold = min(ratio × maxMemory, maxBytes).
+     * Default 0.1 (10%).
+     */
+    private double tieredStoreDispatchMinFreeMemoryRatio = 0.1;
+    /**
+     * Upper cap on the backpressure threshold in bytes, preventing the ratio-based
+     * threshold from becoming too large on big-heap instances. Default 1GB.
+     */
+    private long tieredStoreDispatchMinFreeMemoryMaxBytes = 1024 * 1024 * 1024L;
     private boolean tieredStoreCrcCheckEnable = false;
 
     private String tieredStoreFilePath = "";
@@ -370,6 +381,22 @@ public class MessageStoreConfig {
 
     public void setTieredStoreMaxPendingLimit(int tieredStoreMaxPendingLimit) {
         this.tieredStoreMaxPendingLimit = tieredStoreMaxPendingLimit;
+    }
+
+    public double getTieredStoreDispatchMinFreeMemoryRatio() {
+        return tieredStoreDispatchMinFreeMemoryRatio;
+    }
+
+    public void setTieredStoreDispatchMinFreeMemoryRatio(double tieredStoreDispatchMinFreeMemoryRatio) {
+        this.tieredStoreDispatchMinFreeMemoryRatio = tieredStoreDispatchMinFreeMemoryRatio;
+    }
+
+    public long getTieredStoreDispatchMinFreeMemoryMaxBytes() {
+        return tieredStoreDispatchMinFreeMemoryMaxBytes;
+    }
+
+    public void setTieredStoreDispatchMinFreeMemoryMaxBytes(long tieredStoreDispatchMinFreeMemoryMaxBytes) {
+        this.tieredStoreDispatchMinFreeMemoryMaxBytes = tieredStoreDispatchMinFreeMemoryMaxBytes;
     }
 
     public boolean isTieredStoreCrcCheckEnable() {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
@@ -23,64 +23,73 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.utils.ThreadUtils;
+import org.apache.rocketmq.tieredstore.util.MessageStoreUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MessageStoreExecutor {
 
-    public final BlockingQueue<Runnable> bufferCommitThreadPoolQueue;
-    public final BlockingQueue<Runnable> bufferFetchThreadPoolQueue;
-    public final BlockingQueue<Runnable> fileRecyclingThreadPoolQueue;
+    private static final Logger log = LoggerFactory.getLogger(MessageStoreUtil.TIERED_STORE_LOGGER_NAME);
 
-    public final ScheduledExecutorService commonExecutor;
-    public final ExecutorService bufferCommitExecutor;
-    public final ExecutorService bufferFetchExecutor;
-    public final ExecutorService fileRecyclingExecutor;
+    private final BlockingQueue<Runnable> bufferCommitThreadPoolQueue;
+    private final BlockingQueue<Runnable> bufferFetchThreadPoolQueue;
 
-    private static class SingletonHolder {
-        private static final MessageStoreExecutor INSTANCE = new MessageStoreExecutor();
-    }
-
-    public static MessageStoreExecutor getInstance() {
-        return SingletonHolder.INSTANCE;
-    }
+    private final ScheduledExecutorService commonExecutor;
+    private final ExecutorService bufferCommitExecutor;
+    private final ExecutorService bufferFetchExecutor;
 
     public MessageStoreExecutor() {
         this(10000);
     }
 
     public MessageStoreExecutor(int maxQueueCapacity) {
+        int processors = Runtime.getRuntime().availableProcessors();
 
         this.commonExecutor = ThreadUtils.newScheduledThreadPool(
-            Math.max(4, Runtime.getRuntime().availableProcessors()),
+            Math.max(4, processors),
             new ThreadFactoryImpl("TieredCommonExecutor_"));
 
         this.bufferCommitThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
         this.bufferCommitExecutor = ThreadUtils.newThreadPoolExecutor(
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
+            Math.max(4, processors),
+            Math.max(16, processors * 2),
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.bufferCommitThreadPoolQueue,
             new ThreadFactoryImpl("BufferCommitExecutor_"));
 
         this.bufferFetchThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
         this.bufferFetchExecutor = ThreadUtils.newThreadPoolExecutor(
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
+            Math.max(4, processors),
+            Math.max(16, processors * 2),
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.bufferFetchThreadPoolQueue,
             new ThreadFactoryImpl("BufferFetchExecutor_"));
+    }
 
-        this.fileRecyclingThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
-        this.fileRecyclingExecutor = ThreadUtils.newThreadPoolExecutor(
-            Math.max(4, Runtime.getRuntime().availableProcessors()),
-            Math.max(4, Runtime.getRuntime().availableProcessors()),
-            TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
-            this.fileRecyclingThreadPoolQueue,
-            new ThreadFactoryImpl("BufferFetchExecutor_"));
+    public ScheduledExecutorService getCommonExecutor() {
+        return commonExecutor;
+    }
+
+    public ExecutorService getBufferCommitExecutor() {
+        return bufferCommitExecutor;
+    }
+
+    public ExecutorService getBufferFetchExecutor() {
+        return bufferFetchExecutor;
     }
 
     private void shutdownExecutor(ExecutorService executor) {
-        if (executor != null) {
-            executor.shutdown();
+        if (executor == null) {
+            return;
+        }
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -88,6 +97,6 @@ public class MessageStoreExecutor {
         this.shutdownExecutor(this.commonExecutor);
         this.shutdownExecutor(this.bufferCommitExecutor);
         this.shutdownExecutor(this.bufferFetchExecutor);
-        this.shutdownExecutor(this.fileRecyclingExecutor);
+        log.info("MessageStoreExecutor shutdown complete");
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.rocketmq.common.BoundaryType;
@@ -112,7 +113,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
         if (result) {
             indexService.start();
             dispatcher.start();
-            storeExecutor.commonExecutor.scheduleWithFixedDelay(
+            storeExecutor.getCommonExecutor().scheduleWithFixedDelay(
                 flatFileStore::scheduleDeleteExpireFile, storeConfig.getTieredStoreDeleteFileInterval(),
                 storeConfig.getTieredStoreDeleteFileInterval(), TimeUnit.MILLISECONDS);
         }
@@ -294,7 +295,12 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
 
                 return result;
             }).exceptionally(e -> {
-                log.error("GetMessageAsync from tiered store failed", e);
+                Throwable cause = e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                log.error("GetMessageAsync from tiered store failed, fall back to next store, " +
+                    "topic: {}, queue: {}, offset: {}", topic, queueId, offset, cause);
                 return next.getMessage(group, topic, queueId, offset, maxMsgNums, messageFilter);
             });
     }
@@ -419,7 +425,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
         int maxNum, long begin, long end) {
         long earliestTimeInNextStore = next.getEarliestMessageTime();
         if (earliestTimeInNextStore <= 0) {
-            log.warn("TieredMessageStore#queryMessageAsync: get earliest message time in next store failed: {}", earliestTimeInNextStore);
+            log.warn("TieredMessageStore#queryMessageAsync, get earliest message time in next store failed, earliestTime={}", earliestTimeInNextStore);
         }
         boolean isForce = storeConfig.getTieredStorageLevel() == MessageStoreConfig.TieredStorageLevel.FORCE;
         QueryMessageResult result = end < earliestTimeInNextStore || isForce ?
@@ -442,7 +448,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
                         return result;
                     });
             } catch (Exception e) {
-                log.error("TieredMessageStore#queryMessageAsync: query message in tiered store failed", e);
+                log.error("TieredMessageStore#queryMessageAsync, query message in tiered store failed, topic={}, key={}", topic, key, e);
                 return CompletableFuture.completedFuture(result);
             }
         }
@@ -453,7 +459,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
     public CompletableFuture<QueryMessageResult> queryMessageAsync(String topic, String key, int maxNum, long begin, long end, String indexType, String lastKey) {
         long earliestTimeInNextStore = next.getEarliestMessageTime();
         if (earliestTimeInNextStore <= 0) {
-            log.warn("TieredMessageStore queryMessageAsync: get earliest message time in next store failed: {}", earliestTimeInNextStore);
+            log.warn("TieredMessageStore#queryMessageAsync, get earliest message time in next store failed, earliestTime={}", earliestTimeInNextStore);
         }
         boolean isForce = storeConfig.getTieredStorageLevel() == MessageStoreConfig.TieredStorageLevel.FORCE;
         QueryMessageResult result = end < earliestTimeInNextStore || isForce ? new QueryMessageResult() : next.queryMessage(topic, key, maxNum, begin, end, indexType, lastKey);
@@ -474,7 +480,7 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
                         return result;
                     });
             } catch (Exception e) {
-                log.error("TieredMessageStore#queryMessageAsync: query message in tiered store failed", e);
+                log.error("TieredMessageStore#queryMessageAsync, query message in tiered store failed, topic={}, key={}, indexType={}", topic, key, indexType, e);
                 return CompletableFuture.completedFuture(result);
             }
         }
@@ -520,19 +526,17 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
                 flatFileStore.destroyFile(queueMetadata.getQueue());
             });
             metadataStore.deleteTopic(topic);
-            log.info("MessageStore delete topic success, topicName={}", topic);
+            log.info("TieredMessageStore#deleteTopics, delete topic success, topic={}", topic);
         }
         return next.deleteTopics(deleteTopics);
     }
 
     @Override
     public synchronized void shutdown() {
-        if (next != null) {
-            next.shutdown();
-        }
         if (dispatcher != null) {
             dispatcher.shutdown();
         }
+
         if (indexService != null) {
             if (defaultStore.getRunningFlags() != null && defaultStore.getRunningFlags().isStoreWriteable()) {
                 indexService.shutdown();
@@ -540,12 +544,16 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
                 indexService.forceShutdown();
             }
         }
+        if (storeExecutor != null) {
+            storeExecutor.shutdown();
+        }
 
         if (flatFileStore != null) {
             flatFileStore.shutdown();
         }
-        if (storeExecutor != null) {
-            storeExecutor.shutdown();
+
+        if (next != null) {
+            next.shutdown();
         }
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.ServiceThread;
@@ -69,7 +68,6 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
     protected final FlatFileStore flatFileStore;
     protected final MessageStoreExecutor storeExecutor;
     protected final MessageStoreFilter topicFilter;
-    protected final Semaphore semaphore;
     protected final IndexService indexService;
     protected final Map<FlatFileInterface, GroupCommitContext> failedGroupCommitMap;
 
@@ -78,8 +76,6 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
         this.storeConfig = messageStore.getStoreConfig();
         this.defaultStore = messageStore.getDefaultStore();
         this.brokerName = storeConfig.getBrokerName();
-        this.semaphore = new Semaphore(
-            this.storeConfig.getTieredStoreMaxPendingLimit() / 4);
         this.topicFilter = messageStore.getTopicFilter();
         this.flatFileStore = messageStore.getFlatFileStore();
         this.storeExecutor = messageStore.getStoreExecutor();
@@ -97,16 +93,28 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
         return failedGroupCommitMap;
     }
 
-    public void dispatchWithSemaphore(FlatFileInterface flatFile) {
+    protected boolean isMemoryEnough(FlatFileInterface flatFile) {
+        Runtime runtime = Runtime.getRuntime();
+        long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
+        long ratioThreshold = (long) (runtime.maxMemory() * storeConfig.getTieredStoreDispatchMinFreeMemoryRatio());
+        long memoryThreshold = Math.min(ratioThreshold, storeConfig.getTieredStoreDispatchMinFreeMemoryMaxBytes());
+        if (availableMemory < memoryThreshold) {
+            log.warn("MessageStore dispatch skipped due to memory backpressure, " +
+                "availableMemory={}MB, threshold={}MB, topic={}, queueId={}",
+                availableMemory / (1024 * 1024), memoryThreshold / (1024 * 1024),
+                flatFile.getMessageQueue().getTopic(), flatFile.getMessageQueue().getQueueId());
+            return false;
+        }
+        return true;
+    }
+
+    public void dispatch(FlatFileInterface flatFile) {
+        if (stopped || !isMemoryEnough(flatFile)) {
+            return;
+        }
         try {
-            if (stopped) {
-                return;
-            }
-            semaphore.acquire();
-            this.doScheduleDispatch(flatFile, false)
-                .whenComplete((future, throwable) -> semaphore.release());
+            this.doScheduleDispatch(flatFile, false);
         } catch (Throwable t) {
-            semaphore.release();
             log.error("MessageStore dispatch error, topic={}, queueId={}",
                 flatFile.getMessageQueue().getTopic(), flatFile.getMessageQueue().getQueueId(), t);
         }
@@ -308,12 +316,12 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
                             //next commit async,execute constructIndexFile.
                             GroupCommitContext oldCommit = failedGroupCommitMap.put(flatFile, groupCommitContext);
                             if (oldCommit != null) {
-                                log.warn("MessageDispatcher#commitAsync failed,flatFile old failed commit context not release, topic={}, queueId={}  ", topic, queueId);
+                                log.warn("MessageDispatcher#schedule, commitAsync failed, old failed commit context not released, topic={}, queueId={}", topic, queueId);
                                 oldCommit.release();
                             }
                         }
                         if (success && repeat) {
-                            storeExecutor.commonExecutor.submit(() -> dispatchWithSemaphore(flatFile));
+                            storeExecutor.getCommonExecutor().submit(() -> dispatch(flatFile));
                         }
                     }
                 );
@@ -333,13 +341,13 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
     }
 
     public void constructIndexFile(long topicId, GroupCommitContext groupCommitContext) {
-        MessageStoreExecutor.getInstance().bufferCommitExecutor.submit(() -> {
+        storeExecutor.getBufferCommitExecutor().submit(() -> {
             if (storeConfig.isMessageIndexEnable()) {
                 try {
                     groupCommitContext.getDispatchRequests().forEach(request -> constructIndexFile0(topicId, request));
                 }
                 catch (Throwable e) {
-                    log.error("constructIndexFile error {}", topicId, e);
+                    log.error("MessageDispatcher#constructIndexFile, construct index file error, topicId={}", topicId, e);
                 }
             }
             groupCommitContext.release();
@@ -378,7 +386,7 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
         log.info("{} service started", this.getServiceName());
         while (!this.isStopped()) {
             try {
-                flatFileStore.deepCopyFlatFileToList().forEach(this::dispatchWithSemaphore);
+                flatFileStore.deepCopyFlatFileToList().forEach(this::dispatch);
 
                 releaseClosedPendingGroupCommit();
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreFetcherImpl.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreFetcherImpl.java
@@ -219,7 +219,7 @@ public class MessageStoreFetcherImpl implements MessageStoreFetcher {
         // this method may trigger an RPC call, causing buffer fetch thread starvation
         return fetchMessageThenPutToCache(flatFile, queueOffset, fetchSize)
             .thenApplyAsync(maxOffset -> getMessageFromCache(flatFile, queueOffset, maxCount, messageFilter),
-                messageStore.getStoreExecutor().commonExecutor);
+                messageStore.getStoreExecutor().getCommonExecutor());
     }
 
     public CompletableFuture<GetMessageResultExt> getMessageFromTieredStoreAsync(

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
@@ -38,6 +37,7 @@ public class FlatAppendFile {
 
     protected static final Logger log = LoggerFactory.getLogger(MessageStoreUtil.TIERED_STORE_LOGGER_NAME);
     public static final long GET_FILE_SIZE_ERROR = -1L;
+    public static final long GET_TIMESTAMP_ERROR = -1L;
 
     protected final String filePath;
     protected final FileSegmentType fileType;
@@ -81,22 +81,15 @@ public class FlatAppendFile {
      * @see <a href="https://github.com/apache/rocketmq/issues/9544">Related GitHub Issue</a>
      */
     public long getFileCorrectSize(FileSegment fileSegment) {
-        while (true) {
+        for (int retry = 0; retry < 3; retry++) {
             long fileSize = fileSegment.getSize();
             if (fileSize != GET_FILE_SIZE_ERROR) {
-                log.debug("FlatAppendFile get file correct size, filePath={} fileType={}, fileSize={}",
-                    fileSegment.getPath(), fileSegment.getFileType(), fileSize);
                 return fileSize;
-            } else {
-                log.warn("FlatAppendFile get file correct size error, filePath={}, fileType={}",
-                    fileSegment.getPath(), fileSegment.getFileType());
-                try {
-                    TimeUnit.MILLISECONDS.sleep(50);
-                } catch (InterruptedException e) {
-                    log.warn("FlatAppendFile get file correct size interrupted", e);
-                }
             }
         }
+        log.error("FlatAppendFile#getFileCorrectSize, get file correct size failed after 3 retries, path={}, type={}",
+            fileSegment.getPath(), fileSegment.getFileType());
+        return GET_FILE_SIZE_ERROR;
     }
 
     public void recoverFileSize() {
@@ -108,7 +101,7 @@ public class FlatAppendFile {
         if (fileSegment.getCommitPosition() != fileSize) {
             fileSegment.initPosition(fileSize);
             flushFileSegmentMeta(fileSegment);
-            log.warn("FlatAppendFile last file size not correct, filePath: {}", this.filePath);
+            log.warn("FlatAppendFile#recoverFileSize, last file size not correct, filePath={}", this.filePath);
         }
     }
 
@@ -164,12 +157,12 @@ public class FlatAppendFile {
 
     public long getMinTimestamp() {
         List<FileSegment> list = this.fileSegmentTable;
-        return list.isEmpty() ? GET_FILE_SIZE_ERROR : list.get(0).getMinTimestamp();
+        return list.isEmpty() ? GET_TIMESTAMP_ERROR : list.get(0).getMinTimestamp();
     }
 
     public long getMaxTimestamp() {
         List<FileSegment> list = this.fileSegmentTable;
-        return list.isEmpty() ? GET_FILE_SIZE_ERROR : list.get(list.size() - 1).getMaxTimestamp();
+        return list.isEmpty() ? GET_TIMESTAMP_ERROR : list.get(list.size() - 1).getMaxTimestamp();
     }
 
     public FileSegment rollingNewFile(long offset) {
@@ -202,7 +195,7 @@ public class FlatAppendFile {
             result = fileSegment.append(buffer, timestamp);
             if (result == AppendResult.FILE_FULL) {
                 boolean commitResult = fileSegment.commitAsync().join();
-                log.info("FlatAppendFile#append not successful for the file {} is full, commit result={}",
+                log.info("FlatAppendFile#append, file is full, filePath={}, commitResult={}",
                     fileSegment.getPath(), commitResult);
                 if (commitResult) {
                     this.flushFileSegmentMeta(fileSegment);
@@ -279,9 +272,8 @@ public class FlatAppendFile {
 
                 if (fileSegment.getMaxTimestamp() != Long.MAX_VALUE &&
                     fileSegment.getMaxTimestamp() >= expireTimestamp) {
-                    log.debug("FileSegment has not expired, filePath={}, fileType={}, " +
-                            "offset={}, expireTimestamp={}, maxTimestamp={}", filePath, fileType,
-                        fileSegment.getBaseOffset(), expireTimestamp, fileSegment.getMaxTimestamp());
+                    log.debug("FlatAppendFile#destroyExpiredFile, file not expired, filePath={}, fileType={}, offset={}, expireTimestamp={}, maxTimestamp={}",
+                        filePath, fileType, fileSegment.getBaseOffset(), expireTimestamp, fileSegment.getMaxTimestamp());
                     break;
                 }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFile.java
@@ -54,8 +54,11 @@ public class FlatCommitLogFile extends FlatAppendFile {
     }
 
     public long getMinOffsetFromFile() {
-        return firstOffset.get() == GET_OFFSET_ERROR ?
-            this.getMinOffsetFromFileAsync().join() : firstOffset.get();
+        long cached = firstOffset.get();
+        if (cached != GET_OFFSET_ERROR) {
+            return cached;
+        }
+        return getMinOffsetFromFileAsync().join();
     }
 
     public CompletableFuture<Long> getMinOffsetFromFileAsync() {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatFileFactory.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatFileFactory.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.tieredstore.file;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
 import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.common.FileSegmentType;
@@ -29,13 +28,6 @@ public class FlatFileFactory {
     private final MetadataStore metadataStore;
     private final MessageStoreConfig storeConfig;
     private final FileSegmentFactory fileSegmentFactory;
-
-    @VisibleForTesting
-    public FlatFileFactory(MetadataStore metadataStore, MessageStoreConfig storeConfig) {
-        this.metadataStore = metadataStore;
-        this.storeConfig = storeConfig;
-        this.fileSegmentFactory = new FileSegmentFactory(metadataStore, storeConfig, new MessageStoreExecutor());
-    }
 
     public FlatFileFactory(MetadataStore metadataStore,
         MessageStoreConfig storeConfig, MessageStoreExecutor executor) {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatFileStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatFileStore.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -71,18 +70,14 @@ public class FlatFileStore {
     }
 
     public void recover() {
-        Semaphore semaphore = new Semaphore(storeConfig.getTieredStoreMaxPendingLimit() / 4);
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        metadataStore.iterateTopic(topicMetadata -> {
-            semaphore.acquireUninterruptibly();
+        metadataStore.iterateTopic(topicMetadata ->
             futures.add(this.recoverAsync(topicMetadata)
                 .whenComplete((unused, throwable) -> {
                     if (throwable != null) {
-                        log.error("FlatFileStore recover file error, topic={}", topicMetadata.getTopic(), throwable);
+                        log.error("FlatFileStore#recoverAsync, recover file error, topic={}", topicMetadata.getTopic(), throwable);
                     }
-                    semaphore.release();
-                }));
-        });
+                })));
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
 
@@ -100,7 +95,7 @@ public class FlatFileStore {
             });
             log.info("FlatFileStore recover file, topic={}, total={}, cost={}ms",
                 topicMetadata.getTopic(), queueCount.get(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
-        }, executor.bufferCommitExecutor);
+        }, executor.getCommonExecutor());
     }
 
     public void scheduleDeleteExpireFile() {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatMessageFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatMessageFile.java
@@ -22,8 +22,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -48,8 +46,8 @@ public class FlatMessageFile implements FlatFileInterface {
     protected static final Logger log = LoggerFactory.getLogger(MessageStoreUtil.TIERED_STORE_LOGGER_NAME);
     protected volatile boolean closed = false;
 
-    protected TopicMetadata topicMetadata;
-    protected QueueMetadata queueMetadata;
+    protected volatile TopicMetadata topicMetadata;
+    protected volatile QueueMetadata queueMetadata;
 
     protected final String filePath;
     protected final ReentrantLock fileLock;
@@ -58,8 +56,6 @@ public class FlatMessageFile implements FlatFileInterface {
     protected final MetadataStore metadataStore;
     protected final FlatCommitLogFile commitLog;
     protected final FlatConsumeQueueFile consumeQueue;
-
-    protected final ConcurrentMap<String, CompletableFuture<?>> inFlightRequestMap;
 
     public FlatMessageFile(FlatFileFactory fileFactory, String topic, int queueId) {
         this(fileFactory, MessageStoreUtil.toFilePath(
@@ -75,7 +71,6 @@ public class FlatMessageFile implements FlatFileInterface {
         this.metadataStore = fileFactory.getMetadataStore();
         this.commitLog = fileFactory.createFlatFileForCommitLog(filePath);
         this.consumeQueue = fileFactory.createFlatFileForConsumeQueue(filePath);
-        this.inFlightRequestMap = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -236,8 +231,7 @@ public class FlatMessageFile implements FlatFileInterface {
 
     @Override
     public CompletableFuture<Boolean> commitAsync() {
-        // acquire lock
-        if (commitLock.drainPermits() <= 0) {
+        if (!commitLock.tryAcquire()) {
             return CompletableFuture.completedFuture(false);
         }
 
@@ -287,16 +281,16 @@ public class FlatMessageFile implements FlatFileInterface {
         ByteBuffer buffer = getMessageAsync(cqMax).join();
         long storeTime = MessageFormatUtil.getStoreTimeStamp(buffer);
         if (storeTime < timestamp) {
-            log.info("FlatMessageFile getQueueOffsetByTimeAsync, exceeded maximum time, " +
-                "filePath={}, timestamp={}, result={}", filePath, timestamp, cqMax + 1);
+            log.info("FlatMessageFile#getQueueOffsetByTimeAsync, exceeded maximum time, filePath={}, timestamp={}, result={}",
+                filePath, timestamp, cqMax + 1);
             return CompletableFuture.completedFuture(cqMax + 1);
         }
 
         buffer = getMessageAsync(cqMin).join();
         storeTime = MessageFormatUtil.getStoreTimeStamp(buffer);
         if (storeTime > timestamp) {
-            log.info("FlatMessageFile getQueueOffsetByTimeAsync, less than minimum time, " +
-                "filePath={}, timestamp={}, result={}", filePath, timestamp, cqMin);
+            log.info("FlatMessageFile#getQueueOffsetByTimeAsync, less than minimum time, filePath={}, timestamp={}, result={}",
+                filePath, timestamp, cqMin);
             return CompletableFuture.completedFuture(cqMin);
         }
 
@@ -351,7 +345,7 @@ public class FlatMessageFile implements FlatFileInterface {
             }
         }
 
-        log.info("FlatMessageFile getQueueOffsetByTimeAsync, filePath={}, timestamp={}, result={}, log={}",
+        log.info("FlatMessageFile#getQueueOffsetByTimeAsync, filePath={}, timestamp={}, result={}, log={}",
             filePath, timestamp, offset, JSON.toJSONString(queryLog));
         return CompletableFuture.completedFuture(offset);
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -161,9 +161,12 @@ public class IndexStoreFile implements IndexFile {
         return String.format("%s#%s", topic, key);
     }
 
+    /**
+     * Equivalent to {@code org.apache.rocketmq.store.index.IndexFile#indexKeyHashMethod}.
+     * Bitmask ensures non-negative result, including Integer.MIN_VALUE → 0.
+     */
     protected int hashCode(String keyStr) {
-        int keyHash = keyStr.hashCode();
-        return (keyHash < 0) ? -keyHash : keyHash;
+        return keyStr.hashCode() & 0x7FFFFFFF;
     }
 
     protected void flushNewMetadata(ByteBuffer byteBuffer, boolean end) throws IOException {
@@ -210,6 +213,7 @@ public class IndexStoreFile implements IndexFile {
 
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public AppendResult putKey(
         String topic, int topicId, int queueId, Set<String> keySet, long offset, int size, long timestamp) {
@@ -234,11 +238,13 @@ public class IndexStoreFile implements IndexFile {
                 return AppendResult.FILE_FULL;
             }
 
+            ByteBuffer slotBuffer = ByteBuffer.allocate(Integer.BYTES);
             for (String key : keySet) {
                 int hashCode = this.hashCode(this.buildKey(topic, key));
                 int slotPosition = this.getSlotPosition(hashCode % this.hashSlotMaxCount);
                 int slotOldValue = this.getSlotValue(slotPosition);
-                int timeDiff = (int) ((timestamp - this.beginTimestamp.get()) / 1000L);
+                int timeDiff = (int) Math.max(0, Math.min(Integer.MAX_VALUE,
+                    (timestamp - this.beginTimestamp.get()) / 1000L));
 
                 IndexItem indexItem = new IndexItem(
                     topicId, queueId, offset, size, hashCode, timeDiff, slotOldValue);
@@ -251,10 +257,7 @@ public class IndexStoreFile implements IndexFile {
                     fileChannel.position(itemPosition);
                     fileChannel.write(itemBuffer);
 
-                    ByteBuffer slotBuffer = ByteBuffer.allocate(Integer.BYTES);
                     slotBuffer.putInt(0, itemIndex);
-                    slotBuffer.position(0);
-                    slotBuffer.limit(Integer.BYTES);
                     fileChannel.position(slotPosition);
                     fileChannel.write(slotBuffer);
                 } else {
@@ -272,13 +275,13 @@ public class IndexStoreFile implements IndexFile {
                 }
                 this.flushNewMetadata(byteBuffer, indexItemMaxCount == this.indexItemCount.get() + 1);
 
-                log.trace("IndexStoreFile put key, timestamp: {}, topic: {}, key: {}, slot: {}, item: {}, previous item: {}, content: {}",
+                log.trace("IndexStoreFile#putKey, put key, timestamp={}, topic={}, key={}, slot={}, item={}, previousItem={}, content={}",
                     this.getTimestamp(), topic, key, hashCode % this.hashSlotMaxCount, itemIndex, slotOldValue, indexItem);
             }
             return AppendResult.SUCCESS;
         } catch (Throwable e) {
-            log.error("IndexStoreFile put key error, topic: {}, topicId: {}, queueId: {}, keySet: {}, offset: {}, " +
-                "size: {}, timestamp: {}", topic, topicId, queueId, keySet, offset, size, timestamp, e);
+            log.error("IndexStoreFile#putKey, put key error, topic={}, topicId={}, queueId={}, keySet={}, offset={}, size={}, timestamp={}",
+                topic, topicId, queueId, keySet, offset, size, timestamp, e);
         } finally {
             fileReadWriteLock.writeLock().unlock();
         }
@@ -306,6 +309,7 @@ public class IndexStoreFile implements IndexFile {
         String key, int maxCount, long beginTime, long endTime) {
 
         List<IndexItem> result = new ArrayList<>();
+        boolean held = false;
         try {
             fileReadWriteLock.readLock().lock();
             if (!UNSEALED.equals(this.fileStatus.get()) && !SEALED.equals(this.fileStatus.get())) {
@@ -315,6 +319,7 @@ public class IndexStoreFile implements IndexFile {
             if (mappedFile == null || !mappedFile.hold()) {
                 return CompletableFuture.completedFuture(result);
             }
+            held = true;
 
             int hashCode = this.hashCode(key);
             int slotPosition = this.getSlotPosition(hashCode % this.hashSlotMaxCount);
@@ -334,7 +339,7 @@ public class IndexStoreFile implements IndexFile {
                 if (hashCode == indexItem.getHashCode() &&
                     beginTime <= storeTimestamp && storeTimestamp <= endTime) {
                     result.add(indexItem);
-                    if (result.size() > maxCount) {
+                    if (result.size() >= maxCount) {
                         break;
                     }
                 }
@@ -342,15 +347,16 @@ public class IndexStoreFile implements IndexFile {
                 left--;
             }
 
-            log.debug("IndexStoreFile query from unsealed mapped file, timestamp: {}, result size: {}, " +
-                    "key: {}, hashCode: {}, maxCount: {}, timestamp={}-{}",
+            log.debug("IndexStoreFile#queryAsyncFromUnsealedFile, query from unsealed mapped file, timestamp={}, resultSize={}, key={}, hashCode={}, maxCount={}, timeRange={}-{}",
                 getTimestamp(), result.size(), key, hashCode, maxCount, beginTime, endTime);
         } catch (Exception e) {
-            log.error("IndexStoreFile query from unsealed mapped file error, timestamp: {}, " +
-                "key: {}, maxCount: {}, timestamp={}-{}", getTimestamp(), key, maxCount, beginTime, endTime, e);
+            log.error("IndexStoreFile#queryAsyncFromUnsealedFile, query from unsealed mapped file error, timestamp={}, key={}, maxCount={}, timeRange={}-{}",
+                getTimestamp(), key, maxCount, beginTime, endTime, e);
         } finally {
             fileReadWriteLock.readLock().unlock();
-            mappedFile.release();
+            if (held) {
+                mappedFile.release();
+            }
         }
 
         return CompletableFuture.completedFuture(result);
@@ -371,8 +377,8 @@ public class IndexStoreFile implements IndexFile {
         CompletableFuture<List<IndexItem>> future = this.fileSegment.readAsync(slotPosition, HASH_SLOT_SIZE)
             .thenCompose(slotBuffer -> {
                 if (slotBuffer.remaining() < HASH_SLOT_SIZE) {
-                    log.error("IndexStoreFile query from tiered storage return error slot buffer, " +
-                        "key: {}, maxCount: {}, timestamp={}-{}", key, maxCount, beginTime, endTime);
+                    log.error("IndexStoreFile#queryAsyncFromSegmentFile, slot buffer too small, key={}, maxCount={}, timeRange={}-{}",
+                        key, maxCount, beginTime, endTime);
                     return CompletableFuture.completedFuture(null);
                 }
                 int indexPosition = slotBuffer.getInt();
@@ -389,8 +395,8 @@ public class IndexStoreFile implements IndexFile {
                 }
 
                 if (itemBuffer.remaining() % COMPACT_INDEX_ITEM_SIZE != 0) {
-                    log.error("IndexStoreFile query from tiered storage return error item buffer, " +
-                        "key: {}, maxCount: {}, timestamp={}-{}", key, maxCount, beginTime, endTime);
+                    log.error("IndexStoreFile#queryAsyncFromSegmentFile, item buffer size mismatch, key={}, maxCount={}, timeRange={}-{}",
+                        key, maxCount, beginTime, endTime);
                     return result;
                 }
 
@@ -412,8 +418,7 @@ public class IndexStoreFile implements IndexFile {
         return future.whenComplete((result, throwable) -> {
             long costTime = stopwatch.elapsed(TimeUnit.MILLISECONDS);
             if (throwable != null) {
-                log.error("IndexStoreFile query from segment file, cost: {}ms, timestamp: {}, " +
-                        "key: {}, hashCode: {}, maxCount: {}, timestamp={}-{}",
+                log.error("IndexStoreFile#queryAsyncFromSegmentFile, query from segment file error, cost={}ms, timestamp={}, key={}, hashCode={}, maxCount={}, timeRange={}-{}",
                     costTime, getTimestamp(), key, hashCode, maxCount, beginTime, endTime, throwable);
             } else {
                 String details = Optional.ofNullable(result)
@@ -422,8 +427,7 @@ public class IndexStoreFile implements IndexFile {
                         .collect(Collectors.joining(", ")))
                     .orElse("");
 
-                log.debug("IndexStoreFile query from segment file, cost: {}ms, timestamp: {}, result size: {}, ({}), " +
-                        "key: {}, hashCode: {}, maxCount: {}, timestamp={}-{}",
+                log.debug("IndexStoreFile#queryAsyncFromSegmentFile, query from segment file, cost={}ms, timestamp={}, resultSize={}, ({}), key={}, hashCode={}, maxCount={}, timeRange={}-{}",
                     costTime, getTimestamp(), result != null ? result.size() : 0, details, key, hashCode, maxCount, beginTime, endTime);
             }
         });
@@ -435,12 +439,12 @@ public class IndexStoreFile implements IndexFile {
         ByteBuffer buffer;
         try {
             buffer = compactToNewFile();
-            log.debug("IndexStoreFile do compaction, timestamp: {}, file size: {}, cost: {}ms",
+            log.debug("IndexStoreFile#doCompaction, compaction done, timestamp={}, fileSize={}, cost={}ms",
                 this.getTimestamp(), buffer.capacity(), stopwatch.elapsed(TimeUnit.MICROSECONDS));
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         } catch (Throwable e) {
-            log.error("IndexStoreFile do compaction, timestamp: {}, cost: {}ms",
+            log.error("IndexStoreFile#doCompaction, compaction failed, timestamp={}, cost={}ms",
                 this.getTimestamp(), stopwatch.elapsed(TimeUnit.MICROSECONDS), e);
             return null;
         }
@@ -450,7 +454,7 @@ public class IndexStoreFile implements IndexFile {
             fileReadWriteLock.writeLock().lock();
             fileStatus.set(IndexStatusEnum.SEALED);
         } catch (Exception e) {
-            log.error("IndexStoreFile change file status to sealed error, timestamp={}", this.getTimestamp());
+            log.error("IndexStoreFile#doCompaction, change file status to sealed error, timestamp={}", this.getTimestamp(), e);
         } finally {
             fileReadWriteLock.writeLock().unlock();
         }
@@ -547,7 +551,7 @@ public class IndexStoreFile implements IndexFile {
                 this.compactMappedFile.cleanResources();
             }
         } catch (Throwable e) {
-            log.error("IndexStoreFile shutdown failed, timestamp: {}, status: {}", this.getTimestamp(), fileStatus.get(), e);
+            log.error("IndexStoreFile#shutdown, shutdown failed, timestamp={}, status={}", this.getTimestamp(), fileStatus.get(), e);
         } finally {
             fileReadWriteLock.writeLock().unlock();
         }
@@ -568,13 +572,13 @@ public class IndexStoreFile implements IndexFile {
                     if (this.compactMappedFile != null) {
                         this.compactMappedFile.destroy(TimeUnit.SECONDS.toMillis(10));
                     }
-                    log.debug("IndexStoreService destroy local file, timestamp: {}, status: {}", this.getTimestamp(), fileStatus.get());
+                    log.debug("IndexStoreFile#destroy, destroy local file, timestamp={}, status={}", this.getTimestamp(), fileStatus.get());
                     break;
                 case UPLOAD:
-                    log.warn("[BUG] IndexStoreService destroy remote file, timestamp: {}", this.getTimestamp());
+                    log.warn("IndexStoreFile#destroy, unexpected destroy for upload status, timestamp={}", this.getTimestamp());
             }
         } catch (Exception e) {
-            log.error("IndexStoreService destroy failed, timestamp: {}, status: {}", this.getTimestamp(), fileStatus.get(), e);
+            log.error("IndexStoreFile#destroy, destroy failed, timestamp={}, status={}", this.getTimestamp(), fileStatus.get(), e);
         } finally {
             fileReadWriteLock.writeLock().unlock();
         }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
@@ -105,7 +105,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                 mappedFile.shutdown(TimeUnit.SECONDS.toMillis(10));
             }
         } catch (Exception e) {
-            log.error("IndexStoreService do convert old format error, file: {}", filePath, e);
+            log.error("IndexStoreService#doConvertOldFormatFile, convert old format error, file={}", filePath, e);
         }
     }
 
@@ -134,9 +134,13 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                 try {
                     IndexFile indexFile = new IndexStoreFile(storeConfig, Long.parseLong(file.getName()));
                     timeStoreTable.put(indexFile.getTimestamp(), indexFile);
-                    log.info("IndexStoreService recover load local file, timestamp: {}", indexFile.getTimestamp());
+                    log.info("IndexStoreService#recover, load local file, timestamp={}", indexFile.getTimestamp());
                 } catch (Exception e) {
-                    log.error("IndexStoreService recover, load local file error", e);
+                    log.error("IndexStoreService#recover, load local file error, destroying={}", file.getName(), e);
+                    try {
+                        UtilAll.deleteFile(file);
+                    } catch (Exception ignored) {
+                    }
                 }
             }
         }
@@ -162,11 +166,11 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                 localFile.destroy();
             }
             timeStoreTable.put(indexFile.getTimestamp(), indexFile);
-            log.info("IndexStoreService recover load remote file, timestamp: {}, end timestamp: {}",
+            log.info("IndexStoreService#recover, load remote file, timestamp={}, endTimestamp={}",
                 indexFile.getTimestamp(), indexFile.getEndTimestamp());
         }
 
-        log.info("IndexStoreService recover finished, total: {}, cost: {}ms, directory: {}",
+        log.info("IndexStoreService#recover, recover finished, total={}, cost={}ms, directory={}",
             timeStoreTable.size(), stopwatch.elapsed(TimeUnit.MILLISECONDS), dir.getAbsolutePath());
     }
 
@@ -186,9 +190,9 @@ public class IndexStoreService extends ServiceThread implements IndexService {
             IndexStoreFile newStoreFile = new IndexStoreFile(storeConfig, timestamp);
             this.timeStoreTable.put(timestamp, newStoreFile);
             this.currentWriteFile = newStoreFile;
-            log.info("IndexStoreService construct next file, timestamp: {}", timestamp);
+            log.info("IndexStoreService#createNewIndexFile, construct next file, timestamp={}", timestamp);
         } catch (Exception e) {
-            log.error("IndexStoreService construct next file, timestamp: {}", timestamp, e);
+            log.error("IndexStoreService#createNewIndexFile, construct next file error, timestamp={}", timestamp, e);
         } finally {
             this.readWriteLock.writeLock().unlock();
         }
@@ -223,8 +227,8 @@ public class IndexStoreService extends ServiceThread implements IndexService {
             }
         }
 
-        log.error("IndexStoreService put key three times return error, topic: {}, topicId: {}, " +
-            "queueId: {}, keySize: {}, timestamp: {}", topic, topicId, queueId, keySet.size(), timestamp);
+        log.error("IndexStoreService#putKey, put key three times return error, topic={}, topicId={}, queueId={}, keySize={}, timestamp={}",
+            topic, topicId, queueId, keySet.size(), timestamp);
         return AppendResult.SUCCESS;
     }
 
@@ -264,14 +268,14 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                     // Try to return the query results as much as possible here
                     // rather than directly throwing exceptions
                     if (t != null) {
-                        log.error("IndexStoreService#queryAsync, topicId={}, key={}, maxCount={}, timestamp={}-{}",
+                        log.warn("IndexStoreService#queryAsync, partial query error, topicId={}, key={}, maxCount={}, timeRange={}-{}",
                             topic, key, maxCount, beginTime, endTime, t);
                     }
                     List<IndexItem> resultList = new ArrayList<>(result.values());
                     future.complete(resultList.subList(0, Math.min(resultList.size(), maxCount)));
                 });
         } catch (Exception e) {
-            log.error("IndexStoreService#queryAsync, topicId={}, key={}, maxCount={}, timestamp={}-{}",
+            log.error("IndexStoreService#queryAsync, query error, topicId={}, key={}, maxCount={}, timeRange={}-{}",
                 topic, key, maxCount, beginTime, endTime, e);
             future.completeExceptionally(e);
         } finally {
@@ -297,7 +301,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                 }
             }
         } catch (Exception e) {
-            log.error("IndexStoreService force upload error", e);
+            log.error("IndexStoreService#forceUpload, force upload error", e);
             throw new RuntimeException(e);
         } finally {
             readWriteLock.writeLock().unlock();
@@ -306,7 +310,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
 
     public boolean doCompactThenUploadFile(IndexFile indexFile) {
         if (IndexFile.IndexStatusEnum.UPLOAD.equals(indexFile.getFileStatus())) {
-            log.error("IndexStoreService file status not correct, so skip, timestamp: {}, status: {}",
+            log.warn("IndexStoreService#doCompactThenUploadFile, file status not correct, skip, timestamp={}, status={}",
                 indexFile.getTimestamp(), indexFile.getFileStatus());
             indexFile.destroy();
             return true;
@@ -316,7 +320,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
         if (flatAppendFile.getCommitOffset() == flatAppendFile.getAppendOffset()) {
             ByteBuffer byteBuffer = indexFile.doCompaction();
             if (byteBuffer == null) {
-                log.error("IndexStoreService found compaction buffer is null, timestamp: {}", indexFile.getTimestamp());
+                log.warn("IndexStoreService#doCompactThenUploadFile, compaction buffer is null, timestamp={}", indexFile.getTimestamp());
                 return false;
             }
             flatAppendFile.rollingNewFile(Math.max(0L, flatAppendFile.getAppendOffset()));
@@ -327,12 +331,16 @@ public class IndexStoreService extends ServiceThread implements IndexService {
         boolean result = flatAppendFile.commitAsync().join();
 
         List<FileSegment> fileSegmentList = flatAppendFile.getFileSegmentList();
+        if (fileSegmentList.isEmpty()) {
+            log.warn("IndexStoreService#doCompactThenUploadFile, upload error, fileSegmentList empty, timestamp={}", indexFile.getTimestamp());
+            return false;
+        }
         FileSegment fileSegment = fileSegmentList.get(fileSegmentList.size() - 1);
         if (!result || fileSegment == null || fileSegment.getMinTimestamp() != indexFile.getTimestamp()) {
-            log.warn("IndexStoreService upload compacted file error, timestamp: {}", indexFile.getTimestamp());
+            log.warn("IndexStoreService#doCompactThenUploadFile, upload compacted file error, timestamp={}", indexFile.getTimestamp());
             return false;
         } else {
-            log.info("IndexStoreService upload compacted file success, timestamp: {}", indexFile.getTimestamp());
+            log.info("IndexStoreService#doCompactThenUploadFile, upload compacted file success, timestamp={}", indexFile.getTimestamp());
         }
 
         readWriteLock.writeLock().lock();
@@ -341,7 +349,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
             timeStoreTable.put(storeFile.getTimestamp(), storeFile);
             indexFile.destroy();
         } catch (Exception e) {
-            log.error("IndexStoreService rolling file error, timestamp: {}, cost: {}ms",
+            log.error("IndexStoreService#doCompactThenUploadFile, rolling file error, timestamp={}, cost={}ms",
                 indexFile.getTimestamp(), stopwatch.elapsed(TimeUnit.MILLISECONDS), e);
         } finally {
             readWriteLock.writeLock().unlock();
@@ -361,7 +369,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
             int tableSize = (int) timeStoreTable.entrySet().stream()
                 .filter(entry -> IndexFile.IndexStatusEnum.UPLOAD.equals(entry.getValue().getFileStatus()))
                 .count();
-            log.debug("IndexStoreService delete file, timestamp={}, remote={}, table={}, all={}",
+            log.debug("IndexStoreService#destroyExpiredFile, delete file, timestamp={}, remote={}, table={}, all={}",
                 expireTimestamp, flatAppendFile.getFileSegmentList().size(), tableSize, timeStoreTable.size());
         } finally {
             readWriteLock.writeLock().unlock();
@@ -384,7 +392,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                 flatAppendFile.destroy();
             }
         } catch (Exception e) {
-            log.error("IndexStoreService destroy all file error", e);
+            log.error("IndexStoreService#destroy, destroy all file error", e);
         } finally {
             readWriteLock.writeLock().unlock();
         }
@@ -397,7 +405,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
 
     public void setCompactTimestamp(long timestamp) {
         this.compactTimestamp.set(timestamp);
-        log.debug("IndexStoreService set compact timestamp to: {}", timestamp);
+        log.debug("IndexStoreService#setCompactTimestamp, timestamp={}", timestamp);
     }
 
     protected IndexFile getNextSealedFile() {
@@ -412,19 +420,26 @@ public class IndexStoreService extends ServiceThread implements IndexService {
     @Override
     public void shutdown() {
         super.shutdown();
-        // Wait index service upload then clear time store table
-        while (!this.timeStoreTable.isEmpty()) {
-            try {
-                TimeUnit.MILLISECONDS.sleep(50);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+        readWriteLock.writeLock().lock();
+        try {
+            if (autoCreateNewFile) {
+                this.forceUpload();
             }
+        } catch (Exception e) {
+            log.error("IndexStoreService#shutdown, shutdown error", e);
+        } finally {
+            this.timeStoreTable.forEach((timestamp, file) -> file.shutdown());
+            this.timeStoreTable.clear();
+            readWriteLock.writeLock().unlock();
         }
+        log.info("{} service shutdown", this.getServiceName());
     }
 
     @Override
     public void forceShutdown() {
         super.shutdown();
+        this.timeStoreTable.forEach((timestamp, file) -> file.shutdown());
+        this.timeStoreTable.clear();
     }
 
     @Override
@@ -442,23 +457,9 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                     }
                 }
             } catch (Throwable e) {
-                log.error("IndexStoreService running error", e);
+                log.error("IndexStoreService#run, dispatch loop error", e);
             }
             this.waitForRunning(TimeUnit.SECONDS.toMillis(10));
         }
-        readWriteLock.writeLock().lock();
-        try {
-            if (autoCreateNewFile) {
-                this.forceUpload();
-            }
-        } catch (Exception e) {
-            log.error("IndexStoreService shutdown error", e);
-        } finally {
-            this.timeStoreTable.forEach((timestamp, file) -> file.shutdown());
-            this.timeStoreTable.clear();
-            readWriteLock.writeLock().unlock();
-        }
-
-        log.info(this.getServiceName() + " service shutdown");
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
 import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
@@ -153,6 +154,14 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
         } finally {
             fileLock.unlock();
         }
+        CompletableFuture<Boolean> inflight = this.flightCommitRequest;
+        if (inflight != null && !inflight.isDone()) {
+            try {
+                inflight.get(30, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                log.warn("FileSegment#close, await in-flight commit timeout, filePath={}", filePath, e);
+            }
+        }
     }
 
     protected List<ByteBuffer> borrowBuffer() {
@@ -228,7 +237,7 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
         if (fileSegmentInputStream != null) {
             long fileSize = this.getSize();
             if (fileSize == GET_FILE_SIZE_ERROR) {
-                log.error("FileSegment correct position error, fileName={}, commit={}, append={}, buffer={}",
+                log.error("FileSegment#commitAsync, correct position error, fileName={}, commit={}, append={}, buffer={}",
                     this.getPath(), commitPosition, appendPosition, fileSegmentInputStream.getContentLength());
                 releaseCommitLock();
                 return CompletableFuture.completedFuture(false);
@@ -272,7 +281,7 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
 
     private boolean handleCommitException(Throwable e) {
 
-        log.warn("FileSegment commit exception, filePath={}", this.filePath, e);
+        log.warn("FileSegment#handleCommitException, commit exception, filePath={}", this.filePath, e);
 
         // Get root cause here
         Throwable rootCause = e.getCause() != null ? e.getCause() : e;
@@ -282,7 +291,7 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
 
         long expectPosition = commitPosition + fileSegmentInputStream.getContentLength();
         if (fileSize == GET_FILE_SIZE_ERROR) {
-            log.error("Get file size error after commit, FileName: {}, Commit: {}, Content: {}, Expect: {}, Append: {}",
+            log.error("FileSegment#handleCommitException, get file size error after commit, fileName={}, commit={}, content={}, expect={}, append={}",
                 this.getPath(), commitPosition, fileSegmentInputStream.getContentLength(), expectPosition, appendPosition);
             return false;
         }
@@ -326,26 +335,26 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
     public CompletableFuture<ByteBuffer> readAsync(long position, int length) {
         CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
 
-        if (position < 0 || position >= commitPosition) {
+        long currentCommitPosition = commitPosition;
+        if (position < 0 || position >= currentCommitPosition) {
             future.completeExceptionally(new TieredStoreException(TieredStoreErrorCode.ILLEGAL_PARAM,
                 String.format("FileSegment read position illegal, filePath=%s, fileType=%s, position=%d, length=%d, commit=%d",
-                    filePath, fileType, position, length, commitPosition)));
+                    filePath, fileType, position, length, currentCommitPosition)));
             return future;
         }
 
         if (length <= 0) {
             future.completeExceptionally(new TieredStoreException(TieredStoreErrorCode.ILLEGAL_PARAM,
                 String.format("FileSegment read length illegal, filePath=%s, fileType=%s, position=%d, length=%d, commit=%d",
-                    filePath, fileType, position, length, commitPosition)));
+                    filePath, fileType, position, length, currentCommitPosition)));
             return future;
         }
 
-        int readableBytes = (int) (commitPosition - position);
+        int readableBytes = (int) (currentCommitPosition - position);
         if (readableBytes < length) {
+            log.debug("FileSegment#readAsync, request position exceeds commit position, file={}, requestPosition={}, commitPosition={}, changeLength={} to {}",
+                getPath(), position, currentCommitPosition, length, readableBytes);
             length = readableBytes;
-            log.debug("FileSegment expect request position is greater than commit position, " +
-                    "file: {}, request position: {}, commit position: {}, change length from {} to {}",
-                getPath(), position, commitPosition, length, readableBytes);
         }
         return this.read0(position, length);
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegmentFactory.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegmentFactory.java
@@ -42,7 +42,7 @@ public class FileSegmentFactory {
             fileSegmentConstructor = clazz.getConstructor(
                 MessageStoreConfig.class, FileSegmentType.class, String.class, Long.TYPE, MessageStoreExecutor.class);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to load FileSegment provider: " + storeConfig.getTieredBackendServiceProvider(), e);
         }
     }
 
@@ -58,7 +58,7 @@ public class FileSegmentFactory {
         try {
             return fileSegmentConstructor.newInstance(this.storeConfig, fileType, filePath, baseOffset, executor);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to create FileSegment: type=" + fileType + ", path=" + filePath, e);
         }
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/MemoryFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/MemoryFileSegment.java
@@ -92,7 +92,7 @@ public class MemoryFileSegment extends FileSegment {
 
         try {
             if (blocker != null && !blocker.get()) {
-                log.info("Commit Blocker Exception for Memory Test");
+                log.debug("MemoryFileSegment#commit0, commit blocker exception for memory test");
                 return CompletableFuture.completedFuture(false);
             }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/PosixFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/PosixFileSegment.java
@@ -58,22 +58,23 @@ public class PosixFileSegment extends FileSegment {
     private volatile File file;
     private volatile FileChannel readFileChannel;
     private volatile FileChannel writeFileChannel;
+    private volatile RandomAccessFile readRandomAccessFile;
+    private volatile RandomAccessFile writeRandomAccessFile;
 
     public PosixFileSegment(MessageStoreConfig storeConfig,
         FileSegmentType fileType, String filePath, long baseOffset, MessageStoreExecutor executor) {
 
         super(storeConfig, fileType, filePath, baseOffset, executor);
 
-        // basePath
-        String basePath = StringUtils.defaultString(storeConfig.getTieredStoreFilePath(),
-            StringUtils.appendIfMissing(storeConfig.getTieredStoreFilePath(), File.separator));
+        String basePath = StringUtils.isNotBlank(storeConfig.getTieredStoreFilePath())
+            ? storeConfig.getTieredStoreFilePath() : storeConfig.getStorePathRootDir();
 
         // fullPath: basePath/hash_cluster/broker/topic/queueId/fileType/baseOffset
         String clusterName = storeConfig.getBrokerClusterName();
         String clusterBasePath = String.format("%s_%s", MessageStoreUtil.getHash(clusterName), clusterName);
         fullPath = Paths.get(basePath, clusterBasePath, filePath,
             fileType.toString(), MessageStoreUtil.offset2FileName(baseOffset)).toString();
-        log.info("Constructing Posix FileSegment, filePath: {}", fullPath);
+        log.info("PosixFileSegment#init, constructing, filePath={}", fullPath);
 
         this.createFile();
     }
@@ -113,7 +114,7 @@ public class PosixFileSegment extends FileSegment {
         }
     }
 
-    @SuppressWarnings({"resource", "ResultOfMethodCallIgnored"})
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     private void createFile0() {
         try {
             File file = new File(fullPath);
@@ -123,14 +124,16 @@ public class PosixFileSegment extends FileSegment {
             }
             if (!file.exists()) {
                 if (file.createNewFile()) {
-                    log.debug("Create Posix FileSegment, filePath: {}", fullPath);
+                    log.debug("PosixFileSegment#createFile0, create file, filePath={}", fullPath);
                 }
             }
-            this.readFileChannel = new RandomAccessFile(file, "r").getChannel();
-            this.writeFileChannel = new RandomAccessFile(file, "rwd").getChannel();
+            this.readRandomAccessFile = new RandomAccessFile(file, "r");
+            this.readFileChannel = this.readRandomAccessFile.getChannel();
+            this.writeRandomAccessFile = new RandomAccessFile(file, "rwd");
+            this.writeFileChannel = this.writeRandomAccessFile.getChannel();
             this.file = file;
         } catch (Exception e) {
-            log.error("PosixFileSegment#createFile: create file {} failed: ", filePath, e);
+            log.error("PosixFileSegment#createFile0, create file failed, filePath={}", filePath, e);
         }
     }
 
@@ -140,9 +143,9 @@ public class PosixFileSegment extends FileSegment {
         this.close();
         if (file != null && file.exists()) {
             if (file.delete()) {
-                log.info("Destroy Posix FileSegment, filePath: {}", fullPath);
+                log.info("PosixFileSegment#destroyFile, destroy file, filePath={}", fullPath);
             } else {
-                log.warn("Destroy Posix FileSegment error, filePath: {}", fullPath);
+                log.warn("PosixFileSegment#destroyFile, destroy file error, filePath={}", fullPath);
             }
         }
     }
@@ -155,12 +158,20 @@ public class PosixFileSegment extends FileSegment {
                 readFileChannel.close();
                 readFileChannel = null;
             }
+            if (readRandomAccessFile != null) {
+                readRandomAccessFile.close();
+                readRandomAccessFile = null;
+            }
             if (writeFileChannel != null && writeFileChannel.isOpen()) {
                 writeFileChannel.close();
                 writeFileChannel = null;
             }
+            if (writeRandomAccessFile != null) {
+                writeRandomAccessFile.close();
+                writeRandomAccessFile = null;
+            }
         } catch (IOException e) {
-            log.error("Destroy Posix FileSegment failed, filePath: {}", fullPath, e);
+            log.error("PosixFileSegment#close, close failed, filePath={}", fullPath, e);
         }
     }
 
@@ -173,8 +184,7 @@ public class PosixFileSegment extends FileSegment {
         return CompletableFuture.supplyAsync((Supplier<ByteBuffer>) () -> {
             ByteBuffer byteBuffer = ByteBuffer.allocate(length);
             try {
-                readFileChannel.position(position);
-                readFileChannel.read(byteBuffer);
+                readFileChannel.read(byteBuffer, position);
                 byteBuffer.flip();
                 byteBuffer.limit(length);
 
@@ -191,9 +201,10 @@ public class PosixFileSegment extends FileSegment {
                 long costTime = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
                 attributesBuilder.put(LABEL_SUCCESS, false);
                 TieredStoreMetricsManager.providerRpcLatency.record(costTime, attributesBuilder.build());
+                throw new RuntimeException(e);
             }
             return byteBuffer;
-        }, executor.bufferFetchExecutor);
+        }, executor.getBufferFetchExecutor());
     }
 
     @Override
@@ -229,6 +240,6 @@ public class PosixFileSegment extends FileSegment {
                 return false;
             }
             return true;
-        }, executor.bufferCommitExecutor);
+        }, executor.getBufferCommitExecutor());
     }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/stream/CommitLogInputStream.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/stream/CommitLogInputStream.java
@@ -147,9 +147,9 @@ public class CommitLogInputStream extends FileSegmentInputStream {
                 posInCurBuffer += readLen;
                 continue;
             }
+            curBuf = bufferList.get(bufIndex);
             remaining = curBuf.remaining() - posInCurBuffer;
             readLen = Math.min(remaining, needRead);
-            curBuf = bufferList.get(bufIndex);
             if (posInCurBuffer < MessageFormatUtil.PHYSICAL_OFFSET_POSITION) {
                 realReadLen = Math.min(MessageFormatUtil.PHYSICAL_OFFSET_POSITION - posInCurBuffer, readLen);
                 // read from commitLog buffer

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageFormatUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageFormatUtil.java
@@ -104,7 +104,9 @@ public class MessageFormatUtil {
     public static List<SelectBufferResult> splitMessageBuffer(ByteBuffer cqBuffer, ByteBuffer msgBuffer) {
 
         if (cqBuffer == null || msgBuffer == null) {
-            log.error("MessageFormatUtil split buffer error, cq buffer or msg buffer is null");
+            log.error("MessageFormatUtil#splitMessageBuffer, cqBuffer={}, msgBuffer={}",
+                cqBuffer == null ? "null" : "size=" + cqBuffer.remaining(),
+                msgBuffer == null ? "null" : "size=" + msgBuffer.remaining());
             return new ArrayList<>();
         }
 
@@ -115,12 +117,13 @@ public class MessageFormatUtil {
             cqBuffer.remaining() / CONSUME_QUEUE_UNIT_SIZE);
 
         if (msgBuffer.remaining() == 0) {
-            log.error("MessageFormatUtil split buffer error, msg buffer length is 0");
+            log.error("MessageFormatUtil#splitMessageBuffer, msgBuffer is empty, cqBufferSize={}", cqBuffer.remaining());
             return bufferResultList;
         }
 
         if (cqBuffer.remaining() == 0 || cqBuffer.remaining() % CONSUME_QUEUE_UNIT_SIZE != 0) {
-            log.error("MessageFormatUtil split buffer error, cq buffer size is {}", cqBuffer.remaining());
+            log.error("MessageFormatUtil#splitMessageBuffer, cqBuffer size invalid, cqBufferSize={}, msgBufferSize={}",
+                cqBuffer.remaining(), msgBuffer.remaining());
             return bufferResultList;
         }
 
@@ -137,8 +140,10 @@ public class MessageFormatUtil {
 
                 int offset = (int) (logOffset - firstCommitLogOffset);
                 if (offset + bufferSize > msgBuffer.limit()) {
-                    log.error("MessageFormatUtil split buffer error, message buffer offset exceeded limit. " +
-                        "Expect length: {}, Actual length: {}", offset + bufferSize, msgBuffer.limit());
+                    log.error("MessageFormatUtil#splitMessageBuffer, message buffer offset exceeded limit, " +
+                            "index={}, total={}, firstCommitLogOffset={}, logOffset={}, bufferSize={}, msgBufferLimit={}",
+                        position / CONSUME_QUEUE_UNIT_SIZE, bufferResultList.size(), firstCommitLogOffset,
+                        logOffset, bufferSize, msgBuffer.limit());
                     break;
                 }
 
@@ -151,14 +156,16 @@ public class MessageFormatUtil {
                 }
                 if (magicCode != MessageDecoder.MESSAGE_MAGIC_CODE &&
                     magicCode != MessageDecoder.MESSAGE_MAGIC_CODE_V2) {
-                    log.error("MessageFormatUtil split buffer error, found unknown magic code. " +
-                        "Message offset: {}, wrong magic code: {}", offset, magicCode);
+                    log.error("MessageFormatUtil#splitMessageBuffer, unknown magic code, " +
+                            "index={}, messageOffset={}, logOffset={}, magicCode={}",
+                        position / CONSUME_QUEUE_UNIT_SIZE, offset, logOffset, magicCode);
                     continue;
                 }
 
                 if (bufferSize != getTotalSize(msgBuffer)) {
-                    log.error("MessageFormatUtil split buffer error, message length not match. " +
-                        "CommitLog length: {}, buffer length: {}", getTotalSize(msgBuffer), bufferSize);
+                    log.error("MessageFormatUtil#splitMessageBuffer, message length not match, " +
+                            "index={}, messageOffset={}, logOffset={}, commitLogLength={}, cqRecordedLength={}",
+                        position / CONSUME_QUEUE_UNIT_SIZE, offset, logOffset, getTotalSize(msgBuffer), bufferSize);
                     continue;
                 }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtil.java
@@ -20,7 +20,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import org.apache.rocketmq.common.message.MessageQueue;
 
@@ -37,10 +36,8 @@ public class MessageStoreUtil {
     public static final long PB = TB << 10;
     public static final long EB = PB << 10;
 
-    private static final DecimalFormat DEC_FORMAT = new DecimalFormat("#.##");
-
     private static String formatSize(long size, long divider, String unitName) {
-        return DEC_FORMAT.format((double) size / divider) + unitName;
+        return String.format("%.2f%s", (double) size / divider, unitName);
     }
 
     public static String toHumanReadable(long size) {

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/TieredMessageStoreTest.java
@@ -84,6 +84,7 @@ public class TieredMessageStoreTest {
         Properties properties = new Properties();
         properties.setProperty("recordGetMessageResult", Boolean.TRUE.toString().toLowerCase(Locale.ROOT));
         properties.setProperty("tieredBackendServiceProvider", PosixFileSegment.class.getName());
+        properties.setProperty("tieredStoreFilePath", storePath);
 
         configuration = new Configuration(LoggerFactory.getLogger(
             MessageStoreUtil.TIERED_STORE_LOGGER_NAME), storePath + File.separator + "conf",

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
@@ -37,6 +37,7 @@ import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.TieredMessageStore;
 import org.apache.rocketmq.tieredstore.common.GroupCommitContext;
 import org.apache.rocketmq.tieredstore.file.FlatFileFactory;
+import org.apache.rocketmq.tieredstore.file.FlatFileInterface;
 import org.apache.rocketmq.tieredstore.file.FlatFileStore;
 import org.apache.rocketmq.tieredstore.file.FlatMessageFile;
 import org.apache.rocketmq.tieredstore.index.IndexItem;
@@ -88,6 +89,7 @@ public class MessageStoreDispatcherImplTest {
         if (messageStore != null) {
             messageStore.destroy();
         }
+        executor.shutdown();
         MessageStoreUtilTest.deleteStoreDirectory(storePath);
     }
 
@@ -99,7 +101,7 @@ public class MessageStoreDispatcherImplTest {
 
         messageStore = Mockito.mock(TieredMessageStore.class);
         IndexService indexService =
-            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
+            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig, executor), storePath);
         indexService.start();
         Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
         Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
@@ -167,7 +169,7 @@ public class MessageStoreDispatcherImplTest {
 
         messageStore = Mockito.mock(TieredMessageStore.class);
         IndexService indexService =
-            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
+            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig, executor), storePath);
         indexService.start();
         Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
         Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
@@ -231,7 +233,7 @@ public class MessageStoreDispatcherImplTest {
 
         messageStore = Mockito.mock(TieredMessageStore.class);
         IndexService indexService =
-            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
+            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig, executor), storePath);
         indexService.start();
         Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
         Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
@@ -288,7 +290,7 @@ public class MessageStoreDispatcherImplTest {
         MessageStore defaultStore = Mockito.mock(MessageStore.class);
         messageStore = Mockito.mock(TieredMessageStore.class);
         IndexService indexService =
-            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig), storePath);
+            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig, executor), storePath);
         Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
         Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
         Mockito.when(messageStore.getStoreExecutor()).thenReturn(executor);
@@ -311,7 +313,7 @@ public class MessageStoreDispatcherImplTest {
         Mockito.doAnswer(mock -> {
             result.set(true);
             return true;
-        }).when(dispatcherSpy).dispatchWithSemaphore(any());
+        }).when(dispatcherSpy).dispatch(any(FlatFileInterface.class));
         dispatcherSpy.start();
         Awaitility.await().atMost(Duration.ofSeconds(10)).until(result::get);
         dispatcherSpy.shutdown();

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatAppendFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatAppendFileTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.concurrent.CompletionException;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.common.FileSegmentType;
 import org.apache.rocketmq.tieredstore.exception.TieredStoreErrorCode;
 import org.apache.rocketmq.tieredstore.exception.TieredStoreException;
@@ -43,6 +44,7 @@ public class FlatAppendFileTest {
     private MessageQueue queue;
     private MetadataStore metadataStore;
     private MessageStoreConfig storeConfig;
+    private MessageStoreExecutor executor;
     private FlatFileFactory flatFileFactory;
 
     @Before
@@ -56,11 +58,13 @@ public class FlatAppendFileTest {
         storeConfig.setTieredStoreConsumeQueueMaxSize(2000L);
         queue = new MessageQueue("TieredFlatFileTest", storeConfig.getBrokerName(), 0);
         metadataStore = new DefaultMetadataStore(storeConfig);
-        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig);
+        executor = new MessageStoreExecutor();
+        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig, executor);
     }
 
     @After
     public void shutdown() throws IOException {
+        executor.shutdown();
         MessageStoreUtilTest.deleteStoreDirectory(storePath);
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatCommitLogFileTest.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
 import org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore;
 import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
@@ -40,6 +41,7 @@ public class FlatCommitLogFileTest {
     private MessageQueue queue;
     private MetadataStore metadataStore;
     private MessageStoreConfig storeConfig;
+    private MessageStoreExecutor executor;
     private FlatFileFactory flatFileFactory;
 
     @Before
@@ -53,11 +55,13 @@ public class FlatCommitLogFileTest {
         storeConfig.setTieredStoreConsumeQueueMaxSize(2000L);
         queue = new MessageQueue("TieredFlatFileTest", storeConfig.getBrokerName(), 0);
         metadataStore = new DefaultMetadataStore(storeConfig);
-        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig);
+        executor = new MessageStoreExecutor();
+        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig, executor);
     }
 
     @After
     public void shutdown() throws IOException {
+        executor.shutdown();
         MessageStoreUtilTest.deleteStoreDirectory(storePath);
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatFileFactoryTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatFileFactoryTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.tieredstore.file;
 
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore;
 import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
 import org.apache.rocketmq.tieredstore.util.MessageStoreUtilTest;
@@ -30,7 +31,8 @@ public class FlatFileFactoryTest {
         MessageStoreConfig storeConfig = new MessageStoreConfig();
         storeConfig.setTieredStoreFilePath(MessageStoreUtilTest.getRandomStorePath());
         MetadataStore metadataStore = new DefaultMetadataStore(storeConfig);
-        FlatFileFactory factory = new FlatFileFactory(metadataStore, storeConfig);
+        MessageStoreExecutor executor = new MessageStoreExecutor();
+        FlatFileFactory factory = new FlatFileFactory(metadataStore, storeConfig, executor);
         Assert.assertEquals(storeConfig, factory.getStoreConfig());
         Assert.assertEquals(metadataStore, factory.getMetadataStore());
 
@@ -45,5 +47,6 @@ public class FlatFileFactoryTest {
         flatFile1.destroy();
         flatFile2.destroy();
         flatFile3.destroy();
+        executor.shutdown();
     }
 }

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatFileStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatFileStoreTest.java
@@ -45,6 +45,7 @@ public class FlatFileStoreTest {
     public void init() {
         storeConfig = new MessageStoreConfig();
         storeConfig.setStorePathRootDir(storePath);
+        storeConfig.setTieredStoreFilePath(storePath);
         storeConfig.setTieredBackendServiceProvider(PosixFileSegment.class.getName());
         storeConfig.setBrokerName("brokerName");
         metadataStore = new DefaultMetadataStore(storeConfig);

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatMessageFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatMessageFileTest.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.store.ConsumeQueue;
 import org.apache.rocketmq.store.DispatchRequest;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
 import org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore;
 import org.apache.rocketmq.tieredstore.metadata.MetadataStore;
@@ -41,6 +42,7 @@ public class FlatMessageFileTest {
     private final String storePath = MessageStoreUtilTest.getRandomStorePath();
     private MessageStoreConfig storeConfig;
     private MetadataStore metadataStore;
+    private MessageStoreExecutor executor;
     private FlatFileFactory flatFileFactory;
 
     @Before
@@ -48,15 +50,18 @@ public class FlatMessageFileTest {
         storeConfig = new MessageStoreConfig();
         storeConfig.setBrokerName("brokerName");
         storeConfig.setStorePathRootDir(storePath);
+        storeConfig.setTieredStoreFilePath(storePath);
         storeConfig.setTieredBackendServiceProvider(PosixFileSegment.class.getName());
         storeConfig.setCommitLogRollingInterval(0);
         storeConfig.setCommitLogRollingMinimumSize(999);
         metadataStore = new DefaultMetadataStore(storeConfig);
-        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig);
+        executor = new MessageStoreExecutor();
+        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig, executor);
     }
 
     @After
     public void shutdown() throws IOException {
+        executor.shutdown();
         MessageStoreUtilTest.deleteStoreDirectory(storePath);
     }
 
@@ -142,7 +147,7 @@ public class FlatMessageFileTest {
 
         // replace provider, need new factory again
         storeConfig.setTieredBackendServiceProvider(PosixFileSegment.class.getName());
-        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig);
+        flatFileFactory = new FlatFileFactory(metadataStore, storeConfig, executor);
 
         // inject store time: 0, +100, +100, +100, +200
         MessageQueue mq = new MessageQueue("TopicTest", "BrokerName", 1);

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceBenchTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceBenchTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
 import org.apache.rocketmq.tieredstore.file.FlatFileFactory;
 import org.apache.rocketmq.tieredstore.metadata.DefaultMetadataStore;
@@ -61,6 +62,7 @@ public class IndexStoreServiceBenchTest {
     private static final Logger log = LoggerFactory.getLogger(MessageStoreUtil.TIERED_STORE_LOGGER_NAME);
     private static final String TOPIC_NAME = "TopicTest";
     private MessageStoreConfig storeConfig;
+    private MessageStoreExecutor executor;
     private IndexStoreService indexStoreService;
     private final LongAdder failureCount = new LongAdder();
 
@@ -77,7 +79,8 @@ public class IndexStoreServiceBenchTest {
         storeConfig.setTieredStoreIndexFileMaxHashSlotNum(500 * 1000);
         storeConfig.setTieredStoreIndexFileMaxIndexNum(2000 * 1000);
         MetadataStore metadataStore = new DefaultMetadataStore(storeConfig);
-        FlatFileFactory flatFileFactory = new FlatFileFactory(metadataStore, storeConfig);
+        executor = new MessageStoreExecutor();
+        FlatFileFactory flatFileFactory = new FlatFileFactory(metadataStore, storeConfig, executor);
         indexStoreService = new IndexStoreService(flatFileFactory, storePath);
         indexStoreService.start();
     }
@@ -86,6 +89,7 @@ public class IndexStoreServiceBenchTest {
     public void shutdown() throws IOException {
         indexStoreService.shutdown();
         indexStoreService.destroy();
+        executor.shutdown();
     }
 
     //@Benchmark

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceTest.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.store.logfile.DefaultMappedFile;
 import org.apache.rocketmq.tieredstore.MessageStoreConfig;
+import org.apache.rocketmq.tieredstore.MessageStoreExecutor;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
 import org.apache.rocketmq.tieredstore.file.FlatAppendFile;
 import org.apache.rocketmq.tieredstore.file.FlatFileFactory;
@@ -67,6 +68,7 @@ public class IndexStoreServiceTest {
 
     private String filePath;
     private MessageStoreConfig storeConfig;
+    private MessageStoreExecutor executor;
     private FlatFileFactory fileAllocator;
     private IndexStoreService indexService;
 
@@ -81,7 +83,8 @@ public class IndexStoreServiceTest {
         storeConfig.setTieredStoreIndexFileMaxIndexNum(20);
         storeConfig.setTieredBackendServiceProvider("org.apache.rocketmq.tieredstore.provider.PosixFileSegment");
         MetadataStore metadataStore = new DefaultMetadataStore(storeConfig);
-        fileAllocator = new FlatFileFactory(metadataStore, storeConfig);
+        executor = new MessageStoreExecutor();
+        fileAllocator = new FlatFileFactory(metadataStore, storeConfig, executor);
     }
 
     @After
@@ -90,6 +93,7 @@ public class IndexStoreServiceTest {
             indexService.shutdown();
             indexService.destroy();
         }
+        executor.shutdown();
         MessageStoreUtilTest.deleteStoreDirectory(storeConfig.getTieredStoreFilePath());
     }
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtilTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/util/MessageStoreUtilTest.java
@@ -53,14 +53,14 @@ public class MessageStoreUtilTest {
         Map<Long, String> capacityTable = new HashMap<Long, String>() {
             {
                 put(-1L, "-1");
-                put(0L, "0B");
-                put(1023L, "1023B");
-                put(1024L, "1KB");
+                put(0L, "0.00B");
+                put(1023L, "1023.00B");
+                put(1024L, "1.00KB");
                 put(12_345L, "12.06KB");
                 put(10_123_456L, "9.65MB");
                 put(10_123_456_798L, "9.43GB");
-                put(123 * 1024L * 1024L * 1024L * 1024L, "123TB");
-                put(123 * 1024L * 1024L * 1024L * 1024L * 1024L, "123PB");
+                put(123 * 1024L * 1024L * 1024L * 1024L, "123.00TB");
+                put(123 * 1024L * 1024L * 1024L * 1024L * 1024L, "123.00PB");
                 put(1_777_777_777_777_777_777L, "1.54EB");
             }
         };


### PR DESCRIPTION
## What is the purpose of the change

Closes #10462

Systematic improvements to the tieredstore module covering memory backpressure, concurrency safety, resource leak fixes, thread pool optimization, error handling, and log standardization.

## Brief changelog

**Memory backpressure**
- Add `tieredStoreDispatchMinFreeMemoryRatio` (default 0.1) and `tieredStoreDispatchMinFreeMemoryMaxBytes` (default 1GB)
- Check available heap memory via `isMemoryEnough()` before dispatch

**Concurrency fixes**
- PosixFileSegment: `read(ByteBuffer, long)` instead of `position() + read()`
- IndexStoreFile: hash `& 0x7FFFFFFF` to prevent MIN_VALUE overflow; `held` flag fixes unmatched `mappedFile.release()`; `>= maxCount` fixes off-by-one
- FlatCommitLogFile: local variable snapshot for firstOffset to prevent TOCTOU
- FlatMessageFile: add `volatile` to `topicMetadata`/`queueMetadata`

**Resource management**
- FileSegment `close()` waits for in-flight commit (30s timeout)
- PosixFileSegment: store RAF references to prevent handle leaks
- MessageStoreExecutor `shutdown()`: add `awaitTermination(30s)`
- Remove MessageStoreExecutor singleton pattern and `fileRecyclingExecutor`
- FlatFileFactory: remove test constructor that leaks thread pool
- FlatMessageFile: remove dead code `inFlightRequestMap`

**Thread pool optimization**
- commit/fetch pools: core `max(4, processors)`, max `max(16, processors * 2)`

**Error handling**
- TieredMessageStore: unwrap `CompletionException`, re-throw `Error`
- PosixFileSegment: throw `RuntimeException` on IOException instead of silently returning empty buffer
- FlatAppendFile: `getFileCorrectSize` changed to bounded 3-retry
- IndexStoreFile: `timeDiff` clamped to `[0, Integer.MAX_VALUE]`
- `commitAsync`: use `tryAcquire()` instead of `drainPermits()`

**Log standardization**
- Unify to `ClassName#methodName, description, key={}` format
- Fix wrong class name `IndexStoreService` in IndexStoreFile logs
- Fix SLF4J placeholder count mismatches and missing commas

## Verifying this change

- [x] Make sure there is no an existing issue for this
- [x] Make sure that this PR is sent to `develop` branch
- [x] Documentation is not needed
- [x] `mvn compile` succeeds
- [x] `mvn test -pl tieredstore` passes (112 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)