### PR TITLE
[ISSUE #10575] Fix race condition between scanResponseTable and processResponseCommand

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -467,11 +467,9 @@ public abstract class NettyRemotingAbstract {
      */
     public void processResponseCommand(ChannelHandlerContext ctx, RemotingCommand cmd) {
         final int opaque = cmd.getOpaque();
-        final ResponseFuture responseFuture = responseTable.get(opaque);
+        final ResponseFuture responseFuture = responseTable.remove(opaque);
         if (responseFuture != null) {
             responseFuture.setResponseCommand(cmd);
-
-            responseTable.remove(opaque);
 
             if (responseFuture.getInvokeCallback() != null) {
                 executeInvokeCallback(responseFuture);
@@ -564,10 +562,12 @@ public abstract class NettyRemotingAbstract {
             ResponseFuture rep = next.getValue();
 
             if ((rep.getBeginTimestamp() + rep.getTimeoutMillis() + 1000) <= System.currentTimeMillis()) {
-                rep.release();
-                it.remove();
-                rfList.add(rep);
-                log.warn("remove timeout request, " + rep);
+                ResponseFuture removed = responseTable.remove(next.getKey());
+                if (removed != null) {
+                    removed.release();
+                    rfList.add(removed);
+                    log.warn("remove timeout request, " + removed);
+                }
             }
         }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10575

### Brief Description

`processResponseCommand` used `responseTable.get(opaque)` + `responseTable.remove(opaque)` (non-atomic) to retrieve ResponseFuture. `scanResponseTable` used `iterator.remove()`. If the response arrived between `scanResponseTable`'s remove and `processResponseCommand`'s get, the response was logged as `not matched any request` and silently dropped.

Fix: Use `ConcurrentHashMap.remove(key)` (atomic) in both methods. Either `processResponseCommand` gets the future (success callback) or `scanResponseTable` gets it (timeout callback), but never both and never neither.

### How Did You Implement It

**processResponseCommand**: Changed `responseTable.get(opaque)` + `responseTable.remove(opaque)` to a single `responseTable.remove(opaque)` call.

**scanResponseTable**: Changed `it.remove()` to `responseTable.remove(next.getKey())` and added a null check on the return value.

### How to Verify It

Reproduction: 256 threads, 50ms timeout, 1MB commitlog, single send thread pool. In 2 minutes, 776 `not matched any request` warnings appeared in client `remoting.log` — all with `code=0` (SEND_OK) and valid msgId/queueOffset. After applying this fix, the warnings should disappear.

Existing tests: `NettyRemotingAbstractTest` (5 tests) all pass.