### PR TITLE
[ISSUE #9195] Propagate MessageBatch user properties to inner messages

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageBatch.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageBatch.java
@@ -39,6 +39,17 @@ public class MessageBatch extends Message implements Iterable<Message> {
         return messages.iterator();
     }
 
+    @Override
+    public void putUserProperty(String name, String value) {
+        super.putUserProperty(name, value);
+        if (messages == null) {
+            return;
+        }
+        for (Message message : messages) {
+            message.putUserProperty(name, value);
+        }
+    }
+
     public static MessageBatch generateFromList(Collection<? extends Message> messages) {
         if (messages == null || messages.isEmpty()) {
             throw new IllegalArgumentException("messages must not be null or empty");

--- a/common/src/test/java/org/apache/rocketmq/common/MessageBatchTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageBatchTest.java
@@ -23,6 +23,8 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageBatch;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class MessageBatchTest {
 
     public List<Message> generateMessages() {
@@ -77,5 +79,13 @@ public class MessageBatchTest {
         List<Message> messages = generateMessages();
         messages.get(1).setTopic(MixAll.RETRY_GROUP_TOPIC_PREFIX + "topic");
         MessageBatch.generateFromList(messages);
+    }
+
+    @Test
+    public void testPutUserPropertyWithNullMessages() {
+        MessageBatch messageBatch = new MessageBatch(null);
+        messageBatch.putUserProperty("name", "value");
+
+        assertEquals("value", messageBatch.getUserProperty("name"));
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
@@ -104,6 +104,8 @@ public class MessageEncodeDecodeTest {
 
         messageBatch.putUserProperty("name", "value");
 
+        assertEquals("value", messageBatch.getUserProperty("name"));
+
         ByteBuffer buffer = ByteBuffer.wrap(messageBatch.encode());
         List<Message> decodedMessages = MessageDecoder.decodeMessages(buffer);
 

--- a/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
@@ -21,9 +21,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageBatch;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MessageEncodeDecodeTest {
@@ -70,6 +72,44 @@ public class MessageEncodeDecodeTest {
             assertTrue(newMessage.getProperty("key").equals(newMessage.getProperty("key")));
             assertTrue(Arrays.equals(newMessage.getBody(), message.getBody()));
 
+        }
+    }
+
+    @Test
+    public void testMessageBatchEncodePreservesInnerMessageUserProperty() throws Exception {
+        List<Message> messages = new ArrayList<>(2);
+        for (int i = 0; i < 2; i++) {
+            Message message = new Message("topic", ("body" + i).getBytes());
+            message.putUserProperty("name", "value");
+            messages.add(message);
+        }
+        MessageBatch messageBatch = MessageBatch.generateFromList(messages);
+
+        ByteBuffer buffer = ByteBuffer.wrap(messageBatch.encode());
+        List<Message> decodedMessages = MessageDecoder.decodeMessages(buffer);
+
+        assertEquals(messages.size(), decodedMessages.size());
+        for (Message decodedMessage : decodedMessages) {
+            assertEquals("value", decodedMessage.getUserProperty("name"));
+        }
+    }
+
+    @Test
+    public void testMessageBatchUserPropertyPropagatesToInnerMessages() throws Exception {
+        List<Message> messages = new ArrayList<>(2);
+        for (int i = 0; i < 2; i++) {
+            messages.add(new Message("topic", ("body" + i).getBytes()));
+        }
+        MessageBatch messageBatch = MessageBatch.generateFromList(messages);
+
+        messageBatch.putUserProperty("name", "value");
+
+        ByteBuffer buffer = ByteBuffer.wrap(messageBatch.encode());
+        List<Message> decodedMessages = MessageDecoder.decodeMessages(buffer);
+
+        assertEquals(messages.size(), decodedMessages.size());
+        for (Message decodedMessage : decodedMessages) {
+            assertEquals("value", decodedMessage.getUserProperty("name"));
         }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #9195

### Brief Description

`MessageBatch` encodes the inner message list via `MessageDecoder.encodeMessages(messages)`. If a caller sets a user property on the `MessageBatch` wrapper itself, that wrapper property is not part of the encoded inner messages and therefore is not visible after decoding or consumption.

This PR makes `MessageBatch.putUserProperty(...)` propagate the user property to every inner message while still preserving the property on the wrapper. This keeps batch-level user property setters aligned with the payload that is actually encoded and consumed.

The tests also cover the existing behavior where user properties already set on inner messages are preserved during batch encode/decode.

### How Did You Test This Change?

- `mvn -pl common -Dtest=MessageEncodeDecodeTest,MessageBatchTest,MessageTest test`

Result: `BUILD SUCCESS`, `Tests run: 17, Failures: 0, Errors: 0, Skipped: 0`