### PR TITLE
[ISSUE #380] Fix message track showing NOT_CONSUME_YET for consumed messages

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -1546,7 +1546,7 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
                 if (brokerData != null) {
                     String addr = NetworkUtil.convert2IpString(brokerData.getBrokerAddrs().get(MixAll.MASTER_ID));
                     if (NetworkUtil.socketAddress2String(msg.getStoreHost()).equals(addr)) {
-                        if (next.getValue().getConsumerOffset() > msg.getQueueOffset()) {
+                        if (next.getValue().getConsumerOffset() >= msg.getQueueOffset()) {
                             return true;
                         }
                     }
@@ -1576,7 +1576,7 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
                     if (brokerData != null) {
                         String addr = brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
                         if (addr.equals(NetworkUtil.socketAddress2String(msg.getStoreHost()))) {
-                            if (next.getValue().getConsumerOffset() > msg.getQueueOffset()) {
+                            if (next.getValue().getConsumerOffset() >= msg.getQueueOffset()) {
                                 return true;
                             }
                         }

--- a/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
@@ -667,6 +667,32 @@ public class DefaultMQAdminExtImplTest {
         assertTrue(defaultMQAdminExtImpl.consumed(messageExt, defaultGroup));
     }
 
+    @Test
+    public void testConsumedConcurrentWithEqualOffset() throws Exception {
+        MessageExt messageExt = createMessageExt();
+        messageExt.setQueueOffset(10L);
+
+        ConsumeStats consumeStats = mock(ConsumeStats.class);
+        Map<MessageQueue, OffsetWrapper> offsetTable = new HashMap<>();
+        OffsetWrapper offsetWrapper = new OffsetWrapper();
+        offsetWrapper.setConsumerOffset(10L);
+        offsetTable.put(new MessageQueue(defaultTopic, defaultBroker, 0), offsetWrapper);
+        when(consumeStats.getOffsetTable()).thenReturn(offsetTable);
+        when(mqClientAPIImpl.getConsumeStats(anyString(), anyString(), anyString(), anyLong())).thenReturn(consumeStats);
+
+        ClusterInfo ci = mock(ClusterInfo.class);
+        Map<String, BrokerData> brokerAddrTable = new HashMap<>();
+        BrokerData brokerData = mock(BrokerData.class);
+        HashMap<Long, String> brokerAddrs = new HashMap<>();
+        brokerAddrs.put(MixAll.MASTER_ID, defaultBrokerAddr);
+        when(brokerData.getBrokerAddrs()).thenReturn(brokerAddrs);
+        brokerAddrTable.put(defaultBroker, brokerData);
+        when(ci.getBrokerAddrTable()).thenReturn(brokerAddrTable);
+        when(mqClientAPIImpl.getBrokerClusterInfo(anyLong())).thenReturn(ci);
+
+        assertTrue(defaultMQAdminExtImpl.consumedConcurrent(messageExt, defaultGroup));
+    }
+
 //    @Test
 //    public void testConsumedConcurrent() throws Exception {
 //        ConsumeStats consumeStats = mock(ConsumeStats.class);

--- a/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.client.impl.MQClientAPIImpl;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.constant.PermName;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.exception.RemotingConnectException;
@@ -638,6 +639,32 @@ public class DefaultMQAdminExtImplTest {
         when(mqClientAPIImpl.getConsumerConnectionList(anyString(), anyString(), anyLong())).thenReturn(consumerConnection);
         List<MessageTrack> actual = defaultMQAdminExtImpl.messageTrackDetailConcurrent(messageExt);
         assertEquals(1, actual.size());
+    }
+
+    @Test
+    public void testConsumedWithEqualOffset() throws Exception {
+        MessageExt messageExt = createMessageExt();
+        messageExt.setQueueOffset(10L);
+
+        ConsumeStats consumeStats = mock(ConsumeStats.class);
+        Map<MessageQueue, OffsetWrapper> offsetTable = new HashMap<>();
+        OffsetWrapper offsetWrapper = new OffsetWrapper();
+        offsetWrapper.setConsumerOffset(10L);
+        offsetTable.put(new MessageQueue(defaultTopic, defaultBroker, 0), offsetWrapper);
+        when(consumeStats.getOffsetTable()).thenReturn(offsetTable);
+        when(mqClientAPIImpl.getConsumeStats(anyString(), anyString(), anyString(), anyLong())).thenReturn(consumeStats);
+
+        ClusterInfo ci = mock(ClusterInfo.class);
+        Map<String, BrokerData> brokerAddrTable = new HashMap<>();
+        BrokerData brokerData = mock(BrokerData.class);
+        HashMap<Long, String> brokerAddrs = new HashMap<>();
+        brokerAddrs.put(MixAll.MASTER_ID, defaultBrokerAddr);
+        when(brokerData.getBrokerAddrs()).thenReturn(brokerAddrs);
+        brokerAddrTable.put(defaultBroker, brokerData);
+        when(ci.getBrokerAddrTable()).thenReturn(brokerAddrTable);
+        when(mqClientAPIImpl.getBrokerClusterInfo(anyLong())).thenReturn(ci);
+
+        assertTrue(defaultMQAdminExtImpl.consumed(messageExt, defaultGroup));
     }
 
 //    @Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes apache/rocketmq-dashboard#380

In `DefaultMQAdminExtImpl.consumed()` and `consumedConcurrent()`, the consumer offset comparison used strict `>` instead of `>=`. When the consumer offset exactly matched the message's queue offset, the message was incorrectly reported as `NOT_CONSUME_YET` instead of `CONSUMED`.

## Brief changelog

- Changed `>` to `>=` in `consumed()` method
- Changed `>` to `>=` in `consumedConcurrent()` method
- Added test `testConsumedWithEqualOffset` verifying the fix

## Verifying this change

Added test case `testConsumedWithEqualOffset` that sets consumerOffset equal to the message's queueOffset and verifies `consumed()` returns true.