### PR TITLE
[ISSUE #9583] Re-register receipt handle after changing invisible duration

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
@@ -67,7 +67,14 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
                 MessagingProcessor.DEFAULT_TIMEOUT_MILLS,
                 request.getSuspend()
             ).thenApply(
-                ackResult -> convertToChangeInvisibleDurationResponse(ctx, request, ackResult, messageReceiptHandle, channel));
+                ackResult -> convertToChangeInvisibleDurationResponse(ctx, request, ackResult, messageReceiptHandle, channel))
+                .whenComplete((response, throwable) -> {
+                    // The broker call threw (or the callback did): re-register the old managed handle
+                    // so that later renew/ack can still find it, then let the failure propagate.
+                    if (throwable != null) {
+                        restoreReceiptHandle(ctx, request, messageReceiptHandle, channel);
+                    }
+                });
         } catch (Throwable t) {
             future.completeExceptionally(t);
         }
@@ -89,8 +96,19 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
                 .setReceiptHandle(receiptHandle)
                 .build();
         }
+        // Broker returned a non-OK status: re-register the old managed handle so that later
+        // renew/ack can still find it instead of losing it after the upfront removal.
+        restoreReceiptHandle(ctx, request, messageReceiptHandle, channel);
         return ChangeInvisibleDurationResponse.newBuilder()
             .setStatus(ResponseBuilder.getInstance().buildStatus(Code.INTERNAL_SERVER_ERROR, "changeInvisibleDuration failed: status is abnormal"))
             .build();
+    }
+
+    private void restoreReceiptHandle(ProxyContext ctx, ChangeInvisibleDurationRequest request,
+        MessageReceiptHandle messageReceiptHandle, Channel channel) {
+        if (messageReceiptHandle != null && channel != null) {
+            messagingProcessor.addReceiptHandle(ctx, channel,
+                request.getGroup().getName(), request.getMessageId(), messageReceiptHandle);
+        }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java
@@ -20,6 +20,7 @@ import apache.rocketmq.v2.ChangeInvisibleDurationRequest;
 import apache.rocketmq.v2.ChangeInvisibleDurationResponse;
 import apache.rocketmq.v2.Code;
 import com.google.protobuf.util.Durations;
+import io.netty.channel.Channel;
 import java.util.concurrent.CompletableFuture;
 import org.apache.rocketmq.client.consumer.AckResult;
 import org.apache.rocketmq.client.consumer.AckStatus;
@@ -49,8 +50,9 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
 
             ReceiptHandle receiptHandle = ReceiptHandle.decode(request.getReceiptHandle());
             String group = request.getGroup().getName();
+            Channel channel = grpcChannelManager.getChannel(ctx.getClientID());
 
-            MessageReceiptHandle messageReceiptHandle = messagingProcessor.removeReceiptHandle(ctx, grpcChannelManager.getChannel(ctx.getClientID()), group, request.getMessageId(), receiptHandle.getReceiptHandle());
+            MessageReceiptHandle messageReceiptHandle = messagingProcessor.removeReceiptHandle(ctx, channel, group, request.getMessageId(), receiptHandle.getReceiptHandle());
             if (messageReceiptHandle != null) {
                 receiptHandle = ReceiptHandle.decode(messageReceiptHandle.getReceiptHandleStr());
             }
@@ -65,7 +67,7 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
                 MessagingProcessor.DEFAULT_TIMEOUT_MILLS,
                 request.getSuspend()
             ).thenApply(
-                ackResult -> convertToChangeInvisibleDurationResponse(ctx, request, ackResult));
+                ackResult -> convertToChangeInvisibleDurationResponse(ctx, request, ackResult, messageReceiptHandle, channel));
         } catch (Throwable t) {
             future.completeExceptionally(t);
         }
