### PR TITLE
[ISSUE #9633] Enable retry topic V2 by default to prevent name collision

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
@@ -520,11 +520,17 @@ public class PopMessageProcessor implements NettyRequestProcessor {
         long popTime = System.currentTimeMillis();
         CompletableFuture<Long> getMessageFuture = CompletableFuture.completedFuture(0L);
         if (needRetry && !requestHeader.isOrder()) {
-            if (needRetryV1) {
+            // In priority mode this is the only chance to serve retry messages ahead of the
+            // normal topic, so cover both retry topic naming schemes instead of alternating
+            // between them while the V1 compatibility window is open.
+            boolean coverBothRetryTopics = usePriorityMode && brokerConfig.isEnableRetryTopicV2()
+                && brokerConfig.isRetrieveMessageFromPopRetryTopicV1();
+            if (needRetryV1 || coverBothRetryTopics) {
                 String retryTopic = KeyBuilder.buildPopRetryTopicV1(requestHeader.getTopic(), requestHeader.getConsumerGroup());
                 getMessageFuture = popMsgFromTopic(retryTopic, true, getMessageResult, requestHeader, reviveQid, channel,
                     popTime, finalMessageFilter, startOffsetInfo, msgOffsetInfo, orderCountInfo, randomQ, getMessageFuture);
-            } else {
+            }
+            if (!needRetryV1 || coverBothRetryTopics) {
                 String retryTopic = KeyBuilder.buildPopRetryTopic(requestHeader.getTopic(), requestHeader.getConsumerGroup(), brokerConfig.isEnableRetryTopicV2());
                 getMessageFuture = popMsgFromTopic(retryTopic, true, getMessageResult, requestHeader, reviveQid, channel,
                     popTime, finalMessageFilter, startOffsetInfo, msgOffsetInfo, orderCountInfo, randomQ, getMessageFuture);

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PopMessageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PopMessageProcessorTest.java
@@ -166,8 +166,11 @@ public class PopMessageProcessorTest {
     @Test
     public void testGetInitOffset_retryTopic() throws RemotingCommandException {
         when(messageStore.getMessageStoreConfig()).thenReturn(new MessageStoreConfig());
+        // pin the retry topic version so the pop path does not randomly switch between V1 and V2
+        brokerController.getBrokerConfig().setRetrieveMessageFromPopRetryTopicV1(false);
         String newGroup = group + "-" + System.currentTimeMillis();
-        String retryTopic = KeyBuilder.buildPopRetryTopic(topic, newGroup);
+        String retryTopic = KeyBuilder.buildPopRetryTopic(topic, newGroup,
+            brokerController.getBrokerConfig().isEnableRetryTopicV2());
         long minOffset = 100L;
         when(messageStore.getMinOffsetInQueue(retryTopic, 0)).thenReturn(minOffset);
         brokerController.getTopicConfigManager().getTopicConfigTable().put(retryTopic, new TopicConfig(retryTopic, 1, 1));

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
@@ -258,7 +258,7 @@ public class PopReviveServiceTest {
         });
 
         popReviveService.mergeAndRevive(reviveObj);
-        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, false), actualRetryTopic.toString());
+        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, brokerConfig.isEnableRetryTopicV2()), actualRetryTopic.toString());
         verify(escapeBridge, times(1)).putMessageToSpecificQueue(any(MessageExtBrokerInner.class)); // write retry
         verify(messageStore, times(0)).putMessage(any(MessageExtBrokerInner.class)); // rewrite CK
     }
@@ -293,7 +293,7 @@ public class PopReviveServiceTest {
         // Wait for async operations to complete
         Thread.sleep(1000);
         
-        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, false), actualRetryTopic.toString());
+        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, brokerConfig.isEnableRetryTopicV2()), actualRetryTopic.toString());
         Assert.assertEquals(REVIVE_TOPIC, actualReviveTopic.toString());
         Assert.assertEquals(INVISIBLE_TIME + 10 * 1000L, actualInvisibleTime.get()); // first interval is 10s
         verify(escapeBridge, times(1)).putMessageToSpecificQueue(any(MessageExtBrokerInner.class)); // write retry
@@ -319,7 +319,7 @@ public class PopReviveServiceTest {
         });
 
         popReviveService.mergeAndRevive(reviveObj);
-        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, false), actualRetryTopic.toString());
+        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, brokerConfig.isEnableRetryTopicV2()), actualRetryTopic.toString());
         verify(escapeBridge, times(1)).putMessageToSpecificQueue(any(MessageExtBrokerInner.class)); // write retry
         verify(messageStore, times(0)).putMessage(any(MessageExtBrokerInner.class)); // rewrite CK
     }
