### PR TITLE
Reference CODECOV_TOKEN secret instead of a hardcoded token in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
-          token: cf0cba0a-22f8-4580-89ab-4f1dec3bda6f
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Follow-up to #10617 (as invited on that issue).

## What this changes

`.github/workflows/coverage.yml` line 30 passes the Codecov upload token as a hardcoded literal. This one-line change makes it read from a repository secret instead:

```yaml
token: ${{ secrets.CODECOV_TOKEN }}
```

Single file, single line, no other changes.

## Important — this is only half the fix

Removing the literal from the workflow does **not** invalidate the value that is already in the git history. As noted on #10617, the token should be treated as compromised and **rotated by a maintainer** (regenerate it in the Codecov dashboard, then store the new value as the `CODECOV_TOKEN` repository secret). This PR just makes sure the workflow reads from that secret once it exists. Until the secret is set, the upload step will run without a token (which is fine for public-repo Codecov uploads).

I kept this PR to the single security concern. I did not touch `actions/checkout@master` or pin the actions to SHAs in this PR — happy to open a separate small PR for that supply-chain hardening if the maintainers would like it.

---

*Disclosure: I used an AI tool to help identify and prepare this. I verified the change myself against the workflow and take responsibility for it. I understand this contribution is subject to the Apache ICLA.*
