### PR TITLE
[ISSUE #10622] [Enhancement] LiteEventDispatcher resolve ConsumerOffsetManager dynamically for better extensibility

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteEventDispatcher.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteEventDispatcher.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.rocketmq.broker.BrokerController;
-import org.apache.rocketmq.broker.offset.ConsumerOffsetManager;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.ServiceThread;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -63,7 +62,6 @@ public class LiteEventDispatcher extends ServiceThread {
     private final BrokerController brokerController;
     private final LiteSubscriptionRegistry liteSubscriptionRegistry;
     private final AbstractLiteLifecycleManager liteLifecycleManager;
-    private final ConsumerOffsetManager consumerOffsetManager;
 
     protected final ConcurrentMap<String, ClientEventSet> clientEventMap = new ConcurrentHashMap<>();
     protected final ConcurrentSkipListSet<FullDispatchRequest> fullDispatchSet = new ConcurrentSkipListSet<>(COMPARATOR);
@@ -78,7 +76,6 @@ public class LiteEventDispatcher extends ServiceThread {
         this.brokerController = brokerController;
         this.liteSubscriptionRegistry = liteSubscriptionRegistry;
         this.liteLifecycleManager = liteLifecycleManager;
-        this.consumerOffsetManager = brokerController.getConsumerOffsetManager();
     }
 
     public void init() {
@@ -230,7 +227,7 @@ public class LiteEventDispatcher extends ServiceThread {
             if (maxOffset <= 0) {
                 continue;
             }
-            long consumerOffset = consumerOffsetManager.queryOffset(group, lmqName, 0);
+            long consumerOffset = brokerController.getConsumerOffsetManager().queryOffset(group, lmqName, 0);
             if (consumerOffset >= maxOffset) {
                 continue;
             }
@@ -274,7 +271,7 @@ public class LiteEventDispatcher extends ServiceThread {
             if (maxOffset <= 0) {
                 return true;
             }
-            long consumerOffset = consumerOffsetManager.queryOffset(group, lmqName, 0);
+            long consumerOffset = brokerController.getConsumerOffsetManager().queryOffset(group, lmqName, 0);
             if (consumerOffset >= maxOffset) {
                 return true;
             }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10622

### Brief Description

Projects that build on top of this core may replace the `ConsumerOffsetManager` implementation at the upper level. The dispatcher currently caches the manager as a final field at construction time, so the customized manager never takes effect.

This PR resolves the manager lazily via `brokerController.getConsumerOffsetManager()` instead of caching it in a field, allowing downstream projects to swap in their own implementation after the broker is fully initialized.

### How Did You Test This Change?

Existing unit tests cover the dispatcher logic. The change is minimal (2 insertions, 5 deletions) and does not alter behavior — only the resolution path.