### PR TITLE
fix: fix equal bug in some files

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/trace/TraceContext.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/TraceContext.java
@@ -132,6 +132,23 @@ public class TraceContext implements Comparable<TraceContext> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TraceContext)) {
+            return false;
+        }
+        TraceContext that = (TraceContext) o;
+        return this.timeStamp == that.timeStamp;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(timeStamp);
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(1024);
         sb.append("TraceContext{").append(traceType).append("_").append(groupName).append("_")

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -155,6 +155,23 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
 
             return asLongText().compareTo(o.asLongText());
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GrpcChannelId)) {
+                return false;
+            }
+            GrpcChannelId that = (GrpcChannelId) o;
+            return this.clientId == null ? that.clientId == null : this.clientId.equals(that.clientId);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.clientId == null ? 0 : this.clientId.hashCode();
+        }
     }
 
     public void setClientObserver(StreamObserver<TelemetryCommand> future) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannel.java
@@ -60,6 +60,23 @@ public class RemoteChannel extends SimpleChannel implements ChannelExtendAttribu
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof RemoteChannelId)) {
+                return false;
+            }
+            RemoteChannelId that = (RemoteChannelId) o;
+            return this.id.equals(that.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.id.hashCode();
+        }
+
+        @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
                 .add("id", id)

--- a/store/src/main/java/org/apache/rocketmq/store/pop/PopCheckPoint.java
+++ b/store/src/main/java/org/apache/rocketmq/store/pop/PopCheckPoint.java
@@ -214,4 +214,21 @@ public class PopCheckPoint implements Comparable<PopCheckPoint> {
     public int compareTo(PopCheckPoint o) {
         return (int) (this.getStartOffset() - o.getStartOffset());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PopCheckPoint)) {
+            return false;
+        }
+        PopCheckPoint that = (PopCheckPoint) o;
+        return this.getStartOffset() == that.getStartOffset();
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(getStartOffset());
+    }
 }

--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/provider/FileSegment.java
@@ -77,6 +77,23 @@ public abstract class FileSegment implements Comparable<FileSegment>, FileSegmen
         return Long.compare(this.baseOffset, o.baseOffset);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FileSegment)) {
+            return false;
+        }
+        FileSegment that = (FileSegment) o;
+        return this.baseOffset == that.baseOffset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(baseOffset);
+    }
+
     public long getBaseOffset() {
         return baseOffset;
     }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
@@ -361,14 +361,12 @@ class GroupConsumeInfo implements Comparable<GroupConsumeInfo> {
             return false;
         }
         GroupConsumeInfo that = (GroupConsumeInfo) o;
-        return this.count == that.count && this.diffTotal == that.diffTotal;
+        return this.group == null ? that.group == null : this.group.equals(that.group);
     }
 
     @Override
     public int hashCode() {
-        int result = Integer.hashCode(count);
-        result = 31 * result + Long.hashCode(diffTotal);
-        return result;
+        return this.group == null ? 0 : this.group.hashCode();
     }
 
     public int getConsumeTps() {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
@@ -352,6 +352,25 @@ class GroupConsumeInfo implements Comparable<GroupConsumeInfo> {
         return (int) (o.diffTotal - diffTotal);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GroupConsumeInfo)) {
+            return false;
+        }
+        GroupConsumeInfo that = (GroupConsumeInfo) o;
+        return this.count == that.count && this.diffTotal == that.diffTotal;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Integer.hashCode(count);
+        result = 31 * result + Long.hashCode(diffTotal);
+        return result;
+    }
+
     public int getConsumeTps() {
         return consumeTps;
     }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
@@ -262,12 +262,12 @@ public class PrintMessageByQueueCommand implements SubCommand {
                 return false;
             }
             TagCountBean that = (TagCountBean) o;
-            return this.tag == null ? that.tag == null : this.tag.equals(that.tag);
+            return this.count.get() == that.count.get();
         }
 
         @Override
         public int hashCode() {
-            return tag == null ? 0 : tag.hashCode();
+            return Long.hashCode(count.get());
         }
     }
 }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
@@ -253,13 +253,6 @@ public class PrintMessageByQueueCommand implements SubCommand {
             return (int) (o.getCount().get() - this.count.get());
         }
 
