### PR TITLE
[ISSUE #9725] Maintain heartbeat between Proxy and Broker

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/mqclient/MQClientAPIExt.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/mqclient/MQClientAPIExt.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.client.impl.mqclient;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -147,6 +148,26 @@ public class MQClientAPIExt extends MQClientAPIImpl {
             future.completeExceptionally(t);
         }
         return future;
+    }
+
+    /**
+     * Return active broker channels while excluding configured and discovered NameServer channels.
+     */
+    public Set<String> getActiveBrokerAddresses() {
+        List<String> activeChannelAddresses = this.getRemotingClient().getActiveChannelAddresses();
+        Set<String> activeAddresses = activeChannelAddresses == null
+            ? new HashSet<>() : new HashSet<>(activeChannelAddresses);
+        List<String> configuredNameServers = this.getRemotingClient().getNameServerAddressList();
+        if (configuredNameServers != null) {
+            activeAddresses.removeAll(configuredNameServers);
+        }
+        List<String> availableNameServers = this.getRemotingClient().getAvailableNameSrvList();
+        if (availableNameServers != null) {
+            activeAddresses.removeAll(availableNameServers);
+        }
+        activeAddresses.remove(null);
+        activeAddresses.remove("");
+        return activeAddresses;
     }
 
     public CompletableFuture<Integer> sendHeartbeatAsync(

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -164,6 +164,13 @@ public class ProxyConfig implements ConfigFile {
 
     private int rocketmqMQClientNum = 6;
 
+    /**
+     * Keep already established Proxy-to-Broker remoting channels alive during low-traffic periods.
+     */
+    private boolean enableProxyBrokerHeartbeat = true;
+    private long proxyBrokerHeartbeatIntervalMillis = Duration.ofSeconds(30).toMillis();
+    private long proxyBrokerHeartbeatTimeoutMillis = Duration.ofSeconds(3).toMillis();
+
     private long grpcProxyRelayRequestTimeoutInSeconds = 5;
     private int grpcProducerThreadPoolNums = PROCESSOR_NUMBER;
     private int grpcProducerThreadQueueCapacity = 10000;
@@ -296,6 +303,14 @@ public class ProxyConfig implements ConfigFile {
     @Override
     public void initData() {
         parseDelayLevel();
+        if (enableProxyBrokerHeartbeat && proxyBrokerHeartbeatIntervalMillis <= 0) {
+            throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR,
+                "proxyBrokerHeartbeatIntervalMillis must be greater than zero");
+        }
+        if (enableProxyBrokerHeartbeat && proxyBrokerHeartbeatTimeoutMillis <= 0) {
+            throw new ProxyException(ProxyExceptionCode.INTERNAL_SERVER_ERROR,
+                "proxyBrokerHeartbeatTimeoutMillis must be greater than zero");
+        }
         if (StringUtils.isBlank(localServeAddr)) {
             this.localServeAddr = NetworkUtil.getLocalAddress();
         }
@@ -737,6 +752,30 @@ public class ProxyConfig implements ConfigFile {
 
     public void setRocketmqMQClientNum(int rocketmqMQClientNum) {
         this.rocketmqMQClientNum = rocketmqMQClientNum;
+    }
+
+    public boolean isEnableProxyBrokerHeartbeat() {
+        return enableProxyBrokerHeartbeat;
+    }
+
+    public void setEnableProxyBrokerHeartbeat(boolean enableProxyBrokerHeartbeat) {
+        this.enableProxyBrokerHeartbeat = enableProxyBrokerHeartbeat;
+    }
+
+    public long getProxyBrokerHeartbeatIntervalMillis() {
+        return proxyBrokerHeartbeatIntervalMillis;
+    }
+
+    public void setProxyBrokerHeartbeatIntervalMillis(long proxyBrokerHeartbeatIntervalMillis) {
+        this.proxyBrokerHeartbeatIntervalMillis = proxyBrokerHeartbeatIntervalMillis;
+    }
+
+    public long getProxyBrokerHeartbeatTimeoutMillis() {
+        return proxyBrokerHeartbeatTimeoutMillis;
+    }
+
+    public void setProxyBrokerHeartbeatTimeoutMillis(long proxyBrokerHeartbeatTimeoutMillis) {
+        this.proxyBrokerHeartbeatTimeoutMillis = proxyBrokerHeartbeatTimeoutMillis;
     }
 
     public long getGrpcProxyRelayRequestTimeoutInSeconds() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/ClusterServiceManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/ClusterServiceManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.proxy.service;
 
+import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.broker.client.ClientChannelInfo;
@@ -73,6 +74,7 @@ public class ClusterServiceManager extends AbstractStartAndShutdown implements S
     protected MQClientAPIFactory operationClientAPIFactory;
     protected MQClientAPIFactory transactionClientAPIFactory;
     protected MQClientAPIFactory liteSubscriptionAPIFactory;
+    protected ProxyBrokerHeartbeatService proxyBrokerHeartbeatService;
 
     public ClusterServiceManager(RPCHook rpcHook) {
         this(rpcHook, null);
@@ -136,6 +138,11 @@ public class ClusterServiceManager extends AbstractStartAndShutdown implements S
             scheduledExecutorService);
         this.liteSubscriptionService = new LiteSubscriptionService(this.topicRouteService, this.liteSubscriptionAPIFactory);
 
+        this.proxyBrokerHeartbeatService = new ProxyBrokerHeartbeatService(
+            Arrays.asList(this.messagingClientAPIFactory, this.operationClientAPIFactory,
+                this.transactionClientAPIFactory, this.liteSubscriptionAPIFactory),
+            this.scheduledExecutorService, proxyConfig);
+
         this.init();
     }
 
@@ -156,6 +163,7 @@ public class ClusterServiceManager extends AbstractStartAndShutdown implements S
         this.appendStartAndShutdown(this.operationClientAPIFactory);
         this.appendStartAndShutdown(this.transactionClientAPIFactory);
         this.appendStartAndShutdown(this.liteSubscriptionAPIFactory);
+        this.appendStartAndShutdown(this.proxyBrokerHeartbeatService);
         this.appendStartAndShutdown(this.topicRouteService);
         this.appendStartAndShutdown(this.clusterTransactionService);
         this.appendStartAndShutdown(this.metadataService);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/ProxyBrokerHeartbeatService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/ProxyBrokerHeartbeatService.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
+import org.apache.rocketmq.client.impl.mqclient.MQClientAPIExt;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.utils.StartAndShutdown;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.remoting.protocol.heartbeat.HeartbeatData;
+
+/**
+ * Sends lightweight heartbeats over channels that Proxy clients have already established with brokers.
+ *
+ * <p>The service deliberately uses the active-channel snapshot instead of topic route data. It therefore never opens
+ * a connection merely to keep it alive and does not fan out to every broker in a large cluster.</p>
+ */
+public class ProxyBrokerHeartbeatService implements StartAndShutdown {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+    private static final String CLIENT_ID_PREFIX = "ProxyBrokerHeartbeat_";
+
+    private final List<MQClientAPIFactory> clientFactories;
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final boolean enabled;
+    private final long heartbeatIntervalMillis;
+    private final long heartbeatTimeoutMillis;
+    private final String clientId;
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean roundRunning = new AtomicBoolean();
+    private final AtomicReference<HeartbeatRoundStats> lastRoundStats =
+        new AtomicReference<>(HeartbeatRoundStats.empty());
+
+    private volatile ScheduledFuture<?> scheduledFuture;
+
+    public ProxyBrokerHeartbeatService(List<MQClientAPIFactory> clientFactories,
+        ScheduledExecutorService scheduledExecutorService, ProxyConfig proxyConfig) {
+        this(clientFactories, scheduledExecutorService, proxyConfig.isEnableProxyBrokerHeartbeat(),
+            proxyConfig.getProxyBrokerHeartbeatIntervalMillis(), proxyConfig.getProxyBrokerHeartbeatTimeoutMillis(),
+            CLIENT_ID_PREFIX + proxyConfig.getProxyName());
+    }
+
+    ProxyBrokerHeartbeatService(List<MQClientAPIFactory> clientFactories,
+        ScheduledExecutorService scheduledExecutorService, boolean enabled, long heartbeatIntervalMillis,
+        long heartbeatTimeoutMillis, String clientId) {
+        this.clientFactories = clientFactories == null
+            ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(clientFactories));
+        this.scheduledExecutorService = scheduledExecutorService;
+        this.enabled = enabled;
+        this.heartbeatIntervalMillis = heartbeatIntervalMillis;
+        this.heartbeatTimeoutMillis = heartbeatTimeoutMillis;
+        this.clientId = clientId;
+    }
+
+    @Override
+    public void start() {
+        if (!enabled || !started.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            this.scheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(
+                this::runHeartbeatRoundSafely,
+                heartbeatIntervalMillis,
+                heartbeatIntervalMillis,
+                TimeUnit.MILLISECONDS);
+        } catch (RuntimeException e) {
+            started.set(false);
+            throw e;
+        }
+        log.info("Proxy-to-Broker heartbeat service started. intervalMillis={}, timeoutMillis={}",
+            heartbeatIntervalMillis, heartbeatTimeoutMillis);
+    }
+
+    @Override
+    public void shutdown() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+        ScheduledFuture<?> future = this.scheduledFuture;
+        this.scheduledFuture = null;
+        if (future != null) {
+            future.cancel(false);
+        }
+        log.info("Proxy-to-Broker heartbeat service stopped");
+    }
+
+    void runHeartbeatRoundSafely() {
+        try {
+            runHeartbeatRound();
+        } catch (Throwable t) {
+            log.error("Unexpected error while sending Proxy-to-Broker heartbeats", t);
+        }
+    }
+
+    void runHeartbeatRound() {
+        if (!enabled) {
+            return;
+        }
+        if (!roundRunning.compareAndSet(false, true)) {
+            log.warn("Skip Proxy-to-Broker heartbeat round because the previous round is still running");
+            return;
+        }
+
+        long startTimestamp = System.currentTimeMillis();
+        MutableRoundStats stats = new MutableRoundStats();
+        try {
+            for (MQClientAPIFactory clientFactory : clientFactories) {
+                collectFactoryHeartbeats(clientFactory, stats);
+            }
+        } finally {
+            HeartbeatRoundStats snapshot = stats.snapshot(startTimestamp, System.currentTimeMillis());
+            lastRoundStats.set(snapshot);
+            roundRunning.set(false);
+            if (snapshot.getFailedHeartbeatCount() > 0 || snapshot.getFailedClientCount() > 0) {
+                log.warn("Proxy-to-Broker heartbeat round completed with failures. {}", snapshot);
+            } else {
+                log.debug("Proxy-to-Broker heartbeat round completed. {}", snapshot);
+            }
+        }
+    }
+
+    private void collectFactoryHeartbeats(MQClientAPIFactory clientFactory, MutableRoundStats stats) {
+        if (clientFactory == null) {
+            return;
+        }
+
+        final MQClientAPIExt[] clients;
+        try {
+            clients = clientFactory.getClients();
+        } catch (Throwable t) {
+            stats.failedClientCount++;
+            log.warn("Failed to get clients while preparing Proxy-to-Broker heartbeat", t);
+            return;
+        }
+        if (clients == null) {
+            return;
+        }
+
+        for (MQClientAPIExt client : clients) {
+            collectClientHeartbeats(client, stats);
+        }
+    }
+
+    private void collectClientHeartbeats(MQClientAPIExt client, MutableRoundStats stats) {
+        if (client == null) {
+            return;
+        }
+        stats.clientCount++;
+
+        final Set<String> brokerAddresses;
+        try {
+            brokerAddresses = client.getActiveBrokerAddresses();
+        } catch (Throwable t) {
+            stats.failedClientCount++;
+            log.warn("Failed to list active broker channels while preparing Proxy-to-Broker heartbeat", t);
+            return;
+        }
+        if (brokerAddresses == null || brokerAddresses.isEmpty()) {
+            return;
+        }
+
+        for (String brokerAddress : brokerAddresses) {
+            if (StringUtils.isBlank(brokerAddress)) {
+                continue;
+            }
+            sendHeartbeat(client, brokerAddress, stats);
+        }
+    }
+
+    private void sendHeartbeat(MQClientAPIExt client, String brokerAddress, MutableRoundStats stats) {
+        stats.attemptedHeartbeatCount++;
+        HeartbeatData heartbeatData = new HeartbeatData();
+        heartbeatData.setClientID(clientId);
+        try {
+            CompletableFuture<Void> future = client.sendHeartbeatOneway(
+                brokerAddress, heartbeatData, heartbeatTimeoutMillis);
+            if (future == null) {
+                stats.failedHeartbeatCount++;
+                log.warn("Failed to send Proxy-to-Broker heartbeat to {}: no completion future returned",
+                    brokerAddress);
+            } else if (future.isCompletedExceptionally()) {
+                stats.failedHeartbeatCount++;
+                future.whenComplete((result, throwable) ->
+                    log.warn("Failed to send Proxy-to-Broker heartbeat to {}", brokerAddress, throwable));
+            } else {
+                stats.successfulHeartbeatCount++;
+            }
+        } catch (Throwable t) {
+            stats.failedHeartbeatCount++;
+            log.warn("Failed to send Proxy-to-Broker heartbeat to {}", brokerAddress, t);
+        }
+    }
+
+    HeartbeatRoundStats getLastRoundStats() {
+        return lastRoundStats.get();
+    }
+
+    boolean isStarted() {
+        return started.get();
+    }
+
+    boolean isRoundRunning() {
+        return roundRunning.get();
+    }
+
+    static class HeartbeatRoundStats {
+        private final long startTimestamp;
+        private final long finishTimestamp;
+        private final int clientCount;
+        private final int failedClientCount;
+        private final int attemptedHeartbeatCount;
+        private final int successfulHeartbeatCount;
+        private final int failedHeartbeatCount;
+
+        HeartbeatRoundStats(long startTimestamp, long finishTimestamp, int clientCount, int failedClientCount,
+            int attemptedHeartbeatCount, int successfulHeartbeatCount, int failedHeartbeatCount) {
+            this.startTimestamp = startTimestamp;
+            this.finishTimestamp = finishTimestamp;
+            this.clientCount = clientCount;
+            this.failedClientCount = failedClientCount;
+            this.attemptedHeartbeatCount = attemptedHeartbeatCount;
+            this.successfulHeartbeatCount = successfulHeartbeatCount;
+            this.failedHeartbeatCount = failedHeartbeatCount;
+        }
+
+        static HeartbeatRoundStats empty() {
+            return new HeartbeatRoundStats(0, 0, 0, 0, 0, 0, 0);
+        }
+
+        public long getStartTimestamp() {
+            return startTimestamp;
+        }
+
+        public long getFinishTimestamp() {
+            return finishTimestamp;
+        }
+
+        public long getElapsedMillis() {
+            return Math.max(0, finishTimestamp - startTimestamp);
+        }
+
+        public int getClientCount() {
+            return clientCount;
+        }
+
+        public int getFailedClientCount() {
+            return failedClientCount;
+        }
+
+        public int getAttemptedHeartbeatCount() {
+            return attemptedHeartbeatCount;
+        }
+
+        public int getSuccessfulHeartbeatCount() {
+            return successfulHeartbeatCount;
+        }
+
+        public int getFailedHeartbeatCount() {
+            return failedHeartbeatCount;
+        }
+
+        @Override
+        public String toString() {
+            return "HeartbeatRoundStats{" +
+                "elapsedMillis=" + getElapsedMillis() +
+                ", clientCount=" + clientCount +
+                ", failedClientCount=" + failedClientCount +
+                ", attemptedHeartbeatCount=" + attemptedHeartbeatCount +
+                ", successfulHeartbeatCount=" + successfulHeartbeatCount +
+                ", failedHeartbeatCount=" + failedHeartbeatCount +
+                '}';
+        }
+    }
+
+    private static class MutableRoundStats {
+        private int clientCount;
+        private int failedClientCount;
+        private int attemptedHeartbeatCount;
+        private int successfulHeartbeatCount;
+        private int failedHeartbeatCount;
+
+        private HeartbeatRoundStats snapshot(long startTimestamp, long finishTimestamp) {
+            return new HeartbeatRoundStats(startTimestamp, finishTimestamp, clientCount, failedClientCount,
+                attemptedHeartbeatCount, successfulHeartbeatCount, failedHeartbeatCount);
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyBrokerHeartbeatConfigTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyBrokerHeartbeatConfigTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.config;
+
+import java.time.Duration;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProxyBrokerHeartbeatConfigTest {
+
+    @Test
+    public void testHeartbeatDefaultsKeepIdleBrokerChannelsAlive() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+
+        assertTrue(proxyConfig.isEnableProxyBrokerHeartbeat());
+        assertEquals(Duration.ofSeconds(30).toMillis(),
+            proxyConfig.getProxyBrokerHeartbeatIntervalMillis());
+        assertEquals(Duration.ofSeconds(3).toMillis(),
+            proxyConfig.getProxyBrokerHeartbeatTimeoutMillis());
+    }
+
+    @Test
+    public void testHeartbeatConfigurationSetters() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+
+        proxyConfig.setEnableProxyBrokerHeartbeat(false);
+        proxyConfig.setProxyBrokerHeartbeatIntervalMillis(45_000);
+        proxyConfig.setProxyBrokerHeartbeatTimeoutMillis(5_000);
+
+        assertFalse(proxyConfig.isEnableProxyBrokerHeartbeat());
+        assertEquals(45_000, proxyConfig.getProxyBrokerHeartbeatIntervalMillis());
+        assertEquals(5_000, proxyConfig.getProxyBrokerHeartbeatTimeoutMillis());
+    }
+
+    @Test
+    public void testEnabledHeartbeatRejectsZeroInterval() {
+        ProxyConfig proxyConfig = validProxyConfig();
+        proxyConfig.setProxyBrokerHeartbeatIntervalMillis(0);
+
+        assertThatThrownBy(proxyConfig::initData)
+            .hasMessageContaining("proxyBrokerHeartbeatIntervalMillis must be greater than zero");
+    }
+
+    @Test
+    public void testEnabledHeartbeatRejectsNegativeInterval() {
+        ProxyConfig proxyConfig = validProxyConfig();
+        proxyConfig.setProxyBrokerHeartbeatIntervalMillis(-1);
+
+        assertThatThrownBy(proxyConfig::initData)
+            .hasMessageContaining("proxyBrokerHeartbeatIntervalMillis must be greater than zero");
+    }
+
+    @Test
+    public void testEnabledHeartbeatRejectsZeroTimeout() {
+        ProxyConfig proxyConfig = validProxyConfig();
+        proxyConfig.setProxyBrokerHeartbeatTimeoutMillis(0);
+
+        assertThatThrownBy(proxyConfig::initData)
+            .hasMessageContaining("proxyBrokerHeartbeatTimeoutMillis must be greater than zero");
+    }
+
+    @Test
+    public void testEnabledHeartbeatRejectsNegativeTimeout() {
+        ProxyConfig proxyConfig = validProxyConfig();
+        proxyConfig.setProxyBrokerHeartbeatTimeoutMillis(-1);
+
+        assertThatThrownBy(proxyConfig::initData)
+            .hasMessageContaining("proxyBrokerHeartbeatTimeoutMillis must be greater than zero");
+    }
+
+    @Test
+    public void testDisabledHeartbeatAllowsUnusedTimingValues() {
+        ProxyConfig proxyConfig = validProxyConfig();
+        proxyConfig.setEnableProxyBrokerHeartbeat(false);
+        proxyConfig.setProxyBrokerHeartbeatIntervalMillis(0);
+        proxyConfig.setProxyBrokerHeartbeatTimeoutMillis(0);
+
+        proxyConfig.initData();
+
+        assertFalse(proxyConfig.isEnableProxyBrokerHeartbeat());
+    }
+
+    private ProxyConfig validProxyConfig() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+        proxyConfig.setLocalServeAddr("127.0.0.1");
+        return proxyConfig;
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/ProxyBrokerHeartbeatServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/ProxyBrokerHeartbeatServiceTest.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
+import org.apache.rocketmq.client.impl.mqclient.MQClientAPIExt;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+import org.apache.rocketmq.remoting.protocol.heartbeat.HeartbeatData;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ProxyBrokerHeartbeatServiceTest {
+    private static final String BROKER_ONE = "127.0.0.1:10911";
+    private static final String BROKER_TWO = "127.0.0.2:10911";
+    private static final String CLIENT_ID = "ProxyBrokerHeartbeat_test-proxy";
+    private static final long INTERVAL_MILLIS = 30_000;
+    private static final long TIMEOUT_MILLIS = 3_000;
+
+    @Test
+    public void testDisabledServiceDoesNotScheduleOrRun() {
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        MQClientAPIExt client = clientWithAddresses(BROKER_ONE);
+        ProxyBrokerHeartbeatService service = service(
+            Collections.singletonList(factoryWithClients(client)), scheduler, false);
+
+        service.start();
+        service.runHeartbeatRound();
+        service.shutdown();
+
+        assertFalse(service.isStarted());
+        assertThat(service.getLastRoundStats().getStartTimestamp()).isZero();
+        verify(scheduler, never()).scheduleWithFixedDelay(
+            any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        verify(client, never()).sendHeartbeatOneway(anyString(), any(HeartbeatData.class), anyLong());
+    }
+
+    @Test
+    public void testStartSchedulesHeartbeatWithConfiguredTiming() {
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
+        MQClientAPIExt client = clientWithAddresses(BROKER_ONE);
+        doReturn(completedHeartbeat()).when(client).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        doReturn(scheduledFuture).when(scheduler).scheduleWithFixedDelay(
+            any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        ProxyBrokerHeartbeatService service = service(
+            Collections.singletonList(factoryWithClients(client)), scheduler, true);
+
+        service.start();
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).scheduleWithFixedDelay(taskCaptor.capture(), eq(INTERVAL_MILLIS),
+            eq(INTERVAL_MILLIS), eq(TimeUnit.MILLISECONDS));
+        assertTrue(service.isStarted());
+
+        taskCaptor.getValue().run();
+
+        verify(client).sendHeartbeatOneway(eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        assertThat(service.getLastRoundStats().getSuccessfulHeartbeatCount()).isOne();
+    }
+
+    @Test
+    public void testStartAndShutdownAreIdempotent() {
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
+        doReturn(scheduledFuture).when(scheduler).scheduleWithFixedDelay(
+            any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        ProxyBrokerHeartbeatService service = service(Collections.emptyList(), scheduler, true);
+
+        service.start();
+        service.start();
+
+        verify(scheduler, times(1)).scheduleWithFixedDelay(
+            any(Runnable.class), anyLong(), anyLong(), eq(TimeUnit.MILLISECONDS));
+
+        service.shutdown();
+        service.shutdown();
+
+        assertFalse(service.isStarted());
+        verify(scheduledFuture, times(1)).cancel(false);
+    }
+
+    @Test
+    public void testStartResetsStateWhenSchedulerRejectsTask() {
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        doThrow(new RejectedExecutionException("scheduler stopped")).when(scheduler).scheduleWithFixedDelay(
+            any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        ProxyBrokerHeartbeatService service = service(Collections.emptyList(), scheduler, true);
+
+        assertThatThrownBy(service::start).isInstanceOf(RejectedExecutionException.class);
+
+        assertFalse(service.isStarted());
+    }
+
+    @Test
+    public void testSuccessfulRoundCoversEveryActiveChannel() {
+        MQClientAPIExt firstClient = clientWithAddresses(BROKER_ONE, BROKER_TWO);
+        MQClientAPIExt secondClient = clientWithAddresses("127.0.0.3:10911");
+        doReturn(completedHeartbeat()).when(firstClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        doReturn(completedHeartbeat()).when(secondClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = service(Arrays.asList(
+            factoryWithClients(firstClient), factoryWithClients(secondClient)),
+            mock(ScheduledExecutorService.class), true);
+
+        service.runHeartbeatRound();
+
+        ArgumentCaptor<String> addressCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<HeartbeatData> heartbeatCaptor = ArgumentCaptor.forClass(HeartbeatData.class);
+        verify(firstClient, times(2)).sendHeartbeatOneway(addressCaptor.capture(), heartbeatCaptor.capture(),
+            eq(TIMEOUT_MILLIS));
+        assertThat(addressCaptor.getAllValues()).containsExactlyInAnyOrder(BROKER_ONE, BROKER_TWO);
+        assertThat(heartbeatCaptor.getAllValues()).allSatisfy(
+            heartbeatData -> assertThat(heartbeatData.getClientID()).isEqualTo(CLIENT_ID));
+        verify(secondClient).sendHeartbeatOneway(eq("127.0.0.3:10911"), any(HeartbeatData.class),
+            eq(TIMEOUT_MILLIS));
+
+        ProxyBrokerHeartbeatService.HeartbeatRoundStats stats = service.getLastRoundStats();
+        assertThat(stats.getClientCount()).isEqualTo(2);
+        assertThat(stats.getFailedClientCount()).isZero();
+        assertThat(stats.getAttemptedHeartbeatCount()).isEqualTo(3);
+        assertThat(stats.getSuccessfulHeartbeatCount()).isEqualTo(3);
+        assertThat(stats.getFailedHeartbeatCount()).isZero();
+        assertThat(stats.getFinishTimestamp()).isGreaterThanOrEqualTo(stats.getStartTimestamp());
+        assertThat(stats.getElapsedMillis()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    public void testSameAddressOnSeparateClientsKeepsBothPhysicalChannelsAlive() {
+        MQClientAPIExt firstClient = clientWithAddresses(BROKER_ONE);
+        MQClientAPIExt secondClient = clientWithAddresses(BROKER_ONE);
+        doReturn(completedHeartbeat()).when(firstClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        doReturn(completedHeartbeat()).when(secondClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = service(
+            Collections.singletonList(factoryWithClients(firstClient, secondClient)),
+            mock(ScheduledExecutorService.class), true);
+
+        service.runHeartbeatRound();
+
+        verify(firstClient).sendHeartbeatOneway(eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        verify(secondClient).sendHeartbeatOneway(eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        assertThat(service.getLastRoundStats().getAttemptedHeartbeatCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testHeartbeatFailuresAreCountedAndDoNotStopRound() {
+        String exceptionalBroker = "127.0.0.3:10911";
+        String nullFutureBroker = "127.0.0.4:10911";
+        String throwingBroker = "127.0.0.5:10911";
+        MQClientAPIExt client = clientWithAddresses(
+            BROKER_ONE, exceptionalBroker, nullFutureBroker, throwingBroker, BROKER_TWO);
+        CompletableFuture<Void> failedHeartbeat = new CompletableFuture<>();
+        failedHeartbeat.completeExceptionally(new IllegalStateException("send failed"));
+        doAnswer(invocation -> {
+            String address = invocation.getArgument(0);
+            if (exceptionalBroker.equals(address)) {
+                return failedHeartbeat;
+            }
+            if (nullFutureBroker.equals(address)) {
+                return null;
+            }
+            if (throwingBroker.equals(address)) {
+                throw new IllegalStateException("invoke failed");
+            }
+            return completedHeartbeat();
+        }).when(client).sendHeartbeatOneway(anyString(), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        ProxyBrokerHeartbeatService service = service(
+            Collections.singletonList(factoryWithClients(client)), mock(ScheduledExecutorService.class), true);
+
+        service.runHeartbeatRound();
+
+        verify(client, times(5)).sendHeartbeatOneway(anyString(), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        ProxyBrokerHeartbeatService.HeartbeatRoundStats stats = service.getLastRoundStats();
+        assertThat(stats.getAttemptedHeartbeatCount()).isEqualTo(5);
+        assertThat(stats.getSuccessfulHeartbeatCount()).isEqualTo(2);
+        assertThat(stats.getFailedHeartbeatCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void testClientDiscoveryFailureDoesNotBlockOtherClients() {
+        MQClientAPIExt failedClient = mock(MQClientAPIExt.class);
+        doThrow(new IllegalStateException("channel table unavailable"))
+            .when(failedClient).getActiveBrokerAddresses();
+        MQClientAPIExt healthyClient = clientWithAddresses(BROKER_ONE);
+        doReturn(completedHeartbeat()).when(healthyClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = service(
+            Collections.singletonList(factoryWithClients(failedClient, healthyClient)),
+            mock(ScheduledExecutorService.class), true);
+
+        service.runHeartbeatRound();
+
+        verify(healthyClient).sendHeartbeatOneway(eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        ProxyBrokerHeartbeatService.HeartbeatRoundStats stats = service.getLastRoundStats();
+        assertThat(stats.getClientCount()).isEqualTo(2);
+        assertThat(stats.getFailedClientCount()).isOne();
+        assertThat(stats.getSuccessfulHeartbeatCount()).isOne();
+    }
+
+    @Test
+    public void testFactoryFailureDoesNotBlockOtherFactories() {
+        MQClientAPIFactory failedFactory = mock(MQClientAPIFactory.class);
+        doThrow(new IllegalStateException("factory unavailable")).when(failedFactory).getClients();
+        MQClientAPIExt healthyClient = clientWithAddresses(BROKER_ONE);
+        doReturn(completedHeartbeat()).when(healthyClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = service(
+            Arrays.asList(failedFactory, factoryWithClients(healthyClient)),
+            mock(ScheduledExecutorService.class), true);
+
+        service.runHeartbeatRound();
+
+        verify(healthyClient).sendHeartbeatOneway(eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        ProxyBrokerHeartbeatService.HeartbeatRoundStats stats = service.getLastRoundStats();
+        assertThat(stats.getClientCount()).isOne();
+        assertThat(stats.getFailedClientCount()).isOne();
+        assertThat(stats.getSuccessfulHeartbeatCount()).isOne();
+    }
+
+    @Test
+    public void testNullAndBlankDiscoveryEntriesAreIgnored() {
+        MQClientAPIFactory nullClientsFactory = mock(MQClientAPIFactory.class);
+        doReturn(null).when(nullClientsFactory).getClients();
+        MQClientAPIExt client = clientWithAddresses(null, "", "   ", BROKER_ONE);
+        doReturn(completedHeartbeat()).when(client).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = service(
+            Arrays.asList(null, nullClientsFactory, factoryWithClients(null, client)),
+            mock(ScheduledExecutorService.class), true);
+
+        service.runHeartbeatRound();
+
+        verify(client, times(1)).sendHeartbeatOneway(
+            eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+        assertThat(service.getLastRoundStats().getClientCount()).isOne();
+        assertThat(service.getLastRoundStats().getAttemptedHeartbeatCount()).isOne();
+    }
+
+    @Test
+    public void testOverlappingRoundIsSkipped() throws Exception {
+        CountDownLatch discoveryStarted = new CountDownLatch(1);
+        CountDownLatch continueDiscovery = new CountDownLatch(1);
+        MQClientAPIExt slowClient = mock(MQClientAPIExt.class);
+        doAnswer(invocation -> {
+            discoveryStarted.countDown();
+            if (!continueDiscovery.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("test timed out waiting to continue discovery");
+            }
+            return Collections.singleton(BROKER_ONE);
+        }).when(slowClient).getActiveBrokerAddresses();
+        doReturn(completedHeartbeat()).when(slowClient).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = service(
+            Collections.singletonList(factoryWithClients(slowClient)),
+            mock(ScheduledExecutorService.class), true);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<?> firstRound = executorService.submit(service::runHeartbeatRound);
+            assertTrue(discoveryStarted.await(5, TimeUnit.SECONDS));
+            assertTrue(service.isRoundRunning());
+
+            service.runHeartbeatRound();
+
+            verify(slowClient, times(1)).getActiveBrokerAddresses();
+            continueDiscovery.countDown();
+            firstRound.get(5, TimeUnit.SECONDS);
+        } finally {
+            continueDiscovery.countDown();
+            executorService.shutdownNow();
+        }
+
+        assertFalse(service.isRoundRunning());
+        verify(slowClient, times(1)).sendHeartbeatOneway(
+            eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+    }
+
+    @Test
+    public void testSafeRunnerContainsUnexpectedFailure() {
+        ProxyBrokerHeartbeatService service = new ProxyBrokerHeartbeatService(
+            Collections.emptyList(), mock(ScheduledExecutorService.class), true,
+            INTERVAL_MILLIS, TIMEOUT_MILLIS, CLIENT_ID) {
+            @Override
+            void runHeartbeatRound() {
+                throw new AssertionError("unexpected failure");
+            }
+        };
+
+        service.runHeartbeatRoundSafely();
+    }
+
+    @Test
+    public void testPublicConstructorUsesConfiguredProxyIdentity() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+        proxyConfig.setProxyName("proxy-a");
+        proxyConfig.setEnableProxyBrokerHeartbeat(true);
+        proxyConfig.setProxyBrokerHeartbeatIntervalMillis(45_000);
+        proxyConfig.setProxyBrokerHeartbeatTimeoutMillis(5_000);
+        MQClientAPIExt client = clientWithAddresses(BROKER_ONE);
+        doReturn(completedHeartbeat()).when(client).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        ProxyBrokerHeartbeatService service = new ProxyBrokerHeartbeatService(
+            Collections.singletonList(factoryWithClients(client)),
+            mock(ScheduledExecutorService.class), proxyConfig);
+
+        service.runHeartbeatRound();
+
+        ArgumentCaptor<HeartbeatData> heartbeatCaptor = ArgumentCaptor.forClass(HeartbeatData.class);
+        verify(client).sendHeartbeatOneway(eq(BROKER_ONE), heartbeatCaptor.capture(), eq(5_000L));
+        assertThat(heartbeatCaptor.getValue().getClientID()).isEqualTo("ProxyBrokerHeartbeat_proxy-a");
+    }
+
+    @Test
+    public void testConstructorTakesDefensiveFactorySnapshot() {
+        MQClientAPIExt client = clientWithAddresses(BROKER_ONE);
+        doReturn(completedHeartbeat()).when(client).sendHeartbeatOneway(
+            anyString(), any(HeartbeatData.class), anyLong());
+        MQClientAPIFactory factory = factoryWithClients(client);
+        List<MQClientAPIFactory> mutableFactories = new ArrayList<>();
+        mutableFactories.add(factory);
+        ProxyBrokerHeartbeatService service = service(
+            mutableFactories, mock(ScheduledExecutorService.class), true);
+
+        mutableFactories.clear();
+        service.runHeartbeatRound();
+
+        verify(factory).getClients();
+        verify(client).sendHeartbeatOneway(eq(BROKER_ONE), any(HeartbeatData.class), eq(TIMEOUT_MILLIS));
+    }
+
+    @Test
+    public void testRoundStatsDescribeFailuresForOperationalLogs() {
+        ProxyBrokerHeartbeatService.HeartbeatRoundStats stats =
+            new ProxyBrokerHeartbeatService.HeartbeatRoundStats(100, 125, 4, 1, 3, 2, 1);
+
+        assertThat(stats.getElapsedMillis()).isEqualTo(25);
+        assertThat(stats.toString())
+            .contains("elapsedMillis=25")
+            .contains("clientCount=4")
+            .contains("failedClientCount=1")
+            .contains("attemptedHeartbeatCount=3")
+            .contains("successfulHeartbeatCount=2")
+            .contains("failedHeartbeatCount=1");
+    }
+
+    private ProxyBrokerHeartbeatService service(List<MQClientAPIFactory> factories,
+        ScheduledExecutorService scheduler, boolean enabled) {
+        return new ProxyBrokerHeartbeatService(factories, scheduler, enabled,
+            INTERVAL_MILLIS, TIMEOUT_MILLIS, CLIENT_ID);
+    }
+
+    private MQClientAPIFactory factoryWithClients(MQClientAPIExt... clients) {
+        MQClientAPIFactory factory = mock(MQClientAPIFactory.class);
+        doReturn(clients).when(factory).getClients();
+        return factory;
+    }
+
+    private MQClientAPIExt clientWithAddresses(String... addresses) {
+        MQClientAPIExt client = mock(MQClientAPIExt.class);
+        Set<String> addressSet = new LinkedHashSet<>(Arrays.asList(addresses));
+        doReturn(addressSet).when(client).getActiveBrokerAddresses();
+        return client;
+    }
+
+    private CompletableFuture<Void> completedHeartbeat() {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/mqclient/MQClientAPIExtTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/mqclient/MQClientAPIExtTest.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -120,6 +122,39 @@ public class MQClientAPIExtTest {
         doReturn(future).when(remotingClient).invoke(anyString(), any(RemotingCommand.class), anyLong());
 
         assertNotNull(mqClientAPI.sendHeartbeatAsync(BROKER_ADDR, new HeartbeatData(), TIMEOUT).get());
+    }
+
+    @Test
+    public void testGetActiveBrokerAddressesExcludesNameServerChannels() {
+        String configuredNameServer = "127.0.0.1:9876";
+        String discoveredNameServer = "127.0.0.2:9876";
+        String secondBroker = "127.0.0.2:10911";
+        doReturn(Arrays.asList(BROKER_ADDR, secondBroker, configuredNameServer, discoveredNameServer, null, ""))
+            .when(remotingClient).getActiveChannelAddresses();
+        doReturn(Collections.singletonList(configuredNameServer)).when(remotingClient).getNameServerAddressList();
+        doReturn(Collections.singletonList(discoveredNameServer)).when(remotingClient).getAvailableNameSrvList();
+
+        Set<String> activeBrokerAddresses = mqClientAPI.getActiveBrokerAddresses();
+
+        assertEquals(2, activeBrokerAddresses.size());
+        assertTrue(activeBrokerAddresses.contains(BROKER_ADDR));
+        assertTrue(activeBrokerAddresses.contains(secondBroker));
+    }
+
+    @Test
+    public void testGetActiveBrokerAddressesHandlesMissingNameServerLists() {
+        doReturn(Collections.singletonList(BROKER_ADDR)).when(remotingClient).getActiveChannelAddresses();
+        doReturn(null).when(remotingClient).getNameServerAddressList();
+        doReturn(null).when(remotingClient).getAvailableNameSrvList();
+
+        assertEquals(Collections.singleton(BROKER_ADDR), mqClientAPI.getActiveBrokerAddresses());
+    }
+
+    @Test
+    public void testGetActiveBrokerAddressesHandlesMissingActiveChannelSnapshot() {
+        doReturn(null).when(remotingClient).getActiveChannelAddresses();
+
+        assertTrue(mqClientAPI.getActiveBrokerAddresses().isEmpty());
     }
 
     @Test

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/RemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/RemotingClient.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.remoting;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -34,6 +35,13 @@ public interface RemotingClient extends RemotingService {
     List<String> getNameServerAddressList();
 
     List<String> getAvailableNameSrvList();
+
+    /**
+     * Return a snapshot of remote addresses whose channels are currently active.
+     */
+    default List<String> getActiveChannelAddresses() {
+        return Collections.emptyList();
+    }
 
     RemotingCommand invokeSync(final String addr, final RemotingCommand request,
         final long timeoutMillis) throws InterruptedException, RemotingConnectException,

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -917,6 +917,18 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
     }
 
     @Override
+    public List<String> getActiveChannelAddresses() {
+        List<String> activeAddresses = new ArrayList<>();
+        for (Map.Entry<String, ChannelWrapper> entry : this.channelTables.entrySet()) {
+            ChannelWrapper channelWrapper = entry.getValue();
+            if (channelWrapper != null && channelWrapper.isOK()) {
+                activeAddresses.add(entry.getKey());
+            }
+        }
+        return activeAddresses;
+    }
+
+    @Override
     public ChannelEventListener getChannelEventListener() {
         return channelEventListener;
     }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingClientTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingClientTest.java
@@ -22,6 +22,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.local.LocalChannel;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -305,5 +307,28 @@ public class NettyRemotingClientTest {
         verify(bootstrap).connect(eq("0.0.0.0"), eq(8080));
         assertThat(remotingClient.isAddressReachable("[fe80::]:8080")).isFalse();
         verify(bootstrap).connect(eq("[fe80::]"), eq(8080));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetActiveChannelAddressesReturnsSnapshotOfHealthyChannels() throws Exception {
+        Field field = NettyRemotingClient.class.getDeclaredField("channelTables");
+        field.setAccessible(true);
+        ConcurrentMap<String, NettyRemotingClient.ChannelWrapper> channelTables =
+            (ConcurrentMap<String, NettyRemotingClient.ChannelWrapper>) field.get(remotingClient);
+
+        NettyRemotingClient.ChannelWrapper activeChannel = mock(NettyRemotingClient.ChannelWrapper.class);
+        NettyRemotingClient.ChannelWrapper inactiveChannel = mock(NettyRemotingClient.ChannelWrapper.class);
+        doReturn(true).when(activeChannel).isOK();
+        doReturn(false).when(inactiveChannel).isOK();
+        channelTables.put("127.0.0.1:10911", activeChannel);
+        channelTables.put("127.0.0.1:10912", inactiveChannel);
+
+        List<String> activeAddresses = remotingClient.getActiveChannelAddresses();
+
+        assertThat(activeAddresses).containsExactly("127.0.0.1:10911");
+        channelTables.clear();
+        assertThat(activeAddresses).containsExactly("127.0.0.1:10911");
+        assertThat(remotingClient.getActiveChannelAddresses()).isEmpty();
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #9725

### Brief Description

Proxy opens remoting channels to brokers on demand, but low-traffic channels can remain completely idle long enough to be closed. The next send or consume request then pays the connection re-establishment cost. The root cause is that Proxy has no lifecycle-managed keepalive for its already-established broker channels.

This change:

- exposes a backward-compatible snapshot API for active remoting channels;
- filters configured and discovered NameServer channels before heartbeat delivery;
- adds a lifecycle-managed Proxy-to-Broker heartbeat service covering messaging, operation, transaction, and lite-subscription clients;
- sends lightweight one-way heartbeats only over existing active broker channels, so it neither discovers nor connects to idle brokers;
- adds enable, interval, and timeout settings with startup validation;
- prevents overlapping rounds, isolates client/channel failures, and records per-round operational statistics.

The default 30-second interval is below the idle close window described in the issue. Existing custom `RemotingClient` implementations remain source/binary compatible through the default empty snapshot implementation.

### Impact

Low-traffic Proxy deployments retain broker connections that are already in use, avoiding avoidable latency spikes on the next request. NameServer connections are excluded, no broker-wide fan-out is introduced, and the behavior can be disabled or tuned through `ProxyConfig`.

### How Did You Test This Change?

Ran on JDK 8:

`mvn -pl proxy -am test -Dtest=ProxyBrokerHeartbeatServiceTest,ProxyBrokerHeartbeatConfigTest,MQClientAPIExtTest,NettyRemotingClientTest -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true -Djacoco.skip=true`

Result: 11-module reactor build successful; 46 targeted tests passed with 0 failures, 0 errors, and 0 skipped. Checkstyle reported 0 violations. The reviewed diff contains 10 files and 983 added lines.