### PR TITLE
[ISSUE #10613] Fix async request-reply RequestCallback firing multiple times

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
@@ -272,15 +272,14 @@ public class ClientRemotingProcessor implements NettyRequestProcessor {
 
     private void processReplyMessage(MessageExt replyMsg) {
         final String correlationId = replyMsg.getUserProperty(MessageConst.PROPERTY_CORRELATION_ID);
-        final RequestResponseFuture requestResponseFuture = RequestFutureHolder.getInstance().getRequestFutureTable().get(correlationId);
+        // Atomically remove so that only one of the reply-arrival path and the timeout-scan path
+        // (RequestFutureHolder#scanExpiredRequest) can take ownership of this request.
+        final RequestResponseFuture requestResponseFuture = RequestFutureHolder.getInstance().getRequestFutureTable().remove(correlationId);
         if (requestResponseFuture != null) {
             requestResponseFuture.putResponseMessage(replyMsg);
-
-            RequestFutureHolder.getInstance().getRequestFutureTable().remove(correlationId);
-
-            if (requestResponseFuture.getRequestCallback() != null) {
-                requestResponseFuture.getRequestCallback().onSuccess(replyMsg);
-            }
+            // Route through executeRequestCallback so the single-callback guard applies to the
+            // reply-success path too; sync callers (null callback) are woken by putResponseMessage.
+            requestResponseFuture.executeRequestCallback();
         } else {
             String bornHost = replyMsg.getBornHostString();
             logger.warn("receive reply message, but not matched any request, CorrelationId: {} , reply from host: {}",

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -1662,8 +1662,11 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         this.sendDefaultImpl(msg, CommunicationMode.ASYNC, new SendCallback() {
             @Override
             public void onSuccess(SendResult sendResult) {
+                // Only mark the request as sent here. The user callback must fire when the reply
+                // arrives (processReplyMessage), on timeout (scanExpiredRequest), or on send
+                // failure (requestFail). Invoking it here delivers a premature onSuccess(null)
+                // and, combined with the later reply/timeout callback, causes a double callback.
                 requestResponseFuture.setSendRequestOk(true);
-                requestResponseFuture.executeRequestCallback();
             }
 
             @Override

--- a/client/src/main/java/org/apache/rocketmq/client/producer/RequestFutureHolder.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/RequestFutureHolder.java
@@ -54,9 +54,13 @@ public class RequestFutureHolder {
             RequestResponseFuture rep = next.getValue();
 
             if (rep.isTimeout()) {
-                it.remove();
-                rfList.add(rep);
-                log.warn("remove timeout request, CorrelationId={}" + rep.getCorrelationId());
+                // Atomically remove so the timeout path and the reply-arrival path in
+                // ClientRemotingProcessor#processReplyMessage cannot both handle the same request.
+                RequestResponseFuture removed = requestFutureTable.remove(next.getKey());
+                if (removed != null) {
+                    rfList.add(removed);
+                    log.warn("remove timeout request, CorrelationId={}", removed.getCorrelationId());
+                }
             }
         }
 

--- a/client/src/main/java/org/apache/rocketmq/client/producer/RequestResponseFuture.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/RequestResponseFuture.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.client.producer;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.rocketmq.common.message.Message;
 
 public class RequestResponseFuture {
@@ -31,6 +32,7 @@ public class RequestResponseFuture {
     private volatile Message responseMsg = null;
     private volatile boolean sendRequestOk = true;
     private volatile Throwable cause = null;
+    private final AtomicBoolean executeCallbackOnlyOnce = new AtomicBoolean(false);
 
     public RequestResponseFuture(String correlationId, long timeoutMillis, RequestCallback requestCallback) {
         this.correlationId = correlationId;
@@ -39,12 +41,18 @@ public class RequestResponseFuture {
     }
 
     public void executeRequestCallback() {
-        if (requestCallback != null) {
-            if (sendRequestOk && cause == null) {
-                requestCallback.onSuccess(responseMsg);
-            } else {
-                requestCallback.onException(cause);
-            }
+        if (requestCallback == null) {
+            return;
+        }
+        // Ensure the callback fires exactly once even if the reply-arrival path and the
+        // timeout-scan path race on the same request. Whoever wins the CAS runs the callback.
+        if (!this.executeCallbackOnlyOnce.compareAndSet(false, true)) {
+            return;
+        }
+        if (sendRequestOk && cause == null) {
+            requestCallback.onSuccess(responseMsg);
+        } else {
+            requestCallback.onException(cause);
         }
     }
 

--- a/client/src/test/java/org/apache/rocketmq/client/producer/RequestResponseFutureTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/RequestResponseFutureTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.client.producer;
 
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.rocketmq.common.message.Message;
 import org.junit.Test;
@@ -42,6 +43,71 @@ public class RequestResponseFutureTest {
         future.setSendRequestOk(true);
         future.executeRequestCallback();
         assertThat(cc.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testExecuteRequestCallbackSuccessThenTimeoutFiresOnce() {
+        final AtomicInteger success = new AtomicInteger(0);
+        final AtomicInteger exception = new AtomicInteger(0);
+        RequestResponseFuture future = new RequestResponseFuture(UUID.randomUUID().toString(), 3 * 1000L, new RequestCallback() {
+            @Override
+            public void onSuccess(Message message) {
+                success.incrementAndGet();
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                exception.incrementAndGet();
+            }
+        });
+
+        // Reply-arrival path wins first (success), then the timeout-scan path tries to fire again.
+        future.setSendRequestOk(true);
+        future.executeRequestCallback();
+
+        future.setCause(new RuntimeException("request timeout, no reply message."));
+        future.executeRequestCallback();
+
+        // The same request must never deliver both a success and a timeout callback.
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(exception.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void testExecuteRequestCallbackConcurrentlyFiresOnce() throws Exception {
+        final AtomicInteger total = new AtomicInteger(0);
+        final RequestResponseFuture future = new RequestResponseFuture(UUID.randomUUID().toString(), 3 * 1000L, new RequestCallback() {
+            @Override
+            public void onSuccess(Message message) {
+                total.incrementAndGet();
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                total.incrementAndGet();
+            }
+        });
+        future.setSendRequestOk(true);
+
+        int threads = 16;
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(threads);
+        for (int i = 0; i < threads; i++) {
+            new Thread(() -> {
+                try {
+                    start.await();
+                    future.executeRequestCallback();
+                } catch (InterruptedException ignored) {
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+        start.countDown();
+        done.await();
+
+        // Under concurrent contention the CAS guard still allows exactly one callback.
+        assertThat(total.get()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10613

### Brief Description

The async request-reply API `DefaultMQProducer#request(Message, RequestCallback, long)` could invoke the user `RequestCallback` **more than once** for a single request, due to two combined problems:

1. **Premature `onSuccess(null)`** — the async send `onSuccess` called `executeRequestCallback()` right after the *request* message was sent, so the caller received `onSuccess(null)` before any reply arrived. The other async overloads (`request(msg, selector, arg, callback, timeout)`, `request(msg, mq, callback, timeout)`) do not do this.
2. **reply-vs-timeout race** — `ClientRemotingProcessor#processReplyMessage` (non-atomic `get` + `remove`) and `RequestFutureHolder#scanExpiredRequest` (`iterator.remove`) could both take ownership of the same request, and `RequestResponseFuture#executeRequestCallback` had no single-shot guard.

### How Did You Fix It

- `DefaultMQProducerImpl#request(Message, RequestCallback, long)`: drop `executeRequestCallback()` from the async send `onSuccess`; only set `sendRequestOk`, consistent with the other async overloads. The user callback now fires only on reply arrival, timeout, or send failure.
- `RequestResponseFuture`: add an `AtomicBoolean executeCallbackOnlyOnce` guard so the callback runs at most once regardless of which path wins.
- `RequestFutureHolder#scanExpiredRequest`: use `ConcurrentHashMap.remove(key)` to atomically claim ownership instead of `iterator.remove()`; also fix the malformed log placeholder.
- `ClientRemotingProcessor#processReplyMessage`: use atomic `remove(correlationId)` and route the reply through `executeRequestCallback` so the single-shot guard also covers the reply-success path.

### How to Verify

**Unit tests** (`RequestResponseFutureTest`): success-then-timeout fires exactly once; 16-thread concurrent invocation fires exactly once. Full `client` module test suite passes.

**End-to-end** on a 4-node cluster (2000 async requests, 16 threads, `timeout=1000ms`, consumer reply delay=200ms), identical reply flow (`consumed=1312, replySent=1280`):

| Metric | before (develop) | after (this PR) |
|---|---|---|
| successReply (real reply callback) | 284 | 286 |
| successNull (premature onSuccess(null)) | **2000** | **0** |
| doubleCallback | **2000** | **0** |
| nullThenReply / successAndException | 284 / 1716 | 0 / 0 |

After the fix each request delivers exactly one callback (286 `onSuccess(reply)` + 1714 `onException(timeout)` = 2000).
