### PR TITLE
[ISSUE #10490] Eliminate per-RPC allocation from Logback status, TopicMessageType toLowerCase, and RemotingHelper eager evaluation

### DIFF
--- a/broker/src/main/resources/rmq.broker.logback.xml
+++ b/broker/src/main/resources/rmq.broker.logback.xml
@@ -18,6 +18,8 @@
 
 <configuration scan="true" scanPeriod="30 seconds">
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
     <appender name="DefaultSiftingAppender_inner" class="ch.qos.logback.classic.sift.SiftingAppender">
         <discriminator>
             <key>brokerContainerLogDir</key>

--- a/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java
+++ b/common/src/main/java/org/apache/rocketmq/common/attribute/TopicMessageType.java
@@ -33,9 +33,11 @@ public enum TopicMessageType {
     MIXED("MIXED");
 
     private final String value;
+    private final String metricsValue;
 
     TopicMessageType(String value) {
         this.value = value;
+        this.metricsValue = value.toLowerCase(java.util.Locale.ROOT);
     }
 
     public static Set<String> topicMessageTypeSet() {
@@ -67,6 +69,6 @@ public enum TopicMessageType {
     }
 
     public String getMetricsValue() {
-        return value.toLowerCase();
+        return metricsValue;
     }
 }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
@@ -369,10 +369,12 @@ public class RemotingHelper {
     }
 
     public static String getRequestCodeDesc(int code) {
-        return REQUEST_CODE_MAP.getOrDefault(code, String.valueOf(code));
+        String desc = REQUEST_CODE_MAP.get(code);
+        return desc != null ? desc : String.valueOf(code);
     }
 
     public static String getResponseCodeDesc(int code) {
-        return RESPONSE_CODE_MAP.getOrDefault(code, String.valueOf(code));
+        String desc = RESPONSE_CODE_MAP.get(code);
+        return desc != null ? desc : String.valueOf(code);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10490

### Brief Description

Three independent per-RPC micro-allocations eliminated:

1. **Logback `NopStatusListener`** — Add `<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>` to `rmq.broker.logback.xml` to suppress Logback internal status event callbacks.
2. **`TopicMessageType.metricsValue` cache** — `getMetricsValue()` was calling `value.toLowerCase()` per invocation. Now caches `metricsValue` as a `final` field with `Locale.ROOT`.
3. **`RemotingHelper` eager evaluation fix** — `Map.getOrDefault(code, String.valueOf(code))` eagerly evaluates `String.valueOf(code)` even on cache hit. Changed to `get()` + null check.

Stacked on PR #10443. Will rebase on `develop` after #10443 merges to show only the 3 files.

### How Did You Test This Change?

1. Full CI passes (maven-compile + bazel-compile on all JDK versions).
2. Commercial compatibility verified.
