### PR TITLE
[ISSUE #10578] Fix master election maxOffset comparator overflow

### DIFF
--- a/controller/src/main/java/org/apache/rocketmq/controller/elect/impl/DefaultElectPolicy.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/elect/impl/DefaultElectPolicy.java
@@ -37,12 +37,17 @@ public class DefaultElectPolicy implements ElectPolicy {
 
     // Sort in descending order according to<epoch, offset>, and sort in ascending order according to priority
     private final Comparator<BrokerLiveInfo> comparator = (o1, o2) -> {
-        if (o1.getEpoch() == o2.getEpoch()) {
-            return o1.getMaxOffset() == o2.getMaxOffset() ? o1.getElectionPriority() - o2.getElectionPriority() :
-                (int) (o2.getMaxOffset() - o1.getMaxOffset());
-        } else {
-            return o2.getEpoch() - o1.getEpoch();
+        int epochCompare = Integer.compare(o2.getEpoch(), o1.getEpoch());
+        if (epochCompare != 0) {
+            return epochCompare;
         }
+
+        int offsetCompare = Long.compare(o2.getMaxOffset(), o1.getMaxOffset());
+        if (offsetCompare != 0) {
+            return offsetCompare;
+        }
+
+        return Integer.compare(o1.getElectionPriority(), o2.getElectionPriority());
     };
 
     public DefaultElectPolicy(BrokerValidPredicate validPredicate, BrokerLiveInfoGetter brokerLiveInfoGetter) {

--- a/controller/src/test/java/org/apache/rocketmq/controller/elect/impl/DefaultElectPolicyTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/elect/impl/DefaultElectPolicyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.controller.elect.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.rocketmq.controller.impl.heartbeat.BrokerLiveInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultElectPolicyTest {
+
+    @Test
+    public void testElectPrefersHigherOffsetWhenOffsetDifferenceExceedsIntegerMaxValue() {
+        long lowerOffset = 0L;
+        long higherOffset = (long) Integer.MAX_VALUE + 1L;
+        Set<Long> brokers = new HashSet<>();
+        brokers.add(1L);
+        brokers.add(2L);
+
+        DefaultElectPolicy electPolicy = new DefaultElectPolicy((clusterName, brokerName, brokerId) -> true,
+            (clusterName, brokerName, brokerId) -> {
+                if (brokerId == 1L) {
+                    return new BrokerLiveInfo(brokerName, "127.0.0.1:10911", brokerId,
+                        System.currentTimeMillis(), 3000L, null, 1, lowerOffset, 0);
+                }
+                return new BrokerLiveInfo(brokerName, "127.0.0.1:10912", brokerId,
+                    System.currentTimeMillis(), 3000L, null, 1, higherOffset, 0);
+            });
+
+        Long electedBrokerId = electPolicy.elect("cluster", "broker", brokers, null, null, null);
+
+        assertEquals(Long.valueOf(2L), electedBrokerId);
+    }
+}


### PR DESCRIPTION
## What changed

Fix `DefaultElectPolicy` master-election ordering to avoid integer overflow when comparing broker `maxOffset` values.

The election comparator previously used subtraction and cast the `long` offset delta to `int`:

```java
(int) (o2.getMaxOffset() - o1.getMaxOffset())
```

When two brokers have the same epoch and their `maxOffset` difference exceeds `Integer.MAX_VALUE`, the comparator can overflow and return the wrong ordering. That may cause the controller to elect a broker with a lower offset as master.

This PR replaces subtraction-based comparisons with `Integer.compare` and `Long.compare`, preserving the existing ordering rules:

1. Higher epoch first
2. Higher max offset first
3. Lower election priority first

Fixes #10578

## Why

Master election is a control-plane correctness path. A comparator overflow here can select a stale replica when broker offsets diverge by more than `Integer.MAX_VALUE`.

## Tests

Added `DefaultElectPolicyTest` covering the overflow case:

- two brokers with the same epoch
- offset delta greater than `Integer.MAX_VALUE`
- verifies the broker with the higher offset is elected

Verified locally:

```bash
mvn -q -pl controller -DskipTests=false -Dtest=DefaultElectPolicyTest -Djacoco.skip=true test
mvn -q -pl controller -DskipTests compile -Dspotbugs.skip=true -Dcheckstyle.skip=true
mvn -q -DskipTests compile -Dspotbugs.skip=true -Dcheckstyle.skip=true
```

## Notes

`checkstyle:check` was not used as a gating signal because the controller module currently reports existing unrelated checkstyle violations. The targeted test and compile checks pass.