@@ -343,7 +343,7 @@ public class PopReviveServiceTest {
         });
 
         popReviveService.mergeAndRevive(reviveObj);
-        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, false), actualRetryTopic.toString());
+        Assert.assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, GROUP, brokerConfig.isEnableRetryTopicV2()), actualRetryTopic.toString());
         verify(escapeBridge, times(1)).putMessageToSpecificQueue(any(MessageExtBrokerInner.class)); // write retry
         verify(messageStore, times(1)).putMessage(any(MessageExtBrokerInner.class)); // rewrite CK
     }

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -237,7 +237,7 @@ public class BrokerConfig extends BrokerIdentity {
     private boolean initPopOffsetByCheckMsgInMem = true;
     // read message from pop retry topic v1, for the compatibility, will be removed in the future version
     private boolean retrieveMessageFromPopRetryTopicV1 = true;
-    private boolean enableRetryTopicV2 = false;
+    private boolean enableRetryTopicV2 = true;
     private int popFromRetryProbability = 20;
     // pop retry probability for priority mode
     private int popFromRetryProbabilityForPriority = 0;

--- a/common/src/test/java/org/apache/rocketmq/common/KeyBuilderTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/KeyBuilderTest.java
@@ -60,4 +60,27 @@ public class KeyBuilderTest {
         String popRetryTopicV1 = KeyBuilder.buildPopRetryTopicV1(topic, group);
         assertThat(KeyBuilder.isPopRetryTopicV2(popRetryTopicV1)).isEqualTo(false);
     }
+
+    @Test
+    public void testV1CollisionExample() {
+        // Demonstrates the V1 naming collision: different (group, topic) pairs produce the same retry topic
+        // group="A_B" topic="C" vs group="A" topic="B_C" both produce %RETRY%A_B_C
+        String collision1 = KeyBuilder.buildPopRetryTopicV1("C", "A_B");
+        String collision2 = KeyBuilder.buildPopRetryTopicV1("B_C", "A");
+        assertThat(collision1).isEqualTo(collision2); // both are %RETRY%A_B_C
+    }
+
+    @Test
+    public void testV2NoCollision() {
+        // V2 uses '+' separator which is not allowed in topic/group names, so no collision
+        String v2a = KeyBuilder.buildPopRetryTopicV2("C", "A_B");
+        String v2b = KeyBuilder.buildPopRetryTopicV2("B_C", "A");
+        assertThat(v2a).isNotEqualTo(v2b); // %RETRY%A_B+C vs %RETRY%A+B_C
+    }
+
+    @Test
+    public void testDefaultEnableRetryTopicV2IsTrue() {
+        BrokerConfig config = new BrokerConfig();
+        assertThat(config.isEnableRetryTopicV2()).isTrue();
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ConsumerProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ConsumerProcessorTest.java
@@ -33,7 +33,6 @@ import org.apache.rocketmq.client.consumer.AckStatus;
 import org.apache.rocketmq.client.consumer.PopResult;
 import org.apache.rocketmq.client.consumer.PopStatus;
 import org.apache.rocketmq.client.exception.MQBrokerException;
-import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.KeyBuilder;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.constant.ConsumeInitMode;
@@ -173,7 +172,8 @@ public class ConsumerProcessorTest extends BaseProcessorTest {
             CONSUMER_GROUP, TOPIC, null, 3000).get();
 
         assertEquals(AckStatus.OK, ackResult.getStatus());
-        assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, CONSUMER_GROUP, new BrokerConfig().isEnableRetryTopicV2()), requestHeaderArgumentCaptor.getValue().getTopic());
+        // the retry topic version is encoded in the receipt handle (v1-shaped topic above), not taken from broker config
+        assertEquals(KeyBuilder.buildPopRetryTopicV1(TOPIC, CONSUMER_GROUP), requestHeaderArgumentCaptor.getValue().getTopic());
         assertEquals(CONSUMER_GROUP, requestHeaderArgumentCaptor.getValue().getConsumerGroup());
         assertEquals(handle.getReceiptHandle(), requestHeaderArgumentCaptor.getValue().getExtraInfo());
     }
@@ -296,7 +296,8 @@ public class ConsumerProcessorTest extends BaseProcessorTest {
             CONSUMER_GROUP, TOPIC, 1000, null, 3000, true).get();
 
         assertEquals(AckStatus.OK, ackResult.getStatus());
