### PR TITLE
[ISSUE #10462] Optimize thread pool sizes

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreExecutor.java
@@ -48,31 +48,32 @@ public class MessageStoreExecutor {
     }
 
     public MessageStoreExecutor(int maxQueueCapacity) {
+        int processors = Runtime.getRuntime().availableProcessors();
 
         this.commonExecutor = ThreadUtils.newScheduledThreadPool(
-            Math.max(4, Runtime.getRuntime().availableProcessors()),
+            Math.max(4, processors),
             new ThreadFactoryImpl("TieredCommonExecutor_"));
 
         this.bufferCommitThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
         this.bufferCommitExecutor = ThreadUtils.newThreadPoolExecutor(
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
+            Math.max(4, processors),
+            Math.max(16, processors * 2),
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.bufferCommitThreadPoolQueue,
             new ThreadFactoryImpl("BufferCommitExecutor_"));
 
         this.bufferFetchThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
         this.bufferFetchExecutor = ThreadUtils.newThreadPoolExecutor(
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
-            Math.max(16, Runtime.getRuntime().availableProcessors() * 4),
+            Math.max(4, processors),
+            Math.max(16, processors * 2),
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.bufferFetchThreadPoolQueue,
             new ThreadFactoryImpl("BufferFetchExecutor_"));
 
         this.fileRecyclingThreadPoolQueue = new LinkedBlockingQueue<>(maxQueueCapacity);
         this.fileRecyclingExecutor = ThreadUtils.newThreadPoolExecutor(
-            Math.max(4, Runtime.getRuntime().availableProcessors()),
-            Math.max(4, Runtime.getRuntime().availableProcessors()),
+            Math.max(4, processors),
+            Math.max(4, processors),
             TimeUnit.MINUTES.toMillis(1), TimeUnit.MILLISECONDS,
             this.fileRecyclingThreadPoolQueue,
             new ThreadFactoryImpl("BufferFetchExecutor_"));


### PR DESCRIPTION
## What is the purpose of the change

Part of #10462

Optimize thread pool sizes for commit and fetch executors to reduce idle thread count while maintaining throughput.

## Brief changelog

- Reduce core pool from `max(16, processors*4)` to `max(4, processors)`
- Set max pool to `max(16, processors*2)` instead of equal to core
- Allows idle thread recycling (`keepAliveTime=1min` was already set)
- Extract `processors` variable to avoid repeated `Runtime.getRuntime()` calls

## Verifying this change

- [x] `mvn compile` succeeds
- [x] `mvn test -pl tieredstore` passes (112 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)