### PR TITLE
[ISSUE #10609] Detach telemetry observer when gRPC stream closes

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -161,7 +161,7 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
         this.telemetryCommandRef.set(future);
     }
 
-    protected void clearClientObserver(StreamObserver<TelemetryCommand> future) {
+    public void clearClientObserver(StreamObserver<TelemetryCommand> future) {
         this.telemetryCommandRef.compareAndSet(future, null);
     }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -278,13 +278,14 @@ public class ClientActivity extends AbstractMessagingActivity {
     public ContextStreamObserver<TelemetryCommand> telemetry(StreamObserver<TelemetryCommand> responseObserver) {
         return new ContextStreamObserver<TelemetryCommand>() {
             private ProxyContext proxyCtx = null;
+            private GrpcClientChannel grpcClientChannel = null;
             @Override
             public void onNext(ProxyContext ctx, TelemetryCommand request) {
                 this.proxyCtx = ctx;
                 try {
                     switch (request.getCommandCase()) {
                         case SETTINGS: {
-                            processAndWriteClientSettings(ctx, request, responseObserver);
+                            this.grpcClientChannel = processAndWriteClientSettings(ctx, request, responseObserver);
                             break;
                         }
                         case THREAD_STACK_TRACE: {
@@ -305,13 +306,22 @@ public class ClientActivity extends AbstractMessagingActivity {
             public void onError(Throwable t) {
                 log.error("telemetry on error", t);
                 handleGrpcCancel(proxyCtx, t);
+                clearClientObserver(grpcClientChannel, responseObserver);
             }
 
             @Override
             public void onCompleted() {
                 responseObserver.onCompleted();
+                clearClientObserver(grpcClientChannel, responseObserver);
             }
         };
+    }
+
+    private void clearClientObserver(GrpcClientChannel grpcClientChannel, StreamObserver<TelemetryCommand> responseObserver) {
+        if (grpcClientChannel == null) {
+            return;
+        }
+        grpcClientChannel.clearClientObserver(responseObserver);
     }
 
     private static LiteSubscriptionAction toLiteAction(apache.rocketmq.v2.LiteSubscriptionAction gRpcAction) {
@@ -366,7 +376,7 @@ public class ClientActivity extends AbstractMessagingActivity {
         responseObserver.onError(exception);
     }
 
-    protected void processAndWriteClientSettings(ProxyContext ctx, TelemetryCommand request,
+    protected GrpcClientChannel processAndWriteClientSettings(ProxyContext ctx, TelemetryCommand request,
         StreamObserver<TelemetryCommand> responseObserver) {
         GrpcClientChannel grpcClientChannel = null;
         Settings settings = request.getSettings();
@@ -392,7 +402,7 @@ public class ClientActivity extends AbstractMessagingActivity {
             responseObserver.onError(io.grpc.Status.INVALID_ARGUMENT
                 .withDescription("there is no publishing or subscription data in settings")
                 .asRuntimeException());
-            return;
+            return null;
         }
         TelemetryCommand command = processClientSettings(ctx, request);
         if (grpcClientChannel != null) {
@@ -400,6 +410,7 @@ public class ClientActivity extends AbstractMessagingActivity {
         } else {
             responseObserver.onNext(command);
         }
+        return grpcClientChannel;
     }
 
     protected TelemetryCommand processClientSettings(ProxyContext ctx, TelemetryCommand request) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
@@ -20,6 +20,8 @@ package org.apache.rocketmq.proxy.grpc.v2.channel;
 import apache.rocketmq.v2.Publishing;
 import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.TelemetryCommand;
+import io.grpc.stub.StreamObserver;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.InitConfigTest;
@@ -35,7 +37,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,5 +82,48 @@ public class GrpcClientChannelTest extends InitConfigTest {
         assertEquals(clientSettings, GrpcClientChannel.parseChannelExtendAttribute(remoteChannel));
         assertEquals(clientSettings, GrpcClientChannel.parseChannelExtendAttribute(this.grpcClientChannel));
         assertNull(GrpcClientChannel.parseChannelExtendAttribute(mock(RemotingChannel.class)));
+    }
+
+    @Test
+    public void testSetAndClearClientObserver() {
+        StreamObserver<TelemetryCommand> observer = mock(StreamObserver.class);
+        assertFalse(this.grpcClientChannel.isActive());
+        assertFalse(this.grpcClientChannel.isOpen());
+        assertFalse(this.grpcClientChannel.isWritable());
+
+        this.grpcClientChannel.setClientObserver(observer);
+        assertTrue(this.grpcClientChannel.isActive());
+        assertTrue(this.grpcClientChannel.isOpen());
+        assertTrue(this.grpcClientChannel.isWritable());
+
+        this.grpcClientChannel.clearClientObserver(observer);
+        assertFalse(this.grpcClientChannel.isActive());
+        assertFalse(this.grpcClientChannel.isOpen());
+        assertFalse(this.grpcClientChannel.isWritable());
+    }
+
+    @Test
+    public void testClearClientObserverDoesNotClearNewerObserver() {
+        StreamObserver<TelemetryCommand> oldObserver = mock(StreamObserver.class);
+        StreamObserver<TelemetryCommand> newObserver = mock(StreamObserver.class);
+
+        this.grpcClientChannel.setClientObserver(oldObserver);
+        assertTrue(this.grpcClientChannel.isActive());
+
+        // the client reconnects and a newer stream observer replaces the stale one
+        this.grpcClientChannel.setClientObserver(newObserver);
+        assertTrue(this.grpcClientChannel.isActive());
+
+        // a delayed completion of the old stream must not clear the newer observer
+        this.grpcClientChannel.clearClientObserver(oldObserver);
+        assertTrue(this.grpcClientChannel.isActive());
+        assertTrue(this.grpcClientChannel.isOpen());
+        assertTrue(this.grpcClientChannel.isWritable());
+
+        // only the matching (newer) observer clears the channel state
+        this.grpcClientChannel.clearClientObserver(newObserver);
+        assertFalse(this.grpcClientChannel.isActive());
+        assertFalse(this.grpcClientChannel.isOpen());
+        assertFalse(this.grpcClientChannel.isWritable());
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
@@ -71,6 +71,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -407,6 +409,98 @@ public class ClientActivityTest extends BaseActivityTest {
         ProxyRelayResult<ConsumeMessageDirectlyResult> result = resultArgumentCaptor.getValue();
         assertThat(result.getCode()).isEqualTo(ResponseCode.SUCCESS);
         assertThat(result.getResult().getConsumeResult()).isEqualTo(CMResult.CR_SUCCESS);
+    }
+
+    @Test
+    public void testTelemetryOnCompletedClearsClientObserver() throws Throwable {
+        ProxyContext context = createContext();
+        ContextStreamObserver<TelemetryCommand> requestObserver = startProducerTelemetry(context);
+
+        GrpcClientChannel channel = this.grpcChannelManager.getChannel(CLIENT_ID);
+        assertNotNull(channel);
+        assertTrue(channel.isActive());
+        assertTrue(channel.isOpen());
+        assertTrue(channel.isWritable());
+
+        requestObserver.onCompleted();
+
+        assertFalse(channel.isActive());
+        assertFalse(channel.isOpen());
+        assertFalse(channel.isWritable());
+    }
+
+    @Test
+    public void testTelemetryOnErrorClearsClientObserver() throws Throwable {
+        ProxyContext context = createContext();
+        ContextStreamObserver<TelemetryCommand> requestObserver = startProducerTelemetry(context);
+
+        GrpcClientChannel channel = this.grpcChannelManager.getChannel(CLIENT_ID);
+        assertNotNull(channel);
+        assertTrue(channel.isActive());
+
+        requestObserver.onError(new StatusRuntimeException(Status.CANCELLED));
+
+        assertFalse(channel.isActive());
+        assertFalse(channel.isOpen());
+        assertFalse(channel.isWritable());
+    }
+
+    @Test
+    public void testOldStreamCompletionDoesNotClearNewerObserver() throws Throwable {
+        ProxyContext context = createContext();
+        ContextStreamObserver<TelemetryCommand> oldStream = startProducerTelemetry(context);
+
+        GrpcClientChannel channel = this.grpcChannelManager.getChannel(CLIENT_ID);
+        assertNotNull(channel);
+        assertTrue(channel.isActive());
+
+        // the client reconnects with a new telemetry stream on the same channel
+        ContextStreamObserver<TelemetryCommand> newStream = startProducerTelemetry(context);
+        assertTrue(channel.isActive());
+
+        // a delayed completion of the old stream must not detach the newer observer
+        oldStream.onCompleted();
+        assertTrue(channel.isActive());
+        assertTrue(channel.isOpen());
+        assertTrue(channel.isWritable());
+
+        // the active stream completion detaches its own observer
+        newStream.onCompleted();
+        assertFalse(channel.isActive());
+        assertFalse(channel.isOpen());
+        assertFalse(channel.isWritable());
+    }
+
+    private ContextStreamObserver<TelemetryCommand> startProducerTelemetry(ProxyContext context) throws Throwable {
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName(TOPIC).build())
+                .build())
+            .build();
+        when(grpcClientSettingsManager.getClientSettings(any())).thenReturn(settings);
+
+        CompletableFuture<TelemetryCommand> future = new CompletableFuture<>();
+        StreamObserver<TelemetryCommand> responseObserver = new StreamObserver<TelemetryCommand>() {
+            @Override
+            public void onNext(TelemetryCommand value) {
+                future.complete(value);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        };
+        ContextStreamObserver<TelemetryCommand> requestObserver = this.clientActivity.telemetry(responseObserver);
+        requestObserver.onNext(context, TelemetryCommand.newBuilder()
+            .setSettings(settings)
+            .build());
+        future.get();
+        return requestObserver;
     }
 
     protected CompletableFuture<TelemetryCommand> sendClientTelemetry(ProxyContext ctx, Settings settings) {


### PR DESCRIPTION
## What is the purpose of the change

Fix #10609.

Proxy stored the response observer of a gRPC telemetry stream in
`GrpcClientChannel` when the client `SETTINGS` command arrived, but the stream's
`onCompleted()` and `onError()` callbacks never detached it. As a result a
closed telemetry stream remained referenced by the channel, and
`isActive()` / `isOpen()` / `isWritable()` kept returning `true` until a later
`writeTelemetryCommand` failed (or another cleanup path removed the channel).

This makes the channel liveness state reflect stream closure immediately, while
ensuring a delayed callback from an old stream cannot affect a reconnected
client's newer observer.

## Brief changelog

- `proxy/.../grpc/v2/client/ClientActivity.java`
  - The `telemetry` stream observer now captures the `GrpcClientChannel` bound
    to this stream while processing `SETTINGS`.
  - `onCompleted()` and `onError()` detach the stream observer from that
    channel via `clearClientObserver(responseObserver)` (null-safe).
  - `processAndWriteClientSettings` now returns the registered
    `GrpcClientChannel` so the stream observer can clear the correct channel.
- `proxy/.../grpc/v2/channel/GrpcClientChannel.java`
  - `clearClientObserver` is widened from `protected` to `public` so the
    cross-package `ClientActivity` can invoke it. It still uses
    `compareAndSet(future, null)`, so only the observer that actually belongs
    to the finishing stream is removed.

Producer/Consumer unregistration is intentionally untouched; it continues to use
the existing termination and heartbeat timeout mechanisms, as noted in the issue.

## How was this patch verified

Added/extended unit tests:

- `ClientActivityTest`
  - `testTelemetryOnCompletedClearsClientObserver`: channel becomes inactive
    after `onCompleted()`.
  - `testTelemetryOnErrorClearsClientObserver`: channel becomes inactive after
    `onError()`.
  - `testOldStreamCompletionDoesNotClearNewerObserver`: after a reconnect, a
    delayed `onCompleted()` of the old stream does not detach the newer
    observer; only the active stream's completion detaches it.
- `GrpcClientChannelTest`
  - `testSetAndClearClientObserver`: set/clear drives `isActive`/`isOpen`/`isWritable`.
  - `testClearClientObserverDoesNotClearNewerObserver`: `compareAndSet` prevents
    an old observer from clearing a newer one.

Ran the focused tests and checkstyle under JDK 17:

```
mvn -pl proxy -am test -Dtest=ClientActivityTest,GrpcClientChannelTest -DfailIfNoTests=false \
    -Dcheckstyle.skip=true -Drat.skip=true -Dspotbugs.skip=true -Denforcer.skip=true
# Tests run: 21, Failures: 0, Errors: 0, Skipped: 0  (BUILD SUCCESS)

mvn -pl proxy validate -Drat.skip=true
# You have 0 Checkstyle violations.  (BUILD SUCCESS)
```