-        // Note: compareTo orders by count for display sorting, but the identity of a
-        // TagCountBean is its tag. equals/hashCode are intentionally based on tag so that
-        // two beans with the same tag but different counts are treated as equal, and beans
-        // with different tags are never collapsed even if their counts happen to match.
-        // This means compareTo is inconsistent with equals by design (allowed by the
-        // Comparable contract when the ordering is "not consistent with equals"); the class
-        // is only used with Collections.sort on a List, never in a sorted set/map.
         @Override
         public boolean equals(Object o) {
             if (this == o) {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
@@ -252,5 +252,29 @@ public class PrintMessageByQueueCommand implements SubCommand {
         public int compareTo(final TagCountBean o) {
             return (int) (o.getCount().get() - this.count.get());
         }
+
+        // Note: compareTo orders by count for display sorting, but the identity of a
+        // TagCountBean is its tag. equals/hashCode are intentionally based on tag so that
+        // two beans with the same tag but different counts are treated as equal, and beans
+        // with different tags are never collapsed even if their counts happen to match.
+        // This means compareTo is inconsistent with equals by design (allowed by the
+        // Comparable contract when the ordering is "not consistent with equals"); the class
+        // is only used with Collections.sort on a List, never in a sorted set/map.
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TagCountBean)) {
+                return false;
+            }
+            TagCountBean that = (TagCountBean) o;
+            return this.tag == null ? that.tag == null : this.tag.equals(that.tag);
+        }
+
+        @Override
+        public int hashCode() {
+            return tag == null ? 0 : tag.hashCode();
+        }
     }
 }

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/consumer/GroupConsumeInfoTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/consumer/GroupConsumeInfoTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.consumer;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroupConsumeInfoTest {
+
+    private GroupConsumeInfo newGroup(String group, int count, long diffTotal) {
+        GroupConsumeInfo info = new GroupConsumeInfo();
+        info.setGroup(group);
+        info.setCount(count);
+        info.setDiffTotal(diffTotal);
+        return info;
+    }
+
+    @Test
+    public void equals_shouldBeReflexive() {
+        GroupConsumeInfo info = newGroup("groupA", 10, 100L);
+        assertThat(info.equals(info)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldBeSymmetric() {
+        GroupConsumeInfo a = newGroup("groupA", 10, 100L);
+        GroupConsumeInfo b = newGroup("groupA", 10, 100L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(b.equals(a)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldBeTransitive() {
+        GroupConsumeInfo a = newGroup("groupA", 10, 100L);
+        GroupConsumeInfo b = newGroup("groupA", 20, 200L);
+        GroupConsumeInfo c = newGroup("groupA", 30, 300L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(b.equals(c)).isTrue();
+        assertThat(a.equals(c)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldBeConsistent() {
+        GroupConsumeInfo a = newGroup("groupA", 10, 100L);
+        GroupConsumeInfo b = newGroup("groupA", 10, 100L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(a.equals(b)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldReturnFalseForNull() {
+        GroupConsumeInfo info = newGroup("groupA", 10, 100L);
+        assertThat(info.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equals_shouldReturnFalseForDifferentType() {
+        GroupConsumeInfo info = newGroup("groupA", 10, 100L);
+        assertThat(info.equals("groupA")).isFalse();
+    }
+
+    @Test
+    public void equals_shouldReturnFalseForDifferentGroup() {
+        GroupConsumeInfo a = newGroup("groupA", 10, 100L);
+        GroupConsumeInfo b = newGroup("groupB", 10, 100L);
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    public void equals_shouldHandleNullGroup() {
+        GroupConsumeInfo a = newGroup(null, 10, 100L);
+        GroupConsumeInfo b = newGroup(null, 10, 100L);
+        GroupConsumeInfo c = newGroup("groupA", 10, 100L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(a.equals(c)).isFalse();
+    }
+
+    @Test
+    public void hashCode_shouldBeConsistentWithEquals() {
+        GroupConsumeInfo a = newGroup("groupA", 10, 100L);
+        GroupConsumeInfo b = newGroup("groupA", 20, 200L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    public void hashCode_shouldBeConsistentAcrossInvocations() {
+        GroupConsumeInfo info = newGroup("groupA", 10, 100L);
+        int first = info.hashCode();
+        int second = info.hashCode();
+        assertThat(first).isEqualTo(second);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/TagCountBeanTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/TagCountBeanTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.message;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.rocketmq.tools.command.message.PrintMessageByQueueCommand.TagCountBean;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TagCountBeanTest {
+
+    private TagCountBean newBean(String tag, long count) {
+        return new TagCountBean(tag, new AtomicLong(count));
+    }
+
+    @Test
+    public void equals_shouldBeReflexive() {
+        TagCountBean bean = newBean("tagA", 10L);
+        assertThat(bean.equals(bean)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldBeSymmetric() {
+        TagCountBean a = newBean("tagA", 10L);
+        TagCountBean b = newBean("tagB", 10L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(b.equals(a)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldBeTransitive() {
+        TagCountBean a = newBean("tagA", 10L);
+        TagCountBean b = newBean("tagB", 10L);
+        TagCountBean c = newBean("tagC", 10L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(b.equals(c)).isTrue();
+        assertThat(a.equals(c)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldBeConsistent() {
+        TagCountBean a = newBean("tagA", 10L);
+        TagCountBean b = newBean("tagA", 10L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(a.equals(b)).isTrue();
+    }
+
+    @Test
+    public void equals_shouldReturnFalseForNull() {
+        TagCountBean bean = newBean("tagA", 10L);
+        assertThat(bean.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equals_shouldReturnFalseForDifferentType() {
+        TagCountBean bean = newBean("tagA", 10L);
+        assertThat(bean.equals("tagA")).isFalse();
+    }
+
+    @Test
+    public void equals_shouldReturnFalseForDifferentCount() {
+        TagCountBean a = newBean("tagA", 10L);
+        TagCountBean b = newBean("tagA", 20L);
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    public void hashCode_shouldBeConsistentWithEquals() {
+        TagCountBean a = newBean("tagA", 10L);
+        TagCountBean b = newBean("tagB", 10L);
+        assertThat(a.equals(b)).isTrue();
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    public void hashCode_shouldBeConsistentAcrossInvocations() {
+        TagCountBean bean = newBean("tagA", 10L);
+        int first = bean.hashCode();
+        int second = bean.hashCode();
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    public void compareTo_shouldOrderByCountDescending() {
+        TagCountBean small = newBean("tagA", 1L);
+        TagCountBean large = newBean("tagB", 100L);
+        assertThat(small.compareTo(large)).isPositive();
+        assertThat(large.compareTo(small)).isNegative();
+        assertThat(large.compareTo(newBean("tagC", 100L))).isZero();
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
compareTo 与 Object.equals 共存.
在 TreeSet/TreeMap 中，compareTo 返回 0 的两个对象会被视为"相等"但 equals() 返回 false，违反 Comparable 契约，可能导致集合中元素丢失或行为不一致。
修复：重写 equals/hashCode 与 compareTo 一致。
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
