### PR TITLE
[ISSUE #10591] Fix IPv6 NPE in NetworkUtil.string2SocketAddress by stripping brackets

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
@@ -195,6 +195,9 @@ public class NetworkUtil {
         int split = addr.lastIndexOf(":");
         String host = addr.substring(0, split);
         String port = addr.substring(split + 1);
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
         return new InetSocketAddress(host, Integer.parseInt(port));
     }
 

--- a/common/src/test/java/org/apache/rocketmq/common/utils/NetworkUtilTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/NetworkUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.utils;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NetworkUtilTest {
+
+    @Test
+    public void testString2SocketAddressIPv4() {
+        SocketAddress addr = NetworkUtil.string2SocketAddress("127.0.0.1:9876");
+        InetSocketAddress inetAddr = (InetSocketAddress) addr;
+        assertThat(inetAddr.getHostString()).isEqualTo("127.0.0.1");
+        assertThat(inetAddr.getPort()).isEqualTo(9876);
+        assertThat(inetAddr.getAddress()).isNotNull();
+    }
+
+    @Test
+    public void testString2SocketAddressIPv6WithBrackets() {
+        String ipv6 = "[240e:341:6246:c700:c4ad:e645:459e:2]:44880";
+        SocketAddress addr = NetworkUtil.string2SocketAddress(ipv6);
+        InetSocketAddress inetAddr = (InetSocketAddress) addr;
+        assertThat(inetAddr.getPort()).isEqualTo(44880);
+        assertThat(inetAddr.getAddress()).isNotNull();
+    }
+
+    @Test
+    public void testString2SocketAddressIPv6Loopback() {
+        String ipv6 = "[::1]:8080";
+        SocketAddress addr = NetworkUtil.string2SocketAddress(ipv6);
+        InetSocketAddress inetAddr = (InetSocketAddress) addr;
+        assertThat(inetAddr.getPort()).isEqualTo(8080);
+        assertThat(inetAddr.getAddress()).isNotNull();
+    }
+
+    @Test
+    public void testSocketAddress2StringIPv4() {
+        String addr = "127.0.0.1:9876";
+        SocketAddress sa = NetworkUtil.string2SocketAddress(addr);
+        String result = NetworkUtil.socketAddress2String(sa);
+        assertThat(result).isEqualTo(addr);
+    }
+
+    @Test
+    public void testNormalizeAndDenormalizeHostAddress() {
+        String normalized = "[::1]";
+        String denormalized = NetworkUtil.denormalizeHostAddress(normalized);
+        assertThat(denormalized).isEqualTo("::1");
+
+        String noBracket = "127.0.0.1";
+        assertThat(NetworkUtil.denormalizeHostAddress(noBracket)).isEqualTo("127.0.0.1");
+
+        assertThat(NetworkUtil.denormalizeHostAddress(null)).isNull();
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
@@ -88,12 +88,16 @@ public class SimpleChannel extends AbstractChannel {
             return null;
         }
 
-        String[] segments = address.split(":");
-        if (2 == segments.length) {
-            return new InetSocketAddress(segments[0], Integer.parseInt(segments[1]));
+        int split = address.lastIndexOf(":");
+        if (split < 0) {
+            return null;
         }
-
-        return null;
+        String host = address.substring(0, split);
+        String port = address.substring(split + 1);
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
+        return new InetSocketAddress(host, Integer.parseInt(port));
     }
 
     @Override

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/SimpleChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/SimpleChannelTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.channel;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleChannelTest {
+
+    @Test
+    public void testRemoteAddressIPv4() {
+        SimpleChannel channel = new SimpleChannel("127.0.0.1:8080", "127.0.0.1:8081");
+        InetSocketAddress remote = (InetSocketAddress) channel.remoteAddress();
+        assertThat(remote.getHostString()).isEqualTo("127.0.0.1");
+        assertThat(remote.getPort()).isEqualTo(8080);
+        assertThat(remote.getAddress()).isNotNull();
+    }
+
+    @Test
+    public void testRemoteAddressIPv6WithBrackets() {
+        SimpleChannel channel = new SimpleChannel("[240e:341:6246:c700:c4ad:e645:459e:2]:44880", "127.0.0.1:8081");
+        InetSocketAddress remote = (InetSocketAddress) channel.remoteAddress();
+        assertThat(remote.getPort()).isEqualTo(44880);
+        assertThat(remote.getAddress()).isNotNull();
+    }
+
+    @Test
+    public void testLocalAddressIPv6Loopback() {
+        SimpleChannel channel = new SimpleChannel("127.0.0.1:8080", "[::1]:8081");
+        InetSocketAddress local = (InetSocketAddress) channel.localAddress();
+        assertThat(local.getPort()).isEqualTo(8081);
+        assertThat(local.getAddress()).isNotNull();
+    }
+
+    @Test
+    public void testRemoteAddressNull() {
+        SimpleChannel channel = new SimpleChannel("", "127.0.0.1:8081");
+        assertThat(channel.remoteAddress()).isNull();
+    }
+
+    @Test
+    public void testRemoteAddressNoPort() {
+        SimpleChannel channel = new SimpleChannel("127.0.0.1", "127.0.0.1:8081");
+        assertThat(channel.remoteAddress()).isNull();
+    }
+}


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #10591

## Brief Description

When a gRPC client connects to the Proxy via IPv6, the remote address is formatted as `[240e:...:2]:44880` (with brackets). The `NetworkUtil.string2SocketAddress` method splits on the last `:` to separate host and port, but the host part retains the surrounding `[]` brackets.

When `new InetSocketAddress("[240e:...:2]", port)` is constructed with a bracketed host, Java's `InetAddress.getByName()` fails to resolve it, causing `getAddress()` to return `null`. This `null` propagates to `CommitLog.asyncPutMessage` (line 994) where `bornSocketAddress.getAddress()` triggers a `NullPointerException`.

**Root cause**: `string2SocketAddress` does not strip IPv6 brackets before constructing `InetSocketAddress`.

**Fix**: Strip surrounding `[]` from the host part before calling `new InetSocketAddress(host, port)`.

## How Did You Test This Change?

Added `NetworkUtilTest` with 5 test cases:

- `testString2SocketAddressIPv4` — existing IPv4 behavior unchanged
- `testString2SocketAddressIPv6WithBrackets` — reproduces the issue: `[240e:341:6246:c700:c4ad:e645:459e:2]:44880` now resolves correctly with non-null `getAddress()`
- `testString2SocketAddressIPv6Loopback` — `[::1]:8080` resolves correctly
- `testSocketAddress2StringIPv4` — round-trip conversion unchanged
- `testNormalizeAndDenormalizeHostAddress` — bracket normalize/denormalize helpers

```
mvn -pl common -Dtest=NetworkUtilTest test
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```