### PR TITLE
Initialize checkStamp in LatencyFaultToleranceImpl.FaultItem

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImpl.java
@@ -202,6 +202,7 @@ public class LatencyFaultToleranceImpl implements LatencyFaultTolerance<String> 
 
         public FaultItem(final String name) {
             this.name = name;
+            this.checkStamp = System.currentTimeMillis() + LatencyFaultToleranceImpl.this.detectInterval;
         }
 
         public void updateNotAvailableDuration(long notAvailableDuration) {

--- a/client/src/test/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImplTest.java
@@ -19,11 +19,17 @@ package org.apache.rocketmq.client.latency;
 import org.awaitility.core.ThrowingRunnable;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class LatencyFaultToleranceImplTest {
     private LatencyFaultTolerance<String> latencyFaultTolerance;
@@ -79,5 +85,20 @@ public class LatencyFaultToleranceImplTest {
 
         latencyFaultTolerance.updateFaultItem(anotherBrokerName, 1001, 3000, false);
         assertThat(latencyFaultTolerance.isReachable(anotherBrokerName)).isEqualTo(false);
+    }
+
+    @Test
+    public void testDetectByOneRoundRespectsDetectInterval() throws Exception {
+        Resolver resolver = mock(Resolver.class);
+        ServiceDetector serviceDetector = mock(ServiceDetector.class);
+        when(resolver.resolve(brokerName)).thenReturn("127.0.0.1:10911");
+        when(serviceDetector.detect(anyString(), anyLong())).thenReturn(true);
+
+        LatencyFaultToleranceImpl impl = new LatencyFaultToleranceImpl(resolver, serviceDetector);
+        impl.setDetectInterval(3600000); // 1 hour
+        impl.updateFaultItem(brokerName, 1000, 0, true);
+        // fresh FaultItem must wait detectInterval before its first detect
+        impl.detectByOneRound();
+        verify(serviceDetector, Mockito.never()).detect(anyString(), anyLong());
     }
 }


### PR DESCRIPTION
`FaultItem.checkStamp` is never initialized, so it defaults to `0`. A freshly
created fault item is therefore immediately eligible for detection in
`detectByOneRound()` instead of waiting one `detectInterval` like every item
that has gone through `updateFaultItem`. This makes the very first detect round
fire a probe against a broker that was only just recorded.

Initialize `checkStamp` to `now + detectInterval` in the constructor, matching
the value `updateFaultItem` assigns. Added a regression test asserting the first
`detectByOneRound()` does not probe a freshly added item.

## Verifying this change

The added `LatencyFaultToleranceImplTest#testDetectByOneRoundRespectsDetectInterval` fails on the current `develop` and passes with this change:

Before the fix (on `develop`):

```
$ mvn test -Dtest=LatencyFaultToleranceImplTest -pl client
Running org.apache.rocketmq.client.latency.LatencyFaultToleranceImplTest
Tests run: 5, Failures: 1, Errors: 0, Skipped: 1 <<< FAILURE!
	at org.apache.rocketmq.client.latency.LatencyFaultToleranceImplTest.testDetectByOneRoundRespectsDetectInterval(LatencyFaultToleranceImplTest.java:102)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=LatencyFaultToleranceImplTest -pl client
Running org.apache.rocketmq.client.latency.LatencyFaultToleranceImplTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

