### PR TITLE
[ISSUE #10216] Fix potential NPE in EscapeBridge when topicPublishInfo is null

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/failover/EscapeBridge.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/failover/EscapeBridge.java
@@ -185,6 +185,11 @@ public class EscapeBridge {
                 messageExt.setWaitStoreMsgOK(false);
 
                 final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
+                if (null == topicPublishInfo || !topicPublishInfo.ok()) {
+                    LOG.warn("asyncPutMessage: no route info of topic {} when escaping message, msgId={}",
+                        messageExt.getTopic(), messageExt.getMsgId());
+                    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
+                }
                 final String producerGroup = getProducerGroup(messageExt);
 
                 final MessageQueue mqSelected = topicPublishInfo.selectOneMessageQueue();
@@ -250,6 +255,11 @@ public class EscapeBridge {
                 messageExt.setWaitStoreMsgOK(false);
 
                 final TopicPublishInfo topicPublishInfo = this.brokerController.getTopicRouteInfoManager().tryToFindTopicPublishInfo(messageExt.getTopic());
+                if (null == topicPublishInfo || !topicPublishInfo.ok()) {
+                    LOG.warn("asyncRemotePutMessageToSpecificQueue: no route info of topic {} when escaping message, msgId={}",
+                        messageExt.getTopic(), messageExt.getMsgId());
+                    return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL, null, true));
+                }
                 List<MessageQueue> mqs = topicPublishInfo.getMessageQueueList();
 
                 if (null == mqs || mqs.isEmpty()) {


### PR DESCRIPTION
## Summary

Fix NullPointerException in `EscapeBridge` when `tryToFindTopicPublishInfo()` returns null.

## Motivation

In `EscapeBridge.java`, two methods dereference the result of `tryToFindTopicPublishInfo()` without null checks:

1. `asyncPutMessage()` — calls `topicPublishInfo.selectOneMessageQueue()` directly
2. `asyncRemotePutMessageToSpecificQueue()` — calls `topicPublishInfo.getMessageQueueList()` directly

When a slave broker acting as master attempts to escape a message for a topic whose route information is not yet available (e.g., during startup or after a nameserver disconnection), this causes NPE.

In contrast, `putMessageToRemoteBroker()` in the same class already handles this correctly:
```java
if (null == topicPublishInfo || !topicPublishInfo.ok()) {
    LOG.warn("putMessageToRemoteBroker: no route info ...");
    return null;
}
```

## Changes

- Added null/validity checks (`null == topicPublishInfo || !topicPublishInfo.ok()`) in both methods
- Return `PutMessageStatus.PUT_TO_REMOTE_BROKER_FAIL` with a warning log, consistent with the existing pattern
- No behavioral change when `topicPublishInfo` is valid

## Test Plan

- [x] Code compiles without errors (`mvn compile -pl broker -am`)
- [x] Fix follows the exact same pattern as `putMessageToRemoteBroker()` in the same file
- [x] No new dependencies or API changes introduced

Fixes #10216