### PR TITLE
[ISSUE #9985] Bound remoting callback executor queues

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java
@@ -26,6 +26,7 @@ public class NettyClientConfig {
      */
     private int clientWorkerThreads = NettySystemConfig.clientWorkerSize;
     private int clientCallbackExecutorThreads = Runtime.getRuntime().availableProcessors();
+    private int clientCallbackExecutorQueueCapacity = 10000;
     private int clientOnewaySemaphoreValue = NettySystemConfig.CLIENT_ONEWAY_SEMAPHORE_VALUE;
     private int clientAsyncSemaphoreValue = NettySystemConfig.CLIENT_ASYNC_SEMAPHORE_VALUE;
     private int connectTimeoutMillis = NettySystemConfig.connectTimeoutMillis;
@@ -97,6 +98,14 @@ public class NettyClientConfig {
 
     public void setClientCallbackExecutorThreads(int clientCallbackExecutorThreads) {
         this.clientCallbackExecutorThreads = clientCallbackExecutorThreads;
+    }
+
+    public int getClientCallbackExecutorQueueCapacity() {
+        return clientCallbackExecutorQueueCapacity;
+    }
+
+    public void setClientCallbackExecutorQueueCapacity(int clientCallbackExecutorQueueCapacity) {
+        this.clientCallbackExecutorQueueCapacity = clientCallbackExecutorQueueCapacity;
     }
 
     public long getChannelNotActiveInterval() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -86,6 +86,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -159,7 +160,8 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
         }
 
         this.publicExecutor = ThreadUtils.newThreadPoolExecutor(publicThreadNums, publicThreadNums, 0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(queueCapacity), new ThreadFactoryImpl("NettyClientPublicExecutor_"));
+            new LinkedBlockingQueue<>(queueCapacity), new ThreadFactoryImpl("NettyClientPublicExecutor_"),
+            new ThreadPoolExecutor.CallerRunsPolicy());
 
         this.scanExecutor = ThreadUtils.newThreadPoolExecutor(4, 10, 60, TimeUnit.SECONDS,
             new ArrayBlockingQueue<>(32), new ThreadFactoryImpl("NettyClientScan_thread_"));

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -84,7 +84,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -153,8 +153,13 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
         if (publicThreadNums <= 0) {
             publicThreadNums = 4;
         }
+        int queueCapacity = nettyClientConfig.getClientCallbackExecutorQueueCapacity();
+        if (queueCapacity <= 0) {
+            queueCapacity = 10000;
+        }
 
-        this.publicExecutor = Executors.newFixedThreadPool(publicThreadNums, new ThreadFactoryImpl("NettyClientPublicExecutor_"));
+        this.publicExecutor = ThreadUtils.newThreadPoolExecutor(publicThreadNums, publicThreadNums, 0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(queueCapacity), new ThreadFactoryImpl("NettyClientPublicExecutor_"));
 
         this.scanExecutor = ThreadUtils.newThreadPoolExecutor(4, 10, 60, TimeUnit.SECONDS,
             new ArrayBlockingQueue<>(32), new ThreadFactoryImpl("NettyClientScan_thread_"));

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -175,7 +175,8 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         }
 
         return ThreadUtils.newThreadPoolExecutor(publicThreadNums, publicThreadNums, 0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(queueCapacity), new ThreadFactoryImpl("NettyServerPublicExecutor_"));
+            new LinkedBlockingQueue<>(queueCapacity), new ThreadFactoryImpl("NettyServerPublicExecutor_"),
+            new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     private ScheduledExecutorService buildScheduleExecutor() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -86,7 +86,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -169,8 +169,13 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         if (publicThreadNums <= 0) {
             publicThreadNums = 4;
         }
+        int queueCapacity = nettyServerConfig.getServerCallbackExecutorQueueCapacity();
+        if (queueCapacity <= 0) {
+            queueCapacity = 10000;
+        }
 
