### PR TITLE
[ISSUE #10481] Cache OTel Attributes objects in broker/remoting metrics hot path

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/RemotingCodeDistributionHandler.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/RemotingCodeDistributionHandler.java
@@ -33,18 +33,44 @@ public class RemotingCodeDistributionHandler extends ChannelDuplexHandler {
     private final ConcurrentMap<Integer, LongAdder> inboundDistribution;
     private final ConcurrentMap<Integer, LongAdder> outboundDistribution;
 
+    // Packed volatile holder for atomic publication of (code, adder) pair.
+    // Avoids the race where another EventLoop sees updated code but stale adder.
+    private static final class CodeAdderPair {
+        final int code;
+        final LongAdder adder;
+        CodeAdderPair(int code, LongAdder adder) {
+            this.code = code;
+            this.adder = adder;
+        }
+    }
+
+    private volatile CodeAdderPair lastIn = new CodeAdderPair(Integer.MIN_VALUE, null);
+    private volatile CodeAdderPair lastOut = new CodeAdderPair(Integer.MIN_VALUE, null);
+
     public RemotingCodeDistributionHandler() {
         inboundDistribution = new ConcurrentHashMap<>();
         outboundDistribution = new ConcurrentHashMap<>();
     }
 
     private void countInbound(int requestCode) {
+        CodeAdderPair pair = lastIn;
+        if (requestCode == pair.code && pair.adder != null) {
+            pair.adder.increment();
+            return;
+        }
         LongAdder item = inboundDistribution.computeIfAbsent(requestCode, k -> new LongAdder());
+        lastIn = new CodeAdderPair(requestCode, item);
         item.increment();
     }
 
     private void countOutbound(int responseCode) {
+        CodeAdderPair pair = lastOut;
+        if (responseCode == pair.code && pair.adder != null) {
+            pair.adder.increment();
+            return;
+        }
         LongAdder item = outboundDistribution.computeIfAbsent(responseCode, k -> new LongAdder());
+        lastOut = new CodeAdderPair(responseCode, item);
         item.increment();
     }
 

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/RemotingCodeDistributionHandlerTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/RemotingCodeDistributionHandlerTest.java
@@ -69,4 +69,38 @@ public class RemotingCodeDistributionHandlerTest {
             return f1 && f2;
         });
     }
+
+    @Test
+    public void testMultipleCodesIndependent() throws Exception {
+        RemotingCodeDistributionHandler handler = new RemotingCodeDistributionHandler();
+        Class<RemotingCodeDistributionHandler> clazz = RemotingCodeDistributionHandler.class;
+        Method methodIn = clazz.getDeclaredMethod("countInbound", int.class);
+        methodIn.setAccessible(true);
+
+        // Count code=10 three times, code=20 twice
+        methodIn.invoke(handler, 10);
+        methodIn.invoke(handler, 10);
+        methodIn.invoke(handler, 10);
+        methodIn.invoke(handler, 20);
+        methodIn.invoke(handler, 20);
+
+        String snapshot = handler.getInBoundSnapshotString();
+        Assert.assertTrue(snapshot.contains("10:3"));
+        Assert.assertTrue(snapshot.contains("20:2"));
+    }
+
+    @Test
+    public void testCacheHitSameCode() throws Exception {
+        RemotingCodeDistributionHandler handler = new RemotingCodeDistributionHandler();
+        Class<RemotingCodeDistributionHandler> clazz = RemotingCodeDistributionHandler.class;
+        Method methodIn = clazz.getDeclaredMethod("countInbound", int.class);
+        methodIn.setAccessible(true);
+
+        // Same code repeatedly should hit the CodeAdderPair cache and still count correctly
+        for (int i = 0; i < 100; i++) {
+            methodIn.invoke(handler, 42);
+        }
+        String snapshot = handler.getInBoundSnapshotString();
+        Assert.assertTrue(snapshot.contains("42:100"));
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10481

### Brief Description

Fix thread-safety issue in `RemotingCodeDistributionHandler` (a `@Sharable` Netty handler shared across EventLoop threads).

The previous code used two independent `volatile` fields (`lastInCode`, `lastInAdder`) as a fast-path cache. Under concurrent access from multiple EventLoop threads, a thread could observe the updated code but the stale adder (or null), leading to a `NullPointerException` or counting under the wrong request code.

**Fix**: Replace the two independent volatile fields with a single immutable `CodeAdderPair` holder published through one `volatile` reference. A single volatile read returns a self-consistent `(code, adder)` snapshot.

### How Did You Test This Change

- Existing `RemotingCodeDistributionHandlerTest.remotingCodeCountTest`: 4-thread concurrent test with 1M iterations each, verifying correct total counts.
- New `testMultipleCodesIndependent`: verifies different request codes are counted independently.
- New `testCacheHitSameCode`: verifies same code repeated 100 times hits cache correctly.

### Changes

| File | Change |
|------|--------|
| `RemotingCodeDistributionHandler.java` | Replace `lastInCode`/`lastInAdder` + `lastOutCode`/`lastOutAdder` (4 volatile fields) with `lastIn`/`lastOut` (2 volatile `CodeAdderPair` holders) |
| `RemotingCodeDistributionHandlerTest.java` | Add 2 new test cases |