### PR TITLE
[ISSUE #10529] Fix incorrect queue permissions in gRPC QueryRouteResponse

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -242,58 +242,59 @@ public class RouteActivity extends AbstractMessagingActivity {
         TopicMessageType topicMessageType, Broker broker) {
         List<MessageQueue> messageQueueList = new ArrayList<>();
 
-        int r = 0;
-        int w = 0;
-        int rw = 0;
-        int n = 0;
-        if (PermName.isWriteable(queueData.getPerm()) && PermName.isReadable(queueData.getPerm())) {
-            rw = Math.min(queueData.getWriteQueueNums(), queueData.getReadQueueNums());
-            r = queueData.getReadQueueNums() - rw;
-            w = queueData.getWriteQueueNums() - rw;
-        } else if (PermName.isWriteable(queueData.getPerm())) {
-            w = queueData.getWriteQueueNums();
-        } else if (PermName.isReadable(queueData.getPerm())) {
-            r = queueData.getReadQueueNums();
+        int readQueueNums = queueData.getReadQueueNums();
+        int writeQueueNums = queueData.getWriteQueueNums();
+        boolean isReadable = PermName.isReadable(queueData.getPerm());
+        boolean isWriteable = PermName.isWriteable(queueData.getPerm());
+
+        if (isReadable && isWriteable) {
+            // Derive the permission per queue id so that it matches the actual queue id.
+            // Queue id < readQueueNums means readable, id < writeQueueNums means writable.
+            int totalQueueNums = Math.max(readQueueNums, writeQueueNums);
+            for (int queueId = 0; queueId < totalQueueNums; queueId++) {
+                Permission permission;
+                if (queueId < readQueueNums && queueId < writeQueueNums) {
+                    permission = Permission.READ_WRITE;
+                } else if (queueId < writeQueueNums) {
+                    permission = Permission.WRITE;
+                } else {
+                    permission = Permission.READ;
+                }
+                MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
+                    .setId(queueId)
+                    .setPermission(permission)
+                    .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                    .build();
+                messageQueueList.add(messageQueue);
+            }
+        } else if (isWriteable) {
+            for (int queueId = 0; queueId < writeQueueNums; queueId++) {
+                MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
+                    .setId(queueId)
+                    .setPermission(Permission.WRITE)
+                    .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                    .build();
+                messageQueueList.add(messageQueue);
+            }
+        } else if (isReadable) {
+            for (int queueId = 0; queueId < readQueueNums; queueId++) {
+                MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
+                    .setId(queueId)
+                    .setPermission(Permission.READ)
+                    .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                    .build();
+                messageQueueList.add(messageQueue);
+            }
         } else if (!PermName.isAccessible(queueData.getPerm())) {
-            n = Math.max(1, Math.max(queueData.getWriteQueueNums(), queueData.getReadQueueNums()));
-        }
-
-        // r here means readOnly queue nums, w means writeOnly queue nums, while rw means both readable and writable queue nums.
-        int queueIdIndex = 0;
-        for (int i = 0; i < r; i++) {
-            MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
-                .setId(queueIdIndex++)
-                .setPermission(Permission.READ)
-                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
-                .build();
-            messageQueueList.add(messageQueue);
-        }
-
-        for (int i = 0; i < w; i++) {
-            MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
-                .setId(queueIdIndex++)
-                .setPermission(Permission.WRITE)
-                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
-                .build();
-            messageQueueList.add(messageQueue);
-        }
-
-        for (int i = 0; i < rw; i++) {
-            MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
-                .setId(queueIdIndex++)
-                .setPermission(Permission.READ_WRITE)
-                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
-                .build();
-            messageQueueList.add(messageQueue);
-        }
-
-        for (int i = 0; i < n; i++) {
-            MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
-                .setId(queueIdIndex++)
-                .setPermission(Permission.NONE)
-                .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
-                .build();
-            messageQueueList.add(messageQueue);
+            int noneQueueNums = Math.max(1, Math.max(writeQueueNums, readQueueNums));
+            for (int queueId = 0; queueId < noneQueueNums; queueId++) {
+                MessageQueue messageQueue = MessageQueue.newBuilder().setBroker(broker).setTopic(topic)
+                    .setId(queueId)
+                    .setPermission(Permission.NONE)
+                    .addAllAcceptMessageTypes(parseTopicMessageType(topicMessageType))
+                    .build();
+                messageQueueList.add(messageQueue);
+            }
         }
 
         return messageQueueList;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -264,7 +264,8 @@ public class RouteActivityTest extends BaseActivityTest {
         assertEquals(0, partitionWith8R0WPermRW.stream().filter(a -> a.getPermission() == Permission.READ_WRITE).count());
         assertEquals(0, partitionWith8R0WPermRW.stream().filter(a -> a.getPermission() == Permission.WRITE).count());
 
-        // test queueData with 4 read queues, 8 write queues, and rw permission, expect 4 rw queues and  4 write only queues.
+        // test queueData with 4 read queues, 8 write queues, and rw permission, expect 4 rw queues and 4 write only queues.
+        // Queue ids 0..3 are READ_WRITE (readable and writable), ids 4..7 are WRITE (writable only).
         QueueData queueDataWith4R8WPermRW = createQueueData(4, 8, PermName.PERM_READ | PermName.PERM_WRITE);
         List<MessageQueue> partitionWith4R8WPermRW = this.routeActivity.genMessageQueueFromQueueData(queueDataWith4R8WPermRW, GRPC_TOPIC, TopicMessageType.UNSPECIFIED, GRPC_BROKER);
         assertEquals(8, partitionWith4R8WPermRW.size());
@@ -272,6 +273,31 @@ public class RouteActivityTest extends BaseActivityTest {
         assertEquals(4, partitionWith4R8WPermRW.stream().filter(a -> a.getPermission() == Permission.WRITE).count());
         assertEquals(4, partitionWith4R8WPermRW.stream().filter(a -> a.getPermission() == Permission.READ_WRITE).count());
         assertEquals(0, partitionWith4R8WPermRW.stream().filter(a -> a.getPermission() == Permission.READ).count());
+        for (int i = 0; i < 4; i++) {
+            assertEquals(Permission.READ_WRITE, partitionWith4R8WPermRW.get(i).getPermission());
+            assertEquals(i, partitionWith4R8WPermRW.get(i).getId());
+        }
+        for (int i = 4; i < 8; i++) {
+            assertEquals(Permission.WRITE, partitionWith4R8WPermRW.get(i).getPermission());
+            assertEquals(i, partitionWith4R8WPermRW.get(i).getId());
+        }
+
+        // test queueData with 8 read queues, 4 write queues, and rw permission, expect 4 rw queues and 4 read only queues.
+        // Queue ids 0..3 are READ_WRITE (readable and writable), ids 4..7 are READ (readable only).
+        QueueData queueDataWith8R4WPermRW = createQueueData(8, 4, PermName.PERM_READ | PermName.PERM_WRITE);
+        List<MessageQueue> partitionWith8R4WPermRW = this.routeActivity.genMessageQueueFromQueueData(queueDataWith8R4WPermRW, GRPC_TOPIC, TopicMessageType.UNSPECIFIED, GRPC_BROKER);
+        assertEquals(8, partitionWith8R4WPermRW.size());
+        assertEquals(4, partitionWith8R4WPermRW.stream().filter(a -> a.getPermission() == Permission.READ).count());
+        assertEquals(4, partitionWith8R4WPermRW.stream().filter(a -> a.getPermission() == Permission.READ_WRITE).count());
+        assertEquals(0, partitionWith8R4WPermRW.stream().filter(a -> a.getPermission() == Permission.WRITE).count());
+        for (int i = 0; i < 4; i++) {
+            assertEquals(Permission.READ_WRITE, partitionWith8R4WPermRW.get(i).getPermission());
+            assertEquals(i, partitionWith8R4WPermRW.get(i).getId());
+        }
+        for (int i = 4; i < 8; i++) {
+            assertEquals(Permission.READ, partitionWith8R4WPermRW.get(i).getPermission());
+            assertEquals(i, partitionWith8R4WPermRW.get(i).getId());
+        }
 
         // test queueData with 2 read queues, 2 write queues, and no permission, expect 2 no permission queues.
         QueueData queueDataWith2R2WNoPerm = createQueueData(2, 2, 0);


### PR DESCRIPTION
## What Changed

Fixed the permission assignment logic in `RouteActivity#genMessageQueueFromQueueData` so that each `MessageQueue`'s permission is derived from its queue id rather than being assigned by grouped permission counts.

## Why

When the gRPC proxy builds `QueryRouteResponse`, the old implementation calculated the number of read-only, write-only, and read-write queues first, then appended them in groups (READ, WRITE, READ_WRITE) while increasing the queue id. This preserved the count of each permission type but assigned the permission to the wrong queue id.

For example, with `readQueueNums = 4`, `writeQueueNums = 8`, and `PERM_READ | PERM_WRITE`:

- **Expected:** queue ids `0..3` -> `READ_WRITE`, queue ids `4..7` -> `WRITE`
- **Before fix:** queue ids `0..3` -> `WRITE`, queue ids `4..7` -> `READ_WRITE`

Since `MessageQueue.id` is part of the queue identity, the permission must match the actual queue id. The internal route selection logic also builds read/write queues by iterating queue ids from `0` to `readQueueNums - 1` or `writeQueueNums - 1`, confirming that the permission should be derived per queue id.

## How

Instead of grouping by permission type, iterate queue ids from `0` to `max(readQueueNums, writeQueueNums) - 1` and derive the permission per id:
- `id < readQueueNums && id < writeQueueNums` -> `READ_WRITE`
- `id < writeQueueNums` only -> `WRITE`
- `id < readQueueNums` only -> `READ`

The write-only, read-only, and no-access branches remain unchanged.

## Test Plan

- [x] Updated `RouteActivityTest#testGenPartitionFromQueueData` to verify the per-queue-id permission mapping for `readQueueNums = 4, writeQueueNums = 8` (ids `0..3` -> `READ_WRITE`, ids `4..7` -> `WRITE`)
- [x] Added test case for `readQueueNums = 8, writeQueueNums = 4` (ids `0..3` -> `READ_WRITE`, ids `4..7` -> `READ`)
- [x] All existing test cases (equal read/write, read-only, write-only, no-access) continue to pass
- [ ] CI passes (`maven-compile`, `license-checker`)