### PR TITLE
[ISSUE #10114] Support deleting consumer offset by group and topic

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
@@ -434,6 +434,18 @@ public class ConsumerOffsetManager extends ConfigManager {
             "offsetTable={}, resetOffsetTable={}, pullOffsetTable={}", group, clearOffset, clearReset, clearPull);
     }
 
+    public void removeOffset(final String group, final String topic) {
+        String topicAtGroup = topic + TOPIC_GROUP_SEPARATOR + group;
+        boolean clearOffset = this.offsetTable.remove(topicAtGroup) != null;
+        boolean clearReset = this.resetOffsetTable.remove(topicAtGroup) != null;
+        boolean clearPull = this.pullOffsetTable.remove(topicAtGroup) != null;
+
+        removeConsumerOffset(topicAtGroup);
+
+        LOG.info("Consumer offset manager clean group and topic offset, groupName={}, topic={}, " +
+            "offsetTable={}, resetOffsetTable={}, pullOffsetTable={}", group, topic, clearOffset, clearReset, clearPull);
+    }
+
     public void assignResetOffset(String topic, String group, int queueId, long offset) {
         if (Strings.isNullOrEmpty(topic) || Strings.isNullOrEmpty(group) || queueId < 0 || offset < 0) {
             LOG.warn("Illegal arguments when assigning reset offset. Topic={}, group={}, queueId={}, offset={}",

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -160,6 +160,7 @@ import org.apache.rocketmq.remoting.protocol.header.CreateAclRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.CreateTopicRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.CreateUserRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteAclRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.DeleteConsumerOffsetRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteSubscriptionGroupRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteTopicRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteUserRequestHeader;
@@ -316,6 +317,8 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
                 return this.getAllSubscriptionGroup(ctx, request);
             case RequestCode.DELETE_SUBSCRIPTIONGROUP:
                 return this.deleteSubscriptionGroup(ctx, request);
+            case RequestCode.DELETE_CONSUMER_OFFSET:
+                return this.deleteConsumerOffset(ctx, request);
             case RequestCode.DELETE_SUBSCRIPTION_GROUP_LIST:
                 return this.deleteSubscriptionGroupList(ctx, request);
             case RequestCode.GET_TOPIC_STATS_INFO:
@@ -1786,6 +1789,30 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         boolean cleanOffset = requestHeader.isCleanOffset()
             || LiteMetadataUtil.isLiteGroupType(requestHeader.getGroupName(), this.brokerController);
         deleteSubscriptionGroupInBroker(requestHeader.getGroupName(), cleanOffset);
+
+        response.setCode(ResponseCode.SUCCESS);
+        response.setRemark(null);
+        return response;
+    }
+
+    private RemotingCommand deleteConsumerOffset(ChannelHandlerContext ctx,
+        RemotingCommand request) throws RemotingCommandException {
+        final RemotingCommand response = RemotingCommand.createResponseCommand(null);
+        DeleteConsumerOffsetRequestHeader requestHeader =
+            request.decodeCommandCustomHeader(DeleteConsumerOffsetRequestHeader.class);
+
+        if (UtilAll.isBlank(requestHeader.getConsumerGroup()) || UtilAll.isBlank(requestHeader.getTopic())) {
+            response.setCode(ResponseCode.INVALID_PARAMETER);
+            response.setRemark("The specified consumer group or topic is blank.");
+            return response;
+        }
+
+        LOGGER.info("AdminBrokerProcessor#deleteConsumerOffset, caller={}, group={}, topic={}",
+            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), requestHeader.getConsumerGroup(),
+            requestHeader.getTopic());
+
+        this.brokerController.getConsumerOffsetManager().removeOffset(requestHeader.getConsumerGroup(),
+            requestHeader.getTopic());
 
         response.setCode(ResponseCode.SUCCESS);
         response.setRemark(null);

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
@@ -85,6 +85,30 @@ public class ConsumerOffsetManagerTest {
     }
 
     @Test
+    public void removeOffsetByGroupAndTopicTest() {
+        String group = "GroupName";
+        String topic = "TopicName";
+        String otherTopic = "OtherTopic";
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
+        ConsumerOffsetManager manager = Mockito.spy(consumerOffsetManager);
+
+        manager.commitOffset("Commit", group, topic, 0, 100L);
+        manager.assignResetOffset(topic, group, 0, 90L);
+        manager.commitPullOffset("Pull", group, topic, 0, 110L);
+        manager.commitOffset("Commit", group, otherTopic, 0, 200L);
+        manager.commitPullOffset("Pull", group, otherTopic, 0, 210L);
+
+        manager.removeOffset(group, topic);
+
+        Assert.assertEquals(-1L, manager.queryOffset(group, topic, 0));
+        Assert.assertEquals(-1L, manager.queryPullOffset(group, topic, 0));
+        Assert.assertFalse(manager.hasOffsetReset(topic, group, 0));
+        Assert.assertEquals(200L, manager.queryOffset(group, otherTopic, 0));
+        Assert.assertEquals(210L, manager.queryPullOffset(group, otherTopic, 0));
+        Mockito.verify(manager).removeConsumerOffset(topic + TOPIC_GROUP_SEPARATOR + group);
+    }
+
+    @Test
     public void testOffsetPersistInMemory() {
         ConcurrentMap<String, ConcurrentMap<Integer, Long>> offsetTable = consumerOffsetManager.getOffsetTable();
         ConcurrentMap<Integer, Long> table = new ConcurrentHashMap<>();

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
@@ -1064,6 +1064,36 @@ public class AdminBrokerProcessorTest {
     }
 
     @Test
+    public void testDeleteConsumerOffset() throws RemotingCommandException {
+        when(brokerController.getConsumerOffsetManager()).thenReturn(consumerOffsetManager);
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.DELETE_CONSUMER_OFFSET, null);
+        request.addExtField("consumerGroup", "GID-Group-Name");
+        request.addExtField("topic", "TopicName");
+
+        RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        verify(consumerOffsetManager).removeOffset("GID-Group-Name", "TopicName");
+    }
+
+    @Test
+    public void testDeleteConsumerOffsetRejectsBlankResource() throws RemotingCommandException {
+        RemotingCommand blankGroupRequest = RemotingCommand.createRequestCommand(
+            RequestCode.DELETE_CONSUMER_OFFSET, null);
+        blankGroupRequest.addExtField("consumerGroup", " ");
+        blankGroupRequest.addExtField("topic", "TopicName");
+        RemotingCommand blankGroupResponse = adminBrokerProcessor.processRequest(handlerContext, blankGroupRequest);
+        assertThat(blankGroupResponse.getCode()).isEqualTo(ResponseCode.INVALID_PARAMETER);
+
+        RemotingCommand blankTopicRequest = RemotingCommand.createRequestCommand(
+            RequestCode.DELETE_CONSUMER_OFFSET, null);
+        blankTopicRequest.addExtField("consumerGroup", "GID-Group-Name");
+        blankTopicRequest.addExtField("topic", " ");
+        RemotingCommand blankTopicResponse = adminBrokerProcessor.processRequest(handlerContext, blankTopicRequest);
+        assertThat(blankTopicResponse.getCode()).isEqualTo(ResponseCode.INVALID_PARAMETER);
+    }
+
+    @Test
     public void testGetTopicStatsInfo() throws RemotingCommandException {
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_TOPIC_STATS_INFO, null);
         request.addExtField("topic", "topicTest");

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -169,6 +169,7 @@ import org.apache.rocketmq.remoting.protocol.header.CreateTopicListRequestHeader
 import org.apache.rocketmq.remoting.protocol.header.CreateTopicRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.CreateUserRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteAclRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.DeleteConsumerOffsetRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteSubscriptionGroupRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteTopicRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.DeleteUserRequestHeader;
@@ -2298,6 +2299,25 @@ public class MQClientAPIImpl implements NameServerUpdateCallback, StartAndShutdo
             }
             default:
                 break;
+        }
+
+        throw new MQClientException(response.getCode(), response.getRemark());
+    }
+
+    public void deleteConsumerOffset(final String addr, final String consumerGroup, final String topic,
+        final long timeoutMillis) throws RemotingException, InterruptedException, MQClientException {
+        DeleteConsumerOffsetRequestHeader requestHeader = new DeleteConsumerOffsetRequestHeader();
+        requestHeader.setConsumerGroup(consumerGroup);
+        requestHeader.setTopic(topic);
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.DELETE_CONSUMER_OFFSET, requestHeader);
+
+        RemotingCommand response = this.remotingClient.invokeSync(
+            MixAll.brokerVIPChannel(this.clientConfig.isVipChannelEnabled(), addr), request, timeoutMillis);
+        if (response == null) {
+            throw new MQClientException(ResponseCode.SYSTEM_ERROR, "response is null when deleting consumer offset");
+        }
+        if (response.getCode() == ResponseCode.SUCCESS) {
+            return;
         }
 
         throw new MQClientException(response.getCode(), response.getRemark());