-        return Executors.newFixedThreadPool(publicThreadNums, new ThreadFactoryImpl("NettyServerPublicExecutor_"));
+        return ThreadUtils.newThreadPoolExecutor(publicThreadNums, publicThreadNums, 0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(queueCapacity), new ThreadFactoryImpl("NettyServerPublicExecutor_"));
     }
 
     private ScheduledExecutorService buildScheduleExecutor() {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java
@@ -26,6 +26,7 @@ public class NettyServerConfig implements Cloneable {
     private int listenPort = 0;
     private int serverWorkerThreads = 8;
     private int serverCallbackExecutorThreads = 0;
+    private int serverCallbackExecutorQueueCapacity = 10000;
     private int serverSelectorThreads = 3;
     private int serverOnewaySemaphoreValue = 256;
     private int serverAsyncSemaphoreValue = 64;
@@ -97,6 +98,14 @@ public class NettyServerConfig implements Cloneable {
 
     public void setServerCallbackExecutorThreads(int serverCallbackExecutorThreads) {
         this.serverCallbackExecutorThreads = serverCallbackExecutorThreads;
+    }
+
+    public int getServerCallbackExecutorQueueCapacity() {
+        return serverCallbackExecutorQueueCapacity;
+    }
+
+    public void setServerCallbackExecutorQueueCapacity(int serverCallbackExecutorQueueCapacity) {
+        this.serverCallbackExecutorQueueCapacity = serverCallbackExecutorQueueCapacity;
     }
 
     public int getServerAsyncSemaphoreValue() {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingClientTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingClientTest.java
@@ -92,6 +92,24 @@ public class NettyRemotingClientTest {
             assertThat(publicExecutor.getCorePoolSize()).isEqualTo(1);
             assertThat(publicExecutor.getMaximumPoolSize()).isEqualTo(1);
             assertThat(publicExecutor.getQueue().remainingCapacity()).isEqualTo(3);
+            assertThat(publicExecutor.getRejectedExecutionHandler())
+                .isInstanceOf(ThreadPoolExecutor.CallerRunsPolicy.class);
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    public void publicExecutorShouldFallBackToDefaultQueueCapacityWhenMisconfigured() {
+        NettyClientConfig nettyClientConfig = new NettyClientConfig();
+        nettyClientConfig.setClientCallbackExecutorThreads(1);
+        nettyClientConfig.setClientCallbackExecutorQueueCapacity(0);
+        NettyRemotingClient client = new NettyRemotingClient(nettyClientConfig);
+
+        try {
+            ThreadPoolExecutor publicExecutor = (ThreadPoolExecutor) client.getCallbackExecutor();
+
+            assertThat(publicExecutor.getQueue().remainingCapacity()).isEqualTo(10000);
         } finally {
             client.shutdown();
         }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingClientTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingClientTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.common.SemaphoreReleaseOnlyOnce;
@@ -37,6 +38,7 @@ import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -64,11 +66,35 @@ public class NettyRemotingClientTest {
     @Mock
     private RPCHook rpcHookMock;
 
+    @After
+    public void tearDown() {
+        remotingClient.shutdown();
+    }
+
     @Test
     public void testSetCallbackExecutor() {
         ExecutorService customized = Executors.newCachedThreadPool();
         remotingClient.setCallbackExecutor(customized);
         assertThat(remotingClient.getCallbackExecutor()).isEqualTo(customized);
+        customized.shutdown();
+    }
+
+    @Test
+    public void publicExecutorShouldUseBoundedQueue() {
+        NettyClientConfig nettyClientConfig = new NettyClientConfig();
+        nettyClientConfig.setClientCallbackExecutorThreads(1);
+        nettyClientConfig.setClientCallbackExecutorQueueCapacity(3);
+        NettyRemotingClient client = new NettyRemotingClient(nettyClientConfig);
+
+        try {
+            ThreadPoolExecutor publicExecutor = (ThreadPoolExecutor) client.getCallbackExecutor();
+
+            assertThat(publicExecutor.getCorePoolSize()).isEqualTo(1);
+            assertThat(publicExecutor.getMaximumPoolSize()).isEqualTo(1);
+            assertThat(publicExecutor.getQueue().remainingCapacity()).isEqualTo(3);
+        } finally {
+            client.shutdown();
+        }
     }
 
     @Test

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
@@ -82,6 +82,23 @@ public class NettyRemotingServerTest {
             Assert.assertEquals(1, publicExecutor.getCorePoolSize());
             Assert.assertEquals(1, publicExecutor.getMaximumPoolSize());
             Assert.assertEquals(3, publicExecutor.getQueue().remainingCapacity());
+            Assert.assertTrue(publicExecutor.getRejectedExecutionHandler() instanceof ThreadPoolExecutor.CallerRunsPolicy);
+        } finally {
+            remotingServer.shutdown();
+        }
+    }
+
+    @Test
+    public void publicExecutorShouldFallBackToDefaultQueueCapacityWhenMisconfigured() {
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setServerCallbackExecutorThreads(1);
+        nettyServerConfig.setServerCallbackExecutorQueueCapacity(0);
+        NettyRemotingServer remotingServer = new NettyRemotingServer(nettyServerConfig);
+
+        try {
+            ThreadPoolExecutor publicExecutor = (ThreadPoolExecutor) remotingServer.getCallbackExecutor();
+
+            Assert.assertEquals(10000, publicExecutor.getQueue().remainingCapacity());
         } finally {
             remotingServer.shutdown();
         }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerTest.java
@@ -23,6 +23,9 @@ import io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +53,11 @@ public class NettyRemotingServerTest {
         nettyRemotingServer = new NettyRemotingServer(nettyServerConfig);
     }
 
+    @After
+    public void tearDown() {
+        nettyRemotingServer.shutdown();
+    }
+
     @Test
     public void handleHAProxyTLV() {
         when(channel.attr(any(AttributeKey.class))).thenReturn(attribute);
@@ -59,5 +67,23 @@ public class NettyRemotingServerTest {
         content.writeBytes("xxxx".getBytes(StandardCharsets.UTF_8));
         HAProxyTLV haProxyTLV = new HAProxyTLV((byte) 0xE1, content);
         nettyRemotingServer.handleHAProxyTLV(haProxyTLV, channel);
+    }
+
+    @Test
+    public void publicExecutorShouldUseBoundedQueue() {
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setServerCallbackExecutorThreads(1);
+        nettyServerConfig.setServerCallbackExecutorQueueCapacity(3);
+        NettyRemotingServer remotingServer = new NettyRemotingServer(nettyServerConfig);
+
+        try {
+            ThreadPoolExecutor publicExecutor = (ThreadPoolExecutor) remotingServer.getCallbackExecutor();
+
+            Assert.assertEquals(1, publicExecutor.getCorePoolSize());
+            Assert.assertEquals(1, publicExecutor.getMaximumPoolSize());
+            Assert.assertEquals(3, publicExecutor.getQueue().remainingCapacity());
+        } finally {
+            remotingServer.shutdown();
+        }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #9985

### Brief Description

`NettyRemotingServer` used `Executors.newFixedThreadPool` for its public callback executor, which creates an unbounded `LinkedBlockingQueue`. Under a callback backlog, queued tasks can grow without a memory bound and increase OOM risk.

`NettyRemotingClient` used the same pattern for its public callback executor, so this PR fixes both sides.

### How Did You Fix It?

- Added `serverCallbackExecutorQueueCapacity` to `NettyServerConfig`, defaulting to `10000`.
- Added `clientCallbackExecutorQueueCapacity` to `NettyClientConfig`, defaulting to `10000`.
- Replaced `Executors.newFixedThreadPool` in `NettyRemotingServer` and `NettyRemotingClient` with bounded `LinkedBlockingQueue` based executors via the existing `ThreadUtils` factory.
- Added unit tests to verify both client and server callback executors use the configured bounded queue capacity.

### How to Verify

```bash
mvn -pl remoting -Dtest=NettyRemotingServerTest,NettyRemotingClientTest test -Dspotbugs.skip=true -Dcheckstyle.skip=true
git diff --check
```

Result:

- `BUILD SUCCESS`
- `Tests run: 17, Failures: 0, Errors: 0`

Note: On JDK 17, the existing JaCoCo 0.8.5 setup prints instrumentation warnings, but the tests pass successfully.