### PR TITLE
[ISSUE #10488] Optimize gRPC message body conversion with zero-copy ByteString

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
@@ -102,8 +102,10 @@ public class GrpcConverter {
                 .setTopic(topic)
                 .putAllUserProperties(userProperties)
                 .setSystemProperties(systemProperties)
-                // Safe: body is a dedicated byte[] allocated during deserialization
-                // and is not mutated after this point.
+                // Safety: unsafeWrap() aliases the decoded body byte[].
+                // The decoded body array must not be mutated or reused while the
+                // returned protobuf Message (or any serialized form of it) may still
+                // be referenced.
                 .setBody(UnsafeByteOperations.unsafeWrap(messageExt.getBody()))
                 .build();
     }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
@@ -28,7 +28,7 @@ import apache.rocketmq.v2.MessageQueue;
 import apache.rocketmq.v2.MessageType;
 import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.SystemProperties;
-import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import com.google.protobuf.util.Timestamps;
 import java.net.SocketAddress;
 import java.util.Arrays;
@@ -99,11 +99,13 @@ public class GrpcConverter {
         Resource topic = buildResource(messageExt.getTopic());
 
         return Message.newBuilder()
-            .setTopic(topic)
-            .putAllUserProperties(userProperties)
-            .setSystemProperties(systemProperties)
-            .setBody(ByteString.copyFrom(messageExt.getBody()))
-            .build();
+                .setTopic(topic)
+                .putAllUserProperties(userProperties)
+                .setSystemProperties(systemProperties)
+                // Safe: body is a dedicated byte[] allocated during deserialization
+                // and is not mutated after this point.
+                .setBody(UnsafeByteOperations.unsafeWrap(messageExt.getBody()))
+                .build();
     }
 
     protected Map<String, String> buildUserAttributes(MessageExt messageExt) {


### PR DESCRIPTION
## What is changed

Replace `ByteString.copyFrom(messageExt.getBody())` with `UnsafeByteOperations.unsafeWrap(messageExt.getBody())` in `GrpcConverter.buildMessage()`.

## Why

On the Proxy receive path, the message body has already been materialized as a dedicated `byte[]` during decoding.

`ByteString.copyFrom()` performs an additional allocation and array copy before gRPC serialization. Using `UnsafeByteOperations.unsafeWrap()` allows the existing buffer to be wrapped directly, eliminating an unnecessary copy.

## Impact

* Removes one heap allocation per received message.
* Avoids an extra `System.arraycopy`.
* Reduces GC pressure on high-throughput consumer workloads.

## Compatibility

No behavioral changes. The resulting `ByteString` contents remain identical. Only the internal copy is removed.

## Verification

* Verified the change is limited to `GrpcConverter.buildMessage()`.
* Checkstyle passes successfully.
* `UnsafeByteOperations` is available through the existing protobuf dependency.

Closes #10488.
