### PR TITLE
[ISSUE #10494] Fix flaky HATest.testSemiSyncReplica

### DIFF
--- a/store/src/test/java/org/apache/rocketmq/store/HATest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/HATest.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,6 +39,7 @@ import org.apache.rocketmq.common.message.MessageExtBrokerInner;
 import org.apache.rocketmq.store.config.BrokerRole;
 import org.apache.rocketmq.store.config.FlushDiskType;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.apache.rocketmq.store.ha.HAConnection;
 import org.apache.rocketmq.store.ha.HAConnectionState;
 import org.apache.rocketmq.store.stats.BrokerStatsManager;
 import org.junit.After;
@@ -104,6 +106,7 @@ public class HATest {
         slaveMessageStore.start();
         slaveMessageStore.updateHaMasterAddress("127.0.0.1:" + masterMessageStoreConfig.getHaListenPort());
         await().atMost(6, SECONDS).until(() -> slaveMessageStore.getHaService().getHAClient().getCurrentState() == HAConnectionState.TRANSFER);
+        await().atMost(6, SECONDS).until(this::isSlaveReadyForReplication);
     }
 
     @Test
@@ -279,6 +282,20 @@ public class HATest {
         msg.setBornHost(bornHost);
         msg.setPropertiesString(MessageDecoder.messageProperties2String(msg.getProperties()));
         return msg;
+    }
+
+    private boolean isSlaveReadyForReplication() {
+        if (slaveMessageStore.getHaService().getHAClient().getCurrentState() != HAConnectionState.TRANSFER) {
+            return false;
+        }
+
+        long slaveMaxOffset = slaveMessageStore.getMaxPhyOffset();
+        List<HAConnection> connections = messageStore.getHaService().getConnectionList();
+        synchronized (connections) {
+            return connections.stream().anyMatch(connection ->
+                connection.getCurrentState() == HAConnectionState.TRANSFER
+                    && connection.getSlaveAckOffset() >= slaveMaxOffset);
+        }
     }
 
     private boolean isCommitLogAvailable(DefaultMessageStore store) {


### PR DESCRIPTION
## Summary
- Wait for the master-side HA connection to observe the slave's initial ack offset before running `HATest` semi-sync message writes.
- Add a condition-based readiness helper that checks the slave client is in `TRANSFER` and the master connection ack offset covers the slave max physical offset.

## Root Cause
`HATest` previously waited only for the slave-side HA client to enter `TRANSFER`. That state can be reached before the master-side `HAConnection` receives the slave's initial offset report, leaving `slaveAckOffset` at `-1`. The first semi-sync write can race that initial report and return `FLUSH_SLAVE_TIMEOUT` instead of `PUT_OK` on slower CI machines.

## Impact
This stabilizes `HATest.testSemiSyncReplica` without changing production HA behavior.

Fixes #10494

## Validation
```bash
/tmp/codex-maven/apache-maven-3.9.9/bin/mvn -pl store -am -Dtest=HATest#testSemiSyncReplica -DskipITs -DfailIfNoTests=false test
/tmp/codex-maven/apache-maven-3.9.9/bin/mvn -pl store -am -Dtest=HATest -DskipITs -DfailIfNoTests=false test
```

Full `HATest` result: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 1`.

Stress check:

```bash
for i in $(seq 1 100); do
  /tmp/codex-maven/apache-maven-3.9.9/bin/mvn -q -pl store -am \
    -Dtest=HATest#testSemiSyncReplica \
    -DskipITs -DfailIfNoTests=false \
    -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true test
done
```

Result: 100 consecutive `HATest#testSemiSyncReplica` runs passed.
