### PR TITLE
[ISSUE #10500]Fix outdated constructor signatures in trace documentation

### DIFF
--- a/docs/cn/msg_trace/user_guide.md
+++ b/docs/cn/msg_trace/user_guide.md
@@ -54,7 +54,7 @@ RocketMQ的消息轨迹特性支持两种存储轨迹数据的方式：
 
 ### 4.1 发送消息时开启消息轨迹
 ```java
-        DefaultMQProducer producer = new DefaultMQProducer("ProducerGroupName",true);
+        DefaultMQProducer producer = new DefaultMQProducer("ProducerGroupName",true,null);
         producer.setNamesrvAddr("XX.XX.XX.XX1");
         producer.start();
             try {
@@ -74,7 +74,7 @@ RocketMQ的消息轨迹特性支持两种存储轨迹数据的方式：
 
 ### 4.2 订阅消息时开启消息轨迹
 ```java
-        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("CID_JODIE_1",true);
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("CID_JODIE_1",true,null);
         consumer.subscribe("TopicTest", "*");
         consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
         consumer.setConsumeTimestamp("20181109221800");

--- a/docs/en/msg_trace/user_guide.md
+++ b/docs/en/msg_trace/user_guide.md
@@ -54,7 +54,7 @@ For business system adapting to use RocketMQ's message trace feature easily, in 
 
 ### 4.1 Enable message trace when sending messages
 ```
-        DefaultMQProducer producer = new DefaultMQProducer("ProducerGroupName",true);
+        DefaultMQProducer producer = new DefaultMQProducer("ProducerGroupName",true,null);
         producer.setNamesrvAddr("XX.XX.XX.XX1");
         producer.start();
             try {
@@ -74,7 +74,7 @@ For business system adapting to use RocketMQ's message trace feature easily, in 
 
 ### 4.2 Enable message trace when subscribe messages
 ```
-        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("CID_JODIE_1",true);
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("CID_JODIE_1",true,null);
         consumer.subscribe("TopicTest", "*");
         consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
         consumer.setConsumeTimestamp("20181109221800");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10500

### Brief Description

The trace documentation (both English and Chinese) uses two-argument
constructors that do not exist in RocketMQ 5.x:

  // ❌ Does not compile in 5.x
  new DefaultMQProducer("ProducerGroupName", true)
  new DefaultMQPushConsumer("CID_JODIE_1", true)

Verified by checking DefaultMQProducer.java — there is no
(String, boolean) constructor. The closest two-argument versions
accepts (String, RPCHook).

The correct three-argument form adds a third parameter for the
custom trace topic name. Passing null uses the system default
RMQ_SYS_TRACE_TOPIC:

  // ✅ Compiles in 5.x
  new DefaultMQProducer("ProducerGroupName", true, null)
  new DefaultMQPushConsumer("CID_JODIE_1", true, null)

This PR fixes both English and Chinese trace user guides.

### How Did You Test This Change?

1. During homework development, attempted to use
   `new DefaultMQProducer("TraceProducerGroup", true)` and got:
   "no suitable constructor found for DefaultMQProducer(String,boolean)"

2. Checked the actual constructor list in
   client/src/main/java/.../DefaultMQProducer.java and
   client/src/main/java/.../DefaultMQPushConsumer.java
   — confirmed no (String, boolean) signature exists

3. Successfully built and ran a trace-enabled producer using
   `new DefaultMQProducer("TraceProducerGroup", true, null)`
   on RocketMQ 5.5.0 with traceTopicEnable=true on the broker.
   Trace data appeared correctly in RMQ_SYS_TRACE_TOPIC,
   verified via "mqadmin queryMsgTraceById".