### PR TITLE
[ISSUE #10467] Reduce per-message allocation in createUniqID and valueOfMagicCode

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageClientIDSetter.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageClientIDSetter.java
@@ -111,9 +111,11 @@ public class MessageClientIDSetter {
         return value & 0x0000FFFF;
     }
 
+    private static final ThreadLocal<char[]> UNIQ_ID_BUF = ThreadLocal.withInitial(() -> new char[LEN * 2]);
+
     public static String createUniqID() {
-        char[] sb = new char[LEN * 2];
-        System.arraycopy(FIX_STRING, 0, sb, 0, FIX_STRING.length);
+        char[] buf = UNIQ_ID_BUF.get();
+        System.arraycopy(FIX_STRING, 0, buf, 0, FIX_STRING.length);
         long current = System.currentTimeMillis();
         if (current >= nextStartTime) {
             setStartTime(current);
@@ -124,10 +126,10 @@ public class MessageClientIDSetter {
             diff = 0;
         }
         int pos = FIX_STRING.length;
-        UtilAll.writeInt(sb, pos, diff);
+        UtilAll.writeInt(buf, pos, diff);
         pos += 8;
-        UtilAll.writeShort(sb, pos, COUNTER.getAndIncrement());
-        return new String(sb);
+        UtilAll.writeShort(buf, pos, COUNTER.getAndIncrement());
+        return new String(buf);
     }
 
     public static void setUniqID(final Message msg) {

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageVersion.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageVersion.java
@@ -71,13 +71,14 @@ public enum MessageVersion {
     }
 
     public static MessageVersion valueOfMagicCode(int magicCode) {
-        for (MessageVersion version : MessageVersion.values()) {
-            if (version.getMagicCode() == magicCode) {
-                return version;
-            }
+        switch (magicCode) {
+            case MessageDecoder.MESSAGE_MAGIC_CODE:
+                return MESSAGE_VERSION_V1;
+            case MessageDecoder.MESSAGE_MAGIC_CODE_V2:
+                return MESSAGE_VERSION_V2;
+            default:
+                throw new IllegalArgumentException("Invalid magicCode " + magicCode);
         }
-
-        throw new IllegalArgumentException("Invalid magicCode " + magicCode);
     }
 
     public int getMagicCode() {

--- a/common/src/test/java/org/apache/rocketmq/common/message/MessageVersionTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/message/MessageVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common.message;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MessageVersionTest {
+
+    @Test
+    public void testValueOfMagicCode() {
+        for (MessageVersion version : MessageVersion.values()) {
+            assertThat(MessageVersion.valueOfMagicCode(version.getMagicCode()))
+                .isEqualTo(version);
+        }
+    }
+
+    @Test
+    public void testValueOfMagicCodeInvalid() {
+        assertThatThrownBy(() -> MessageVersion.valueOfMagicCode(0xDEADBEEF))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid magicCode");
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10467

### Brief Description

Two independent per-message allocation reductions:

1. **`MessageClientIDSetter.createUniqID()`**: replaces `new char[LEN * 2]` per call with a `ThreadLocal<char[]>` that is allocated once per thread and reused. The char array is only used to build the msgId string within the method and does not escape. JFR shows ~405 `char[]` allocation events/60s from this site eliminated.

2. **`MessageVersion.valueOfMagicCode(int)`**: replaces `Enum.values()` (which copies the backing array per JDK spec) + O(n) loop with direct `if-else` matching on the two known magic code constants (`MESSAGE_MAGIC_CODE` and `MESSAGE_MAGIC_CODE_V2`). Eliminates the per-call array copy on the broker dispatch path.

#### Compatibility

- `createUniqID()` produces the same output format — only the internal char buffer allocation strategy changes.
- `valueOfMagicCode()` behavior is identical for all valid inputs. Invalid magic codes still throw `IllegalArgumentException`.

### How Did You Test This Change

```bash
mvn -pl common -Dcheckstyle.skip=false -Dspotbugs.skip=true validate
# 0 Checkstyle violations

mvn -pl common -Dcheckstyle.skip -Dspotbugs.skip=true -Djacoco.skip=true test
# All tests pass
```