-        assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, CONSUMER_GROUP, new BrokerConfig().isEnableRetryTopicV2()), requestHeaderArgumentCaptor.getValue().getTopic());
+        // the retry topic version is encoded in the receipt handle (v1-shaped topic above), not taken from broker config
+        assertEquals(KeyBuilder.buildPopRetryTopicV1(TOPIC, CONSUMER_GROUP), requestHeaderArgumentCaptor.getValue().getTopic());
         assertEquals(CONSUMER_GROUP, requestHeaderArgumentCaptor.getValue().getConsumerGroup());
         assertEquals(1000, requestHeaderArgumentCaptor.getValue().getInvisibleTime().longValue());
         assertEquals(handle.getReceiptHandle(), requestHeaderArgumentCaptor.getValue().getExtraInfo());
@@ -456,7 +457,8 @@ public class ConsumerProcessorTest extends BaseProcessorTest {
             CONSUMER_GROUP, TOPIC, 1000, null, 3000, false).get();
 
         assertEquals(AckStatus.OK, ackResult.getStatus());
-        assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, CONSUMER_GROUP, new BrokerConfig().isEnableRetryTopicV2()), requestHeaderArgumentCaptor.getValue().getTopic());
+        // the retry topic version is encoded in the receipt handle (v1-shaped topic above), not taken from broker config
+        assertEquals(KeyBuilder.buildPopRetryTopicV1(TOPIC, CONSUMER_GROUP), requestHeaderArgumentCaptor.getValue().getTopic());
         assertEquals(CONSUMER_GROUP, requestHeaderArgumentCaptor.getValue().getConsumerGroup());
         assertEquals(1000, requestHeaderArgumentCaptor.getValue().getInvisibleTime().longValue());
         assertEquals(handle.getReceiptHandle(), requestHeaderArgumentCaptor.getValue().getExtraInfo());
@@ -478,7 +480,8 @@ public class ConsumerProcessorTest extends BaseProcessorTest {
             CONSUMER_GROUP, TOPIC, 1000, null, 3000, true).get();
 
         assertEquals(AckStatus.OK, ackResult.getStatus());
-        assertEquals(KeyBuilder.buildPopRetryTopic(TOPIC, CONSUMER_GROUP, new BrokerConfig().isEnableRetryTopicV2()), requestHeaderArgumentCaptor.getValue().getTopic());
+        // the retry topic version is encoded in the receipt handle (v1-shaped topic above), not taken from broker config
+        assertEquals(KeyBuilder.buildPopRetryTopicV1(TOPIC, CONSUMER_GROUP), requestHeaderArgumentCaptor.getValue().getTopic());
         assertEquals(CONSUMER_GROUP, requestHeaderArgumentCaptor.getValue().getConsumerGroup());
         assertEquals(1000, requestHeaderArgumentCaptor.getValue().getInvisibleTime().longValue());
         assertEquals(handle.getReceiptHandle(), requestHeaderArgumentCaptor.getValue().getExtraInfo());


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #9633

### Brief Description

V1 retry topic naming uses underscore as separator (`%RETRY%{cid}_{topic}`), which is ambiguous because both topic and group names may contain underscores. This causes different (group, topic) pairs to map to the same retry topic, leading to cross-topic consumption.

V2 naming (using `+` separator) already exists but was disabled by default. This PR changes `enableRetryTopicV2` default from false to true.

Existing V1 retry topics are still readable because `retrieveMessageFromPopRetryTopicV1` remains true (backward compatible).

While validating this default flip, CI exposed a pre-existing gap in the V1 compatibility window that only becomes visible once V2 is the default: when both `enableRetryTopicV2` and `retrieveMessageFromPopRetryTopicV1` are on, `PopMessageProcessor` picks V1 **or** V2 retry topic per request by `randomQ % 2`. In normal mode that alternation is fine (a miss is covered by the next request), but in priority mode (`popFromRetryProbabilityForPriority`) the retry read happens exactly once before the normal topic, so landing on the (often empty) V1 topic silently skips the V2 retry messages for that request — `PopPriorityIT#test_priority_consume_retry_as_highest` fails ~50% of the time. This PR fixes it by reading both naming schemes in priority mode while the compatibility window is open (`coverBothRetryTopics`), keeping the alternation unchanged for normal mode.

### How Did You Test This Change

Unit tests: `KeyBuilderTest` (3 new tests demonstrating V1 collision and V2 correctness).

Integration tests: `PopPriorityIT#test_priority_consume_retry_as_highest` reproduced the priority-mode gap (~50% failure, `expected:<1> but was:<0>` on the first popped message) and passes 4/4 parameter combinations across repeated runs after the fix. `PopMessageProcessorTest` 8/8 and `PopReviveServiceTest` 12/12 under the V2 default.
