### PR TITLE
[ISSUE #10498] Update ACL documentation to include required 5.x properties

### DIFF
--- a/docs/cn/acl/user_guide.md
+++ b/docs/cn/acl/user_guide.md
@@ -34,7 +34,7 @@ ACL客户端可以参考：**org.apache.rocketmq.example.simple**包下面的**A
 具体可以参考**distribution/conf/plain_acl.yml**配置文件
 
 ## 3. 支持权限控制的集群部署
-在**distribution/conf/plain_acl.yml**配置文件中按照上述说明定义好权限属性后，在Broker配置文件中设置以下属性即可开启RocketMQ集群的ACL特性：
+在Broker配置文件中设置以下属性即可开启RocketMQ集群的ACL 2.0特性：
 
 ```
 brokerClusterName=DefaultCluster
@@ -47,17 +47,26 @@ flushDiskType=ASYNC_FLUSH
 storePathRootDir=/data/rocketmq/rootdir-a-m
 storePathCommitLog=/data/rocketmq/commitlog-a-m
 autoCreateSubscriptionGroup=true
-## if acl is open,the flag will be true
-aclEnable=true
-## RocketMQ 5.x 需要额外配置以下ACL属性
-authenticationEnabled=true
-authorizationEnabled=true
-migrateAuthFromV1Enabled=true
-authenticationMetadataProvider=org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider
-authorizationMetadataProvider=org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider
 listenPort=10911
 brokerIP1=XX.XX.XX.XX1
 namesrvAddr=XX.XX.XX.XX:9876
+
+## 启用认证
+authenticationEnabled=true
+authenticationMetadataProvider=org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider
+
+## 启用授权
+authorizationEnabled=true
+authorizationMetadataProvider=org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider
+
+## 初始化超级用户(首次启动自动创建)
+initAuthenticationUser={"username":"rocketmq","password":"12345678"}
+
+## Broker间内部通信凭证
+innerClientAuthenticationCredentials={"accessKey":"rocketmq","secretKey":"12345678"}
+```
+
+> 说明：RocketMQ 5.x 中 `aclEnable=true` 已被 `authenticationEnabled` 和 `authorizationEnabled` 取代。详见 [ACL 2.0 文档](https://rocketmq.apache.org/docs/bestPractice/06access)。
 ```
 
 ## 4. 权限控制主要流程

--- a/docs/cn/acl/user_guide.md
+++ b/docs/cn/acl/user_guide.md
@@ -34,7 +34,8 @@ ACL客户端可以参考：**org.apache.rocketmq.example.simple**包下面的**A
 具体可以参考**distribution/conf/plain_acl.yml**配置文件
 
 ## 3. 支持权限控制的集群部署
-在**distribution/conf/plain_acl.yml**配置文件中按照上述说明定义好权限属性后，打开**aclEnable**开关变量即可开启RocketMQ集群的ACL特性。这里贴出Broker端开启ACL特性的properties配置文件内容：
+在**distribution/conf/plain_acl.yml**配置文件中按照上述说明定义好权限属性后，在Broker配置文件中设置以下属性即可开启RocketMQ集群的ACL特性：
+
 ```
 brokerClusterName=DefaultCluster
 brokerName=broker-a
@@ -48,6 +49,12 @@ storePathCommitLog=/data/rocketmq/commitlog-a-m
 autoCreateSubscriptionGroup=true
 ## if acl is open,the flag will be true
 aclEnable=true
+## RocketMQ 5.x 需要额外配置以下ACL属性
+authenticationEnabled=true
+authorizationEnabled=true
+migrateAuthFromV1Enabled=true
+authenticationMetadataProvider=org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider
+authorizationMetadataProvider=org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider
 listenPort=10911
 brokerIP1=XX.XX.XX.XX1
 namesrvAddr=XX.XX.XX.XX:9876

--- a/docs/en/acl/Operations_ACL.md
+++ b/docs/en/acl/Operations_ACL.md
@@ -33,7 +33,7 @@ The definition of Topic resource access control for RocketMQ is mainly as shown 
 For details, please refer to the **distribution/conf/plain_acl.yml** configuration file.
 
 ## 3. Cluster deployment with permission control
-After defining the permission attribute in the **distribution/conf/plain_acl.yml** configuration file as described above, enable the ACL feature by setting the following properties in the broker configuration file:
+Add the following ACL 2.0 properties to the broker configuration file:
 
 ```properties
 brokerClusterName=DefaultCluster
@@ -46,18 +46,26 @@ flushDiskType=ASYNC_FLUSH
 storePathRootDir=/data/rocketmq/rootdir-a-m
 storePathCommitLog=/data/rocketmq/commitlog-a-m
 autoCreateSubscriptionGroup=true
-## if acl is open,the flag will be true
-aclEnable=true
-## RocketMQ 5.x requires the following additional ACL properties
-authenticationEnabled=true
-authorizationEnabled=true
-migrateAuthFromV1Enabled=true
-authenticationMetadataProvider=org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider
-authorizationMetadataProvider=org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider
 listenPort=10911
 brokerIP1=XX.XX.XX.XX1
 namesrvAddr=XX.XX.XX.XX:9876
+
+## Enable authentication
+authenticationEnabled=true
+authenticationMetadataProvider=org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider
+
+## Enable authorization
+authorizationEnabled=true
+authorizationMetadataProvider=org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider
+
+## Initialize super user (auto-created on first startup)
+initAuthenticationUser={"username":"rocketmq","password":"12345678"}
+
+## Internal credentials for broker-to-broker communication
+innerClientAuthenticationCredentials={"accessKey":"rocketmq","secretKey":"12345678"}
 ```
+
+> Note: `aclEnable=true` from RocketMQ 4.x ACL has been replaced by `authenticationEnabled` and `authorizationEnabled` in 5.x. See the [ACL 2.0 documentation](https://rocketmq.apache.org/docs/bestPractice/06access) for details.
 ## 4. Main process of access control
 The main ACL process is divided into two parts, including privilege resolution and privilege check.
 

--- a/docs/en/acl/Operations_ACL.md
+++ b/docs/en/acl/Operations_ACL.md
@@ -33,7 +33,8 @@ The definition of Topic resource access control for RocketMQ is mainly as shown 
 For details, please refer to the **distribution/conf/plain_acl.yml** configuration file.
 
 ## 3. Cluster deployment with permission control
-After defining the permission attribute in the **distribution/conf/plain_acl.yml** configuration file as described above, open the **aclEnable** switch variable to enable the ACL feature of the RocketMQ cluster.The configuration file of the ACL feature enabled on the broker is as follows:
+After defining the permission attribute in the **distribution/conf/plain_acl.yml** configuration file as described above, enable the ACL feature by setting the following properties in the broker configuration file:
+
 ```properties
 brokerClusterName=DefaultCluster
 brokerName=broker-a
@@ -47,6 +48,12 @@ storePathCommitLog=/data/rocketmq/commitlog-a-m
 autoCreateSubscriptionGroup=true
 ## if acl is open,the flag will be true
 aclEnable=true
+## RocketMQ 5.x requires the following additional ACL properties
+authenticationEnabled=true
+authorizationEnabled=true
+migrateAuthFromV1Enabled=true
+authenticationMetadataProvider=org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider
+authorizationMetadataProvider=org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider
 listenPort=10911
 brokerIP1=XX.XX.XX.XX1
 namesrvAddr=XX.XX.XX.XX:9876


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10498

### Brief Description

The current ACL documentation (both English and Chinese) only lists
`aclEnable=true` as the required broker property. In RocketMQ 5.x,
this is insufficient — the new authentication/authorization framework
introduced in 5.x requires five additional properties to function.

Code evidence for each property:

| Property | Source | Effect when omitted |
|----------|--------|---------------------|
| authenticationEnabled | AbstractAuthenticationStrategy.java:54 | Authentication is skipped entirely |
| authorizationEnabled | AbstractAuthorizationStrategy.java:54 | Authorization is skipped entirely |
| migrateAuthFromV1Enabled | AuthMigrator.java:72 | plain_acl.yml is not loaded |
| authenticationMetadataProvider | AuthenticationFactory.java:80-81 | Returns null → "authenticationMetadataProvider is not configured" |
| authorizationMetadataProvider | AuthorizationFactory (same pattern) | Same as above for authorization |

Without these, users experience either:
- ACL silently allowing all traffic (authentication/authorization skipped), or
- "authenticationMetadataProvider is not configured" error on startup

### How Did You Test This Change?

1. Built the project with `mvn -Prelease-all -DskipTests clean install -U`
2. Deployed a fresh RocketMQ 5.5.0 broker with the complete property set
3. Verified ACL authentication works: valid credentials accepted,
   invalid credentials correctly rejected with "User not found"
4. Verified mqadmin commands work with default `tools.yml` credentials
   matching the ACL account
5. Confirmed omission of any single property causes the documented
   failure mode (silent bypass or configuration error)