### PR TITLE
[ISSUE #10511] Replace Enum.values() loop with static array lookup in LanguageCode and SerializeType

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/LanguageCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/LanguageCode.java
@@ -38,6 +38,19 @@ public enum LanguageCode {
     RUST((byte) 12),
     NODE_JS((byte) 13);
 
+    private static final LanguageCode[] BY_CODE;
+    static {
+        LanguageCode[] all = values();
+        int max = 0;
+        for (LanguageCode lc : all) {
+            max = Math.max(max, lc.code & 0xFF);
+        }
+        BY_CODE = new LanguageCode[max + 1];
+        for (LanguageCode lc : all) {
+            BY_CODE[lc.code & 0xFF] = lc;
+        }
+    }
+
     private byte code;
 
     LanguageCode(byte code) {
@@ -45,12 +58,8 @@ public enum LanguageCode {
     }
 
     public static LanguageCode valueOf(byte code) {
-        for (LanguageCode languageCode : LanguageCode.values()) {
-            if (languageCode.getCode() == code) {
-                return languageCode;
-            }
-        }
-        return null;
+        int idx = code & 0xFF;
+        return idx < BY_CODE.length ? BY_CODE[idx] : null;
     }
 
     public byte getCode() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/SerializeType.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/SerializeType.java
@@ -21,6 +21,8 @@ public enum SerializeType {
     JSON((byte) 0),
     ROCKETMQ((byte) 1);
 
+    private static final SerializeType[] BY_CODE = {JSON, ROCKETMQ};
+
     private byte code;
 
     SerializeType(byte code) {
@@ -28,12 +30,8 @@ public enum SerializeType {
     }
 
     public static SerializeType valueOf(byte code) {
-        for (SerializeType serializeType : SerializeType.values()) {
-            if (serializeType.getCode() == code) {
-                return serializeType;
-            }
-        }
-        return null;
+        int idx = code & 0xFF;
+        return idx < BY_CODE.length ? BY_CODE[idx] : null;
     }
 
     public byte getCode() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10511

### Brief Description

Replace `Enum.values()` + O(n) loop with static `BY_CODE[]` array for O(1) lookup in `LanguageCode.valueOf(byte)` and `SerializeType.valueOf(byte)`.

JDK requires `Enum.values()` to return a fresh array on every call (defensive copy). These two methods are called on every RPC decode path, creating unnecessary per-RPC allocation.

### How Did You Test This Change?

1. Full CI passes (maven-compile + bazel-compile on all JDK versions).
2. Commercial compatibility verified — both enums are used in protocol decode, no commercial override exists.
