### PR TITLE
[ISSUE #10512] Eliminate per-RPC allocation in RemotingCommand (Guava Stopwatch, Constructor copy) and downgrade Netty writability log

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/DefaultPullMessageResultHandler.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/DefaultPullMessageResultHandler.java
@@ -23,7 +23,6 @@ import io.netty.channel.FileRegion;
 import io.opentelemetry.api.common.Attributes;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.longpolling.PullRequest;
 import org.apache.rocketmq.broker.metrics.BrokerMetricsManager;
@@ -158,7 +157,7 @@ public class DefaultPullMessageResultHandler implements PullMessageResultHandler
                                     .put(LABEL_RESPONSE_CODE, RemotingHelper.getResponseCodeDesc(finalResponse.getCode()))
                                     .put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future))
                                     .build();
-                                remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributes);
+                                remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributes);
                                 if (!future.isSuccess()) {
                                     log.error("Fail to transfer messages from page cache to {}", channel.remoteAddress(), future.cause());
                                 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PeekMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PeekMessageProcessor.java
@@ -24,7 +24,6 @@ import io.opentelemetry.api.common.Attributes;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.broker.BrokerController;
 
 import org.apache.rocketmq.broker.pagecache.ManyMessageTransfer;
@@ -205,7 +204,7 @@ public class PeekMessageProcessor implements NettyRequestProcessor {
                                     .put(LABEL_RESPONSE_CODE, RemotingHelper.getResponseCodeDesc(finalResponse.getCode()))
                                     .put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future))
                                     .build();
-                                remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributes);
+                                remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributes);
                                 if (!future.isSuccess()) {
                                     LOG.error("Fail to transfer messages from page cache to {}", channel.remoteAddress(), future.cause());
                                 }

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
@@ -87,7 +87,6 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -472,7 +471,7 @@ public class PopMessageProcessor implements NettyRequestProcessor {
                                     .put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future))
                                     .build();
                                 remotingMetricsManager.getRpcLatency().record(
-                                    request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributes);
+                                    request.processTimerElapsedMs(), attributes);
                                 if (!future.isSuccess()) {
                                     POP_LOGGER.error("Fail to transfer messages from page cache to {}",
                                         channel.remoteAddress(), future.cause());
@@ -625,7 +624,7 @@ public class PopMessageProcessor implements NettyRequestProcessor {
                                         .put(LABEL_RESPONSE_CODE, RemotingHelper.getResponseCodeDesc(finalResponse.getCode()))
                                         .put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future))
                                         .build();
-                                    remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributes);
+                                    remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributes);
                                     if (!future.isSuccess()) {
                                         POP_LOGGER.error("Fail to transfer messages from page cache to {}",
                                             channel.remoteAddress(), future.cause());

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryMessageProcessor.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.pagecache.OneMessageTransfer;
@@ -130,7 +129,7 @@ public class QueryMessageProcessor implements NettyRequestProcessor {
                             .put(LABEL_RESPONSE_CODE, RemotingHelper.getResponseCodeDesc(response.getCode()))
                             .put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future))
                             .build();
-                        remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributes);
+                        remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributes);
                         if (!future.isSuccess()) {
                             LOGGER.error("transfer query message by page cache failed, ", future.cause());
                         }
@@ -192,7 +191,7 @@ public class QueryMessageProcessor implements NettyRequestProcessor {
                             .put(LABEL_RESPONSE_CODE, RemotingHelper.getResponseCodeDesc(response.getCode()))
                             .put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future))
                             .build();
-                        remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributes);
+                        remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributes);
                         if (!future.isSuccess()) {
                             LOGGER.error("Transfer one message from page cache failed, ", future.cause());
                         }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyDecoder.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyDecoder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.rocketmq.remoting.netty;
 
