### PR TITLE
[ISSUE #407] Support wildcard IPs in ACL whitelist

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/IPAddressUtils.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/IPAddressUtils.java
@@ -83,6 +83,11 @@ public class IPAddressUtils {
 
     public static boolean isIPInRange(String ip, String cidr) {
         try {
+            if (StringUtils.equals(cidr, "*") || StringUtils.equals(cidr, "0.0.0.0")
+                || StringUtils.equals(cidr, "0.0.0.0/0") || StringUtils.equals(cidr, "::")
+                || StringUtils.equals(cidr, "::/0")) {
+                return true;
+            }
             String[] parts = cidr.split(SLASH);
             if (parts.length == 1) {
                 return StringUtils.equals(ip, cidr);

--- a/common/src/test/java/org/apache/rocketmq/common/utils/IPAddressUtilsTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/IPAddressUtilsTest.java
@@ -40,6 +40,17 @@ public class IPAddressUtilsTest {
     }
 
     @Test
+    public void isIPInRangeWildcard() {
+        assert IPAddressUtils.isIPInRange("192.168.1.10", "0.0.0.0");
+        assert IPAddressUtils.isIPInRange("10.0.0.1", "0.0.0.0/0");
+        assert IPAddressUtils.isIPInRange("192.168.1.10", "*");
+        assert IPAddressUtils.isIPInRange("2001:0db8:85a3::8a2e:0370:7334", "::");
+        assert IPAddressUtils.isIPInRange("2001:0db8:85a3::8a2e:0370:7334", "::/0");
+        assert IPAddressUtils.isIPInRange("192.168.1.10", "::/0");
+        assert IPAddressUtils.isIPInRange("2001:0db8::1", "0.0.0.0/0");
+    }
+
+    @Test
     public void isValidCidr() {
         String ipv4Cidr = "192.168.1.0/24";
         String ipv6Cidr = "2001:0db8:1234:5678::/64";


### PR DESCRIPTION
Fixes apache/rocketmq-dashboard#407. IPAddressUtils.isIPInRange did not recognize 0.0.0.0, ::, or * as wildcard addresses. When users configured 0.0.0.0 in ACL IP whitelist, it only matched the exact IP instead of all IPs.