### PR TITLE
[ISSUE #10580] Fix static topic epoch comparator overflow

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtils.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtils.java
@@ -338,7 +338,7 @@ public class TopicQueueMappingUtils {
 
 
     public static Map<Integer, TopicQueueMappingOne> checkAndBuildMappingItems(List<TopicQueueMappingDetail> mappingDetailList, boolean replace, boolean checkConsistence) {
-        mappingDetailList.sort((o1, o2) -> (int) (o2.getEpoch() - o1.getEpoch()));
+        mappingDetailList.sort((o1, o2) -> Long.compare(o2.getEpoch(), o1.getEpoch()));
 
         int maxNum = 0;
         Map<Integer, TopicQueueMappingOne> globalIdMap = new HashMap<>();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtils.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtils.java
@@ -22,6 +22,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -338,7 +339,7 @@ public class TopicQueueMappingUtils {
 
 
     public static Map<Integer, TopicQueueMappingOne> checkAndBuildMappingItems(List<TopicQueueMappingDetail> mappingDetailList, boolean replace, boolean checkConsistence) {
-        mappingDetailList.sort((o1, o2) -> Long.compare(o2.getEpoch(), o1.getEpoch()));
+        mappingDetailList.sort(Comparator.comparingLong(TopicQueueMappingDetail::getEpoch).reversed());
 
         int maxNum = 0;
         Map<Integer, TopicQueueMappingOne> globalIdMap = new HashMap<>();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.remoting.rpc;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,8 @@ public class ClientMetadata {
             Map<String, TopicQueueMappingInfo> topicQueueMappingInfoMap =  mapEntry.getValue();
             ConcurrentMap<MessageQueue, TopicQueueMappingInfo> mqEndPoints = new ConcurrentHashMap<>();
             List<Map.Entry<String, TopicQueueMappingInfo>> mappingInfos = new ArrayList<>(topicQueueMappingInfoMap.entrySet());
-            mappingInfos.sort((o1, o2) -> Long.compare(o2.getValue().getEpoch(), o1.getValue().getEpoch()));
+            mappingInfos.sort(Comparator.comparingLong(
+                (Map.Entry<String, TopicQueueMappingInfo> entry) -> entry.getValue().getEpoch()).reversed());
             int maxTotalNums = 0;
             long maxTotalNumOfEpoch = -1;
             for (Map.Entry<String, TopicQueueMappingInfo> entry : mappingInfos) {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
@@ -119,7 +119,7 @@ public class ClientMetadata {
             Map<String, TopicQueueMappingInfo> topicQueueMappingInfoMap =  mapEntry.getValue();
             ConcurrentMap<MessageQueue, TopicQueueMappingInfo> mqEndPoints = new ConcurrentHashMap<>();
             List<Map.Entry<String, TopicQueueMappingInfo>> mappingInfos = new ArrayList<>(topicQueueMappingInfoMap.entrySet());
-            mappingInfos.sort((o1, o2) -> (int) (o2.getValue().getEpoch() - o1.getValue().getEpoch()));
+            mappingInfos.sort((o1, o2) -> Long.compare(o2.getValue().getEpoch(), o1.getValue().getEpoch()));
             int maxTotalNums = 0;
             long maxTotalNumOfEpoch = -1;
             for (Map.Entry<String, TopicQueueMappingInfo> entry : mappingInfos) {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
@@ -126,7 +126,10 @@ public class ClientMetadata {
             long maxTotalNumOfEpoch = -1;
             for (Map.Entry<String, TopicQueueMappingInfo> entry : mappingInfos) {
                 TopicQueueMappingInfo info = entry.getValue();
-                if (info.getEpoch() >= maxTotalNumOfEpoch && info.getTotalQueues() > maxTotalNums) {
+                if (info.getEpoch() > maxTotalNumOfEpoch) {
+                    maxTotalNumOfEpoch = info.getEpoch();
+                    maxTotalNums = info.getTotalQueues();
+                } else if (info.getEpoch() == maxTotalNumOfEpoch && info.getTotalQueues() > maxTotalNums) {
                     maxTotalNums = info.getTotalQueues();
                 }
                 for (Map.Entry<Integer, Integer> idEntry : entry.getValue().getCurrIdMap().entrySet()) {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
@@ -120,12 +120,18 @@ public class ClientMetadata {
             Map<String, TopicQueueMappingInfo> topicQueueMappingInfoMap =  mapEntry.getValue();
             ConcurrentMap<MessageQueue, TopicQueueMappingInfo> mqEndPoints = new ConcurrentHashMap<>();
             List<Map.Entry<String, TopicQueueMappingInfo>> mappingInfos = new ArrayList<>(topicQueueMappingInfoMap.entrySet());
+            // Sort mappings by epoch descending, so the newest epoch is visited first.
+            // Subtracting long epochs and casting to int overflows when the epoch gap exceeds
+            // Integer.MAX_VALUE and reverses the ordering, so use an overflow-safe comparison.
             mappingInfos.sort(Comparator.comparingLong(
                 (Map.Entry<String, TopicQueueMappingInfo> entry) -> entry.getValue().getEpoch()).reversed());
             int maxTotalNums = 0;
             long maxTotalNumOfEpoch = -1;
             for (Map.Entry<String, TopicQueueMappingInfo> entry : mappingInfos) {
                 TopicQueueMappingInfo info = entry.getValue();
+                // Scope total queue count to the latest epoch only: a stale mapping must not
+                // inflate maxTotalNums beyond what the newest epoch advertises. Among mappings
+                // sharing that latest epoch, keep the largest total queue count.
                 if (info.getEpoch() > maxTotalNumOfEpoch) {
                     maxTotalNumOfEpoch = info.getEpoch();
                     maxTotalNums = info.getTotalQueues();

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtilsTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtilsTest.java
@@ -82,6 +82,32 @@ public class TopicQueueMappingUtilsTest {
     }
 
     @Test
+    public void testCheckAndBuildMappingItemsUsesLatestEpochWhenReplacingDuplicatedQueue() {
+        String topic = "static";
+        String oldBroker = "oldBroker";
+        String newBroker = "newBroker";
+        long oldEpoch = 0L;
+        long newEpoch = (long) Integer.MAX_VALUE + 1L;
+        List<TopicQueueMappingDetail> mappingDetails = new ArrayList<>();
+        mappingDetails.add(buildMappingDetail(topic, oldBroker, oldEpoch));
+        mappingDetails.add(buildMappingDetail(topic, newBroker, newEpoch));
+
+        Map<Integer, TopicQueueMappingOne> globalIdMap =
+            TopicQueueMappingUtils.checkAndBuildMappingItems(mappingDetails, true, false);
+
+        TopicQueueMappingOne mappingOne = globalIdMap.get(0);
+        Assert.assertEquals(newEpoch, mappingOne.getMappingDetail().getEpoch());
+        Assert.assertEquals(newBroker, mappingOne.getBname());
+    }
+
+    private TopicQueueMappingDetail buildMappingDetail(String topic, String brokerName, long epoch) {
+        TopicQueueMappingDetail mappingDetail = new TopicQueueMappingDetail(topic, 1, brokerName, epoch);
+        mappingDetail.getHostedQueues().put(0, new ArrayList<>(Collections.singletonList(
+            new LogicQueueMappingItem(0, 0, brokerName, 0, 0, -1, -1, -1))));
+        return mappingDetail;
+    }
+
+    @Test
     public void testAllocator() {
         //stability
         for (int i = 0; i < 10; i++) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -143,12 +144,37 @@ public class ClientMetadataTest {
         assertEquals(newBroker, actual.get(mq));
     }
 
+    @Test
+    public void testTopicRouteData2EndpointsForStaticTopicUsesLatestEpochTotalQueues() {
+        String scope = "scope";
+        String oldBroker = "oldBroker";
+        String newBroker = "newBroker";
+        long oldEpoch = 0L;
+        long newEpoch = (long) Integer.MAX_VALUE + 1L;
+        TopicRouteData topicRouteData = new TopicRouteData();
+        Map<String, TopicQueueMappingInfo> mappingInfos = new LinkedHashMap<>();
+        mappingInfos.put(oldBroker, buildMappingInfo(scope, oldBroker, oldEpoch, 2));
+        mappingInfos.put(newBroker, buildMappingInfo(scope, newBroker, newEpoch, 1));
+        topicRouteData.setTopicQueueMappingByBroker(mappingInfos);
+
+        ConcurrentMap<MessageQueue, String> actual =
+            ClientMetadata.topicRouteData2EndpointsForStaticTopic(defaultTopic, topicRouteData);
+
+        MessageQueue staleQueue = new MessageQueue(defaultTopic, TopicQueueMappingUtils.getMockBrokerName(scope), 1);
+        assertEquals(1, actual.size());
+        assertFalse(actual.containsKey(staleQueue));
+    }
+
     private TopicQueueMappingInfo buildMappingInfo(String scope, String brokerName, long epoch) {
+        return buildMappingInfo(scope, brokerName, epoch, 1);
+    }
+
+    private TopicQueueMappingInfo buildMappingInfo(String scope, String brokerName, long epoch, int totalQueues) {
         TopicQueueMappingInfo info = new TopicQueueMappingInfo();
         info.setScope(scope);
         info.setCurrIdMap(new ConcurrentHashMap<>());
         info.getCurrIdMap().put(0, 0);
-        info.setTotalQueues(1);
+        info.setTotalQueues(totalQueues);
         info.setBname(brokerName);
         info.setEpoch(epoch);
         return info;

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.remoting.rpc;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingInfo;
@@ -163,6 +164,26 @@ public class ClientMetadataTest {
         MessageQueue staleQueue = new MessageQueue(defaultTopic, TopicQueueMappingUtils.getMockBrokerName(scope), 1);
         assertEquals(1, actual.size());
         assertFalse(actual.containsKey(staleQueue));
+    }
+
+    @Test
+    public void testTopicRouteData2EndpointsForStaticTopicUsesMaxTotalQueuesInSameEpoch() {
+        String scope = "scope";
+        String brokerA = "brokerA";
+        String brokerB = "brokerB";
+        long epoch = (long) Integer.MAX_VALUE + 1L;
+        TopicRouteData topicRouteData = new TopicRouteData();
+        Map<String, TopicQueueMappingInfo> mappingInfos = new LinkedHashMap<>();
+        mappingInfos.put(brokerA, buildMappingInfo(scope, brokerA, epoch, 1));
+        mappingInfos.put(brokerB, buildMappingInfo(scope, brokerB, epoch, 2));
+        topicRouteData.setTopicQueueMappingByBroker(mappingInfos);
+
+        ConcurrentMap<MessageQueue, String> actual =
+            ClientMetadata.topicRouteData2EndpointsForStaticTopic(defaultTopic, topicRouteData);
+
+        MessageQueue missingQueue = new MessageQueue(defaultTopic, TopicQueueMappingUtils.getMockBrokerName(scope), 1);
+        assertEquals(2, actual.size());
+        assertEquals(MixAll.LOGICAL_QUEUE_MOCK_BROKER_NAME_NOT_EXIST, actual.get(missingQueue));
     }
 
     private TopicQueueMappingInfo buildMappingInfo(String scope, String brokerName, long epoch) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingInfo;
+import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -119,5 +120,36 @@ public class ClientMetadataTest {
 
         ConcurrentMap<MessageQueue, String> actual = ClientMetadata.topicRouteData2EndpointsForStaticTopic(defaultTopic, topicRouteData);
         assertEquals(1, actual.size());
+    }
+
+    @Test
+    public void testTopicRouteData2EndpointsForStaticTopicUsesLatestEpoch() {
+        String scope = "scope";
+        String oldBroker = "oldBroker";
+        String newBroker = "newBroker";
+        long oldEpoch = 0L;
+        long newEpoch = (long) Integer.MAX_VALUE + 1L;
+        TopicRouteData topicRouteData = new TopicRouteData();
+        Map<String, TopicQueueMappingInfo> mappingInfos = new HashMap<>();
+        mappingInfos.put(oldBroker, buildMappingInfo(scope, oldBroker, oldEpoch));
+        mappingInfos.put(newBroker, buildMappingInfo(scope, newBroker, newEpoch));
+        topicRouteData.setTopicQueueMappingByBroker(mappingInfos);
+
+        ConcurrentMap<MessageQueue, String> actual =
+            ClientMetadata.topicRouteData2EndpointsForStaticTopic(defaultTopic, topicRouteData);
+
+        MessageQueue mq = new MessageQueue(defaultTopic, TopicQueueMappingUtils.getMockBrokerName(scope), 0);
+        assertEquals(newBroker, actual.get(mq));
+    }
+
+    private TopicQueueMappingInfo buildMappingInfo(String scope, String brokerName, long epoch) {
+        TopicQueueMappingInfo info = new TopicQueueMappingInfo();
+        info.setScope(scope);
+        info.setCurrIdMap(new ConcurrentHashMap<>());
+        info.getCurrIdMap().put(0, 0);
+        info.setTotalQueues(1);
+        info.setBname(brokerName);
+        info.setEpoch(epoch);
+        return info;
     }
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/rpc/ClientMetadataTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -130,7 +131,7 @@ public class ClientMetadataTest {
         long oldEpoch = 0L;
         long newEpoch = (long) Integer.MAX_VALUE + 1L;
         TopicRouteData topicRouteData = new TopicRouteData();
-        Map<String, TopicQueueMappingInfo> mappingInfos = new HashMap<>();
+        Map<String, TopicQueueMappingInfo> mappingInfos = new LinkedHashMap<>();
         mappingInfos.put(oldBroker, buildMappingInfo(scope, oldBroker, oldEpoch));
         mappingInfos.put(newBroker, buildMappingInfo(scope, newBroker, newEpoch));
         topicRouteData.setTopicQueueMappingByBroker(mappingInfos);


### PR DESCRIPTION
## What changed

Fix static topic epoch ordering to avoid integer overflow when comparing mapping epoch values.

Two comparators previously subtracted `long` epoch values and cast the result to `int`:

```java
(int) (o2.getValue().getEpoch() - o1.getValue().getEpoch())
```

and:

```java
(int) (o2.getEpoch() - o1.getEpoch())
```

When the epoch difference exceeds `Integer.MAX_VALUE`, the comparator can overflow and process stale mapping metadata before newer metadata.

This PR replaces subtraction-based comparisons with `Long.compare(...)` in:

- `ClientMetadata.topicRouteData2EndpointsForStaticTopic(...)`
- `TopicQueueMappingUtils.checkAndBuildMappingItems(...)`

Fixes #10580

## Why

Static topic mapping epochs fence old metadata. Ordering by epoch must remain correct even when epoch gaps are larger than `Integer.MAX_VALUE`, otherwise route building or duplicate queue replacement can prefer stale mapping data.

## Tests

Added regression coverage for large epoch gaps:

- `ClientMetadataTest`: verifies routing resolves to the latest epoch broker mapping
- `TopicQueueMappingUtilsTest`: verifies duplicate global queue replacement keeps the latest epoch mapping

Verified locally:

```bash
mvn -q -pl remoting -DskipTests=false -Dtest=ClientMetadataTest,TopicQueueMappingUtilsTest -Djacoco.skip=true test
mvn -q -pl remoting -DskipTests compile -Dspotbugs.skip=true -Dcheckstyle.skip=true
mvn -q -DskipTests compile -Dspotbugs.skip=true -Dcheckstyle.skip=true
git diff --check
```

## Notes

The change keeps the existing ordering semantics: higher epoch first. It only replaces unsafe subtraction with `Long.compare(...)`.