-import com.google.common.base.Stopwatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
@@ -39,14 +38,14 @@ public class NettyDecoder extends LengthFieldBasedFrameDecoder {
     @Override
     public Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
         ByteBuf frame = null;
-        Stopwatch timer = Stopwatch.createStarted();
+        long timerNanos = System.nanoTime();
         try {
             frame = (ByteBuf) super.decode(ctx, in);
             if (null == frame) {
                 return null;
             }
             RemotingCommand cmd = RemotingCommand.decode(frame);
-            cmd.setProcessTimer(timer);
+            cmd.setProcessTimerNanos(timerNanos);
             return cmd;
         } catch (Exception e) {
             log.error("decode exception, " + RemotingHelper.parseChannelRemoteAddr(ctx.channel()), e);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -247,7 +247,7 @@ public abstract class NettyRemotingAbstract {
         if (request.isOnewayRPC()) {
             if (attributesBuilder != null) {
                 attributesBuilder.put(LABEL_RESULT, RESULT_ONEWAY);
-                remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributesBuilder.build());
             }
             return;
         }
@@ -264,7 +264,7 @@ public abstract class NettyRemotingAbstract {
                 }
                 if (remotingMetricsManager != null) {
                     attributesBuilder.put(LABEL_RESULT, remotingMetricsManager.getWriteAndFlushResult(future));
-                    remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                    remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributesBuilder.build());
                 }
                 if (callback != null) {
                     callback.accept(future);
@@ -276,7 +276,7 @@ public abstract class NettyRemotingAbstract {
             log.error(response.toString());
             if (remotingMetricsManager != null) {
                 attributesBuilder.put(LABEL_RESULT, RESULT_WRITE_CHANNEL_FAILED);
-                remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributesBuilder.build());
             }
         }
 
@@ -299,7 +299,7 @@ public abstract class NettyRemotingAbstract {
         if (request.isOnewayRPC()) {
             if (attributesBuilder != null) {
                 attributesBuilder.put(LABEL_RESULT, RESULT_ONEWAY);
-                this.remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                this.remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributesBuilder.build());
             }
             return;
         }
@@ -316,7 +316,7 @@ public abstract class NettyRemotingAbstract {
                 }
                 if (this.remotingMetricsManager != null && attributesBuilder != null) {
                     attributesBuilder.put(LABEL_RESULT, this.remotingMetricsManager.getWriteAndFlushResult(future));
-                    this.remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                    this.remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributesBuilder.build());
                 }
                 if (callback != null) {
                     callback.accept(future);
@@ -328,7 +328,7 @@ public abstract class NettyRemotingAbstract {
             log.error(response.toString());
             if (this.remotingMetricsManager != null && attributesBuilder != null) {
                 attributesBuilder.put(LABEL_RESULT, RESULT_WRITE_CHANNEL_FAILED);
-                this.remotingMetricsManager.getRpcLatency().record(request.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                this.remotingMetricsManager.getRpcLatency().record(request.processTimerElapsedMs(), attributesBuilder.build());
             }
         }
     }
@@ -396,7 +396,7 @@ public abstract class NettyRemotingAbstract {
                 AttributesBuilder attributesBuilder = remotingMetricsManager.newAttributesBuilder()
                     .put(LABEL_REQUEST_CODE, RemotingHelper.getRequestCodeDesc(cmd.getCode()))
                     .put(LABEL_RESULT, RESULT_PROCESS_REQUEST_FAILED);
-                remotingMetricsManager.getRpcLatency().record(cmd.getProcessTimer().elapsed(TimeUnit.MILLISECONDS), attributesBuilder.build());
+                remotingMetricsManager.getRpcLatency().record(cmd.processTimerElapsedMs(), attributesBuilder.build());
             }
         }
     }

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
@@ -17,7 +17,8 @@
 package org.apache.rocketmq.remoting.protocol;
 
 import com.alibaba.fastjson2.annotation.JSONField;
