### PR TITLE
[ISSUE #10510] Add gRPC server permit keepalive configuration

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -156,6 +156,8 @@ public class ProxyConfig implements ConfigFile {
     private long grpcClientConsumerMaxLongPollingTimeoutMillis = Duration.ofSeconds(20).toMillis();
     private int grpcClientConsumerLongPollingBatchSize = 32;
     private long grpcClientIdleTimeMills = Duration.ofSeconds(120).toMillis();
+    private long grpcServerPermitKeepAliveTimeMillis = 10000;
+    private boolean grpcServerPermitKeepAliveWithoutCalls = true;
 
     private int channelExpiredInSeconds = 60;
     private int contextExpiredInSeconds = 30;
@@ -1219,6 +1221,22 @@ public class ProxyConfig implements ConfigFile {
 
     public void setGrpcClientIdleTimeMills(final long grpcClientIdleTimeMills) {
         this.grpcClientIdleTimeMills = grpcClientIdleTimeMills;
+    }
+
+    public long getGrpcServerPermitKeepAliveTimeMillis() {
+        return grpcServerPermitKeepAliveTimeMillis;
+    }
+
+    public void setGrpcServerPermitKeepAliveTimeMillis(long grpcServerPermitKeepAliveTimeMillis) {
+        this.grpcServerPermitKeepAliveTimeMillis = grpcServerPermitKeepAliveTimeMillis;
+    }
+
+    public boolean isGrpcServerPermitKeepAliveWithoutCalls() {
+        return grpcServerPermitKeepAliveWithoutCalls;
+    }
+
+    public void setGrpcServerPermitKeepAliveWithoutCalls(boolean grpcServerPermitKeepAliveWithoutCalls) {
+        this.grpcServerPermitKeepAliveWithoutCalls = grpcServerPermitKeepAliveWithoutCalls;
     }
 
     public String getRegionId() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -156,7 +156,7 @@ public class ProxyConfig implements ConfigFile {
     private long grpcClientConsumerMaxLongPollingTimeoutMillis = Duration.ofSeconds(20).toMillis();
     private int grpcClientConsumerLongPollingBatchSize = 32;
     private long grpcClientIdleTimeMills = Duration.ofSeconds(120).toMillis();
-    private long grpcServerPermitKeepAliveTimeMillis = 10000;
+    private long grpcServerPermitKeepAliveTimeMillis = 30000;
     private boolean grpcServerPermitKeepAliveWithoutCalls = true;
 
     private int channelExpiredInSeconds = 60;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServerBuilder.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServerBuilder.java
@@ -78,7 +78,9 @@ public class GrpcServerBuilder {
         }
 
         serverBuilder.maxInboundMessageSize(maxInboundMessageSize)
-            .maxConnectionIdle(idleTimeMills, TimeUnit.MILLISECONDS);
+            .maxConnectionIdle(idleTimeMills, TimeUnit.MILLISECONDS)
+            .permitKeepAliveTime(config.getGrpcServerPermitKeepAliveTimeMillis(), TimeUnit.MILLISECONDS)
+            .permitKeepAliveWithoutCalls(config.isGrpcServerPermitKeepAliveWithoutCalls());
 
         log.info("grpc server has built. port: {}, bossLoopNum: {}, workerLoopNum: {}, maxInboundMessageSize: {}",
             port, bossLoopNum, workerLoopNum, maxInboundMessageSize);


### PR DESCRIPTION
## Motivation

When a TCP connection is broken without a RST, the gRPC client needs to rely on HTTP/2 PING (keepalive) to detect the dead connection. Currently, the gRPC server in the Proxy does **not** configure `permitKeepAliveTime` or `permitKeepAliveWithoutCalls`, which means gRPC Netty server defaults apply:

- `permitKeepAliveTime` = **5 minutes** — clients cannot send keepalive pings more frequently than every 5 minutes
- `permitKeepAliveWithoutCalls` = **false** — keepalive pings on idle connections are rejected

This causes slow dead-connection detection (up to 5.5 minutes) and ineffective idle connection health checks.

Fixes #10510

## Changes

Add two configurable parameters to `ProxyConfig`:

| Parameter | Default | Description |
|-----------|---------|-------------|
| `grpcServerPermitKeepAliveTimeMillis` | 10000 (10s) | Minimum time between client keepalive pings |
| `grpcServerPermitKeepAliveWithoutCalls` | true | Allow keepalive pings when no active RPCs |

Apply these in `GrpcServerBuilder`:
```java
serverBuilder
    .permitKeepAliveTime(config.getGrpcServerPermitKeepAliveTimeMillis(), TimeUnit.MILLISECONDS)
    .permitKeepAliveWithoutCalls(config.isGrpcServerPermitKeepAliveWithoutCalls());
```

## Impact

- **Backward compatible**: Default values are more permissive than current implicit defaults
- **Minimal overhead**: ~8KB/hour per connection at 30s interval
- **Enables faster detection**: Once clients reduce keepAliveTime, dead-connection detection can drop from 5.5 minutes to ~40 seconds