@@ -73,11 +75,18 @@ public class ChangeInvisibleDurationActivity extends AbstractMessagingActivity {
     }
 
     protected ChangeInvisibleDurationResponse convertToChangeInvisibleDurationResponse(ProxyContext ctx,
-        ChangeInvisibleDurationRequest request, AckResult ackResult) {
+        ChangeInvisibleDurationRequest request, AckResult ackResult, MessageReceiptHandle messageReceiptHandle,
+        Channel channel) {
         if (AckStatus.OK.equals(ackResult.getStatus())) {
+            String receiptHandle = ackResult.getExtraInfo();
+            if (messageReceiptHandle != null && channel != null) {
+                messageReceiptHandle.updateReceiptHandle(receiptHandle);
+                messagingProcessor.addReceiptHandle(ctx, channel,
+                    request.getGroup().getName(), request.getMessageId(), messageReceiptHandle);
+            }
             return ChangeInvisibleDurationResponse.newBuilder()
                 .setStatus(ResponseBuilder.getInstance().buildStatus(Code.OK, Code.OK.name()))
-                .setReceiptHandle(ackResult.getExtraInfo())
+                .setReceiptHandle(receiptHandle)
                 .build();
         }
         return ChangeInvisibleDurationResponse.newBuilder()

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
@@ -22,6 +22,7 @@ import apache.rocketmq.v2.ChangeInvisibleDurationResponse;
 import apache.rocketmq.v2.Code;
 import apache.rocketmq.v2.Resource;
 import com.google.protobuf.util.Durations;
+import io.netty.channel.Channel;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +41,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
@@ -160,6 +164,132 @@ public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
 
         assertEquals(Code.INTERNAL_SERVER_ERROR, response.getStatus().getCode());
         assertEquals(TimeUnit.SECONDS.toMillis(3), invisibleTimeArgumentCaptor.getValue().longValue());
+    }
+
+    @Test
+    public void testChangeInvisibleDurationReRegistersNewHandleWhenOldHandleIsManaged() throws Throwable {
+        String oldHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 3000);
+        String newHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 5000);
+        String msgId = "msgId";
+        grpcChannelManager.createChannel(createContext(), CLIENT_ID);
+        MessageReceiptHandle messageReceiptHandle =
+            new MessageReceiptHandle(CONSUMER_GROUP, TOPIC, 0, oldHandle, msgId, 1, 2);
+        AckResult ackResult = new AckResult();
+        ackResult.setExtraInfo(newHandle);
+        ackResult.setStatus(AckStatus.OK);
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyBoolean()
+        )).thenReturn(CompletableFuture.completedFuture(ackResult));
+        when(messagingProcessor.removeReceiptHandle(any(), any(), anyString(), anyString(), anyString()))
+            .thenReturn(messageReceiptHandle);
+
+        ChangeInvisibleDurationResponse response = this.changeInvisibleDurationActivity.changeInvisibleDuration(
+            createContext(),
+            ChangeInvisibleDurationRequest.newBuilder()
+                .setInvisibleDuration(Durations.fromSeconds(5))
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageId(msgId)
+                .setReceiptHandle(oldHandle)
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        assertEquals(newHandle, response.getReceiptHandle());
+        assertEquals(newHandle, messageReceiptHandle.getReceiptHandleStr());
+        verify(messagingProcessor).addReceiptHandle(any(), any(), eq(CONSUMER_GROUP), eq(msgId),
+            eq(messageReceiptHandle));
+    }
+
+    @Test
+    public void testChangeInvisibleDurationReusesOriginalChannelWhenClientDisconnectsBeforeCallback() throws Throwable {
+        String oldHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 3000);
+        String newHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 5000);
+        String msgId = "msgId";
+        Channel channel = grpcChannelManager.createChannel(createContext(), CLIENT_ID);
+        MessageReceiptHandle messageReceiptHandle =
+            new MessageReceiptHandle(CONSUMER_GROUP, TOPIC, 0, oldHandle, msgId, 1, 2);
+        CompletableFuture<AckResult> ackResultFuture = new CompletableFuture<>();
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyBoolean()
+        )).thenReturn(ackResultFuture);
+        when(messagingProcessor.removeReceiptHandle(any(), eq(channel), anyString(), anyString(), anyString()))
+            .thenReturn(messageReceiptHandle);
+
+        CompletableFuture<ChangeInvisibleDurationResponse> responseFuture =
+            this.changeInvisibleDurationActivity.changeInvisibleDuration(
+                createContext(),
+                ChangeInvisibleDurationRequest.newBuilder()
+                    .setInvisibleDuration(Durations.fromSeconds(5))
+                    .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                    .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                    .setMessageId(msgId)
+                    .setReceiptHandle(oldHandle)
+                    .build()
+            );
+
+        grpcChannelManager.removeChannel(CLIENT_ID);
+        AckResult ackResult = new AckResult();
+        ackResult.setExtraInfo(newHandle);
+        ackResult.setStatus(AckStatus.OK);
+        ackResultFuture.complete(ackResult);
+
+        assertEquals(Code.OK, responseFuture.get().getStatus().getCode());
+        verify(messagingProcessor).addReceiptHandle(any(), eq(channel), eq(CONSUMER_GROUP), eq(msgId),
+            eq(messageReceiptHandle));
+    }
+
+    @Test
+    public void testChangeInvisibleDurationDoesNotRegisterNewHandleWhenOldHandleIsNotManaged() throws Throwable {
+        String newHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 5000);
+        AckResult ackResult = new AckResult();
+        ackResult.setExtraInfo(newHandle);
+        ackResult.setStatus(AckStatus.OK);
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyBoolean()
+        )).thenReturn(CompletableFuture.completedFuture(ackResult));
+        when(messagingProcessor.removeReceiptHandle(any(), any(), anyString(), anyString(), anyString()))
+            .thenReturn(null);
+
+        ChangeInvisibleDurationResponse response = this.changeInvisibleDurationActivity.changeInvisibleDuration(
+            createContext(),
+            ChangeInvisibleDurationRequest.newBuilder()
+                .setInvisibleDuration(Durations.fromSeconds(5))
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageId("msgId")
+                .setReceiptHandle(buildReceiptHandle(TOPIC, System.currentTimeMillis(), 3000))
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        assertEquals(newHandle, response.getReceiptHandle());
+        verify(messagingProcessor, never()).addReceiptHandle(any(), any(), anyString(), anyString(),
+            any(MessageReceiptHandle.class));
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivityTest.java
@@ -293,6 +293,92 @@ public class ChangeInvisibleDurationActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testChangeInvisibleDurationRestoresOldHandleWhenBrokerReturnsNonOk() throws Throwable {
+        String oldHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 3000);
+        String msgId = "msgId";
+        grpcChannelManager.createChannel(createContext(), CLIENT_ID);
+        MessageReceiptHandle messageReceiptHandle =
+            new MessageReceiptHandle(CONSUMER_GROUP, TOPIC, 0, oldHandle, msgId, 1, 2);
+        AckResult ackResult = new AckResult();
+        ackResult.setStatus(AckStatus.NO_EXIST);
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyBoolean()
+        )).thenReturn(CompletableFuture.completedFuture(ackResult));
+        when(messagingProcessor.removeReceiptHandle(any(), any(), anyString(), anyString(), anyString()))
+            .thenReturn(messageReceiptHandle);
+
+        ChangeInvisibleDurationResponse response = this.changeInvisibleDurationActivity.changeInvisibleDuration(
+            createContext(),
+            ChangeInvisibleDurationRequest.newBuilder()
+                .setInvisibleDuration(Durations.fromSeconds(5))
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageId(msgId)
+                .setReceiptHandle(oldHandle)
+                .build()
+        ).get();
+
+        assertEquals(Code.INTERNAL_SERVER_ERROR, response.getStatus().getCode());
+        // The old handle was re-registered (restored) and left unmodified.
+        assertEquals(oldHandle, messageReceiptHandle.getReceiptHandleStr());
+        verify(messagingProcessor).addReceiptHandle(any(), any(), eq(CONSUMER_GROUP), eq(msgId),
+            eq(messageReceiptHandle));
+    }
+
+    @Test
+    public void testChangeInvisibleDurationRestoresOldHandleWhenBrokerFutureFails() throws Throwable {
+        String oldHandle = buildReceiptHandle(TOPIC, System.currentTimeMillis(), 3000);
+        String msgId = "msgId";
+        grpcChannelManager.createChannel(createContext(), CLIENT_ID);
+        MessageReceiptHandle messageReceiptHandle =
+            new MessageReceiptHandle(CONSUMER_GROUP, TOPIC, 0, oldHandle, msgId, 1, 2);
+        CompletableFuture<AckResult> ackResultFuture = new CompletableFuture<>();
+        ackResultFuture.completeExceptionally(new RuntimeException("broker boom"));
+        when(this.messagingProcessor.changeInvisibleTime(
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyBoolean()
+        )).thenReturn(ackResultFuture);
+        when(messagingProcessor.removeReceiptHandle(any(), any(), anyString(), anyString(), anyString()))
+            .thenReturn(messageReceiptHandle);
+
+        try {
+            this.changeInvisibleDurationActivity.changeInvisibleDuration(
+                createContext(),
+                ChangeInvisibleDurationRequest.newBuilder()
+                    .setInvisibleDuration(Durations.fromSeconds(5))
+                    .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                    .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                    .setMessageId(msgId)
+                    .setReceiptHandle(oldHandle)
+                    .build()
+            ).get();
+            org.junit.Assert.fail("expected ExecutionException");
+        } catch (ExecutionException executionException) {
+            // expected: the failure surfaces to the caller
+        }
+
+        // The old handle was re-registered (restored) and left unmodified.
+        assertEquals(oldHandle, messageReceiptHandle.getReceiptHandleStr());
+        verify(messagingProcessor).addReceiptHandle(any(), any(), eq(CONSUMER_GROUP), eq(msgId),
+            eq(messageReceiptHandle));
+    }
+
+    @Test
     public void testChangeInvisibleDurationInvisibleTimeTooSmall() throws Throwable {
         try {
             this.changeInvisibleDurationActivity.changeInvisibleDuration(


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #9583

### Brief Description

When proxy auto-renew is managing a receipt handle, `changeInvisibleDuration` removes the old handle from the receipt handle manager before calling `changeInvisibleTime`. The broker returns a new receipt handle on success, but the proxy previously only returned it to the client and did not put the managed handle back into `ReceiptHandleManager`.

This leaves the updated handle unmanaged, so later ACK requests can fail to find the receipt handle mapping.

This PR updates the removed `MessageReceiptHandle` with the new receipt handle returned by the broker and re-registers it only when the old handle was already managed. Non-managed handles keep the existing behavior.

### How Did You Test This Change?

- `mvn -pl proxy -Dtest=ChangeInvisibleDurationActivityTest test`

Result: `BUILD SUCCESS`, `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`