### PR TITLE
[ISSUE #10617] Use repository secret for Codecov upload token in coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
-          token: cf0cba0a-22f8-4580-89ab-4f1dec3bda6f
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes #10617

### What

`.github/workflows/coverage.yml` passed the Codecov upload token as a plaintext value. This PR replaces it with a repository secret reference, matching every other credential in this repo's workflows (e.g. `DOCKERHUB_TOKEN`, `NEXUS_PW`):

```diff
-          token: cf0cba0a-22f8-4580-89ab-4f1dec3bda6f
+          token: ${{ secrets.CODECOV_TOKEN }}
```

### Why

A credential committed to a public repo is readable by anyone and should be treated as compromised. This one line was the only workflow credential not using `${{ secrets.* }}`.

### Maintainer action required

This code change alone is not sufficient — a maintainer needs to:
1. **Rotate** the exposed Codecov upload token (treat the old one as compromised).
2. Add the new token as a repository secret named `CODECOV_TOKEN`.

Codecov *upload* tokens are limited in scope (upload coverage only, not code read/push), so the blast radius is bounded, but rotation is still the standard response.

### Test plan

- Change is a single line in an existing workflow; no source/build impact.
- Coverage job will read `secrets.CODECOV_TOKEN` once the secret is configured.

Scope kept to the token fix only (1 file, 1 line). The supply-chain hardening mentioned in the issue (pinning `codecov/codecov-action@v3` and `actions/checkout@master` to commit SHAs) is left as a separate follow-up to keep this PR reviewable.