--- a/client/src/test/java/org/apache/rocketmq/client/impl/MQClientAPIImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/MQClientAPIImplTest.java
@@ -106,6 +106,7 @@ import org.apache.rocketmq.remoting.protocol.body.UserInfo;
 import org.apache.rocketmq.remoting.protocol.header.AckMessageRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ChangeInvisibleTimeRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ChangeInvisibleTimeResponseHeader;
+import org.apache.rocketmq.remoting.protocol.header.DeleteConsumerOffsetRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.EndTransactionRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ExtraInfoUtil;
 import org.apache.rocketmq.remoting.protocol.header.GetConsumerListByGroupResponseBody;
@@ -1362,6 +1363,41 @@ public class MQClientAPIImplTest {
     public void testDeleteSubscriptionGroup() throws RemotingException, InterruptedException, MQClientException {
         mockInvokeSync();
         mqClientAPI.deleteSubscriptionGroup(defaultBrokerAddr, "", true, defaultTimeout);
+    }
+
+    @Test
+    public void testDeleteConsumerOffset() throws Exception {
+        mockInvokeSync();
+        org.mockito.ArgumentCaptor<RemotingCommand> captor = org.mockito.ArgumentCaptor.forClass(RemotingCommand.class);
+
+        mqClientAPI.deleteConsumerOffset(defaultBrokerAddr, group, topic, defaultTimeout);
+
+        org.mockito.Mockito.verify(remotingClient).invokeSync(any(), captor.capture(), anyLong());
+        RemotingCommand captured = captor.getValue();
+        captured.makeCustomHeaderToNet();
+        DeleteConsumerOffsetRequestHeader requestHeader =
+            captured.decodeCommandCustomHeader(DeleteConsumerOffsetRequestHeader.class);
+        assertEquals(RequestCode.DELETE_CONSUMER_OFFSET, captured.getCode());
+        assertEquals(group, requestHeader.getConsumerGroup());
+        assertEquals(topic, requestHeader.getTopic());
+    }
+
+    @Test(expected = MQClientException.class)
+    public void testDeleteConsumerOffsetFail()
+        throws RemotingException, InterruptedException, MQClientException {
+        when(response.getCode()).thenReturn(ResponseCode.SYSTEM_ERROR);
+        when(response.getRemark()).thenReturn("error");
+        when(remotingClient.invokeSync(any(), any(), anyLong())).thenReturn(response);
+
+        mqClientAPI.deleteConsumerOffset(defaultBrokerAddr, group, topic, defaultTimeout);
+    }
+
+    @Test(expected = MQClientException.class)
+    public void testDeleteConsumerOffsetNullResponse()
+        throws RemotingException, InterruptedException, MQClientException {
+        when(remotingClient.invokeSync(any(), any(), anyLong())).thenReturn(null);
+
+        mqClientAPI.deleteConsumerOffset(defaultBrokerAddr, group, topic, defaultTimeout);
     }
 
     @Test

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java
@@ -228,6 +228,7 @@ public class RequestCode {
 
     public static final int LITE_PULL_MESSAGE = 361;
     public static final int RECALL_MESSAGE = 370;
+    public static final int DELETE_CONSUMER_OFFSET = 380;
 
     public static final int QUERY_ASSIGNMENT = 400;
     public static final int SET_MESSAGE_REQUEST_MODE = 401;

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/DeleteConsumerOffsetRequestHeader.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/DeleteConsumerOffsetRequestHeader.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.remoting.protocol.header;
+
+import org.apache.rocketmq.common.action.Action;
+import org.apache.rocketmq.common.action.RocketMQAction;
+import org.apache.rocketmq.common.resource.ResourceType;
+import org.apache.rocketmq.common.resource.RocketMQResource;
+import org.apache.rocketmq.remoting.annotation.CFNotNull;
+import org.apache.rocketmq.remoting.exception.RemotingCommandException;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.rpc.RpcRequestHeader;
+
+@RocketMQAction(value = RequestCode.DELETE_CONSUMER_OFFSET, action = Action.DELETE)
+public class DeleteConsumerOffsetRequestHeader extends RpcRequestHeader {
+    @CFNotNull
+    @RocketMQResource(ResourceType.GROUP)
+    private String consumerGroup;
+
+    @CFNotNull
+    @RocketMQResource(ResourceType.TOPIC)
+    private String topic;
+
+    @Override
+    public void checkFields() throws RemotingCommandException {
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExt.java
@@ -431,6 +431,12 @@ public class DefaultMQAdminExt extends ClientConfig implements MQAdminExt {
     }
 
     @Override
+    public void deleteConsumerOffset(String addr, String consumerGroup, String topic)
+        throws RemotingException, InterruptedException, MQClientException {
+        defaultMQAdminExtImpl.deleteConsumerOffset(addr, consumerGroup, topic);
+    }
+
+    @Override
     public void createAndUpdateKvConfig(String namespace, String key,
         String value) throws RemotingException, MQBrokerException,
         InterruptedException, MQClientException {

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -777,6 +777,12 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
     }
 
     @Override
+    public void deleteConsumerOffset(String addr, String consumerGroup, String topic)
+        throws RemotingException, InterruptedException, MQClientException {
+        this.mqClientInstance.getMQClientAPIImpl().deleteConsumerOffset(addr, consumerGroup, topic, timeoutMillis);
+    }
+
+    @Override
     public void createAndUpdateKvConfig(String namespace, String key,
         String value) throws RemotingException, MQBrokerException, InterruptedException, MQClientException {
         this.mqClientInstance.getMQClientAPIImpl().putKVConfigValue(namespace, key, value, timeoutMillis);

--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/MQAdminExt.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/MQAdminExt.java
@@ -212,6 +212,9 @@ public interface MQAdminExt extends MQAdmin {
         boolean removeOffset) throws RemotingException, MQBrokerException,
         InterruptedException, MQClientException;
 
+    void deleteConsumerOffset(final String addr, final String consumerGroup, final String topic)
+        throws RemotingException, InterruptedException, MQClientException;
+
     void createAndUpdateKvConfig(String namespace, String key,
         String value) throws RemotingException, MQBrokerException,
         InterruptedException, MQClientException;

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -105,6 +105,7 @@ import org.apache.rocketmq.tools.command.namesrv.UpdateKvConfigCommand;
 import org.apache.rocketmq.tools.command.namesrv.UpdateNamesrvConfigCommand;
 import org.apache.rocketmq.tools.command.namesrv.WipeWritePermSubCommand;
 import org.apache.rocketmq.tools.command.offset.CloneGroupOffsetCommand;
+import org.apache.rocketmq.tools.command.offset.DeleteConsumerOffsetCommand;
 import org.apache.rocketmq.tools.command.offset.ResetOffsetByTimeCommand;
 import org.apache.rocketmq.tools.command.offset.SkipAccumulationSubCommand;
 import org.apache.rocketmq.tools.command.producer.ProducerSubCommand;
@@ -227,6 +228,7 @@ public class MQAdminStartup {
         initCommand(new ConsumerProgressSubCommand());
         initCommand(new ConsumerStatusSubCommand());
         initCommand(new CloneGroupOffsetCommand());
+        initCommand(new DeleteConsumerOffsetCommand());
         //for producer
         initCommand(new ProducerSubCommand());
 

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/offset/DeleteConsumerOffsetCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/offset/DeleteConsumerOffsetCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.offset;
+
+import java.util.Set;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.command.CommandUtil;
+import org.apache.rocketmq.tools.command.SubCommand;
+import org.apache.rocketmq.tools.command.SubCommandException;
+
+public class DeleteConsumerOffsetCommand implements SubCommand {
+
+    @Override
+    public String commandName() {
+        return "deleteConsumerOffset";
+    }
+
+    @Override
+    public String commandDesc() {
+        return "Delete consumer offset for a consumer group and topic.";
+    }
+
+    @Override
+    public Options buildCommandlineOptions(Options options) {
+        Option opt = new Option("g", "consumerGroup", true, "consumer group name");
+        opt.setRequired(true);
+        options.addOption(opt);
+
+        opt = new Option("t", "topic", true, "topic name");
+        opt.setRequired(true);
+        options.addOption(opt);
+
+        OptionGroup target = new OptionGroup();
+        target.addOption(new Option("b", "brokerAddr", true, "delete consumer offset from which broker"));
+        target.addOption(new Option("c", "clusterName", true, "delete consumer offset from which cluster"));
+        target.setRequired(true);
+        options.addOptionGroup(target);
+
+        return options;
+    }
+
+    @Override
+    public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) throws SubCommandException {
+        DefaultMQAdminExt adminExt = new DefaultMQAdminExt(rpcHook);
+        adminExt.setInstanceName(Long.toString(System.currentTimeMillis()));
+        try {
+            String consumerGroup = commandLine.getOptionValue('g').trim();
+            String topic = commandLine.getOptionValue('t').trim();
+            adminExt.start();
+
+            if (commandLine.hasOption('b')) {
+                String brokerAddr = commandLine.getOptionValue('b').trim();
+                adminExt.deleteConsumerOffset(brokerAddr, consumerGroup, topic);
+                System.out.printf(
+                    "delete consumer offset for group [%s] and topic [%s] from broker [%s] success.%n",
+                    consumerGroup, topic, brokerAddr);
+                return;
+            }
+
+            String clusterName = commandLine.getOptionValue('c').trim();
+            Set<String> masterSet = CommandUtil.fetchMasterAddrByClusterName(adminExt, clusterName);
+            for (String master : masterSet) {
+                adminExt.deleteConsumerOffset(master, consumerGroup, topic);
+                System.out.printf(
+                    "delete consumer offset for group [%s] and topic [%s] from broker [%s] in cluster [%s] success.%n",
+                    consumerGroup, topic, master, clusterName);
+            }
+        } catch (Exception e) {
+            throw new SubCommandException(this.getClass().getSimpleName() + " command failed", e);
+        } finally {
+            adminExt.shutdown();
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/offset/DeleteConsumerOffsetCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/offset/DeleteConsumerOffsetCommandTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.offset;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.server.ServerResponseMocker;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeleteConsumerOffsetCommandTest {
+
+    @Test
+    public void testCommandMetadata() {
+        DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+
+        Assert.assertEquals("deleteConsumerOffset", command.commandName());
+        Assert.assertEquals("Delete consumer offset for a consumer group and topic.", command.commandDesc());
+    }
+
+    @Test
+    public void testBuildCommandlineOptions() {
+        DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+        Options options = command.buildCommandlineOptions(new Options());
+
+        Assert.assertTrue(options.hasOption("g"));
+        Assert.assertTrue(options.hasOption("t"));
+        Assert.assertTrue(options.hasOption("b"));
+        Assert.assertTrue(options.hasOption("c"));
+        Assert.assertTrue(options.getOption("g").isRequired());
+        Assert.assertTrue(options.getOption("t").isRequired());
+    }
+
+    @Test
+    public void testBrokerTargetOption() throws ParseException {
+        DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+        Options options = command.buildCommandlineOptions(new Options());
+
+        CommandLine commandLine = new DefaultParser().parse(options,
+            new String[] {"-g", "GroupName", "-t", "TopicName", "-b", "127.0.0.1:10911"});
+
+        Assert.assertTrue(commandLine.hasOption('b'));
+        Assert.assertFalse(commandLine.hasOption('c'));
+    }
+
+    @Test
+    public void testClusterTargetOption() throws ParseException {
+        DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+        Options options = command.buildCommandlineOptions(new Options());
+
+        CommandLine commandLine = new DefaultParser().parse(options,
+            new String[] {"-g", "GroupName", "-t", "TopicName", "-c", "DefaultCluster"});
+
+        Assert.assertFalse(commandLine.hasOption('b'));
+        Assert.assertTrue(commandLine.hasOption('c'));
+    }
+
+    @Test
+    public void testTargetIsRequired() {
+        DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+        Options options = command.buildCommandlineOptions(new Options());
+
+        try {
+            new DefaultParser().parse(options, new String[] {"-g", "GroupName", "-t", "TopicName"});
+            Assert.fail("Expected a ParseException when no broker or cluster is specified");
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTargetsAreMutuallyExclusive() {
+        DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+        Options options = command.buildCommandlineOptions(new Options());
+
+        try {
+            new DefaultParser().parse(options, new String[] {
+                "-g", "GroupName", "-t", "TopicName", "-b", "127.0.0.1:10911", "-c", "DefaultCluster"
+            });
+            Assert.fail("Expected a ParseException when both broker and cluster are specified");
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testExecuteByBrokerAddress() throws Exception {
+        ServerResponseMocker brokerMocker = ServerResponseMocker.startServer(new byte[0]);
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(output));
+        try {
+            DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+            Options options = ServerUtil.buildCommandlineOptions(new Options());
+            String brokerAddress = "127.0.0.1:" + brokerMocker.listenPort();
+            CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + command.commandName(),
+                new String[] {"-g", "GroupName", "-t", "TopicName", "-b", brokerAddress},
+                command.buildCommandlineOptions(options), new DefaultParser());
+
+            command.execute(commandLine, options, null);
+
+            Assert.assertTrue(output.toString().contains(
+                "delete consumer offset for group [GroupName] and topic [TopicName] from broker ["
+                    + brokerAddress + "] success."));
+        } finally {
+            System.setOut(originalOut);
+            brokerMocker.shutdown();
+        }
+    }
+
+    @Test
+    public void testExecuteByClusterName() throws Exception {
+        ServerResponseMocker brokerMocker = ServerResponseMocker.startServer(new byte[0]);
+        ServerResponseMocker nameServerMocker = startNameServer(brokerMocker.listenPort());
+        String originalNamesrvAddr = System.getProperty(MixAll.NAMESRV_ADDR_PROPERTY);
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(output));
+        System.setProperty(MixAll.NAMESRV_ADDR_PROPERTY, "127.0.0.1:" + nameServerMocker.listenPort());
+        try {
+            DeleteConsumerOffsetCommand command = new DeleteConsumerOffsetCommand();
+            Options options = ServerUtil.buildCommandlineOptions(new Options());
+            CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + command.commandName(),
+                new String[] {"-g", "GroupName", "-t", "TopicName", "-c", "MockCluster"},
+                command.buildCommandlineOptions(options), new DefaultParser());
+
+            command.execute(commandLine, options, null);
+
+            Assert.assertTrue(output.toString().contains(
+                "delete consumer offset for group [GroupName] and topic [TopicName] from broker [127.0.0.1:"
+                    + brokerMocker.listenPort() + "] in cluster [MockCluster] success."));
+        } finally {
+            if (originalNamesrvAddr == null) {
+                System.clearProperty(MixAll.NAMESRV_ADDR_PROPERTY);
+            } else {
+                System.setProperty(MixAll.NAMESRV_ADDR_PROPERTY, originalNamesrvAddr);
+            }
+            System.setOut(originalOut);
+            nameServerMocker.shutdown();
+            brokerMocker.shutdown();
+        }
+    }
+
+    private ServerResponseMocker startNameServer(int brokerPort) {
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("MockBroker");
+        brokerData.setCluster("MockCluster");
+        HashMap<Long, String> brokerAddresses = new HashMap<>();
+        brokerAddresses.put(MixAll.MASTER_ID, "127.0.0.1:" + brokerPort);
+        brokerData.setBrokerAddrs(brokerAddresses);
+
+        ClusterInfo clusterInfo = new ClusterInfo();
+        HashMap<String, BrokerData> brokerAddressTable = new HashMap<>();
+        brokerAddressTable.put("MockBroker", brokerData);
+        clusterInfo.setBrokerAddrTable(brokerAddressTable);
+        HashMap<String, Set<String>> clusterAddressTable = new HashMap<>();
+        Set<String> brokerNames = new HashSet<>();
+        brokerNames.add("MockBroker");
+        clusterAddressTable.put("MockCluster", brokerNames);
+        clusterInfo.setClusterAddrTable(clusterAddressTable);
+
+        return ServerResponseMocker.startServer(clusterInfo.encode());
+    }
+}


### PR DESCRIPTION
## Problem

A consumer group can accidentally consume a topic, but the current administration API only removes all offsets with the subscription group. Operators cannot clean up one group-topic relationship without affecting the group's progress on unrelated topics.

Closes #10114.

## Root cause

Consumer offsets are keyed by topic and group internally, but the broker protocol and mqadmin surface expose only group-wide removal. The precise storage operation was not wired through the broker, client, admin API, and CLI layers.

## Changes

- add a dedicated request code and ACL-aware request header for deleting one group-topic offset
- remove the exact key from normal, server-side reset, and pull offset tables, while using the existing persistent offset deletion path
- add broker-side blank resource validation and an idempotent success response
- expose the operation through MQClientAPIImpl, MQAdminExt, and DefaultMQAdminExt
- add the mqadmin deleteConsumerOffset command with required group/topic arguments and a mutually exclusive broker-or-cluster target
- handle a null broker response explicitly instead of relying on Java assertions
- cover exact-key isolation, broker validation/delegation, client success/failure/null responses, CLI parsing, and broker/cluster execution

## Impact

This adds an opt-in administration operation and does not change normal offset commits. It deletes only the selected topic@group offset and leaves the consumer group's offsets for other topics intact. Running consumers can commit the offset again, so operators should stop the affected consumer before cleanup when persistent removal is required.

## Validation

- mvn -pl broker,client,tools -am -DskipTests -Dspotbugs.skip=true compile
- mvn -pl broker,client,tools -am -DskipTests -Dspotbugs.skip=true test-compile
- ConsumerOffsetManagerTest#removeOffsetByGroupAndTopicTest
- AdminBrokerProcessorTest#testDeleteConsumerOffset and #testDeleteConsumerOffsetRejectsBlankResource
- MQClientAPIImplTest#testDeleteConsumerOffset, #testDeleteConsumerOffsetFail, and #testDeleteConsumerOffsetNullResponse
- DeleteConsumerOffsetCommandTest (8 tests, including direct broker and cluster execution)
- git diff --check

## Prior work

#10115 previously explored the same issue but was closed without merge. This PR reimplements the feature on current develop and adds explicit target validation, null-response handling, isolation checks, and broker/cluster command coverage.