### PR TITLE
[studio] feat: expose gRPC client connection diagnostics in proxy GrpcChannelManager

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.proxy.grpc.v2.channel;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -71,6 +73,18 @@ public class GrpcChannelManager implements StartAndShutdown {
 
     public GrpcClientChannel removeChannel(String clientId) {
         return this.clientIdChannelMap.remove(clientId);
+    }
+
+    public int getChannelCount() {
+        return this.clientIdChannelMap.size();
+    }
+
+    public Set<String> getActiveClientIdSet() {
+        return Collections.unmodifiableSet(new HashSet<>(this.clientIdChannelMap.keySet()));
+    }
+
+    public int getPendingResponseFutureCount() {
+        return this.resultNonceFutureMap.size();
     }
 
     public <T> String addResponseFuture(CompletableFuture<ProxyRelayResult<T>> responseFuture) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManagerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.v2.channel;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.config.InitConfigTest;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
+import org.apache.rocketmq.proxy.service.relay.ProxyRelayResult;
+import org.apache.rocketmq.proxy.service.relay.ProxyRelayService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GrpcChannelManagerTest extends InitConfigTest {
+
+    @Mock
+    private ProxyRelayService proxyRelayService;
+    @Mock
+    private GrpcClientSettingsManager grpcClientSettingsManager;
+
+    private GrpcChannelManager grpcChannelManager;
+
+    @Before
+    public void before() throws Throwable {
+        super.before();
+        this.grpcChannelManager = new GrpcChannelManager(proxyRelayService, grpcClientSettingsManager);
+    }
+
+    @After
+    public void after() {
+        if (this.grpcChannelManager != null) {
+            try {
+                this.grpcChannelManager.shutdown();
+            } catch (Exception ignore) {
+            }
+        }
+        super.after();
+    }
+
+    private ProxyContext createContext() {
+        return ProxyContext.create()
+            .setRemoteAddress("10.152.39.53:9768")
+            .setLocalAddress("11.193.0.1:1210");
+    }
+
+    @Test
+    public void testCreateAndGetChannel() {
+        String clientIdA = RandomStringUtils.randomAlphabetic(10);
+        String clientIdB = RandomStringUtils.randomAlphabetic(10);
+
+        assertEquals(0, this.grpcChannelManager.getChannelCount());
+
+        this.grpcChannelManager.createChannel(createContext(), clientIdA);
+        this.grpcChannelManager.createChannel(createContext(), clientIdB);
+
+        assertEquals(2, this.grpcChannelManager.getChannelCount());
+        assertNotNull(this.grpcChannelManager.getChannel(clientIdA));
+        assertNotNull(this.grpcChannelManager.getChannel(clientIdB));
+        assertNull(this.grpcChannelManager.getChannel("notExistClientId"));
+
+        Set<String> activeClientIdSet = this.grpcChannelManager.getActiveClientIdSet();
+        assertEquals(2, activeClientIdSet.size());
+        assertTrue(activeClientIdSet.contains(clientIdA));
+        assertTrue(activeClientIdSet.contains(clientIdB));
+    }
+
+    @Test
+    public void testCreateChannelIdempotent() {
+        String clientId = RandomStringUtils.randomAlphabetic(10);
+
+        this.grpcChannelManager.createChannel(createContext(), clientId);
+        this.grpcChannelManager.createChannel(createContext(), clientId);
+
+        assertEquals(1, this.grpcChannelManager.getChannelCount());
+    }
+
+    @Test
+    public void testRemoveChannel() {
+        String clientId = RandomStringUtils.randomAlphabetic(10);
+
+        this.grpcChannelManager.createChannel(createContext(), clientId);
+        assertEquals(1, this.grpcChannelManager.getChannelCount());
+
+        assertNotNull(this.grpcChannelManager.removeChannel(clientId));
+        assertEquals(0, this.grpcChannelManager.getChannelCount());
+        assertNull(this.grpcChannelManager.getChannel(clientId));
+        assertFalse(this.grpcChannelManager.getActiveClientIdSet().contains(clientId));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testActiveClientIdSetUnmodifiable() {
+        String clientId = RandomStringUtils.randomAlphabetic(10);
+        this.grpcChannelManager.createChannel(createContext(), clientId);
+
+        this.grpcChannelManager.getActiveClientIdSet().add("anotherClientId");
+    }
+
+    @Test
+    public void testActiveClientIdSetSnapshot() {
+        String clientId = RandomStringUtils.randomAlphabetic(10);
+        this.grpcChannelManager.createChannel(createContext(), clientId);
+
+        Set<String> snapshot = this.grpcChannelManager.getActiveClientIdSet();
+        assertEquals(1, snapshot.size());
+
+        this.grpcChannelManager.removeChannel(clientId);
+        assertEquals(0, this.grpcChannelManager.getChannelCount());
+
+        assertTrue(snapshot.contains(clientId));
+    }
+
+    @Test
+    public void testPendingResponseFutureCount() {
+        assertEquals(0, this.grpcChannelManager.getPendingResponseFutureCount());
+
+        String nonce = this.grpcChannelManager.addResponseFuture(new CompletableFuture<ProxyRelayResult<Void>>());
+        assertEquals(1, this.grpcChannelManager.getPendingResponseFutureCount());
+
+        assertNotNull(this.grpcChannelManager.getAndRemoveResponseFuture(nonce));
+        assertEquals(0, this.grpcChannelManager.getPendingResponseFutureCount());
+        assertNull(this.grpcChannelManager.getAndRemoveResponseFuture(nonce));
+    }
+
+    @Test
+    public void testGetAndRemoveResponseFuture() {
+        CompletableFuture<ProxyRelayResult<Void>> future = new CompletableFuture<>();
+        String nonce = this.grpcChannelManager.addResponseFuture(future);
+        assertEquals(1, this.grpcChannelManager.getPendingResponseFutureCount());
+
+        CompletableFuture<ProxyRelayResult<Void>> removed = this.grpcChannelManager.getAndRemoveResponseFuture(nonce);
+        assertSame(future, removed);
+        assertEquals(0, this.grpcChannelManager.getPendingResponseFutureCount());
+        assertNull(this.grpcChannelManager.getAndRemoveResponseFuture(nonce));
+    }
+}


### PR DESCRIPTION
## [studio] feat: expose gRPC client connection diagnostics in proxy GrpcChannelManager

Relates to #10600 (RocketMQ Studio: AI-Native Management Platform — Track 2: Proxy Admin management capability upgrade).

### Background

`GrpcChannelManager` is the proxy-side source of truth for connected gRPC
clients (`clientIdChannelMap`) and for pending relay response futures
(`resultNonceFutureMap`). Until now it exposed **no** way to observe either,
which makes client connection management and runtime diagnosis impossible for
the Studio management platform and for admin/diagnostic tooling — the exact
capabilities called out by Track 2 of issue #10600 ("client connection
management and runtime diagnostic capabilities").

### What this PR does

Adds three **read-only, purely additive** diagnostic methods to
`org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager`:

| Method | Purpose |
| --- | --- |
| `getChannelCount()` | Number of active gRPC client channels |
| `getActiveClientIdSet()` | Unmodifiable snapshot of connected client ids |
| `getPendingResponseFutureCount()` | Number of pending relay response futures |

These methods do **not** alter any gRPC/proto API or protocol contract, so they
respect the Track 2 guideline that protocol/interface changes must be discussed
in an issue first. They are the foundation on which the Studio platform and
admin tooling can build standardized client-connection observation.

### Why no protocol change here

Issue #10600 explicitly requires that Track 2 protocol/admin interface changes
be discussed and reach community consensus before code is submitted. This PR
intentionally avoids touching the proxy admin gRPC contract; it only opens up
read-only access to existing in-memory state so it can be consumed later by the
standardized admin layer once that design is agreed upon.

### Tests

Adds `GrpcChannelManagerTest` (extends `InitConfigTest`, JUnit 4 + Mockito),
mirroring the existing `GrpcClientChannelTest`, covering:

- Channel create / get / remove and `getChannelCount` tracking
- Idempotent channel creation (same client id keeps a single channel)
- `getActiveClientIdSet()` returns an unmodifiable snapshot (independent of
  later channel removal)
- `getPendingResponseFutureCount()` accounting through
  `addResponseFuture` / `getAndRemoveResponseFuture`
- Proper shutdown of the internal scheduled executor in `@After`

### Self-check

- [x] Title is prefixed with `[studio]`
- [x] Change is limited to a single cohesive concern (2 files)
- [x] No gRPC/proto API or protocol contract is modified (Track 2 discuss-first rule respected)
- [x] Unit tests added for the new behavior