### PR TITLE
[ISSUE #10496]Add sample plain_acl.yml to distribution/conf

### DIFF
--- a/distribution/conf/plain_acl.yml
+++ b/distribution/conf/plain_acl.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+globalWhiteRemoteAddresses:
+  - 10.10.103.*
+  - 192.168.0.*
+
+accounts:
+  - accessKey: rocketmq2
+    secretKey: 12345678
+    admin: true
+    defaultTopicPerm: PUB|SUB
+    defaultGroupPerm: PUB|SUB


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10496

### Brief Description

The official ACL documentation references "distribution/conf/plain_acl.yml"
  but the file was not included in the binary release. This PR adds a sample
  template so users have a working starting point for ACL configuration.
  The default account matches conf/tools.yml for out-of-the-box mqadmin usage.

### How Did You Test This Change?

1. Built distribution with "mvn -Prelease-all -DskipTests clean install -U"
     and confirmed plain_acl.yml is included in the resulting tar.gz.
  2. Extracted the distribution, enabled ACL on a fresh broker instance.
  3. Verified mqadmin commands work with default tools.yml credentials.
  4. Verified ACL correctly allows the rocketmq2 user and rejects unknown users.
