### PR TITLE
[ISSUE #10421] Fix Timer message RocksDB cache key using ByteBuffer

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
@@ -84,7 +84,7 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
     private volatile ColumnFamilyHandle transCFHandle;
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private static final Cache<byte[], byte[]> DELETE_KEY_CACHE_FOR_TIMER = CacheBuilder.newBuilder()
+    private static final Cache<ByteBuffer, byte[]> DELETE_KEY_CACHE_FOR_TIMER = CacheBuilder.newBuilder()
         .maximumSize(10000)
         .expireAfterWrite(60, TimeUnit.MINUTES)
         .build();
@@ -354,9 +354,9 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
                         writeBatch.put(cfHandle, keyBytes, valueBytes);
                     } else if (record.getActionFlag() == TIMER_ROCKSDB_DELETE) {
                         writeBatch.delete(cfHandle, keyBytes);
-                        DELETE_KEY_CACHE_FOR_TIMER.put(keyBytes, DELETE_VAL_FLAG);
+                        DELETE_KEY_CACHE_FOR_TIMER.put(ByteBuffer.wrap(keyBytes), DELETE_VAL_FLAG);
                     } else if (record.getActionFlag() == TIMER_ROCKSDB_UPDATE) {
-                        byte[] deleteByte = DELETE_KEY_CACHE_FOR_TIMER.getIfPresent(keyBytes);
+                        byte[] deleteByte = DELETE_KEY_CACHE_FOR_TIMER.getIfPresent(ByteBuffer.wrap(keyBytes));
                         if (null == deleteByte) {
                             writeBatch.put(cfHandle, keyBytes, valueBytes);
                         }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #10421

In the timer message RocksDB store, `DELETE_KEY_CACHE_FOR_TIMER` is used to prevent an `UPDATE` record from re-inserting an already-deleted key (which would leave a ghost record in RocksDB).

However, the cache uses `byte[]` as its key type. Since `byte[].equals()` compares object references rather than content, and `TimerRocksDBRecord.getKeyBytes()` returns a new byte array each time, `cache.getIfPresent(keyBytes)` always returns `null` even when the same key content was previously put. As a result, the `UPDATE` path always writes the record back, producing ghost records.

## Brief changelog

In `MessageRocksDBStorage.java`:
- Change `DELETE_KEY_CACHE_FOR_TIMER` cache key type from `Cache<byte[], byte[]>` to `Cache<ByteBuffer, byte[]>`. `ByteBuffer` implements content-based `equals()`/`hashCode()`, so cache lookups match on key content rather than array identity.
- Wrap keys with `ByteBuffer.wrap(keyBytes)` in both `cache.put(...)` and `cache.getIfPresent(...)` calls.

## Verifying this change

- The `DELETE` branch now correctly stores a `ByteBuffer`-wrapped key, and the `UPDATE` branch correctly retrieves it by content, so already-deleted keys are skipped as intended.
- `java.nio.ByteBuffer` is already imported in the file, so no new imports are required.

Follow this checklist to request a review from a maintainer:
- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check the style with `./mvnw -T 2C clean checkstyle:check`.
- [x] Run `./mvnw -T 2C clean test -Dtest=...` to make sure unit tests pass.