### PR TITLE
Preserve attribute values containing an equals sign in AttributeParser

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/attribute/AttributeParser.java
+++ b/common/src/main/java/org/apache/rocketmq/common/attribute/AttributeParser.java
@@ -44,7 +44,7 @@ public class AttributeParser {
             String key;
             String value;
             if (kv.contains(ATTR_KEY_VALUE_EQUAL_SIGN)) {
-                String[] splits = kv.split(ATTR_KEY_VALUE_EQUAL_SIGN);
+                String[] splits = kv.split(ATTR_KEY_VALUE_EQUAL_SIGN, 2);
                 key = splits[0];
                 value = splits[1];
                 if (!key.contains(ATTR_ADD_PLUS_SIGN)) {

--- a/common/src/test/java/org/apache/rocketmq/common/attribute/AttributeParserTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/attribute/AttributeParserTest.java
@@ -122,6 +122,13 @@ public class AttributeParserTest {
     }
 
     @Test
+    public void parseToMap_ValueContainingEqualsSign_PreservesFullValue() {
+        String attributesModification = "+key=val=ue";
+        Map<String, String> result = AttributeParser.parseToMap(attributesModification);
+        assertEquals("val=ue", result.get("+key"));
+    }
+
+    @Test
     public void testParseBetweenStringAndMapWithoutDistortion() {
         List<String> testCases = Arrays.asList("-a", "+a=b,+c=d,+z=z,+e=e", "+a=b,-d", "+a=b", "-a,-b");
         for (String testCase : testCases) {


### PR DESCRIPTION
`AttributeParser` splits each `key=value` pair on `=` without a limit, so a value that itself contains `=` is truncated (only the part before the second `=` is kept). Split with a limit of 2 so the full value is preserved.

Added a test for a value containing an `=`.

## Verifying this change

The added `AttributeParserTest#parseToMap_ValueContainingEqualsSign_PreservesFullValue` fails on the current `develop` and passes with this change:

Before the fix (on `develop`):

```
$ mvn test -Dtest=AttributeParserTest -pl common
Running org.apache.rocketmq.common.attribute.AttributeParserTest
Tests run: 12, Failures: 1, Errors: 0, Skipped: 1 <<< FAILURE!
org.junit.ComparisonFailure: expected:<val[=ue]> but was:<val[]>
	at org.apache.rocketmq.common.attribute.AttributeParserTest.parseToMap_ValueContainingEqualsSign_PreservesFullValue(AttributeParserTest.java:128)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=AttributeParserTest -pl common
Running org.apache.rocketmq.common.attribute.AttributeParserTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

