### PR TITLE
[ISSUE #10562] Optimize PopConsumerServiceTest#transferToFsStoreTest to avoid unnecessary background threads

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceTest.java
@@ -464,10 +464,10 @@ public class PopConsumerServiceTest {
             .thenReturn(CompletableFuture.completedFuture(
                 new PutMessageResult(PutMessageStatus.PUT_OK, new AppendMessageResult(AppendMessageStatus.PUT_OK))));
 
-        consumerService.start();
+        consumerService.getPopConsumerStore().start();
         consumerService.getPopConsumerStore().writeRecords(consumerRecordList);
         consumerService.transferToFsStore();
-        consumerService.shutdown();
+        consumerService.getPopConsumerStore().shutdown();
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10562

### Brief Description

`PopConsumerServiceTest#transferToFsStoreTest` takes ~60 seconds to run because `consumerService.start()` launches two background threads (revive + cache cleanup) that are completely unnecessary for the test.

The revive thread repeatedly hits NPE (unmocked `EscapeBridge`) and sleeps 500ms per cycle. During shutdown, `ServiceThread.waitForRunning()` overwrites `this.thread` with the calling thread, causing `wakeup()` to unpark the wrong thread and delaying exit.

**Fix**: Replace `consumerService.start()/shutdown()` with `consumerService.getPopConsumerStore().start()/shutdown()`, which only initializes the RocksDB store without starting background threads. This matches the pattern used by other tests in the same file (`reviveRetryTest`, `reviveBackoffRetryTest`).

**Result**: Test time **~60s → ~1.3s**, same assertions, same pass/fail behavior.

### How Did You Test This Change?

Ran `PopConsumerServiceTest#transferToFsStoreTest` locally:
- Test passes with identical assertions
- `transferToFsStore` completes in ~26ms (3 records)
- RocksDB resources properly cleaned up via `getPopConsumerStore().shutdown()`