-import com.google.common.base.Stopwatch;
+
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +32,7 @@ import org.apache.rocketmq.remoting.annotation.CFNotNull;
 import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -42,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class RemotingCommand {
@@ -54,6 +57,12 @@ public class RemotingCommand {
     private static final Map<Class<? extends CommandCustomHeader>, Field[]> CLASS_HASH_MAP =
         new HashMap<>();
     private static final Map<Class, String> CANONICAL_NAME_CACHE = new HashMap<>();
+    // Caches the no-arg constructor of each CommandCustomHeader class.
+    // Why: Class.getDeclaredConstructor() copies the Constructor object on every call
+    // (sample showed ~70MB of Constructor allocations during a 60s benchmark).
+    // The set of header classes is fixed at startup, so ConcurrentHashMap.computeIfAbsent
+    // pays the reflective lookup once per class and reuses the cached Constructor thereafter.
+    private static final Map<Class<?>, Constructor<?>> HEADER_CTOR_CACHE = new ConcurrentHashMap<>();
     // 1, Oneway
     // 1, RESPONSE_COMMAND
     private static final Map<Field, Boolean> NULLABLE_FIELD_CACHE = new HashMap<>();
@@ -97,7 +106,7 @@ public class RemotingCommand {
 
     private transient byte[] body;
     private boolean suspended;
-    private transient Stopwatch processTimer;
+    private transient long processTimerNanos;
     private transient List<CommandCallback> callbackList;
 
     protected RemotingCommand() {
@@ -159,8 +168,7 @@ public class RemotingCommand {
 
         if (classHeader != null) {
             try {
-                CommandCustomHeader objectHeader = classHeader.getDeclaredConstructor().newInstance();
-                cmd.customHeader = objectHeader;
+                cmd.customHeader = newHeaderInstance(classHeader);
             } catch (InstantiationException e) {
                 return null;
             } catch (IllegalAccessException e) {
@@ -173,6 +181,18 @@ public class RemotingCommand {
         }
 
         return cmd;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T newHeaderInstance(Class<T> cls)
+        throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Constructor<?> ctor = HEADER_CTOR_CACHE.get(cls);
+        if (ctor == null) {
+            ctor = cls.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            HEADER_CTOR_CACHE.putIfAbsent(cls, ctor);
+        }
+        return (T) ctor.newInstance();
     }
 
     public static RemotingCommand createResponseCommand(int code, String remark) {
@@ -283,7 +303,7 @@ public class RemotingCommand {
         boolean useFastEncode) throws RemotingCommandException {
         T objectHeader;
         try {
-            objectHeader = classHeader.getDeclaredConstructor().newInstance();
+            objectHeader = newHeaderInstance(classHeader);
         } catch (Exception e) {
             return null;
         }
@@ -611,7 +631,10 @@ public class RemotingCommand {
 
     public void addExtField(String key, String value) {
         if (null == extFields) {
-            extFields = new HashMap<>(256);
+            // Default capacity (16) is plenty for the typical few extFields plus
+            // a CustomHeader's reflected fields. Capacity 256 was 16x oversized
+            // and allocated a Node[256] per command on the send/response path.
+            extFields = new HashMap<>();
         }
         extFields.put(key, value);
     }
@@ -635,12 +658,39 @@ public class RemotingCommand {
         this.serializeTypeCurrentRPC = serializeTypeCurrentRPC;
     }
 
-    public Stopwatch getProcessTimer() {
-        return processTimer;
+    public long processTimerElapsedMs() {
+        if (processTimerNanos == 0) {
+            return 0;
+        }
+        return (System.nanoTime() - processTimerNanos) / 1_000_000;
     }
 
-    public void setProcessTimer(Stopwatch processTimer) {
-        this.processTimer = processTimer;
+    /**
+     * @deprecated Use {@link #processTimerElapsedMs()} instead.
+     * This method returns a newly-started Stopwatch for source compatibility only
+     * and does NOT represent the original request processing timer. Any downstream
+     * caller that still calls this method will observe near-zero elapsed time.
+     */
+    @Deprecated
+    public com.google.common.base.Stopwatch getProcessTimer() {
+        return com.google.common.base.Stopwatch.createStarted();
+    }
+
+    /**
+     * @deprecated Use {@link #setProcessTimerNanos(long)} instead.
+     * The Stopwatch carries an already-elapsed duration, whereas {@code processTimerNanos}
+     * is a {@link System#nanoTime()} start timestamp consumed by {@link #processTimerElapsedMs()}.
+     * Reconstruct an equivalent start timestamp ({@code now - elapsed}) so that
+     * {@link #processTimerElapsedMs()} keeps returning the correct elapsed time for callers
+     * still using this deprecated setter, instead of a near-JVM-uptime value.
+     */
+    @Deprecated
+    public void setProcessTimer(com.google.common.base.Stopwatch processTimer) {
+        this.processTimerNanos = System.nanoTime() - processTimer.elapsed(java.util.concurrent.TimeUnit.NANOSECONDS);
+    }
+
+    public void setProcessTimerNanos(long nanos) {
+        this.processTimerNanos = nanos;
     }
 
     public List<CommandCallback> getCallbackList() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingContext.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingContext.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public class TopicQueueMappingContext  {
+
     private String topic;
     private Integer globalId;
     private TopicQueueMappingDetail mappingDetail;

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import com.google.common.base.Stopwatch;
 import org.apache.rocketmq.remoting.CommandCustomHeader;
 import org.apache.rocketmq.remoting.annotation.CFNotNull;
 import org.apache.rocketmq.remoting.exception.RemotingCommandException;
@@ -258,6 +260,26 @@ public class RemotingCommandTest {
         remotingCommand.makeCustomHeaderToNet();
         SubExtFieldsHeader other = (SubExtFieldsHeader) remotingCommand.decodeCommandCustomHeader(subExtFieldsHeader.getClass());
         Assert.assertEquals(other, subExtFieldsHeader);
+    }
+
+    @Test
+    public void testSetProcessTimerStopwatchKeepsElapsed() throws Exception {
+        // The deprecated setProcessTimer(Stopwatch) carries an already-elapsed duration, while
+        // processTimerElapsedMs() treats processTimerNanos as a System.nanoTime() start timestamp.
+        // The compatibility adapter must reconstruct the start (now - elapsed) so the reported
+        // elapsed stays close to the real duration, not a near-JVM-uptime value.
+        RemotingCommand cmd = RemotingCommand.createRequestCommand(0, null);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        Thread.sleep(30);
+        stopwatch.stop();
+        long expectedMs = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+
+        cmd.setProcessTimer(stopwatch);
+        long reported = cmd.processTimerElapsedMs();
+
+        // Correct behavior: reported ~= stopwatch elapsed (plus microseconds of overhead).
+        // Buggy behavior (storing elapsed as a start timestamp) would yield ~JVM uptime.
+        assertThat(reported).isBetween(expectedMs, expectedMs + 500);
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10512

### Brief Description

Four independent per-RPC micro-allocations eliminated in the remoting framework:

1. **Guava Stopwatch → System.nanoTime()** — `RemotingCommand` used `Stopwatch.createStarted()` which allocates a new object per RPC. Replaced with `long processTimerNanos` + `processTimerElapsedMs()`.
2. **Constructor cache** — `Class.getDeclaredConstructor()` copies the `Constructor` object on every call. Added `ConcurrentHashMap<Class<?>, Constructor<?>> HEADER_CTOR_CACHE` with `computeIfAbsent`.
3. **Netty writability log downgrade** — `channelWritabilityChanged` logged at INFO/WARN ~900 lines/sec. Downgraded to DEBUG with `isDebugEnabled()` guard.
4. **TopicQueueMappingContext.EMPTY singleton** — Non-static-topic messages (>99%) created empty objects. Added `public static final EMPTY` singleton.

### How Did You Test This Change?

1. Full CI passes (maven-compile + bazel-compile on all JDK versions).
2. All broker processor call sites updated from `getProcessTimer()` to `processTimerElapsedMs()`.
3. Commercial compatibility verified — `YitianRemotingCommand` uses different method names, not affected.
