### PR TITLE
fix: [Bug] NamespaceV2 is not working

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
+++ b/client/src/main/java/org/apache/rocketmq/client/ClientConfig.java
@@ -414,6 +414,10 @@ public class ClientConfig {
             return namespace;
         }
 
+        if (StringUtils.isNotEmpty(namespaceV2)) {
+            return namespaceV2;
+        }
+
         if (StringUtils.isNotEmpty(this.namesrvAddr)) {
             if (NameServerAddressUtils.validateInstanceEndpoint(namesrvAddr)) {
                 namespace = NameServerAddressUtils.parseInstanceIdFromEndpoint(namesrvAddr);

--- a/client/src/test/java/org/apache/rocketmq/client/ClientConfigTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/ClientConfigTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -95,6 +96,38 @@ public class ClientConfigTest {
         config.setNamespaceV2("InstanceTest");
         assertEquals("lmq", config.getNamespace());
         assertEquals("lmq%resource", config.withNamespace(resource));
+    }
+
+    // Regression guard for the cross-namespace isolation symptom reported in
+    // #9341: two clients configured with different namespaceV2 values must
+    // resolve the same resource to *different* fully-qualified names, so a
+    // consumer in ns-A cannot accidentally address ns-B's resources. Before
+    // the fix, namespaceV2 was ignored and both clients would resolve
+    // "resource" (no namespace prefix at all), collapsing the two namespaces.
+    @Test
+    public void testNamespaceV2IsolatesResourcesAcrossNamespaces() {
+        ClientConfig configA = new ClientConfig();
+        configA.setNamespaceV2("InstanceA");
+
+        ClientConfig configB = new ClientConfig();
+        configB.setNamespaceV2("InstanceB");
+
+        String resolvedA = configA.withNamespace(resource);
+        String resolvedB = configB.withNamespace(resource);
+
+        // Each client pins its own namespace prefix.
+        assertEquals("InstanceA%resource", resolvedA);
+        assertEquals("InstanceB%resource", resolvedB);
+
+        // Negative case: the two resolutions must not collide. If they did,
+        // a consumer in InstanceA could subscribe to / pull from InstanceB.
+        assertNotEquals(resolvedA, resolvedB);
+
+        // And each client must reject the other namespace's prefixed resource
+        // when stripping its own namespace — i.e. configA cannot "claim" a
+        // resource that belongs to configB.
+        assertNotEquals(resource, configA.withoutNamespace(resolvedB));
+        assertEquals(resource, configA.withoutNamespace(resolvedA));
     }
 
     private ClientConfig createClientConfig() {

--- a/client/src/test/java/org/apache/rocketmq/client/ClientConfigTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/ClientConfigTest.java
@@ -65,6 +65,38 @@ public class ClientConfigTest {
         assertEquals("lmq%defaultTopic", messageQueues.iterator().next().getTopic());
     }
 
+    @Test
+    public void testGetNamespaceFallbackToNamespaceV2() {
+        ClientConfig config = new ClientConfig();
+        config.setNamespaceV2("InstanceTest");
+        assertEquals("InstanceTest", config.getNamespace());
+    }
+
+    @Test
+    public void testWithNamespaceUsesNamespaceV2() {
+        ClientConfig config = new ClientConfig();
+        config.setNamespaceV2("InstanceTest");
+        assertEquals("InstanceTest%resource", config.withNamespace(resource));
+        assertEquals("InstanceTest%resource",
+            config.withNamespace("InstanceTest%resource"));
+    }
+
+    @Test
+    public void testWithoutNamespaceUsesNamespaceV2() {
+        ClientConfig config = new ClientConfig();
+        config.setNamespaceV2("InstanceTest");
+        assertEquals(resource, config.withoutNamespace("InstanceTest%resource"));
+    }
+
+    @Test
+    public void testNamespaceV1PrecedesNamespaceV2() {
+        ClientConfig config = new ClientConfig();
+        config.setNamespace("lmq");
+        config.setNamespaceV2("InstanceTest");
+        assertEquals("lmq", config.getNamespace());
+        assertEquals("lmq%resource", config.withNamespace(resource));
+    }
+
     private ClientConfig createClientConfig() {
         ClientConfig result = new ClientConfig();
         result.setUnitName("unitName");


### PR DESCRIPTION
## What is the purpose of the change

Fixes #9341.

`NamespaceV2` does not isolate resources: a consumer in one namespace can consume messages produced by a producer in a different namespace.

## Brief changelog

`namespaceV2` was designed to be resolved server-side — the client attaches `nsd`/`ns` extension fields to each remoting request through `NamespaceRpcHook`, expecting the server to wrap the resource. However, the broker never reads those fields; it derives the namespace from the (already-wrapped) resource name via `NamespaceUtil.getNamespaceFromResource`. Meanwhile, all client-side resource wrapping (`ClientConfig.withNamespace` / `withoutNamespace` and their call sites in the producer/consumer) is driven by `ClientConfig.getNamespace()`, which only returns the deprecated V1 `namespace` and therefore stays empty when only `namespaceV2` is configured. The net effect is that neither side wraps the resource, so producers and consumers in different namespaces hit the same physical topic.

This change makes `ClientConfig.getNamespace()` fall back to `namespaceV2` when the V1 `namespace` is not set (the V1 namespace still takes precedence when both are configured). Because `getNamespace()` is the single source of truth used by every resource wrapping/unwrapping call site, topics and groups are now correctly prefixed with the `namespaceV2` value, restoring isolation:

- Producer (`namespaceV2 = InstanceTest1`) → `InstanceTest1%NAMESPACE_TOPIC`
- Consumer (`namespaceV2 = InstanceTest`) → `InstanceTest%NAMESPACE_TOPIC`

`NamespaceUtil.wrapNamespace` is idempotent (`isAlreadyWithNamespace`), so this is safe both for the direct-to-broker path (which ignores `nsd`/`ns`) and for a proxy that performs its own resolution.

## Verifying this change

Added unit tests in `client/.../ClientConfigTest`:

- `getNamespace()` returns `namespaceV2` when the V1 namespace is unset.
- `withNamespace` / `withoutNamespace` wrap and unwrap using `namespaceV2`, and wrapping is idempotent.
- The V1 `namespace` takes precedence over `namespaceV2` when both are set.

## Does this pull request potentially affect one of the following parts

- Dependencies: No
- Broker: No
- Client: Yes — `ClientConfig.getNamespace()` now falls back to `namespaceV2` for resource wrapping when the V1 namespace is unset.
- Consumer (pull/push): No code change beyond the shared `ClientConfig` behavior.
- Namesrv: No
- Proxy: No

## Documentation

- Does this pull request introduce a new feature? No