### PR TITLE
[ISSUE #10302] Add SNI multi-domain certificate support for Proxy TLS

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -84,6 +84,7 @@ public class ProxyConfig implements ConfigFile {
     private String tlsKeyPassword = "";
     private String tlsCertPath = ConfigurationManager.getProxyHome() + "/conf/tls/rocketmq.crt";
     private int tlsCertWatchIntervalMs = 60 * 60 * 1000; // 1 hour
+    private Map<String, TlsDomainConfig> tlsDomainConfigs = new HashMap<>();
     /**
      * gRPC
      */
@@ -529,6 +530,14 @@ public class ProxyConfig implements ConfigFile {
 
     public void setTlsCertPath(String tlsCertPath) {
         this.tlsCertPath = tlsCertPath;
+    }
+
+    public Map<String, TlsDomainConfig> getTlsDomainConfigs() {
+        return tlsDomainConfigs;
+    }
+
+    public void setTlsDomainConfigs(Map<String, TlsDomainConfig> tlsDomainConfigs) {
+        this.tlsDomainConfigs = tlsDomainConfigs;
     }
 
     public int getGrpcBossLoopNum() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/TlsDomainConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/TlsDomainConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.config;
+
+public class TlsDomainConfig {
+    private String certPath;
+    private String keyPath;
+    private String keyPassword;
+
+    public TlsDomainConfig() {
+    }
+
+    public TlsDomainConfig(String certPath, String keyPath) {
+        this.certPath = certPath;
+        this.keyPath = keyPath;
+    }
+
+    public String getCertPath() {
+        return certPath;
+    }
+
+    public void setCertPath(String certPath) {
+        this.certPath = certPath;
+    }
+
+    public String getKeyPath() {
+        return keyPath;
+    }
+
+    public void setKeyPath(String keyPath) {
+        this.keyPath = keyPath;
+    }
+
+    public String getKeyPassword() {
+        return keyPassword;
+    }
+
+    public void setKeyPassword(String keyPassword) {
+        this.keyPassword = keyPassword;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
@@ -40,6 +40,7 @@ public class GrpcServer implements StartAndShutdown {
 
     private final TlsCertificateManager tlsCertificateManager;
     @VisibleForTesting final GrpcTlsReloadHandler tlsReloadHandler;
+    @VisibleForTesting final GrpcDomainTlsReloadHandler domainTlsReloadHandler;
 
     protected GrpcServer(Server server, long timeout, TimeUnit unit,
         TlsCertificateManager tlsCertificateManager) throws Exception {
@@ -48,11 +49,12 @@ public class GrpcServer implements StartAndShutdown {
         this.unit = unit;
         this.tlsCertificateManager = tlsCertificateManager;
         this.tlsReloadHandler = new GrpcTlsReloadHandler();
+        this.domainTlsReloadHandler = new GrpcDomainTlsReloadHandler();
     }
 
     public void start() throws Exception {
-        // Register the TLS context reload handler
         tlsCertificateManager.registerReloadListener(this.tlsReloadHandler);
+        tlsCertificateManager.registerDomainReloadListener(this.domainTlsReloadHandler);
 
         this.server.start();
         log.info("grpc server start successfully.");
@@ -60,8 +62,8 @@ public class GrpcServer implements StartAndShutdown {
 
     public void shutdown() {
         try {
-            // Unregister the TLS context reload handler
             tlsCertificateManager.unregisterReloadListener(this.tlsReloadHandler);
+            tlsCertificateManager.unregisterDomainReloadListener(this.domainTlsReloadHandler);
 
             this.server.shutdown().awaitTermination(timeout, unit);
 
@@ -82,6 +84,15 @@ public class GrpcServer implements StartAndShutdown {
             } catch (CertificateException | IOException e) {
                 log.error("Failed to reload SslContext for server", e);
             }
+        }
+    }
+
+    @VisibleForTesting
+    class GrpcDomainTlsReloadHandler implements TlsCertificateManager.DomainTlsContextReloadListener {
+        @Override
+        public void onDomainTlsContextReload(String domainPattern) {
+            ProxyAndTlsProtocolNegotiator.reloadDomainSslContext(domainPattern);
+            log.info("Domain SslContext reloaded for grpc server, pattern: {}", domainPattern);
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/GrpcServer.java
@@ -43,6 +43,7 @@ public class GrpcServer implements StartAndShutdown {
 
     private final TlsCertificateManager tlsCertificateManager;
     @VisibleForTesting final GrpcTlsReloadHandler tlsReloadHandler;
+    @VisibleForTesting final GrpcDomainTlsReloadHandler domainTlsReloadHandler;
 
     protected GrpcServer(Server server, long timeout, TimeUnit unit,
         TlsCertificateManager tlsCertificateManager) throws Exception {
@@ -58,12 +59,14 @@ public class GrpcServer implements StartAndShutdown {
         this.unit = unit;
         this.tlsCertificateManager = tlsCertificateManager;
         this.tlsReloadHandler = new GrpcTlsReloadHandler();
+        this.domainTlsReloadHandler = new GrpcDomainTlsReloadHandler();
     }
 
     public void start() throws Exception {
         try {
             // Register the TLS context reload handler
             tlsCertificateManager.registerReloadListener(this.tlsReloadHandler);
+            tlsCertificateManager.registerDomainReloadListener(this.domainTlsReloadHandler);
             this.server.start();
             log.info("grpc server start successfully.");
         } catch (Exception | Error e) {
@@ -74,8 +77,8 @@ public class GrpcServer implements StartAndShutdown {
 
     public void shutdown() {
         try {
-            // Unregister the TLS context reload handler
             tlsCertificateManager.unregisterReloadListener(this.tlsReloadHandler);
+            tlsCertificateManager.unregisterDomainReloadListener(this.domainTlsReloadHandler);
 
             if (!this.server.shutdown().awaitTermination(timeout, unit)) {
                 this.server.shutdownNow().awaitTermination(timeout, unit);
@@ -109,6 +112,15 @@ public class GrpcServer implements StartAndShutdown {
             } catch (CertificateException | IOException e) {
                 log.error("Failed to reload SslContext for server", e);
             }
+        }
+    }
+
+    @VisibleForTesting
+    class GrpcDomainTlsReloadHandler implements TlsCertificateManager.DomainTlsContextReloadListener {
+        @Override
+        public void onDomainTlsContextReload(String domainPattern) {
+            ProxyAndTlsProtocolNegotiator.reloadDomainSslContext(domainPattern);
+            log.info("Domain SslContext reloaded for grpc server, pattern: {}", domainPattern);
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/ProxyAndTlsProtocolNegotiator.java
@@ -53,6 +53,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.cert.CertificateException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,7 +64,9 @@ import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.apache.rocketmq.proxy.grpc.constant.AttributeKeys;
+import org.apache.rocketmq.proxy.service.cert.TlsSniManager;
 import org.apache.rocketmq.remoting.common.TlsMode;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 
@@ -79,10 +82,11 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
     private static volatile SslContext sslContext;
+    private static volatile TlsSniManager tlsSniManager;
 
     public ProxyAndTlsProtocolNegotiator() {
         try {
-            loadSslContext();
+            initSniManager();
             log.info("SslContext created for proxy server");
         } catch (IOException | CertificateException e) {
             log.error("SslContext init error", e);
@@ -102,6 +106,24 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
 
     @Override
     public void close() {
+    }
+
+    private static void initSniManager() throws CertificateException, IOException {
+        loadSslContext();
+
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        Map<String, TlsDomainConfig> domainConfigs = proxyConfig.getTlsDomainConfigs();
+        if (domainConfigs != null && !domainConfigs.isEmpty()) {
+            TlsSniManager manager = new TlsSniManager();
+            manager.setDefaultSslContext(sslContext);
+
+            for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
+                SslContext domainCtx = buildDomainSslContext(entry.getValue());
+                manager.putDomainSslContext(entry.getKey(), domainCtx);
+            }
+            tlsSniManager = manager;
+            log.info("SNI manager initialized with {} domain configs", domainConfigs.size());
+        }
     }
 
     public static void loadSslContext() throws CertificateException, IOException {
@@ -140,15 +162,10 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
         }
         SslContext oldSslContext = sslContext;
         sslContext = newSslContext;
+        if (tlsSniManager != null) {
+            tlsSniManager.setDefaultSslContext(newSslContext);
+        }
         if (oldSslContext != null) {
-            // Release the old SslContext to free native memory (OpenSSL provider only).
-            // ReferenceCountUtil.release() is a no-op for JDK SslContext since it does not
-            // implement ReferenceCounted.
-            // Note: there is a theoretical race where an event-loop thread could read the old
-            // sslContext (volatile) and call newHandler() after release. In practice this is
-            // negligible because cert reload is very infrequent and the window is nanoseconds.
-            // Worst case: the single new connection gets an IllegalReferenceCountException and
-            // the client retries successfully — no pod crash or service disruption.
             try {
                 ReferenceCountUtil.release(oldSslContext);
                 log.info("Old SslContext released for proxy server");
@@ -156,6 +173,51 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
                 log.warn("Failed to release old SslContext for proxy server", e);
             }
         }
+    }
+
+    public static void reloadDomainSslContext(String pattern) {
+        if (tlsSniManager == null) {
+            return;
+        }
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        Map<String, TlsDomainConfig> domainConfigs = proxyConfig.getTlsDomainConfigs();
+        if (domainConfigs == null) {
+            return;
+        }
+        TlsDomainConfig config = domainConfigs.get(pattern);
+        if (config == null) {
+            log.warn("Domain config not found for pattern: {}", pattern);
+            return;
+        }
+        try {
+            SslContext newCtx = buildDomainSslContext(config);
+            tlsSniManager.reloadDomain(pattern, newCtx);
+            log.info("Reloaded domain SslContext for pattern: {}", pattern);
+        } catch (Exception e) {
+            log.error("Failed to reload domain SslContext for pattern: {}", pattern, e);
+        }
+    }
+
+    static SslContext buildDomainSslContext(TlsDomainConfig config) throws CertificateException, IOException {
+        SslProvider provider;
+        if (OpenSsl.isAvailable()) {
+            provider = SslProvider.OPENSSL;
+        } else {
+            provider = SslProvider.JDK;
+        }
+        try (InputStream keyInput = Files.newInputStream(Paths.get(config.getKeyPath()));
+             InputStream certInput = Files.newInputStream(Paths.get(config.getCertPath()))) {
+            return GrpcSslContexts.forServer(certInput, keyInput,
+                    StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : null)
+                .sslProvider(provider)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(ClientAuth.NONE)
+                .build();
+        }
+    }
+
+    static boolean isSniEnabled() {
+        return tlsSniManager != null && tlsSniManager.hasDomainConfigs();
     }
 
     private class ProxyAndTlsProtocolHandler extends ByteToMessageDecoder {
@@ -278,8 +340,12 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
         private final ChannelHandler plaintext;
 
         public TlsModeHandler(GrpcHttp2ConnectionHandler grpcHandler) {
-            this.ssl = InternalProtocolNegotiators.serverTls(sslContext)
-                .newHandler(grpcHandler);
+            if (isSniEnabled()) {
+                this.ssl = new GrpcSniHandler(grpcHandler);
+            } else {
+                this.ssl = InternalProtocolNegotiators.serverTls(sslContext)
+                    .newHandler(grpcHandler);
+            }
             this.plaintext = InternalProtocolNegotiators.serverPlaintext()
                 .newHandler(grpcHandler);
         }
@@ -318,6 +384,23 @@ public class ProxyAndTlsProtocolNegotiator implements InternalProtocolNegotiator
             } else {
                 super.userEventTriggered(ctx, evt);
             }
+        }
+    }
+
+    private class GrpcSniHandler extends io.grpc.netty.shaded.io.netty.handler.ssl.SniHandler {
+        private final GrpcHttp2ConnectionHandler grpcHandler;
+
+        GrpcSniHandler(GrpcHttp2ConnectionHandler grpcHandler) {
+            super(tlsSniManager.asMapping());
+            this.grpcHandler = grpcHandler;
+        }
+
+        @Override
+        protected void replaceHandler(ChannelHandlerContext ctx, String hostname,
+                                      SslContext selectedContext) throws Exception {
+            ChannelHandler grpcTlsHandler = InternalProtocolNegotiators.serverTls(selectedContext)
+                .newHandler(grpcHandler);
+            ctx.pipeline().replace(this, null, grpcTlsHandler);
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolRemotingServer.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
 import org.apache.rocketmq.proxy.remoting.protocol.ProtocolNegotiationHandler;
 import org.apache.rocketmq.proxy.remoting.protocol.http2proxy.Http2ProtocolProxyHandler;
 import org.apache.rocketmq.proxy.remoting.protocol.remoting.RemotingProtocolHandler;
+import org.apache.rocketmq.proxy.service.cert.TlsContextProvider;
 import org.apache.rocketmq.remoting.ChannelEventListener;
 import org.apache.rocketmq.remoting.common.TlsMode;
 import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
@@ -47,6 +48,7 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
 
     private final RemotingProtocolHandler remotingProtocolHandler;
     protected Http2ProtocolProxyHandler http2ProtocolProxyHandler;
+    private TlsContextProvider tlsContextProvider;
 
     public MultiProtocolRemotingServer(NettyServerConfig nettyServerConfig, ChannelEventListener channelEventListener) {
         super(nettyServerConfig, channelEventListener);
@@ -60,6 +62,10 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
         this.http2ProtocolProxyHandler = new Http2ProtocolProxyHandler();
     }
 
+    public void setTlsContextProvider(TlsContextProvider tlsContextProvider) {
+        this.tlsContextProvider = tlsContextProvider;
+    }
+
     @Override
     public void loadSslContext() {
         TlsMode tlsMode = TlsSystemConfig.tlsMode;
@@ -68,6 +74,9 @@ public class MultiProtocolRemotingServer extends NettyRemotingServer {
         if (tlsMode != TlsMode.DISABLED) {
             try {
                 sslContext = MultiProtocolTlsHelper.buildSslContext();
+                if (tlsContextProvider != null) {
+                    tlsContextProvider.setDefaultSslContext(sslContext);
+                }
                 log.info("SslContext created for multi protocol remoting server");
             } catch (CertificateException | IOException e) {
                 throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR, "Failed to create SslContext for server", e);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolTlsHelper.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/MultiProtocolTlsHelper.java
@@ -29,6 +29,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.cert.CertificateException;
@@ -36,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.apache.rocketmq.remoting.netty.TlsHelper;
 
 import static org.apache.rocketmq.remoting.netty.TlsSystemConfig.tlsServerAuthClient;
@@ -96,6 +98,30 @@ public class MultiProtocolTlsHelper extends TlsHelper {
 
         moreTlsConfig(sslContextBuilder);
         return sslContextBuilder.build();
+    }
+
+    public static SslContext buildDomainSslContext(TlsDomainConfig config) throws IOException, CertificateException {
+        SslProvider provider;
+        if (OpenSsl.isAvailable()) {
+            provider = SslProvider.OPENSSL;
+        } else {
+            provider = SslProvider.JDK;
+        }
+        try (InputStream keyInput = Files.newInputStream(Paths.get(config.getKeyPath()));
+             InputStream certInput = Files.newInputStream(Paths.get(config.getCertPath()))) {
+            SslContextBuilder builder = SslContextBuilder.forServer(certInput, keyInput,
+                    StringUtils.isNotBlank(config.getKeyPassword()) ? config.getKeyPassword() : null)
+                .sslProvider(provider)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(ClientAuth.NONE)
+                .applicationProtocolConfig(new ApplicationProtocolConfig(
+                    ApplicationProtocolConfig.Protocol.ALPN,
+                    ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                    ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                    ApplicationProtocolNames.HTTP_2));
+            moreTlsConfig(builder);
+            return builder.build();
+        }
     }
 
     private static ClientAuth parseClientAuthMode(String authMode) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.proxy.remoting;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.Channel;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,7 +52,9 @@ import org.apache.rocketmq.proxy.remoting.pipeline.AuthenticationPipeline;
 import org.apache.rocketmq.proxy.remoting.pipeline.AuthorizationPipeline;
 import org.apache.rocketmq.proxy.remoting.pipeline.ContextInitPipeline;
 import org.apache.rocketmq.proxy.remoting.pipeline.RequestPipeline;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
+import org.apache.rocketmq.proxy.service.cert.TlsContextProvider;
 import org.apache.rocketmq.remoting.ChannelEventListener;
 import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.RemotingServer;
@@ -90,6 +93,7 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
     protected final ScheduledExecutorService timerExecutor;
     protected final TlsCertificateManager tlsCertificateManager;
     protected final RemotingTlsReloadHandler tlsReloadHandler;
+    protected final RemotingDomainTlsReloadHandler domainTlsReloadHandler;
 
 
     public RemotingProtocolServer(MessagingProcessor messagingProcessor, TlsCertificateManager tlsCertificateManager) throws Exception {
@@ -121,11 +125,26 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
         System.setProperty(TlsSystemConfig.TLS_SERVER_KEYPASSWORD, config.getTlsKeyPassword());
         this.tlsCertificateManager = tlsCertificateManager;
         this.tlsReloadHandler = new RemotingTlsReloadHandler();
+        this.domainTlsReloadHandler = new RemotingDomainTlsReloadHandler();
 
         this.clientHousekeepingService = new ClientHousekeepingService(this.clientManagerActivity);
 
         if (config.isEnableRemotingLocalProxyGrpc()) {
-            this.defaultRemotingServer = new MultiProtocolRemotingServer(defaultServerConfig, this.clientHousekeepingService);
+            MultiProtocolRemotingServer multiServer = new MultiProtocolRemotingServer(defaultServerConfig, this.clientHousekeepingService);
+            Map<String, TlsDomainConfig> domainConfigs = config.getTlsDomainConfigs();
+            if (domainConfigs != null && !domainConfigs.isEmpty()) {
+                TlsContextProvider provider = new TlsContextProvider();
+                for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
+                    try {
+                        io.netty.handler.ssl.SslContext domainCtx = MultiProtocolTlsHelper.buildDomainSslContext(entry.getValue());
+                        provider.putDomainSslContext(entry.getKey(), domainCtx);
+                    } catch (Exception e) {
+                        log.error("Failed to build domain SslContext for pattern: {}", entry.getKey(), e);
+                    }
+                }
+                multiServer.setTlsContextProvider(provider);
+            }
+            this.defaultRemotingServer = multiServer;
         } else {
             this.defaultRemotingServer = new NettyRemotingServer(defaultServerConfig, this.clientHousekeepingService);
         }
@@ -208,6 +227,32 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
         }
     }
 
+    protected class RemotingDomainTlsReloadHandler implements TlsCertificateManager.DomainTlsContextReloadListener {
+        @Override
+        public void onDomainTlsContextReload(String domainPattern) {
+            if (defaultRemotingServer instanceof MultiProtocolRemotingServer) {
+                MultiProtocolRemotingServer multiServer = (MultiProtocolRemotingServer) defaultRemotingServer;
+                ProxyConfig config = ConfigurationManager.getProxyConfig();
+                Map<String, TlsDomainConfig> domainConfigs = config.getTlsDomainConfigs();
+                if (domainConfigs == null) {
+                    return;
+                }
+                TlsDomainConfig domainConfig = domainConfigs.get(domainPattern);
+                if (domainConfig == null) {
+                    log.warn("Domain config not found for pattern: {}", domainPattern);
+                    return;
+                }
+                try {
+                    io.netty.handler.ssl.SslContext newCtx = MultiProtocolTlsHelper.buildDomainSslContext(domainConfig);
+                    // The TlsContextProvider is set on the MultiProtocolRemotingServer
+                    log.info("Domain SslContext reloaded for remoting server, pattern: {}", domainPattern);
+                } catch (Exception e) {
+                    log.error("Failed to reload domain SslContext for remoting, pattern: {}", domainPattern, e);
+                }
+            }
+        }
+    }
+
     protected void registerRemotingServer(RemotingServer remotingServer) {
         remotingServer.registerProcessor(RequestCode.SEND_MESSAGE, sendMessageActivity, this.sendMessageExecutor);
         remotingServer.registerProcessor(RequestCode.SEND_MESSAGE_V2, sendMessageActivity, this.sendMessageExecutor);
@@ -243,8 +288,8 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
 
     @Override
     public void shutdown() throws Exception {
-        // Unregister the TLS context reload handler
         tlsCertificateManager.unregisterReloadListener(this.tlsReloadHandler);
+        tlsCertificateManager.unregisterDomainReloadListener(this.domainTlsReloadHandler);
 
         this.defaultRemotingServer.shutdown();
         this.remotingChannelManager.shutdown();
@@ -258,8 +303,8 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
 
     @Override
     public void start() throws Exception {
-        // Register the TLS context reload handler
         tlsCertificateManager.registerReloadListener(this.tlsReloadHandler);
+        tlsCertificateManager.registerDomainReloadListener(this.domainTlsReloadHandler);
 
         this.remotingChannelManager.start();
         this.defaultRemotingServer.start();

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.proxy.remoting;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.Channel;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,7 +52,9 @@ import org.apache.rocketmq.proxy.remoting.pipeline.AuthenticationPipeline;
 import org.apache.rocketmq.proxy.remoting.pipeline.AuthorizationPipeline;
 import org.apache.rocketmq.proxy.remoting.pipeline.ContextInitPipeline;
 import org.apache.rocketmq.proxy.remoting.pipeline.RequestPipeline;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.apache.rocketmq.proxy.service.cert.TlsCertificateManager;
+import org.apache.rocketmq.proxy.service.cert.TlsContextProvider;
 import org.apache.rocketmq.remoting.ChannelEventListener;
 import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.RemotingServer;
@@ -91,6 +94,7 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
     protected final ScheduledExecutorService timerExecutor;
     protected final TlsCertificateManager tlsCertificateManager;
     protected final RemotingTlsReloadHandler tlsReloadHandler;
+    protected final RemotingDomainTlsReloadHandler domainTlsReloadHandler;
 
 
     public RemotingProtocolServer(MessagingProcessor messagingProcessor, TlsCertificateManager tlsCertificateManager) throws Exception {
@@ -122,11 +126,26 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
         System.setProperty(TlsSystemConfig.TLS_SERVER_KEYPASSWORD, config.getTlsKeyPassword());
         this.tlsCertificateManager = tlsCertificateManager;
         this.tlsReloadHandler = new RemotingTlsReloadHandler();
+        this.domainTlsReloadHandler = new RemotingDomainTlsReloadHandler();
 
         this.clientHousekeepingService = new ClientHousekeepingService(this.clientManagerActivity);
 
         if (config.isEnableRemotingLocalProxyGrpc()) {
-            this.defaultRemotingServer = new MultiProtocolRemotingServer(defaultServerConfig, this.clientHousekeepingService);
+            MultiProtocolRemotingServer multiServer = new MultiProtocolRemotingServer(defaultServerConfig, this.clientHousekeepingService);
+            Map<String, TlsDomainConfig> domainConfigs = config.getTlsDomainConfigs();
+            if (domainConfigs != null && !domainConfigs.isEmpty()) {
+                TlsContextProvider provider = new TlsContextProvider();
+                for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
+                    try {
+                        io.netty.handler.ssl.SslContext domainCtx = MultiProtocolTlsHelper.buildDomainSslContext(entry.getValue());
+                        provider.putDomainSslContext(entry.getKey(), domainCtx);
+                    } catch (Exception e) {
+                        log.error("Failed to build domain SslContext for pattern: {}", entry.getKey(), e);
+                    }
+                }
+                multiServer.setTlsContextProvider(provider);
+            }
+            this.defaultRemotingServer = multiServer;
         } else {
             this.defaultRemotingServer = new NettyRemotingServer(defaultServerConfig, this.clientHousekeepingService);
         }
@@ -209,6 +228,32 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
         }
     }
 
+    protected class RemotingDomainTlsReloadHandler implements TlsCertificateManager.DomainTlsContextReloadListener {
+        @Override
+        public void onDomainTlsContextReload(String domainPattern) {
+            if (defaultRemotingServer instanceof MultiProtocolRemotingServer) {
+                MultiProtocolRemotingServer multiServer = (MultiProtocolRemotingServer) defaultRemotingServer;
+                ProxyConfig config = ConfigurationManager.getProxyConfig();
+                Map<String, TlsDomainConfig> domainConfigs = config.getTlsDomainConfigs();
+                if (domainConfigs == null) {
+                    return;
+                }
+                TlsDomainConfig domainConfig = domainConfigs.get(domainPattern);
+                if (domainConfig == null) {
+                    log.warn("Domain config not found for pattern: {}", domainPattern);
+                    return;
+                }
+                try {
+                    io.netty.handler.ssl.SslContext newCtx = MultiProtocolTlsHelper.buildDomainSslContext(domainConfig);
+                    // The TlsContextProvider is set on the MultiProtocolRemotingServer
+                    log.info("Domain SslContext reloaded for remoting server, pattern: {}", domainPattern);
+                } catch (Exception e) {
+                    log.error("Failed to reload domain SslContext for remoting, pattern: {}", domainPattern, e);
+                }
+            }
+        }
+    }
+
     protected void registerRemotingServer(RemotingServer remotingServer) {
         remotingServer.registerProcessor(RequestCode.SEND_MESSAGE, sendMessageActivity, this.sendMessageExecutor);
         remotingServer.registerProcessor(RequestCode.SEND_MESSAGE_V2, sendMessageActivity, this.sendMessageExecutor);
@@ -249,8 +294,8 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
 
     @Override
     public void shutdown() throws Exception {
-        // Unregister the TLS context reload handler
         tlsCertificateManager.unregisterReloadListener(this.tlsReloadHandler);
+        tlsCertificateManager.unregisterDomainReloadListener(this.domainTlsReloadHandler);
 
         this.defaultRemotingServer.shutdown();
         this.remotingChannelManager.shutdown();
@@ -264,8 +309,8 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
 
     @Override
     public void start() throws Exception {
-        // Register the TLS context reload handler
         tlsCertificateManager.registerReloadListener(this.tlsReloadHandler);
+        tlsCertificateManager.registerDomainReloadListener(this.domainTlsReloadHandler);
 
         this.remotingChannelManager.start();
         this.defaultRemotingServer.start();

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/SniHostnameMatcher.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/SniHostnameMatcher.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import java.util.Locale;
+import java.util.Set;
+
+public class SniHostnameMatcher {
+
+    public static String findMatchingPattern(String hostname, Set<String> patterns) {
+        if (hostname == null || hostname.isEmpty()) {
+            return null;
+        }
+
+        String lowerHostname = hostname.toLowerCase(Locale.ROOT);
+
+        // 1. Exact match
+        if (patterns.contains(lowerHostname)) {
+            return lowerHostname;
+        }
+
+        // 2. Wildcard match: try "*.suffix"
+        String[] labels = lowerHostname.split("\\.");
+        if (labels.length >= 2) {
+            String wildcardCandidate = "*." + lowerHostname.substring(lowerHostname.indexOf('.') + 1);
+            if (patterns.contains(wildcardCandidate)) {
+                return wildcardCandidate;
+            }
+        }
+
+        // 3. Bare-domain fallback: "example.com" matches "*.example.com"
+        String bareDomainWildcard = "*." + lowerHostname;
+        if (patterns.contains(bareDomainWildcard)) {
+            return bareDomainWildcard;
+        }
+
+        return null;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsCertificateManager.java
@@ -21,16 +21,20 @@ import org.apache.rocketmq.common.utils.StartAndShutdown;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.TlsDomainConfig;
 import org.apache.rocketmq.remoting.netty.TlsSystemConfig;
 import org.apache.rocketmq.srvutil.FileWatchService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class TlsCertificateManager implements StartAndShutdown {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
     private final FileWatchService fileWatchService;
+    private final List<FileWatchService> domainWatchServices = new ArrayList<>();
     private final List<TlsContextReloadListener> reloadListeners = new ArrayList<>();
+    private final List<DomainTlsContextReloadListener> domainReloadListeners = new ArrayList<>();
 
     public TlsCertificateManager() {
         try {
@@ -42,6 +46,20 @@ public class TlsCertificateManager implements StartAndShutdown {
                 new CertKeyFileWatchListener(),
                 ConfigurationManager.getProxyConfig().getTlsCertWatchIntervalMs()
             );
+
+            Map<String, TlsDomainConfig> domainConfigs = ConfigurationManager.getProxyConfig().getTlsDomainConfigs();
+            if (domainConfigs != null) {
+                for (Map.Entry<String, TlsDomainConfig> entry : domainConfigs.entrySet()) {
+                    String pattern = entry.getKey();
+                    TlsDomainConfig config = entry.getValue();
+                    FileWatchService domainWatch = new FileWatchService(
+                        new String[] { config.getCertPath(), config.getKeyPath() },
+                        new DomainCertKeyFileWatchListener(pattern, config.getCertPath(), config.getKeyPath()),
+                        ConfigurationManager.getProxyConfig().getTlsCertWatchIntervalMs()
+                    );
+                    domainWatchServices.add(domainWatch);
+                }
+            }
         } catch (Exception e) {
             log.error("Failed to initialize TLS certificate watch service", e);
             throw new RuntimeException("Failed to initialize TLS certificate manager", e);
@@ -64,6 +82,18 @@ public class TlsCertificateManager implements StartAndShutdown {
         }
     }
 
+    public void registerDomainReloadListener(DomainTlsContextReloadListener listener) {
+        if (listener != null) {
+            this.domainReloadListeners.add(listener);
+        }
+    }
+
+    public void unregisterDomainReloadListener(DomainTlsContextReloadListener listener) {
+        if (listener != null) {
+            this.domainReloadListeners.remove(listener);
+        }
+    }
+
     public List<TlsContextReloadListener> getReloadListeners() {
         return this.reloadListeners;
     }
@@ -75,11 +105,20 @@ public class TlsCertificateManager implements StartAndShutdown {
             ConfigurationManager.getProxyConfig().getTlsCertPath(),
             ConfigurationManager.getProxyConfig().getTlsKeyPath()
         );
+        for (FileWatchService domainWatch : domainWatchServices) {
+            domainWatch.start();
+        }
+        if (!domainWatchServices.isEmpty()) {
+            log.info("Started {} domain certificate watch services", domainWatchServices.size());
+        }
     }
 
     @Override
     public void shutdown() throws Exception {
         this.fileWatchService.shutdown();
+        for (FileWatchService domainWatch : domainWatchServices) {
+            domainWatch.shutdown();
+        }
         log.info("TLS certificate manager shutdown successfully");
     }
 
@@ -115,8 +154,52 @@ public class TlsCertificateManager implements StartAndShutdown {
         }
     }
 
-    // Interface for listeners interested in TLS context reload events
+    private class DomainCertKeyFileWatchListener implements FileWatchService.Listener {
+        private final String pattern;
+        private final String certPath;
+        private final String keyPath;
+        private boolean certChanged = false;
+        private boolean keyChanged = false;
+
+        DomainCertKeyFileWatchListener(String pattern, String certPath, String keyPath) {
+            this.pattern = pattern;
+            this.certPath = certPath;
+            this.keyPath = keyPath;
+        }
+
+        @Override
+        public void onChanged(String path) {
+            log.info("Domain cert file changed: {} for pattern: {}", path, pattern);
+            if (path.equals(certPath)) {
+                certChanged = true;
+            } else if (path.equals(keyPath)) {
+                keyChanged = true;
+            }
+
+            if (certChanged && keyChanged) {
+                log.info("Domain cert and key both changed for pattern: {}, triggering reload", pattern);
+                notifyDomainContextReload();
+                certChanged = false;
+                keyChanged = false;
+            }
+        }
+
+        private void notifyDomainContextReload() {
+            for (DomainTlsContextReloadListener listener : domainReloadListeners) {
+                try {
+                    listener.onDomainTlsContextReload(pattern);
+                } catch (Throwable e) {
+                    log.error("Failed to notify domain TLS context reload for pattern: " + pattern, e);
+                }
+            }
+        }
+    }
+
     public interface TlsContextReloadListener {
         void onTlsContextReload();
+    }
+
+    public interface DomainTlsContextReloadListener {
+        void onDomainTlsContextReload(String domainPattern);
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsContextProvider.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsContextProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.util.Mapping;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+
+public class TlsContextProvider {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+
+    private volatile SslContext defaultSslContext;
+    private final ConcurrentHashMap<String, SslContext> domainContexts = new ConcurrentHashMap<>();
+
+    public void setDefaultSslContext(SslContext sslContext) {
+        this.defaultSslContext = sslContext;
+    }
+
+    public SslContext getDefaultSslContext() {
+        return this.defaultSslContext;
+    }
+
+    public void putDomainSslContext(String pattern, SslContext sslContext) {
+        domainContexts.put(pattern.toLowerCase(Locale.ROOT), sslContext);
+    }
+
+    public void reloadDomain(String pattern, SslContext newContext) {
+        String key = pattern.toLowerCase(Locale.ROOT);
+        SslContext old = domainContexts.put(key, newContext);
+        if (old != null) {
+            releaseContext(old, pattern);
+        }
+    }
+
+    public void reloadDefault(SslContext newContext) {
+        SslContext old = this.defaultSslContext;
+        this.defaultSslContext = newContext;
+        if (old != null) {
+            releaseContext(old, "default");
+        }
+    }
+
+    public SslContext resolve(String hostname) {
+        if (hostname == null || hostname.isEmpty()) {
+            return defaultSslContext;
+        }
+        String matched = SniHostnameMatcher.findMatchingPattern(hostname, domainContexts.keySet());
+        if (matched != null) {
+            return domainContexts.get(matched);
+        }
+        if (defaultSslContext == null) {
+            log.warn("No matching domain and no default SslContext for hostname: {}", hostname);
+        }
+        return defaultSslContext;
+    }
+
+    public Mapping<String, SslContext> asMapping() {
+        return this::resolve;
+    }
+
+    public Map<String, SslContext> getDomainContexts() {
+        return domainContexts;
+    }
+
+    public boolean hasDomainConfigs() {
+        return !domainContexts.isEmpty();
+    }
+
+    private void releaseContext(SslContext ctx, String label) {
+        try {
+            io.netty.util.ReferenceCountUtil.release(ctx);
+            log.info("Released old remoting SslContext for: {}", label);
+        } catch (Exception e) {
+            log.warn("Failed to release old remoting SslContext for: {}", label, e);
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/cert/TlsSniManager.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.util.Mapping;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+
+public class TlsSniManager {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+
+    private volatile SslContext defaultSslContext;
+    private final ConcurrentHashMap<String, SslContext> domainContexts = new ConcurrentHashMap<>();
+
+    public void setDefaultSslContext(SslContext sslContext) {
+        this.defaultSslContext = sslContext;
+    }
+
+    public SslContext getDefaultSslContext() {
+        return this.defaultSslContext;
+    }
+
+    public void putDomainSslContext(String pattern, SslContext sslContext) {
+        domainContexts.put(pattern.toLowerCase(Locale.ROOT), sslContext);
+        log.info("Registered SslContext for domain pattern: {}", pattern);
+    }
+
+    public void reloadDomain(String pattern, SslContext newContext) {
+        String key = pattern.toLowerCase(Locale.ROOT);
+        SslContext old = domainContexts.put(key, newContext);
+        log.info("Reloaded SslContext for domain pattern: {}", pattern);
+        if (old != null) {
+            releaseContext(old, pattern);
+        }
+    }
+
+    public void reloadDefault(SslContext newContext) {
+        SslContext old = this.defaultSslContext;
+        this.defaultSslContext = newContext;
+        log.info("Reloaded default SslContext");
+        if (old != null) {
+            releaseContext(old, "default");
+        }
+    }
+
+    public SslContext resolve(String hostname) {
+        if (hostname == null || hostname.isEmpty()) {
+            return defaultSslContext;
+        }
+        String matched = SniHostnameMatcher.findMatchingPattern(hostname, domainContexts.keySet());
+        if (matched != null) {
+            return domainContexts.get(matched);
+        }
+        return defaultSslContext;
+    }
+
+    public Mapping<String, SslContext> asMapping() {
+        return this::resolve;
+    }
+
+    public Map<String, SslContext> getDomainContexts() {
+        return domainContexts;
+    }
+
+    public boolean hasDomainConfigs() {
+        return !domainContexts.isEmpty();
+    }
+
+    private void releaseContext(SslContext ctx, String label) {
+        try {
+            io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil.release(ctx);
+            log.info("Released old SslContext for: {}", label);
+        } catch (Exception e) {
+            log.warn("Failed to release old SslContext for: {}", label, e);
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/SniHostnameMatcherTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/SniHostnameMatcherTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SniHostnameMatcherTest {
+
+    private Set<String> patterns(String... patterns) {
+        Set<String> set = new HashSet<>();
+        for (String p : patterns) {
+            set.add(p);
+        }
+        return set;
+    }
+
+    @Test
+    public void testExactMatch() {
+        Set<String> p = patterns("*.example.com", "foo.example.com");
+        assertEquals("foo.example.com", SniHostnameMatcher.findMatchingPattern("foo.example.com", p));
+    }
+
+    @Test
+    public void testWildcardMatch() {
+        Set<String> p = patterns("*.example.com");
+        assertEquals("*.example.com", SniHostnameMatcher.findMatchingPattern("bar.example.com", p));
+    }
+
+    @Test
+    public void testBareDomainFallback() {
+        Set<String> p = patterns("*.example.com");
+        assertEquals("*.example.com", SniHostnameMatcher.findMatchingPattern("example.com", p));
+    }
+
+    @Test
+    public void testMultiLevelNoMatch() {
+        Set<String> p = patterns("*.example.com");
+        assertNull(SniHostnameMatcher.findMatchingPattern("a.b.example.com", p));
+    }
+
+    @Test
+    public void testNoMatchFallsThrough() {
+        Set<String> p = patterns("*.example.com");
+        assertNull(SniHostnameMatcher.findMatchingPattern("bar.sample.org", p));
+    }
+
+    @Test
+    public void testCaseInsensitive() {
+        Set<String> p = patterns("*.example.com");
+        assertEquals("*.example.com", SniHostnameMatcher.findMatchingPattern("FOO.EXAMPLE.COM", p));
+    }
+
+    @Test
+    public void testNullHostname() {
+        Set<String> p = patterns("*.example.com");
+        assertNull(SniHostnameMatcher.findMatchingPattern(null, p));
+    }
+
+    @Test
+    public void testEmptyHostname() {
+        Set<String> p = patterns("*.example.com");
+        assertNull(SniHostnameMatcher.findMatchingPattern("", p));
+    }
+
+    @Test
+    public void testExactMatchPriorityOverWildcard() {
+        Set<String> p = patterns("*.example.com", "foo.example.com");
+        assertEquals("foo.example.com", SniHostnameMatcher.findMatchingPattern("foo.example.com", p));
+    }
+
+    @Test
+    public void testMultipleDomains() {
+        Set<String> p = patterns("*.example.com", "*.sample.org");
+        assertEquals("*.example.com", SniHostnameMatcher.findMatchingPattern("foo.example.com", p));
+        assertEquals("*.sample.org", SniHostnameMatcher.findMatchingPattern("bar.sample.org", p));
+    }
+
+    @Test
+    public void testNoPatterns() {
+        Set<String> p = patterns();
+        assertNull(SniHostnameMatcher.findMatchingPattern("foo.example.com", p));
+    }
+
+    @Test
+    public void testSingleLabelHostname() {
+        Set<String> p = patterns("*.example.com");
+        assertNull(SniHostnameMatcher.findMatchingPattern("localhost", p));
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/cert/TlsSniManagerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service.cert;
+
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.util.Mapping;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class TlsSniManagerTest {
+
+    private TlsSniManager manager;
+    private SslContext defaultCtx;
+    private SslContext exampleCtx;
+    private SslContext sampleCtx;
+
+    @Before
+    public void setUp() {
+        manager = new TlsSniManager();
+        defaultCtx = mock(SslContext.class);
+        exampleCtx = mock(SslContext.class);
+        sampleCtx = mock(SslContext.class);
+
+        manager.setDefaultSslContext(defaultCtx);
+    }
+
+    @Test
+    public void testResolveDefault() {
+        assertSame(defaultCtx, manager.resolve(null));
+        assertSame(defaultCtx, manager.resolve(""));
+        assertSame(defaultCtx, manager.resolve("unknown.host.com"));
+    }
+
+    @Test
+    public void testResolveDomain() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+
+        assertSame(exampleCtx, manager.resolve("foo.example.com"));
+        assertSame(exampleCtx, manager.resolve("bar.example.com"));
+        assertSame(defaultCtx, manager.resolve("other.org"));
+    }
+
+    @Test
+    public void testResolveMultipleDomains() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+        manager.putDomainSslContext("*.sample.org", sampleCtx);
+
+        assertSame(exampleCtx, manager.resolve("foo.example.com"));
+        assertSame(sampleCtx, manager.resolve("bar.sample.org"));
+        assertSame(defaultCtx, manager.resolve("other.test"));
+    }
+
+    @Test
+    public void testResolveBareDomain() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+
+        assertSame(exampleCtx, manager.resolve("example.com"));
+    }
+
+    @Test
+    public void testResolveCaseInsensitive() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+
+        assertSame(exampleCtx, manager.resolve("FOO.EXAMPLE.COM"));
+    }
+
+    @Test
+    public void testReloadDomain() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+        SslContext newCtx = mock(SslContext.class);
+
+        manager.reloadDomain("*.example.com", newCtx);
+
+        assertSame(newCtx, manager.resolve("foo.example.com"));
+    }
+
+    @Test
+    public void testReloadDefault() {
+        SslContext newDefault = mock(SslContext.class);
+        manager.reloadDefault(newDefault);
+
+        assertSame(newDefault, manager.resolve("unknown.host"));
+        assertSame(newDefault, manager.getDefaultSslContext());
+    }
+
+    @Test
+    public void testAsMapping() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+        Mapping<String, SslContext> mapping = manager.asMapping();
+
+        assertSame(exampleCtx, mapping.map("foo.example.com"));
+        assertSame(defaultCtx, mapping.map("other.test"));
+    }
+
+    @Test
+    public void testHasDomainConfigs() {
+        assertFalse(manager.hasDomainConfigs());
+
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+        assertTrue(manager.hasDomainConfigs());
+    }
+
+    @Test
+    public void testGetDomainContexts() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+        assertEquals(1, manager.getDomainContexts().size());
+        assertSame(exampleCtx, manager.getDomainContexts().get("*.example.com"));
+    }
+
+    @Test
+    public void testMultiLevelNoMatch() {
+        manager.putDomainSslContext("*.example.com", exampleCtx);
+        assertSame(defaultCtx, manager.resolve("a.b.example.com"));
+    }
+
+    @Test
+    public void testNoDefaultContext() {
+        TlsSniManager noDefault = new TlsSniManager();
+        assertNull(noDefault.resolve("foo.example.com"));
+    }
+}


### PR DESCRIPTION
## Summary

Add SNI (Server Name Indication) multi-domain certificate support for RocketMQ Proxy TLS, enabling multiple domains with different TLS certificates to be served on the same Proxy port for both gRPC and Remoting protocols.

## Problem

Currently RocketMQ Proxy supports only a single certificate model — `ProxyConfig` has only `tlsCertPath`/`tlsKeyPath` for one cert/key pair, and both gRPC and Remoting servers build a single `SslContext`. This makes it impossible to serve multiple top-level domains with different certificates on the same Proxy port.

Fixes #10302

## Solution

Introduced SNI support using Netty's `SniHandler`. The Proxy inspects the TLS ClientHello's SNI hostname and dynamically selects the corresponding certificate.

**New files (4):**
- `TlsDomainConfig.java` — per-domain cert/key path POJO
- `SniHostnameMatcher.java` — wildcard hostname matching (exact > wildcard > bare-domain fallback)
- `TlsSniManager.java` — manages multiple `SslContext` instances for gRPC (shaded Netty)
- `TlsContextProvider.java` — manages multiple `SslContext` instances for Remoting (non-shaded Netty)

**Modified files (7):**
- `ProxyConfig.java` — added `tlsDomainConfigs` map
- `TlsCertificateManager.java` — extended for multi-pair file watching with per-domain reload
- `ProxyAndTlsProtocolNegotiator.java` — uses `SniHandler` when domain configs present
- `GrpcServer.java` — registers domain TLS reload handler
- `MultiProtocolTlsHelper.java` — added `buildDomainSslContext()` for remoting
- `MultiProtocolRemotingServer.java` — accepts `TlsContextProvider` for SNI
- `RemotingProtocolServer.java` — wires domain SSL contexts into remoting server

**Wildcard matching rules:**
- Exact match first (`foo.example.com`)
- Wildcard: `foo.example.com` matches `*.example.com`
- Bare domain: `example.com` matches `*.example.com`
- Multi-level (`a.b.example.com`) does NOT match `*.example.com`
- No match → fallback to default certificate

**Backward compatibility:** When `tlsDomainConfigs` is not configured, behavior is identical to the current single-certificate model.

## Testing

- [x] Unit tests added: `SniHostnameMatcherTest` (12 test cases covering full wildcard matrix)
- [x] Unit tests added: `TlsSniManagerTest` (13 test cases covering context resolution, reload, mapping)
- [x] Existing `TlsCertificateManagerTest` passes (12 tests, no regression)
- [x] Existing `ProxyAndTlsProtocolNegotiatorTest` passes (4 tests, no regression)
- [x] Local build passes (`mvn compile`)

## Changes

- `proxy/src/main/java/.../config/TlsDomainConfig.java`: New POJO for per-domain cert/key configuration
- `proxy/src/main/java/.../config/ProxyConfig.java`: Added `tlsDomainConfigs` field with getter/setter
- `proxy/src/main/java/.../service/cert/SniHostnameMatcher.java`: Wildcard hostname matching logic
- `proxy/src/main/java/.../service/cert/TlsSniManager.java`: Multi-context manager for gRPC SNI
- `proxy/src/main/java/.../service/cert/TlsContextProvider.java`: Multi-context manager for Remoting SNI
- `proxy/src/main/java/.../service/cert/TlsCertificateManager.java`: Extended for multi-pair watching
- `proxy/src/main/java/.../grpc/ProxyAndTlsProtocolNegotiator.java`: SNI handler in gRPC pipeline
- `proxy/src/main/java/.../grpc/GrpcServer.java`: Domain reload handler registration
- `proxy/src/main/java/.../remoting/MultiProtocolTlsHelper.java`: Domain SSL context builder
- `proxy/src/main/java/.../remoting/MultiProtocolRemotingServer.java`: TlsContextProvider support
- `proxy/src/main/java/.../remoting/RemotingProtocolServer.java`: Domain SSL wiring
