### PR TITLE
[ISSUE #10462] Improve error handling in tiered storage

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/TieredMessageStore.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.rocketmq.common.BoundaryType;
@@ -292,7 +293,12 @@ public class TieredMessageStore extends AbstractPluginMessageStore {
 
                 return result;
             }).exceptionally(e -> {
-                log.error("GetMessageAsync from tiered store failed", e);
+                Throwable cause = e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                log.error("TieredMessageStore#getMessageAsync, get message from tiered store failed, " +
+                    "topic={}, queueId={}, offset={}", topic, queueId, offset, cause);
                 return next.getMessage(group, topic, queueId, offset, maxMsgNums, messageFilter);
             });
     }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
@@ -38,6 +37,7 @@ public class FlatAppendFile {
 
     protected static final Logger log = LoggerFactory.getLogger(MessageStoreUtil.TIERED_STORE_LOGGER_NAME);
     public static final long GET_FILE_SIZE_ERROR = -1L;
+    public static final long GET_TIMESTAMP_ERROR = -1L;
 
     protected final String filePath;
     protected final FileSegmentType fileType;
@@ -81,22 +81,15 @@ public class FlatAppendFile {
      * @see <a href="https://github.com/apache/rocketmq/issues/9544">Related GitHub Issue</a>
      */
     public long getFileCorrectSize(FileSegment fileSegment) {
-        while (true) {
+        for (int retry = 0; retry < 3; retry++) {
             long fileSize = fileSegment.getSize();
             if (fileSize != GET_FILE_SIZE_ERROR) {
-                log.debug("FlatAppendFile get file correct size, filePath={} fileType={}, fileSize={}",
-                    fileSegment.getPath(), fileSegment.getFileType(), fileSize);
                 return fileSize;
-            } else {
-                log.warn("FlatAppendFile get file correct size error, filePath={}, fileType={}",
-                    fileSegment.getPath(), fileSegment.getFileType());
-                try {
-                    TimeUnit.MILLISECONDS.sleep(50);
-                } catch (InterruptedException e) {
-                    log.warn("FlatAppendFile get file correct size interrupted", e);
-                }
             }
         }
+        log.error("FlatAppendFile#getFileCorrectSize, get file correct size failed after 3 retries, path={}, type={}",
+            fileSegment.getPath(), fileSegment.getFileType());
+        return GET_FILE_SIZE_ERROR;
     }
 
     public void recoverFileSize() {
@@ -164,12 +157,12 @@ public class FlatAppendFile {
 
     public long getMinTimestamp() {
         List<FileSegment> list = this.fileSegmentTable;
-        return list.isEmpty() ? GET_FILE_SIZE_ERROR : list.get(0).getMinTimestamp();
+        return list.isEmpty() ? GET_TIMESTAMP_ERROR : list.get(0).getMinTimestamp();
     }
 
     public long getMaxTimestamp() {
         List<FileSegment> list = this.fileSegmentTable;
-        return list.isEmpty() ? GET_FILE_SIZE_ERROR : list.get(list.size() - 1).getMaxTimestamp();
+        return list.isEmpty() ? GET_TIMESTAMP_ERROR : list.get(list.size() - 1).getMaxTimestamp();
     }
 
     public FileSegment rollingNewFile(long offset) {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatAppendFile.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import org.apache.rocketmq.tieredstore.common.AppendResult;
@@ -81,15 +82,22 @@ public class FlatAppendFile {
      * @see <a href="https://github.com/apache/rocketmq/issues/9544">Related GitHub Issue</a>
      */
     public long getFileCorrectSize(FileSegment fileSegment) {
-        for (int retry = 0; retry < 3; retry++) {
+        while (true) {
             long fileSize = fileSegment.getSize();
             if (fileSize != GET_FILE_SIZE_ERROR) {
+                log.debug("FlatAppendFile get file correct size, filePath={} fileType={}, fileSize={}",
+                    fileSegment.getPath(), fileSegment.getFileType(), fileSize);
                 return fileSize;
+            } else {
+                log.warn("FlatAppendFile get file correct size error, filePath={}, fileType={}",
+                    fileSegment.getPath(), fileSegment.getFileType());
+                try {
+                    TimeUnit.MILLISECONDS.sleep(50);
+                } catch (InterruptedException e) {
+                    log.warn("FlatAppendFile get file correct size interrupted", e);
+                }
             }
         }
-        log.error("FlatAppendFile#getFileCorrectSize, get file correct size failed after 3 retries, path={}, type={}",
-            fileSegment.getPath(), fileSegment.getFileType());
-        return GET_FILE_SIZE_ERROR;
     }
 
     public void recoverFileSize() {

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatMessageFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/file/FlatMessageFile.java
@@ -231,8 +231,7 @@ public class FlatMessageFile implements FlatFileInterface {
 
     @Override
     public CompletableFuture<Boolean> commitAsync() {
-        // acquire lock
-        if (commitLock.drainPermits() <= 0) {
+        if (!commitLock.tryAcquire()) {
             return CompletableFuture.completedFuture(false);
         }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
@@ -137,10 +137,6 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                     log.info("IndexStoreService#recover, load local file, timestamp={}", indexFile.getTimestamp());
                 } catch (Exception e) {
                     log.error("IndexStoreService#recover, load local file error, destroying={}", file.getName(), e);
-                    try {
-                        UtilAll.deleteFile(file);
-                    } catch (Exception ignored) {
-                    }
                 }
             }
         }
@@ -332,7 +328,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
 
         List<FileSegment> fileSegmentList = flatAppendFile.getFileSegmentList();
         if (fileSegmentList.isEmpty()) {
-            log.warn("IndexStoreService upload error, fileSegmentList empty, timestamp: {}", indexFile.getTimestamp());
+            log.warn("IndexStoreService#doCompactThenUploadFile, fileSegmentList empty, timestamp={}", indexFile.getTimestamp());
             return false;
         }
         FileSegment fileSegment = fileSegmentList.get(fileSegmentList.size() - 1);

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
@@ -137,6 +137,10 @@ public class IndexStoreService extends ServiceThread implements IndexService {
                     log.info("IndexStoreService#recover, load local file, timestamp={}", indexFile.getTimestamp());
                 } catch (Exception e) {
                     log.error("IndexStoreService#recover, load local file error, destroying={}", file.getName(), e);
+                    try {
+                        UtilAll.deleteFile(file);
+                    } catch (Exception ignored) {
+                    }
                 }
             }
         }
@@ -327,6 +331,10 @@ public class IndexStoreService extends ServiceThread implements IndexService {
         boolean result = flatAppendFile.commitAsync().join();
 
         List<FileSegment> fileSegmentList = flatAppendFile.getFileSegmentList();
+        if (fileSegmentList.isEmpty()) {
+            log.warn("IndexStoreService upload error, fileSegmentList empty, timestamp: {}", indexFile.getTimestamp());
+            return false;
+        }
         FileSegment fileSegment = fileSegmentList.get(fileSegmentList.size() - 1);
         if (!result || fileSegment == null || fileSegment.getMinTimestamp() != indexFile.getTimestamp()) {
             log.warn("IndexStoreService#doCompactThenUploadFile, upload compacted file error, timestamp={}", indexFile.getTimestamp());

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
@@ -335,25 +335,26 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
     public CompletableFuture<ByteBuffer> readAsync(long position, int length) {
         CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
 
-        if (position < 0 || position >= commitPosition) {
+        long currentCommitPosition = commitPosition;
+        if (position < 0 || position >= currentCommitPosition) {
             future.completeExceptionally(new TieredStoreException(TieredStoreErrorCode.ILLEGAL_PARAM,
                 String.format("FileSegment read position illegal, filePath=%s, fileType=%s, position=%d, length=%d, commit=%d",
-                    filePath, fileType, position, length, commitPosition)));
+                    filePath, fileType, position, length, currentCommitPosition)));
             return future;
         }
 
         if (length <= 0) {
             future.completeExceptionally(new TieredStoreException(TieredStoreErrorCode.ILLEGAL_PARAM,
                 String.format("FileSegment read length illegal, filePath=%s, fileType=%s, position=%d, length=%d, commit=%d",
-                    filePath, fileType, position, length, commitPosition)));
+                    filePath, fileType, position, length, currentCommitPosition)));
             return future;
         }
 
-        int readableBytes = (int) (commitPosition - position);
+        int readableBytes = (int) (currentCommitPosition - position);
         if (readableBytes < length) {
             log.debug("FileSegment#readAsync, request position exceeds commit position, " +
                     "file={}, requestPosition={}, commitPosition={}, changeLength={} to {}",
-                getPath(), position, commitPosition, length, readableBytes);
+                getPath(), position, currentCommitPosition, length, readableBytes);
             length = readableBytes;
         }
         return this.read0(position, length);

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegmentFactory.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegmentFactory.java
@@ -42,7 +42,7 @@ public class FileSegmentFactory {
             fileSegmentConstructor = clazz.getConstructor(
                 MessageStoreConfig.class, FileSegmentType.class, String.class, Long.TYPE, MessageStoreExecutor.class);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to load FileSegment provider: " + storeConfig.getTieredBackendServiceProvider(), e);
         }
     }
 
@@ -58,7 +58,7 @@ public class FileSegmentFactory {
         try {
             return fileSegmentConstructor.newInstance(this.storeConfig, fileType, filePath, baseOffset, executor);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to create FileSegment: type=" + fileType + ", path=" + filePath, e);
         }
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegmentFactory.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegmentFactory.java
@@ -42,7 +42,9 @@ public class FileSegmentFactory {
             fileSegmentConstructor = clazz.getConstructor(
                 MessageStoreConfig.class, FileSegmentType.class, String.class, Long.TYPE, MessageStoreExecutor.class);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to load FileSegment provider: " + storeConfig.getTieredBackendServiceProvider(), e);
+            throw new RuntimeException(String.format(
+                "FileSegmentFactory#init, failed to load FileSegment provider: %s",
+                storeConfig.getTieredBackendServiceProvider()), e);
         }
     }
 
@@ -58,7 +60,9 @@ public class FileSegmentFactory {
         try {
             return fileSegmentConstructor.newInstance(this.storeConfig, fileType, filePath, baseOffset, executor);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to create FileSegment: type=" + fileType + ", path=" + filePath, e);
+            throw new RuntimeException(String.format(
+                "FileSegmentFactory#createSegment, failed to create FileSegment: type=%s, path=%s, baseOffset=%d",
+                fileType, filePath, baseOffset), e);
         }
     }
 

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/PosixFileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/PosixFileSegment.java
@@ -202,6 +202,7 @@ public class PosixFileSegment extends FileSegment {
                 long costTime = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
                 attributesBuilder.put(LABEL_SUCCESS, false);
                 TieredStoreMetricsManager.providerRpcLatency.record(costTime, attributesBuilder.build());
+                throw new RuntimeException(e);
             }
             return byteBuffer;
         }, executor.getBufferFetchExecutor());

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatAppendFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatAppendFileTest.java
@@ -37,6 +37,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
 
 public class FlatAppendFileTest {
 
@@ -215,5 +218,34 @@ public class FlatAppendFileTest {
         flatFile.commitAsync().join();
         flatFile.destroy();
         Assert.assertEquals(0, flatFile.fileSegmentTable.size());
+    }
+
+    @Test
+    public void getFileCorrectSizeTest() {
+        String filePath = MessageStoreUtil.toFilePath(queue);
+        FlatAppendFile flatFile = flatFileFactory.createFlatFileForConsumeQueue(filePath);
+
+        // first try succeeds
+        FileSegment success = Mockito.mock(FileSegment.class);
+        when(success.getSize()).thenReturn(1024L);
+        Assert.assertEquals(1024L, flatFile.getFileCorrectSize(success));
+        Mockito.verify(success, Mockito.times(1)).getSize();
+
+        // retry then succeed
+        FileSegment retry = Mockito.mock(FileSegment.class);
+        when(retry.getSize())
+            .thenReturn(FlatAppendFile.GET_FILE_SIZE_ERROR)
+            .thenReturn(FlatAppendFile.GET_FILE_SIZE_ERROR)
+            .thenReturn(2048L);
+        Assert.assertEquals(2048L, flatFile.getFileCorrectSize(retry));
+        Mockito.verify(retry, Mockito.times(3)).getSize();
+
+        // all retries fail
+        FileSegment fail = Mockito.mock(FileSegment.class);
+        when(fail.getSize()).thenReturn(FlatAppendFile.GET_FILE_SIZE_ERROR);
+        when(fail.getPath()).thenReturn("/test/path");
+        when(fail.getFileType()).thenReturn(FileSegmentType.CONSUME_QUEUE);
+        Assert.assertEquals(FlatAppendFile.GET_FILE_SIZE_ERROR, flatFile.getFileCorrectSize(fail));
+        Mockito.verify(fail, Mockito.times(3)).getSize();
     }
 }

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatAppendFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/file/FlatAppendFileTest.java
@@ -239,13 +239,5 @@ public class FlatAppendFileTest {
             .thenReturn(2048L);
         Assert.assertEquals(2048L, flatFile.getFileCorrectSize(retry));
         Mockito.verify(retry, Mockito.times(3)).getSize();
-
-        // all retries fail
-        FileSegment fail = Mockito.mock(FileSegment.class);
-        when(fail.getSize()).thenReturn(FlatAppendFile.GET_FILE_SIZE_ERROR);
-        when(fail.getPath()).thenReturn("/test/path");
-        when(fail.getFileType()).thenReturn(FileSegmentType.CONSUME_QUEUE);
-        Assert.assertEquals(FlatAppendFile.GET_FILE_SIZE_ERROR, flatFile.getFileCorrectSize(fail));
-        Mockito.verify(fail, Mockito.times(3)).getSize();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Part of #10462

Improve error handling to prevent silent data corruption and propagate fatal errors.

## Brief changelog

- TieredMessageStore: unwrap `CompletionException`, re-throw `Error`
- PosixFileSegment: throw `RuntimeException` on IOException in `read0`
- FlatAppendFile: add `GET_TIMESTAMP_ERROR` constant, use in `getMin/MaxTimestamp`
- FileSegment: `readAsync` uses local snapshot of `commitPosition` to avoid TOCTOU race
- FileSegmentFactory: include provider class, type, path, baseOffset in `RuntimeException`
- FlatMessageFile: `commitAsync` uses `tryAcquire` instead of `drainPermits`
- IndexStoreService: check `fileSegmentList` empty before accessing last element

## Verifying this change

- [x] `mvn compile` succeeds
- [x] `mvn test -pl tieredstore` passes (118 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
