### PR TITLE
[ISSUE #10522] Reduce Remoting header encoding allocation via FastCodesHeader/RocketMQSerializable optimizations

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/FastCodesHeader.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/FastCodesHeader.java
@@ -38,8 +38,24 @@ public interface FastCodesHeader {
     default void writeIfNotNull(ByteBuf out, String key, Object value) {
         if (value != null) {
             RocketMQSerializable.writeStr(out, true, key);
-            RocketMQSerializable.writeStr(out, false, value.toString());
+            if (value instanceof Long) {
+                RocketMQSerializable.writeDecimalLong(out, (Long) value);
+            } else if (value instanceof Integer) {
+                RocketMQSerializable.writeDecimalInt(out, (Integer) value);
+            } else {
+                RocketMQSerializable.writeStr(out, false, value.toString());
+            }
         }
+    }
+
+    default void writeLong(ByteBuf out, String key, long value) {
+        RocketMQSerializable.writeStr(out, true, key);
+        RocketMQSerializable.writeDecimalLong(out, value);
+    }
+
+    default void writeInt(ByteBuf out, String key, int value) {
+        RocketMQSerializable.writeStr(out, true, key);
+        RocketMQSerializable.writeDecimalInt(out, value);
     }
 
     void encode(ByteBuf out);

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializable.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializable.java
@@ -28,6 +28,75 @@ import io.netty.buffer.ByteBuf;
 
 public class RocketMQSerializable {
     private static final Charset CHARSET_UTF8 = StandardCharsets.UTF_8;
+    private static final String[] SINGLE_BYTE_STRINGS = new String[128];
+    static {
+        for (int i = 0; i < 128; i++) {
+            SINGLE_BYTE_STRINGS[i] = String.valueOf((char) i);
+        }
+    }
+
+    public static void writeDecimalLong(ByteBuf buf, long value) {
+        int lenIndex = buf.writerIndex();
+        buf.writeInt(0);
+        int start = buf.writerIndex();
+        if (value == 0) {
+            buf.writeByte('0');
+        } else {
+            boolean neg = value < 0;
+            if (neg) {
+                buf.writeByte('-');
+                if (value == Long.MIN_VALUE) {
+                    writePositiveDigits(buf, 922337203685477580L);
+                    buf.writeByte('8');
+                    buf.setInt(lenIndex, buf.writerIndex() - start);
+                    return;
+                }
+                value = -value;
+            }
+            writePositiveDigits(buf, value);
+        }
+        buf.setInt(lenIndex, buf.writerIndex() - start);
+    }
+
+    public static void writeDecimalInt(ByteBuf buf, int value) {
+        int lenIndex = buf.writerIndex();
+        buf.writeInt(0);
+        int start = buf.writerIndex();
+        if (value == 0) {
+            buf.writeByte('0');
+        } else {
+            boolean neg = value < 0;
+            if (neg) {
+                buf.writeByte('-');
+                if (value == Integer.MIN_VALUE) {
+                    writePositiveDigits(buf, 214748364L);
+                    buf.writeByte('8');
+                    buf.setInt(lenIndex, buf.writerIndex() - start);
+                    return;
+                }
+                value = -value;
+            }
+            writePositiveDigits(buf, value);
+        }
+        buf.setInt(lenIndex, buf.writerIndex() - start);
+    }
+
+    private static void writePositiveDigits(ByteBuf buf, long value) {
+        int digitStart = buf.writerIndex();
+        int numDigits = 0;
+        long temp = value;
+        while (temp > 0) {
+            numDigits++;
+            temp /= 10;
+        }
+        buf.ensureWritable(numDigits);
+        buf.writerIndex(digitStart + numDigits);
+        temp = value;
+        for (int i = numDigits - 1; i >= 0; i--) {
+            buf.setByte(digitStart + i, (byte) ('0' + (int) (temp % 10)));
+            temp /= 10;
+        }
+    }
 
     public static void writeStr(ByteBuf buf, boolean useShortLength, String str) {
         int lenIndex = buf.writerIndex();
@@ -51,6 +120,13 @@ public class RocketMQSerializable {
         }
         if (len > limit) {
             throw new RemotingCommandException("string length exceed limit:" + limit);
+        }
+        if (len == 1) {
+            byte b = buf.readByte();
+            if (b >= 0) {
+                return SINGLE_BYTE_STRINGS[b];
+            }
+            return new String(new byte[]{b}, CHARSET_UTF8);
         }
         CharSequence cs = buf.readCharSequence(len, StandardCharsets.UTF_8);
         return cs == null ? null : cs.toString();
@@ -231,7 +307,8 @@ public class RocketMQSerializable {
 
     public static HashMap<String, String> mapDeserialize(ByteBuf byteBuffer, int len) throws RemotingCommandException {
 
-        HashMap<String, String> map = new HashMap<>(128);
+        // Typical RocketMQ headers have 5-15 entries; 24 (next power-of-2 above 15*1.33) avoids resize
+        HashMap<String, String> map = new HashMap<>(24);
         int endIndex = byteBuffer.readerIndex() + len;
 
         while (byteBuffer.readerIndex() < endIndex) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #10522

### Brief Description

Enhance `FastCodesHeader` interface and `RocketMQSerializable` utility to reduce allocation and CPU overhead in the Remoting header encoding/decoding hot path.

**`FastCodesHeader.java`**
- Optimize `writeIfNotNull` to route `Long`/`Integer` values through `writeDecimalLong`/`writeDecimalInt` instead of `value.toString()` + `writeStr`, eliminating transient `String` allocation.
- Add `writeLong(ByteBuf, String, long)` and `writeInt(ByteBuf, String, int)` helper methods for direct primitive encoding.

**`RocketMQSerializable.java`**
- Add `writeDecimalLong(ByteBuf, long)` and `writeDecimalInt(ByteBuf, int)` — write decimal numbers directly to `ByteBuf` without `String.valueOf()` allocation.
- Add `SINGLE_BYTE_STRINGS` cache (128 entries) — `readStr` returns cached `String` for single-byte ASCII values instead of creating new `String` via `readCharSequence`.
- Right-size `mapDeserialize` initial `HashMap` capacity from 128 to 24 — typical headers have 5-15 entries, 128 causes unnecessary memory waste.

All changes are additive — no existing method signatures are modified.

### How Did You Test This Change?

**1. Unit tests**

```
mvn test -pl remoting -Dtest=RocketMQSerializableTest,FastCodesHeaderTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

**2. A/B benchmark** (256 threads, 1KB sync send, Dragonwell JDK 21, 6g heap)

| Metric | Baseline (develop) | Optimized (R1) | Change |
|--------|-------------------|----------------|--------|
| TPS | ~196k | ~236k | **+20.6%** |
| p99 RT | 3ms | 2ms | **-33%** |
| Average RT | 1.307ms | 1.085ms | **-17.0%** |
| Max RT | 594ms | 351ms | **-40.9%** |
| Young GCs (total) | 336 | 304 | **-9.5%** |

**3. Commercial compatibility**

- Pure additive changes — no existing API signatures modified.
- No commercial classes implement `FastCodesHeader`.
- Commercial `YitianRemotingCommand` calls `RocketMQSerializable.rocketMQProtocolDecode/Encode` which are unchanged.
