### PR TITLE
[ISSUE #10486] Add getMessageType(Map) overload to eliminate redundant properties decode

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
@@ -229,7 +229,10 @@ public class BrokerMetricsManager {
     }
 
     public static TopicMessageType getMessageType(SendMessageRequestHeader requestHeader) {
-        Map<String, String> properties = MessageDecoder.string2messageProperties(requestHeader.getProperties());
+        return getMessageType(MessageDecoder.string2messageProperties(requestHeader.getProperties()));
+    }
+
+    public static TopicMessageType getMessageType(Map<String, String> properties) {
         String traFlag = properties.get(MessageConst.PROPERTY_TRANSACTION_PREPARED);
         TopicMessageType topicMessageType = TopicMessageType.NORMAL;
         if (Boolean.parseBoolean(traFlag)) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10486

### Brief Description

`BrokerMetricsManager.getMessageType(SendMessageRequestHeader)` is called once per send to classify the message (`NORMAL`/`TRANSACTION`/`DELAY`/`FIFO`). It internally decodes the properties String into a `HashMap`, but the typical caller (`SendMessageProcessor`) has already decoded the same String moments before. The result is a redundant decode allocation per send (one `HashMap` + ~14 `String` substrings + one `Node[]`).

This PR adds a public overload `getMessageType(Map<String, String>)` that lets callers pass an already-decoded `Map` and reuse it. The existing `SendMessageRequestHeader` overload now delegates to the new overload; behavior is unchanged for callers that don't have a decoded `Map`.

```java
// new public overload
public static TopicMessageType getMessageType(Map<String, String> properties) { ... }

// existing overload now delegates
public static TopicMessageType getMessageType(SendMessageRequestHeader requestHeader) {
    return getMessageType(MessageDecoder.string2messageProperties(requestHeader.getProperties()));
}
```

Downstream callers (e.g. `SendMessageProcessor`) can switch to the new overload in a separate broker-layer commit.

### How Did You Test This Change?

- Existing `BrokerMetricsManagerTest` (27 tests) passes. The behavior of the original overload is preserved by delegation.
- The new overload uses the exact same key-lookup logic as before, only sourced from a passed-in `Map` instead of a freshly decoded one.

### Independence

This PR is independent of #10443 and #10481 — it doesn't reference any new constants and only restructures `BrokerMetricsManager.getMessageType(...)` (1 file, +4/-1).
