### PR TITLE
[ISSUE #10518] Add client config to ignore corrupted local offset files

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -106,6 +106,12 @@ public class ClientConfig {
     private int concurrentHeartbeatThreadPoolSize = Runtime.getRuntime().availableProcessors();
 
     /**
+     * When true, corrupted local offset files are ignored (logged at WARN level) instead of throwing an exception.
+     * The consumer starts with an empty offset table and falls back to CONSUME_FROM_TIMESTAMP or broker-side offset.
+     */
+    private boolean localOffsetStoreIgnoreCorrupted = false;
+
+    /**
      * The switch for message trace
      */
     protected boolean enableTrace = false;
@@ -246,6 +252,7 @@ public class ClientConfig {
         this.traceTopic = cc.traceTopic;
         this.enableConcurrentHeartbeat = cc.enableConcurrentHeartbeat;
         this.concurrentHeartbeatThreadPoolSize = cc.concurrentHeartbeatThreadPoolSize;
+        this.localOffsetStoreIgnoreCorrupted = cc.localOffsetStoreIgnoreCorrupted;
     }
 
     public ClientConfig cloneClientConfig() {
@@ -280,6 +287,7 @@ public class ClientConfig {
         cc.traceTopic = traceTopic;
         cc.enableConcurrentHeartbeat = enableConcurrentHeartbeat;
         cc.concurrentHeartbeatThreadPoolSize = concurrentHeartbeatThreadPoolSize;
+        cc.localOffsetStoreIgnoreCorrupted = localOffsetStoreIgnoreCorrupted;
         return cc;
     }
 
@@ -547,6 +555,14 @@ public class ClientConfig {
 
     public void setConcurrentHeartbeatThreadPoolSize(int concurrentHeartbeatThreadPoolSize) {
         this.concurrentHeartbeatThreadPoolSize = concurrentHeartbeatThreadPoolSize;
+    }
+
+    public boolean isLocalOffsetStoreIgnoreCorrupted() {
+        return localOffsetStoreIgnoreCorrupted;
+    }
+
+    public void setLocalOffsetStoreIgnoreCorrupted(boolean localOffsetStoreIgnoreCorrupted) {
+        this.localOffsetStoreIgnoreCorrupted = localOffsetStoreIgnoreCorrupted;
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/store/LocalFileOffsetStore.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/store/LocalFileOffsetStore.java
@@ -263,6 +263,10 @@ public class LocalFileOffsetStore implements OffsetStore {
                 offsetSerializeWrapper =
                     OffsetSerializeWrapper.fromJson(content, OffsetSerializeWrapper.class);
             } catch (Exception e) {
+                if (this.mQClientFactory.getClientConfig().isLocalOffsetStoreIgnoreCorrupted()) {
+                    log.warn("readLocalOffsetBak: local offset file corrupted, ignoring per config. group={}", this.groupName, e);
+                    return null;
+                }
                 log.warn("readLocalOffset Exception", e);
                 throw new MQClientException("readLocalOffset Exception, maybe fastjson version too low"
                     + FAQUrl.suggestTodo(FAQUrl.LOAD_JSON_EXCEPTION),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10518

### Brief Description

When ~/.rocketmq_offsets/ files are corrupted (e.g., truncated due to power loss during persistAll()), readLocalOffsetBak() unconditionally throws MQClientException, crashing the consumer application.

Fix: Add ClientConfig.localOffsetStoreIgnoreCorrupted (default false). When true, corrupted offset files are silently skipped with a warning log, and the consumer starts with an empty offset table (falling back to CONSUME_FROM_TIMESTAMP or broker-side offset). Default false preserves existing behavior (fully backward compatible).

### How Did You Test This Change

Compilation passed. Default false ensures no behavior change for existing users.