### PR TITLE
[ISSUE #10515] Fix TransactionMetricsFlushService busy spin bug

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/TransactionMetricsFlushService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/TransactionMetricsFlushService.java
@@ -41,10 +41,15 @@ public class TransactionMetricsFlushService extends ServiceThread {
         long start = System.currentTimeMillis();
         while (!this.isStopped()) {
             try {
-                if (System.currentTimeMillis() - start > brokerController.getBrokerConfig().getTransactionMetricFlushInterval()) {
+                // Bug fix: original code only called waitForRunning inside the if-branch,
+                // so on every iteration where the interval hadn't elapsed yet the loop
+                // spun without yielding (~170 CPU samples in JFR on idle broker).
+                // Now we always wait, then check whether enough time has passed to persist.
+                long interval = brokerController.getBrokerConfig().getTransactionMetricFlushInterval();
+                this.waitForRunning(interval);
+                if (System.currentTimeMillis() - start >= interval) {
                     start = System.currentTimeMillis();
                     brokerController.getTransactionalMessageService().getTransactionMetrics().persist();
-                    waitForRunning(brokerController.getBrokerConfig().getTransactionMetricFlushInterval());
                 }
             } catch (Throwable e) {
                 log.error("Error occurred in " + getServiceName(), e);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10515

### Brief Description

Fix a busy-spin bug in `TransactionMetricsFlushService.run()`. The `waitForRunning()` call was only inside the `if` branch, so when the flush interval had not elapsed the `while` loop spun without yielding — wasting ~170 CPU samples on an idle broker in JFR.

Move `waitForRunning(interval)` before the `if` check so the thread always sleeps between iterations.

### How Did You Test This Change?

1. Full CI passes (maven-compile + bazel-compile on all JDK versions).
2. Verified idle broker CPU usage drops to near-zero after fix.
3. Commercial compatibility verified — no commercial override on this class.
