### PR TITLE
[ISSUE #9698] Add scriptable cluster health checks

### DIFF
--- a/distribution/bin/mqhealthcheck
+++ b/distribution/bin/mqhealthcheck
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "$ROCKETMQ_HOME" ]; then
+  PRG="$0"
+  while [ -h "$PRG" ]; do
+    LS=`ls -ld "$PRG"`
+    LINK=`expr "$LS" : '.*-> \(.*\)$'`
+    if expr "$LINK" : '/.*' > /dev/null; then
+      PRG="$LINK"
+    else
+      PRG="`dirname "$PRG"`/$LINK"
+    fi
+  done
+
+  SAVED_DIR=`pwd`
+  ROCKETMQ_HOME=`dirname "$PRG"`/..
+  ROCKETMQ_HOME=`cd "$ROCKETMQ_HOME" && pwd`
+  cd "$SAVED_DIR" || exit 2
+fi
+
+export ROCKETMQ_HOME
+
+sh "${ROCKETMQ_HOME}/bin/tools.sh" \
+  -Drmq.logback.configurationFile="${ROCKETMQ_HOME}/conf/rmq.tools.logback.xml" \
+  org.apache.rocketmq.tools.command.MQHealthCheckStartup "$@"

--- a/distribution/bin/mqhealthcheck.cmd
+++ b/distribution/bin/mqhealthcheck.cmd
@@ -1,0 +1,19 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+if not exist "%ROCKETMQ_HOME%\bin\tools.cmd" echo Please set the ROCKETMQ_HOME variable in your environment! & EXIT /B 2
+call "%ROCKETMQ_HOME%\bin\tools.cmd" -Drmq.logback.configurationFile=%ROCKETMQ_HOME%\conf\rmq.tools.logback.xml org.apache.rocketmq.tools.command.MQHealthCheckStartup %*
+EXIT /B %ERRORLEVEL%

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -54,8 +54,9 @@ import org.apache.rocketmq.tools.command.broker.SendMsgStatusCommand;
 import org.apache.rocketmq.tools.command.broker.SwitchTimerEngineSubCommand;
 import org.apache.rocketmq.tools.command.broker.UpdateBrokerConfigSubCommand;
 import org.apache.rocketmq.tools.command.broker.UpdateColdDataFlowCtrGroupConfigSubCommand;
-import org.apache.rocketmq.tools.command.cluster.ClusterSendMsgRTCommand;
+import org.apache.rocketmq.tools.command.cluster.ClusterHealthSubCommand;
 import org.apache.rocketmq.tools.command.cluster.ClusterListSubCommand;
+import org.apache.rocketmq.tools.command.cluster.ClusterSendMsgRTCommand;
 import org.apache.rocketmq.tools.command.connection.ConsumerConnectionSubCommand;
 import org.apache.rocketmq.tools.command.connection.ProducerConnectionSubCommand;
 import org.apache.rocketmq.tools.command.consumer.ConsumerProgressSubCommand;
@@ -231,6 +232,7 @@ public class MQAdminStartup {
         initCommand(new ProducerSubCommand());
 
         initCommand(new ClusterListSubCommand());
+        initCommand(new ClusterHealthSubCommand());
         initCommand(new TopicListSubCommand());
 
         initCommand(new UpdateKvConfigCommand());

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQHealthCheckStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQHealthCheckStartup.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command;
+
+import java.io.PrintStream;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.acl.common.AclUtils;
+import org.apache.rocketmq.common.MQVersion;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.cluster.ClusterHealthReport;
+import org.apache.rocketmq.tools.command.cluster.ClusterHealthSubCommand;
+
+public class MQHealthCheckStartup {
+    public static final int EXIT_HEALTHY = 0;
+    public static final int EXIT_UNHEALTHY = 1;
+    public static final int EXIT_USAGE_OR_ERROR = 2;
+
+    public static void main(String[] args) {
+        int exitCode = main0(args, null, System.out, System.err);
+        System.exit(exitCode);
+    }
+
+    static int main0(String[] args, RPCHook rpcHook, PrintStream out, PrintStream err) {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, Integer.toString(MQVersion.CURRENT_VERSION));
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        options = command.buildCommandlineOptions(options);
+        try {
+            CommandLine commandLine = ServerUtil.parseCmdLine("mqhealthcheck", args, options, new DefaultParser());
+            if (commandLine == null) {
+                return EXIT_USAGE_OR_ERROR;
+            }
+            if (commandLine.hasOption('n')) {
+                System.setProperty(MixAll.NAMESRV_ADDR_PROPERTY, commandLine.getOptionValue('n'));
+            }
+            RPCHook effectiveHook = rpcHook == null ? loadAclHook() : rpcHook;
+            ClusterHealthSubCommand.OutputFormat format = command.outputFormat(commandLine);
+            ClusterHealthReport report = command.run(commandLine, effectiveHook);
+            command.printReport(report, format, out);
+            return report.isHealthy() ? EXIT_HEALTHY : EXIT_UNHEALTHY;
+        } catch (Exception e) {
+            err.println("mqhealthcheck failed: " + conciseMessage(e));
+            return EXIT_USAGE_OR_ERROR;
+        }
+    }
+
+    private static RPCHook loadAclHook() {
+        String home = MixAll.ROCKETMQ_HOME_DIR;
+        if (home == null) {
+            return null;
+        }
+        return AclUtils.getAclRPCHook(home + MixAll.ACL_CONF_TOOLS_FILE);
+    }
+
+    private static String conciseMessage(Throwable throwable) {
+        Throwable root = throwable;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        String message = root.getMessage();
+        return message == null || message.trim().isEmpty()
+            ? root.getClass().getSimpleName() : root.getClass().getSimpleName() + ": " + message;
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/BrokerHealthResult.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/BrokerHealthResult.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+public class BrokerHealthResult {
+    public enum Status {
+        HEALTHY,
+        UNHEALTHY
+    }
+
+    private String clusterName;
+    private String brokerName;
+    private long brokerId;
+    private String brokerAddr;
+    private Status status;
+    private String detail;
+    private long latencyMillis;
+    private String brokerVersion;
+    private Boolean brokerActive;
+
+    public static BrokerHealthResult healthy(BrokerTarget target, long latencyMillis,
+        String brokerVersion, Boolean brokerActive) {
+        BrokerHealthResult result = fromTarget(target);
+        result.setStatus(Status.HEALTHY);
+        result.setDetail("Broker runtime RPC succeeded");
+        result.setLatencyMillis(latencyMillis);
+        result.setBrokerVersion(brokerVersion);
+        result.setBrokerActive(brokerActive);
+        return result;
+    }
+
+    public static BrokerHealthResult unhealthy(BrokerTarget target, long latencyMillis, String detail) {
+        BrokerHealthResult result = fromTarget(target);
+        result.setStatus(Status.UNHEALTHY);
+        result.setDetail(detail);
+        result.setLatencyMillis(latencyMillis);
+        return result;
+    }
+
+    private static BrokerHealthResult fromTarget(BrokerTarget target) {
+        BrokerHealthResult result = new BrokerHealthResult();
+        result.setClusterName(target.getClusterName());
+        result.setBrokerName(target.getBrokerName());
+        result.setBrokerId(target.getBrokerId());
+        result.setBrokerAddr(target.getBrokerAddr());
+        return result;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public String getBrokerName() {
+        return brokerName;
+    }
+
+    public void setBrokerName(String brokerName) {
+        this.brokerName = brokerName;
+    }
+
+    public long getBrokerId() {
+        return brokerId;
+    }
+
+    public void setBrokerId(long brokerId) {
+        this.brokerId = brokerId;
+    }
+
+    public String getBrokerAddr() {
+        return brokerAddr;
+    }
+
+    public void setBrokerAddr(String brokerAddr) {
+        this.brokerAddr = brokerAddr;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+
+    public long getLatencyMillis() {
+        return latencyMillis;
+    }
+
+    public void setLatencyMillis(long latencyMillis) {
+        this.latencyMillis = latencyMillis;
+    }
+
+    public String getBrokerVersion() {
+        return brokerVersion;
+    }
+
+    public void setBrokerVersion(String brokerVersion) {
+        this.brokerVersion = brokerVersion;
+    }
+
+    public Boolean getBrokerActive() {
+        return brokerActive;
+    }
+
+    public void setBrokerActive(Boolean brokerActive) {
+        this.brokerActive = brokerActive;
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/BrokerTarget.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/BrokerTarget.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.util.Comparator;
+
+public class BrokerTarget {
+    public static final long UNKNOWN_BROKER_ID = -1L;
+    public static final String DIRECT_CLUSTER = "direct";
+    public static final String DIRECT_BROKER = "direct";
+
+    public static final Comparator<BrokerTarget> COMPARATOR = Comparator
+        .comparing(BrokerTarget::getClusterName)
+        .thenComparing(BrokerTarget::getBrokerName)
+        .thenComparingLong(BrokerTarget::getBrokerId)
+        .thenComparing(BrokerTarget::getBrokerAddr);
+
+    private final String clusterName;
+    private final String brokerName;
+    private final long brokerId;
+    private final String brokerAddr;
+
+    public BrokerTarget(String clusterName, String brokerName, long brokerId, String brokerAddr) {
+        this.clusterName = clusterName;
+        this.brokerName = brokerName;
+        this.brokerId = brokerId;
+        this.brokerAddr = brokerAddr;
+    }
+
+    public static BrokerTarget direct(String brokerAddr) {
+        return new BrokerTarget(DIRECT_CLUSTER, DIRECT_BROKER, UNKNOWN_BROKER_ID, brokerAddr);
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public String getBrokerName() {
+        return brokerName;
+    }
+
+    public long getBrokerId() {
+        return brokerId;
+    }
+
+    public String getBrokerAddr() {
+        return brokerAddr;
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthChecker.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthChecker.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+
+public class ClusterHealthChecker {
+    public interface AdminAccess {
+        ClusterInfo examineBrokerClusterInfo() throws Exception;
+
+        KVTable fetchBrokerRuntimeStats(String brokerAddr) throws Exception;
+    }
+
+    public static class DefaultAdminAccess implements AdminAccess {
+        private final DefaultMQAdminExt adminExt;
+
+        public DefaultAdminAccess(DefaultMQAdminExt adminExt) {
+            this.adminExt = adminExt;
+        }
+
+        @Override
+        public ClusterInfo examineBrokerClusterInfo() throws Exception {
+            return adminExt.examineBrokerClusterInfo();
+        }
+
+        @Override
+        public KVTable fetchBrokerRuntimeStats(String brokerAddr) throws Exception {
+            return adminExt.fetchBrokerRuntimeStats(brokerAddr);
+        }
+    }
+
+    private final AdminAccess adminAccess;
+
+    public ClusterHealthChecker(AdminAccess adminAccess) {
+        this.adminAccess = adminAccess;
+    }
+
+    public ClusterHealthReport check(ClusterHealthRequest request) {
+        request.validate();
+        long begin = System.currentTimeMillis();
+        ClusterHealthReport report = new ClusterHealthReport();
+        report.setTimestamp(begin);
+        report.setTarget(request.describeTarget());
+
+        if (request.isDirectBrokerCheck()) {
+            checkDirectBroker(request, report);
+        } else {
+            checkThroughNameServer(request, report);
+        }
+
+        report.setDurationMillis(Math.max(0, System.currentTimeMillis() - begin));
+        report.complete();
+        return report;
+    }
+
+    private void checkDirectBroker(ClusterHealthRequest request, ClusterHealthReport report) {
+        report.setNameServerStatus(ClusterHealthReport.NameServerStatus.SKIPPED);
+        report.setNameServerDetail("Direct broker check");
+        BrokerTarget target = BrokerTarget.direct(request.getBrokerAddr());
+        report.setBrokers(Collections.singletonList(probe(target, request.isRequireActive())));
+    }
+
+    private void checkThroughNameServer(ClusterHealthRequest request, ClusterHealthReport report) {
+        ClusterInfo clusterInfo;
+        long begin = System.currentTimeMillis();
+        try {
+            clusterInfo = adminAccess.examineBrokerClusterInfo();
+            if (clusterInfo == null) {
+                throw new IllegalStateException("NameServer returned an empty cluster response");
+            }
+            report.setNameServerStatus(ClusterHealthReport.NameServerStatus.HEALTHY);
+            report.setNameServerDetail("Cluster metadata RPC succeeded in "
+                + Math.max(0, System.currentTimeMillis() - begin) + " ms");
+        } catch (Exception e) {
+            report.setNameServerStatus(ClusterHealthReport.NameServerStatus.UNHEALTHY);
+            report.setNameServerDetail(describeFailure(e));
+            report.setBrokers(Collections.emptyList());
+            return;
+        }
+
+        if (request.isNamesrvOnly()) {
+            report.setBrokers(Collections.emptyList());
+            return;
+        }
+
+        List<BrokerTarget> targets = selectTargets(clusterInfo, request);
+        if (targets.isEmpty()) {
+            report.setBrokers(Collections.emptyList());
+            report.markNoBrokers("No brokers matched " + request.describeTarget());
+            return;
+        }
+        report.setBrokers(probeAll(targets, request));
+    }
+
+    List<BrokerTarget> selectTargets(ClusterInfo clusterInfo, ClusterHealthRequest request) {
+        Map<String, Set<String>> clusterTable = clusterInfo.getClusterAddrTable();
+        Map<String, BrokerData> brokerTable = clusterInfo.getBrokerAddrTable();
+        if (clusterTable == null || brokerTable == null) {
+            return Collections.emptyList();
+        }
+
+        Set<String> requestedClusters = new HashSet<>();
+        if (hasText(request.getClusterName())) {
+            requestedClusters.add(request.getClusterName());
+        } else {
+            requestedClusters.addAll(clusterTable.keySet());
+        }
+
+        List<BrokerTarget> targets = new ArrayList<>();
+        Set<String> identities = new HashSet<>();
+        for (String clusterName : requestedClusters) {
+            Set<String> brokerNames = clusterTable.get(clusterName);
+            if (brokerNames == null) {
+                continue;
+            }
+            for (String brokerName : brokerNames) {
+                BrokerData brokerData = brokerTable.get(brokerName);
+                if (brokerData == null || brokerData.getBrokerAddrs() == null) {
+                    continue;
+                }
+                for (Map.Entry<Long, String> entry : brokerData.getBrokerAddrs().entrySet()) {
+                    if (request.isMastersOnly() && entry.getKey() != MixAll.MASTER_ID) {
+                        continue;
+                    }
+                    if (!hasText(entry.getValue())) {
+                        continue;
+                    }
+                    String identity = clusterName + '\u0000' + brokerName + '\u0000' + entry.getKey()
+                        + '\u0000' + entry.getValue();
+                    if (identities.add(identity)) {
+                        targets.add(new BrokerTarget(clusterName, brokerName, entry.getKey(), entry.getValue()));
+                    }
+                }
+            }
+        }
+        targets.sort(BrokerTarget.COMPARATOR);
+        return targets;
+    }
+
+    private List<BrokerHealthResult> probeAll(List<BrokerTarget> targets, ClusterHealthRequest request) {
+        int threadCount = Math.min(request.getParallelism(), targets.size());
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount, new HealthCheckThreadFactory());
+        CompletionService<BrokerHealthResult> completionService = new ExecutorCompletionService<>(executor);
+        List<Future<BrokerHealthResult>> futures = new ArrayList<>();
+        for (BrokerTarget target : targets) {
+            futures.add(completionService.submit(new ProbeTask(target, request.isRequireActive())));
+        }
+
+        List<BrokerHealthResult> results = new ArrayList<>();
+        long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(request.getTimeoutMillis());
+        try {
+            while (results.size() < targets.size()) {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    break;
+                }
+                Future<BrokerHealthResult> completed = completionService.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                if (completed == null) {
+                    break;
+                }
+                try {
+                    results.add(completed.get());
+                } catch (Exception e) {
+                    // ProbeTask converts broker failures into results. This branch only guards executor failures.
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            for (Future<BrokerHealthResult> future : futures) {
+                future.cancel(true);
+            }
+            executor.shutdownNow();
+        }
+
+        Set<String> completedAddresses = new HashSet<>();
+        for (BrokerHealthResult result : results) {
+            completedAddresses.add(identity(result));
+        }
+        for (BrokerTarget target : targets) {
+            if (!completedAddresses.contains(identity(target))) {
+                results.add(BrokerHealthResult.unhealthy(target, request.getTimeoutMillis(),
+                    "Health check timed out after " + request.getTimeoutMillis() + " ms"));
+            }
+        }
+        return results;
+    }
+
+    private BrokerHealthResult probe(BrokerTarget target, boolean requireActive) {
+        long begin = System.currentTimeMillis();
+        try {
+            KVTable runtime = adminAccess.fetchBrokerRuntimeStats(target.getBrokerAddr());
+            long latency = Math.max(0, System.currentTimeMillis() - begin);
+            if (runtime == null || runtime.getTable() == null || runtime.getTable().isEmpty()) {
+                return BrokerHealthResult.unhealthy(target, latency, "Broker returned an empty runtime response");
+            }
+
+            String brokerVersion = runtime.getTable().get("brokerVersionDesc");
+            Boolean brokerActive = parseBoolean(runtime.getTable().get("brokerActive"));
+            if (requireActive && !Boolean.TRUE.equals(brokerActive)) {
+                String detail = brokerActive == null
+                    ? "brokerActive is missing from the runtime response"
+                    : "brokerActive is false";
+                BrokerHealthResult result = BrokerHealthResult.unhealthy(target, latency, detail);
+                result.setBrokerVersion(brokerVersion);
+                result.setBrokerActive(brokerActive);
+                return result;
+            }
+            return BrokerHealthResult.healthy(target, latency, brokerVersion, brokerActive);
+        } catch (Exception e) {
+            return BrokerHealthResult.unhealthy(target,
+                Math.max(0, System.currentTimeMillis() - begin), describeFailure(e));
+        }
+    }
+
+    private static Boolean parseBoolean(String value) {
+        if (value == null) {
+            return null;
+        }
+        if ("true".equalsIgnoreCase(value)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return Boolean.FALSE;
+        }
+        return null;
+    }
+
+    private static String describeFailure(Throwable throwable) {
+        Throwable root = throwable;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        String message = root.getMessage();
+        if (!hasText(message)) {
+            return root.getClass().getSimpleName();
+        }
+        return root.getClass().getSimpleName() + ": " + message;
+    }
+
+    private static String identity(BrokerHealthResult result) {
+        return result.getClusterName() + '\u0000' + result.getBrokerName() + '\u0000'
+            + result.getBrokerId() + '\u0000' + result.getBrokerAddr();
+    }
+
+    private static String identity(BrokerTarget target) {
+        return target.getClusterName() + '\u0000' + target.getBrokerName() + '\u0000'
+            + target.getBrokerId() + '\u0000' + target.getBrokerAddr();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private class ProbeTask implements Callable<BrokerHealthResult> {
+        private final BrokerTarget target;
+        private final boolean requireActive;
+
+        private ProbeTask(BrokerTarget target, boolean requireActive) {
+            this.target = target;
+            this.requireActive = requireActive;
+        }
+
+        @Override
+        public BrokerHealthResult call() {
+            return probe(target, requireActive);
+        }
+    }
+
+    private static class HealthCheckThreadFactory implements ThreadFactory {
+        private final AtomicInteger counter = new AtomicInteger();
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "ClusterHealthCheck_" + counter.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthReport.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthReport.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
+
+public class ClusterHealthReport {
+    public enum Status {
+        HEALTHY,
+        UNHEALTHY
+    }
+
+    public enum NameServerStatus {
+        HEALTHY,
+        UNHEALTHY,
+        SKIPPED
+    }
+
+    private long timestamp;
+    private long durationMillis;
+    private String target;
+    private Status status;
+    private NameServerStatus nameServerStatus;
+    private String nameServerDetail;
+    private int totalBrokers;
+    private int healthyBrokers;
+    private int unhealthyBrokers;
+    private List<BrokerHealthResult> brokers = new ArrayList<>();
+
+    public void complete() {
+        List<BrokerHealthResult> safeBrokers = brokers == null ? new ArrayList<>() : brokers;
+        safeBrokers.sort(Comparator.comparing(BrokerHealthResult::getClusterName)
+            .thenComparing(BrokerHealthResult::getBrokerName)
+            .thenComparingLong(BrokerHealthResult::getBrokerId)
+            .thenComparing(BrokerHealthResult::getBrokerAddr));
+        brokers = safeBrokers;
+        totalBrokers = brokers.size();
+        healthyBrokers = 0;
+        unhealthyBrokers = 0;
+        for (BrokerHealthResult broker : brokers) {
+            if (BrokerHealthResult.Status.HEALTHY.equals(broker.getStatus())) {
+                healthyBrokers++;
+            } else {
+                unhealthyBrokers++;
+            }
+        }
+
+        boolean explicitlyUnhealthy = Status.UNHEALTHY.equals(status);
+        boolean nameServerHealthy = NameServerStatus.HEALTHY.equals(nameServerStatus)
+            || NameServerStatus.SKIPPED.equals(nameServerStatus);
+        status = !explicitlyUnhealthy && nameServerHealthy && unhealthyBrokers == 0
+            ? Status.HEALTHY : Status.UNHEALTHY;
+    }
+
+    public void markNoBrokers(String detail) {
+        status = Status.UNHEALTHY;
+        nameServerDetail = detail;
+    }
+
+    public boolean isHealthy() {
+        return Status.HEALTHY.equals(status);
+    }
+
+    public String toJson() {
+        return RemotingSerializable.toJson(this, true);
+    }
+
+    public String toText() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("STATUS       ").append(status).append(System.lineSeparator());
+        builder.append("TARGET       ").append(valueOrDash(target)).append(System.lineSeparator());
+        builder.append("NAMESERVER   ").append(nameServerStatus);
+        if (hasText(nameServerDetail)) {
+            builder.append(" (").append(singleLine(nameServerDetail)).append(')');
+        }
+        builder.append(System.lineSeparator());
+        builder.append("SUMMARY      ")
+            .append(healthyBrokers).append(" healthy, ")
+            .append(unhealthyBrokers).append(" unhealthy, ")
+            .append(totalBrokers).append(" total, ")
+            .append(durationMillis).append(" ms")
+            .append(System.lineSeparator());
+
+        if (!brokers.isEmpty()) {
+            builder.append(System.lineSeparator());
+            builder.append(String.format("%-16s %-24s %-5s %-22s %-10s %-8s %-16s %s%n",
+                "#Cluster", "#Broker", "#BID", "#Address", "#Status", "#RT(ms)", "#Version", "#Detail"));
+            for (BrokerHealthResult broker : brokers) {
+                builder.append(String.format("%-16s %-24s %-5d %-22s %-10s %-8d %-16s %s%n",
+                    valueOrDash(broker.getClusterName()),
+                    valueOrDash(broker.getBrokerName()),
+                    broker.getBrokerId(),
+                    valueOrDash(broker.getBrokerAddr()),
+                    broker.getStatus(),
+                    broker.getLatencyMillis(),
+                    valueOrDash(broker.getBrokerVersion()),
+                    singleLine(broker.getDetail())));
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String valueOrDash(String value) {
+        return hasText(value) ? value : "-";
+    }
+
+    private static String singleLine(String value) {
+        if (value == null) {
+            return "-";
+        }
+        return value.replace('\r', ' ').replace('\n', ' ');
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+
+    public void setDurationMillis(long durationMillis) {
+        this.durationMillis = durationMillis;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public NameServerStatus getNameServerStatus() {
+        return nameServerStatus;
+    }
+
+    public void setNameServerStatus(NameServerStatus nameServerStatus) {
+        this.nameServerStatus = nameServerStatus;
+    }
+
+    public String getNameServerDetail() {
+        return nameServerDetail;
+    }
+
+    public void setNameServerDetail(String nameServerDetail) {
+        this.nameServerDetail = nameServerDetail;
+    }
+
+    public int getTotalBrokers() {
+        return totalBrokers;
+    }
+
+    public void setTotalBrokers(int totalBrokers) {
+        this.totalBrokers = totalBrokers;
+    }
+
+    public int getHealthyBrokers() {
+        return healthyBrokers;
+    }
+
+    public void setHealthyBrokers(int healthyBrokers) {
+        this.healthyBrokers = healthyBrokers;
+    }
+
+    public int getUnhealthyBrokers() {
+        return unhealthyBrokers;
+    }
+
+    public void setUnhealthyBrokers(int unhealthyBrokers) {
+        this.unhealthyBrokers = unhealthyBrokers;
+    }
+
+    public List<BrokerHealthResult> getBrokers() {
+        return Collections.unmodifiableList(brokers);
+    }
+
+    public void setBrokers(List<BrokerHealthResult> brokers) {
+        this.brokers = brokers == null ? new ArrayList<>() : new ArrayList<>(brokers);
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthRequest.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthRequest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+public class ClusterHealthRequest {
+    public static final long DEFAULT_TIMEOUT_MILLIS = 3000L;
+    public static final int DEFAULT_PARALLELISM = 4;
+    public static final int MAX_PARALLELISM = 64;
+
+    private String brokerAddr;
+    private String clusterName;
+    private boolean namesrvOnly;
+    private boolean mastersOnly;
+    private boolean requireActive;
+    private long timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+    private int parallelism = DEFAULT_PARALLELISM;
+
+    public void validate() {
+        if (timeoutMillis <= 0) {
+            throw new IllegalArgumentException("timeoutMillis must be greater than zero");
+        }
+        if (parallelism <= 0 || parallelism > MAX_PARALLELISM) {
+            throw new IllegalArgumentException("parallelism must be between 1 and " + MAX_PARALLELISM);
+        }
+        if (hasText(brokerAddr) && hasText(clusterName)) {
+            throw new IllegalArgumentException("brokerAddr and clusterName cannot be used together");
+        }
+        if (hasText(brokerAddr) && namesrvOnly) {
+            throw new IllegalArgumentException("brokerAddr and namesrvOnly cannot be used together");
+        }
+        if (namesrvOnly && mastersOnly) {
+            throw new IllegalArgumentException("mastersOnly does not apply to a NameServer-only check");
+        }
+        if (namesrvOnly && requireActive) {
+            throw new IllegalArgumentException("requireActive does not apply to a NameServer-only check");
+        }
+    }
+
+    public boolean isDirectBrokerCheck() {
+        return hasText(brokerAddr);
+    }
+
+    public String describeTarget() {
+        if (isDirectBrokerCheck()) {
+            return "broker:" + brokerAddr;
+        }
+        if (namesrvOnly) {
+            return "nameserver";
+        }
+        if (hasText(clusterName)) {
+            return "cluster:" + clusterName;
+        }
+        return "all-clusters";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    public String getBrokerAddr() {
+        return brokerAddr;
+    }
+
+    public void setBrokerAddr(String brokerAddr) {
+        this.brokerAddr = normalize(brokerAddr);
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = normalize(clusterName);
+    }
+
+    public boolean isNamesrvOnly() {
+        return namesrvOnly;
+    }
+
+    public void setNamesrvOnly(boolean namesrvOnly) {
+        this.namesrvOnly = namesrvOnly;
+    }
+
+    public boolean isMastersOnly() {
+        return mastersOnly;
+    }
+
+    public void setMastersOnly(boolean mastersOnly) {
+        this.mastersOnly = mastersOnly;
+    }
+
+    public boolean isRequireActive() {
+        return requireActive;
+    }
+
+    public void setRequireActive(boolean requireActive) {
+        this.requireActive = requireActive;
+    }
+
+    public long getTimeoutMillis() {
+        return timeoutMillis;
+    }
+
+    public void setTimeoutMillis(long timeoutMillis) {
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    public int getParallelism() {
+        return parallelism;
+    }
+
+    public void setParallelism(int parallelism) {
+        this.parallelism = parallelism;
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+}

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthSubCommand.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.io.PrintStream;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.command.SubCommand;
+import org.apache.rocketmq.tools.command.SubCommandException;
+
+public class ClusterHealthSubCommand implements SubCommand {
+    public enum OutputFormat {
+        TEXT,
+        JSON
+    }
+
+    interface AdminFactory {
+        DefaultMQAdminExt create(RPCHook rpcHook, long timeoutMillis);
+    }
+
+    private final AdminFactory adminFactory;
+
+    public ClusterHealthSubCommand() {
+        this(DefaultMQAdminExt::new);
+    }
+
+    ClusterHealthSubCommand(AdminFactory adminFactory) {
+        this.adminFactory = adminFactory;
+    }
+
+    @Override
+    public String commandName() {
+        return "clusterHealth";
+    }
+
+    @Override
+    public String commandDesc() {
+        return "Check NameServer and broker health without producing test messages.";
+    }
+
+    @Override
+    public Options buildCommandlineOptions(Options options) {
+        Option option = new Option("b", "brokerAddr", true,
+            "Check one broker directly and skip NameServer discovery");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("c", "clusterName", true, "Check brokers in this cluster only");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("s", "namesrvOnly", false, "Only check the NameServer metadata RPC");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("m", "mastersOnly", false, "Check master broker addresses only");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("a", "requireActive", false,
+            "Also require brokerActive=true (normally appropriate for writable masters)");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("t", "timeoutMillis", true,
+            "RPC and overall broker-check deadline in milliseconds; default 3000");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("p", "parallelism", true,
+            "Maximum concurrent broker probes, from 1 to 64; default 4");
+        option.setRequired(false);
+        options.addOption(option);
+
+        option = new Option("f", "format", true, "Output format: text or json; default text");
+        option.setRequired(false);
+        options.addOption(option);
+        return options;
+    }
+
+    @Override
+    public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) throws SubCommandException {
+        try {
+            OutputFormat format = outputFormat(commandLine);
+            ClusterHealthReport report = run(commandLine, rpcHook);
+            printReport(report, format, System.out);
+            if (!report.isHealthy()) {
+                throw new SubCommandException("Cluster health check reported UNHEALTHY");
+            }
+        } catch (SubCommandException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubCommandException(getClass().getSimpleName() + " command failed", e);
+        }
+    }
+
+    public ClusterHealthReport run(CommandLine commandLine, RPCHook rpcHook) throws Exception {
+        ClusterHealthRequest request = request(commandLine);
+        DefaultMQAdminExt adminExt = adminFactory.create(rpcHook, request.getTimeoutMillis());
+        adminExt.setInstanceName("clusterHealth-" + System.currentTimeMillis());
+        try {
+            adminExt.start();
+            ClusterHealthChecker checker = new ClusterHealthChecker(
+                new ClusterHealthChecker.DefaultAdminAccess(adminExt));
+            return checker.check(request);
+        } finally {
+            adminExt.shutdown();
+        }
+    }
+
+    ClusterHealthRequest request(CommandLine commandLine) {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        if (commandLine.hasOption('b')) {
+            request.setBrokerAddr(commandLine.getOptionValue('b'));
+        }
+        if (commandLine.hasOption('c')) {
+            request.setClusterName(commandLine.getOptionValue('c'));
+        }
+        request.setNamesrvOnly(commandLine.hasOption('s'));
+        request.setMastersOnly(commandLine.hasOption('m'));
+        request.setRequireActive(commandLine.hasOption('a'));
+        if (commandLine.hasOption('t')) {
+            request.setTimeoutMillis(parseLong(commandLine.getOptionValue('t'), "timeoutMillis"));
+        }
+        if (commandLine.hasOption('p')) {
+            request.setParallelism(parseInt(commandLine.getOptionValue('p'), "parallelism"));
+        }
+        request.validate();
+        return request;
+    }
+
+    public OutputFormat outputFormat(CommandLine commandLine) {
+        if (!commandLine.hasOption('f')) {
+            return OutputFormat.TEXT;
+        }
+        String value = commandLine.getOptionValue('f').trim();
+        if ("text".equalsIgnoreCase(value)) {
+            return OutputFormat.TEXT;
+        }
+        if ("json".equalsIgnoreCase(value)) {
+            return OutputFormat.JSON;
+        }
+        throw new IllegalArgumentException("format must be text or json");
+    }
+
+    public void printReport(ClusterHealthReport report, OutputFormat format, PrintStream out) {
+        if (OutputFormat.JSON.equals(format)) {
+            out.println(report.toJson());
+        } else {
+            out.print(report.toText());
+        }
+    }
+
+    private static long parseLong(String value, String optionName) {
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(optionName + " must be an integer", e);
+        }
+    }
+
+    private static int parseInt(String value, String optionName) {
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(optionName + " must be an integer", e);
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/MQHealthCheckStartupTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/MQHealthCheckStartupTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MQHealthCheckStartupTest {
+    @Test
+    public void testInvalidTargetCombinationReturnsUsageExitCode() {
+        ByteArrayOutputStream error = new ByteArrayOutputStream();
+
+        int exitCode = MQHealthCheckStartup.main0(
+            new String[] {"-b", "127.0.0.1:10911", "-s"}, null,
+            new PrintStream(new ByteArrayOutputStream()), new PrintStream(error));
+
+        Assert.assertEquals(MQHealthCheckStartup.EXIT_USAGE_OR_ERROR, exitCode);
+        Assert.assertTrue(error.toString().contains("cannot be used together"));
+    }
+
+    @Test
+    public void testInvalidTimeoutReturnsUsageExitCode() {
+        ByteArrayOutputStream error = new ByteArrayOutputStream();
+
+        int exitCode = MQHealthCheckStartup.main0(
+            new String[] {"-s", "-t", "0"}, null,
+            new PrintStream(new ByteArrayOutputStream()), new PrintStream(error));
+
+        Assert.assertEquals(MQHealthCheckStartup.EXIT_USAGE_OR_ERROR, exitCode);
+        Assert.assertTrue(error.toString().contains("timeoutMillis"));
+    }
+
+    @Test
+    public void testInvalidFormatReturnsUsageExitCodeBeforeNetworkAccess() {
+        ByteArrayOutputStream error = new ByteArrayOutputStream();
+
+        int exitCode = MQHealthCheckStartup.main0(
+            new String[] {"-s", "-f", "yaml"}, null,
+            new PrintStream(new ByteArrayOutputStream()), new PrintStream(error));
+
+        Assert.assertEquals(MQHealthCheckStartup.EXIT_USAGE_OR_ERROR, exitCode);
+        Assert.assertTrue(error.toString().contains("format must be text or json"));
+    }
+
+    @Test
+    public void testExitCodeConstantsAreStableForContainerHealthChecks() {
+        Assert.assertEquals(0, MQHealthCheckStartup.EXIT_HEALTHY);
+        Assert.assertEquals(1, MQHealthCheckStartup.EXIT_UNHEALTHY);
+        Assert.assertEquals(2, MQHealthCheckStartup.EXIT_USAGE_OR_ERROR);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthCheckerTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthCheckerTest.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterHealthCheckerTest {
+    @Test
+    public void testDirectBrokerRpcSuccessIsHealthy() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.response("127.0.0.1:10911", runtime("V5_5_0", "false"));
+        ClusterHealthRequest request = directRequest("127.0.0.1:10911");
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(ClusterHealthReport.NameServerStatus.SKIPPED, report.getNameServerStatus());
+        Assert.assertEquals(1, report.getHealthyBrokers());
+        Assert.assertEquals(Boolean.FALSE, report.getBrokers().get(0).getBrokerActive());
+        Assert.assertEquals("V5_5_0", report.getBrokers().get(0).getBrokerVersion());
+        Assert.assertEquals(0, admin.getDiscoveryCalls());
+    }
+
+    @Test
+    public void testDirectBrokerFailureIsUnhealthy() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.failure("127.0.0.1:10911", new IllegalStateException("connection refused"));
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin)
+            .check(directRequest("127.0.0.1:10911"));
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(1, report.getUnhealthyBrokers());
+        Assert.assertTrue(report.getBrokers().get(0).getDetail().contains("connection refused"));
+    }
+
+    @Test
+    public void testNullBrokerResponseIsUnhealthy() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.response("127.0.0.1:10911", null);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin)
+            .check(directRequest("127.0.0.1:10911"));
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertTrue(report.getBrokers().get(0).getDetail().contains("empty runtime response"));
+    }
+
+    @Test
+    public void testMissingBrokerRuntimeTableIsUnhealthy() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.response("127.0.0.1:10911", new KVTable());
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin)
+            .check(directRequest("127.0.0.1:10911"));
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertTrue(report.getBrokers().get(0).getDetail().contains("empty runtime response"));
+    }
+
+    @Test
+    public void testRequireActiveRejectsFalseFlag() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.response("127.0.0.1:10911", runtime("V5_5_0", "false"));
+        ClusterHealthRequest request = directRequest("127.0.0.1:10911");
+        request.setRequireActive(true);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals("brokerActive is false", report.getBrokers().get(0).getDetail());
+        Assert.assertEquals("V5_5_0", report.getBrokers().get(0).getBrokerVersion());
+    }
+
+    @Test
+    public void testRequireActiveRejectsMissingFlag() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.response("127.0.0.1:10911", runtime("V5_5_0", null));
+        ClusterHealthRequest request = directRequest("127.0.0.1:10911");
+        request.setRequireActive(true);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertTrue(report.getBrokers().get(0).getDetail().contains("missing"));
+    }
+
+    @Test
+    public void testRequireActiveAcceptsTrueFlagIgnoringCase() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.response("127.0.0.1:10911", runtime("V5_5_0", "TRUE"));
+        ClusterHealthRequest request = directRequest("127.0.0.1:10911");
+        request.setRequireActive(true);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(Boolean.TRUE, report.getBrokers().get(0).getBrokerActive());
+    }
+
+    @Test
+    public void testNameServerOnlyAllowsEmptyCluster() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.setClusterInfo(emptyClusterInfo());
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setNamesrvOnly(true);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(ClusterHealthReport.NameServerStatus.HEALTHY, report.getNameServerStatus());
+        Assert.assertEquals(0, report.getTotalBrokers());
+        Assert.assertEquals(1, admin.getDiscoveryCalls());
+    }
+
+    @Test
+    public void testNameServerExceptionIsUnhealthy() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.setDiscoveryFailure(new IllegalStateException("nameserver unavailable"));
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(new ClusterHealthRequest());
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(ClusterHealthReport.NameServerStatus.UNHEALTHY, report.getNameServerStatus());
+        Assert.assertTrue(report.getNameServerDetail().contains("nameserver unavailable"));
+        Assert.assertEquals(0, admin.getProbeCalls());
+    }
+
+    @Test
+    public void testNullNameServerResponseIsUnhealthy() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.setClusterInfo(null);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(new ClusterHealthRequest());
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertTrue(report.getNameServerDetail().contains("empty cluster response"));
+    }
+
+    @Test
+    public void testAllClusterBrokersAreProbed() {
+        FakeAdminAccess admin = twoClusterAdmin();
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(new ClusterHealthRequest());
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(4, report.getTotalBrokers());
+        Assert.assertEquals(4, admin.getProbeCalls());
+        Assert.assertEquals("a-master:10911", report.getBrokers().get(0).getBrokerAddr());
+    }
+
+    @Test
+    public void testClusterFilterOnlyProbesMatchingCluster() {
+        FakeAdminAccess admin = twoClusterAdmin();
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setClusterName("cluster-b");
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(1, report.getTotalBrokers());
+        Assert.assertEquals("cluster-b", report.getBrokers().get(0).getClusterName());
+        Assert.assertEquals("b-master:10911", report.getBrokers().get(0).getBrokerAddr());
+    }
+
+    @Test
+    public void testMissingClusterIsUnhealthy() {
+        FakeAdminAccess admin = twoClusterAdmin();
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setClusterName("missing");
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(0, report.getTotalBrokers());
+        Assert.assertTrue(report.getNameServerDetail().contains("No brokers matched"));
+    }
+
+    @Test
+    public void testMastersOnlySkipsSlaveAddresses() {
+        FakeAdminAccess admin = twoClusterAdmin();
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setMastersOnly(true);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(3, report.getTotalBrokers());
+        for (BrokerHealthResult broker : report.getBrokers()) {
+            Assert.assertEquals(0L, broker.getBrokerId());
+        }
+        Assert.assertFalse(admin.getProbedAddresses().contains("a-slave:10911"));
+    }
+
+    @Test
+    public void testOneBrokerFailureFailsWholeCluster() {
+        FakeAdminAccess admin = twoClusterAdmin();
+        admin.failure("a-slave:10911", new IllegalStateException("not reachable"));
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(new ClusterHealthRequest());
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(3, report.getHealthyBrokers());
+        Assert.assertEquals(1, report.getUnhealthyBrokers());
+    }
+
+    @Test(timeout = 3000)
+    public void testOverallDeadlineMarksSlowProbeAsTimedOut() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.setClusterInfo(clusterInfo("cluster-a", broker("cluster-a", "broker-a",
+            address(0, "fast:10911", 1, "slow:10911"))));
+        admin.response("fast:10911", runtime("V5_5_0", "true"));
+        admin.delay("slow:10911", 500);
+        admin.response("slow:10911", runtime("V5_5_0", "true"));
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setTimeoutMillis(50);
+        request.setParallelism(2);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(request);
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(1, report.getHealthyBrokers());
+        Assert.assertEquals(1, report.getUnhealthyBrokers());
+        Assert.assertTrue(find(report, "slow:10911").getDetail().contains("timed out"));
+    }
+
+    @Test
+    public void testMalformedClusterMetadataIsHandled() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setClusterAddrTable(null);
+        clusterInfo.setBrokerAddrTable(null);
+        admin.setClusterInfo(clusterInfo);
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(new ClusterHealthRequest());
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(0, report.getTotalBrokers());
+    }
+
+    @Test
+    public void testSelectTargetsSkipsMissingBrokerDataAndBlankAddress() {
+        FakeAdminAccess admin = new FakeAdminAccess();
+        ClusterInfo clusterInfo = new ClusterInfo();
+        Map<String, Set<String>> clusters = new HashMap<>();
+        clusters.put("cluster-a", new HashSet<>(Arrays.asList("missing", "blank", "valid")));
+        clusterInfo.setClusterAddrTable(clusters);
+        Map<String, BrokerData> brokers = new HashMap<>();
+        brokers.put("blank", broker("cluster-a", "blank", address(0, " ")));
+        brokers.put("valid", broker("cluster-a", "valid", address(0, "valid:10911")));
+        clusterInfo.setBrokerAddrTable(brokers);
+        admin.setClusterInfo(clusterInfo);
+        admin.response("valid:10911", runtime("V5_5_0", "true"));
+
+        ClusterHealthReport report = new ClusterHealthChecker(admin).check(new ClusterHealthRequest());
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(1, report.getTotalBrokers());
+        Assert.assertEquals("valid:10911", report.getBrokers().get(0).getBrokerAddr());
+    }
+
+    private static BrokerHealthResult find(ClusterHealthReport report, String address) {
+        for (BrokerHealthResult result : report.getBrokers()) {
+            if (address.equals(result.getBrokerAddr())) {
+                return result;
+            }
+        }
+        throw new AssertionError("No broker result for " + address);
+    }
+
+    private static ClusterHealthRequest directRequest(String address) {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setBrokerAddr(address);
+        return request;
+    }
+
+    private static FakeAdminAccess twoClusterAdmin() {
+        BrokerData brokerA = broker("cluster-a", "broker-a",
+            address(0, "a-master:10911", 1, "a-slave:10911"));
+        BrokerData brokerA2 = broker("cluster-a", "broker-a2", address(0, "a2-master:10911"));
+        BrokerData brokerB = broker("cluster-b", "broker-b", address(0, "b-master:10911"));
+        ClusterInfo clusterInfo = clusterInfo(
+            new String[] {"cluster-a", "cluster-a", "cluster-b"}, brokerA, brokerA2, brokerB);
+        FakeAdminAccess admin = new FakeAdminAccess();
+        admin.setClusterInfo(clusterInfo);
+        for (String address : Arrays.asList(
+            "a-master:10911", "a-slave:10911", "a2-master:10911", "b-master:10911")) {
+            admin.response(address, runtime("V5_5_0", "true"));
+        }
+        return admin;
+    }
+
+    private static ClusterInfo emptyClusterInfo() {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setClusterAddrTable(new HashMap<>());
+        clusterInfo.setBrokerAddrTable(new HashMap<>());
+        return clusterInfo;
+    }
+
+    private static ClusterInfo clusterInfo(String cluster, BrokerData... brokers) {
+        String[] clusters = new String[brokers.length];
+        Arrays.fill(clusters, cluster);
+        return clusterInfo(clusters, brokers);
+    }
+
+    private static ClusterInfo clusterInfo(String[] clusterNames, BrokerData... brokers) {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        Map<String, Set<String>> clusters = new HashMap<>();
+        Map<String, BrokerData> brokerTable = new HashMap<>();
+        for (int i = 0; i < brokers.length; i++) {
+            BrokerData broker = brokers[i];
+            clusters.computeIfAbsent(clusterNames[i], ignored -> new HashSet<>())
+                .add(broker.getBrokerName());
+            brokerTable.put(broker.getBrokerName(), broker);
+        }
+        clusterInfo.setClusterAddrTable(clusters);
+        clusterInfo.setBrokerAddrTable(brokerTable);
+        return clusterInfo;
+    }
+
+    private static BrokerData broker(String cluster, String brokerName, HashMap<Long, String> addresses) {
+        return new BrokerData(cluster, brokerName, addresses);
+    }
+
+    private static HashMap<Long, String> address(Object... values) {
+        HashMap<Long, String> addresses = new HashMap<>();
+        for (int i = 0; i < values.length; i += 2) {
+            addresses.put(((Number) values[i]).longValue(), (String) values[i + 1]);
+        }
+        return addresses;
+    }
+
+    private static KVTable runtime(String version, String active) {
+        KVTable table = new KVTable();
+        HashMap<String, String> values = new HashMap<>();
+        if (version != null) {
+            values.put("brokerVersionDesc", version);
+        }
+        if (active != null) {
+            values.put("brokerActive", active);
+        }
+        table.setTable(values);
+        return table;
+    }
+
+    private static class FakeAdminAccess implements ClusterHealthChecker.AdminAccess {
+        private ClusterInfo clusterInfo = emptyClusterInfo();
+        private Exception discoveryFailure;
+        private final Map<String, KVTable> responses = new ConcurrentHashMap<>();
+        private final Map<String, Exception> failures = new ConcurrentHashMap<>();
+        private final Map<String, Long> delays = new ConcurrentHashMap<>();
+        private final Set<String> probedAddresses = ConcurrentHashMap.newKeySet();
+        private int discoveryCalls;
+
+        @Override
+        public ClusterInfo examineBrokerClusterInfo() throws Exception {
+            discoveryCalls++;
+            if (discoveryFailure != null) {
+                throw discoveryFailure;
+            }
+            return clusterInfo;
+        }
+
+        @Override
+        public KVTable fetchBrokerRuntimeStats(String brokerAddr) throws Exception {
+            probedAddresses.add(brokerAddr);
+            Long delay = delays.get(brokerAddr);
+            if (delay != null) {
+                Thread.sleep(delay);
+            }
+            Exception failure = failures.get(brokerAddr);
+            if (failure != null) {
+                throw failure;
+            }
+            return responses.get(brokerAddr);
+        }
+
+        void setClusterInfo(ClusterInfo clusterInfo) {
+            this.clusterInfo = clusterInfo;
+        }
+
+        void setDiscoveryFailure(Exception discoveryFailure) {
+            this.discoveryFailure = discoveryFailure;
+        }
+
+        void response(String address, KVTable response) {
+            if (response == null) {
+                responses.remove(address);
+            } else {
+                responses.put(address, response);
+            }
+        }
+
+        void failure(String address, Exception failure) {
+            failures.put(address, failure);
+        }
+
+        void delay(String address, long delayMillis) {
+            delays.put(address, delayMillis);
+        }
+
+        int getDiscoveryCalls() {
+            return discoveryCalls;
+        }
+
+        int getProbeCalls() {
+            return probedAddresses.size();
+        }
+
+        Set<String> getProbedAddresses() {
+            return Collections.unmodifiableSet(probedAddresses);
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthReportTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthReportTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterHealthReportTest {
+    @Test
+    public void testCompleteHealthyReport() {
+        ClusterHealthReport report = baseReport();
+        report.setBrokers(Collections.singletonList(healthy("cluster-a", "broker-a", 0, "a:10911")));
+
+        report.complete();
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertEquals(1, report.getTotalBrokers());
+        Assert.assertEquals(1, report.getHealthyBrokers());
+        Assert.assertEquals(0, report.getUnhealthyBrokers());
+    }
+
+    @Test
+    public void testBrokerFailureMakesReportUnhealthy() {
+        ClusterHealthReport report = baseReport();
+        BrokerTarget target = new BrokerTarget("cluster-a", "broker-b", 1, "b:10911");
+        report.setBrokers(Arrays.asList(
+            healthy("cluster-a", "broker-a", 0, "a:10911"),
+            BrokerHealthResult.unhealthy(target, 12, "connection refused")));
+
+        report.complete();
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertEquals(2, report.getTotalBrokers());
+        Assert.assertEquals(1, report.getHealthyBrokers());
+        Assert.assertEquals(1, report.getUnhealthyBrokers());
+    }
+
+    @Test
+    public void testNameServerFailureMakesReportUnhealthy() {
+        ClusterHealthReport report = baseReport();
+        report.setNameServerStatus(ClusterHealthReport.NameServerStatus.UNHEALTHY);
+        report.setBrokers(Collections.emptyList());
+
+        report.complete();
+
+        Assert.assertFalse(report.isHealthy());
+    }
+
+    @Test
+    public void testSkippedNameServerAllowsDirectBrokerSuccess() {
+        ClusterHealthReport report = baseReport();
+        report.setNameServerStatus(ClusterHealthReport.NameServerStatus.SKIPPED);
+        report.setBrokers(Collections.singletonList(healthy("direct", "direct", -1, "a:10911")));
+
+        report.complete();
+
+        Assert.assertTrue(report.isHealthy());
+    }
+
+    @Test
+    public void testExplicitNoBrokerFailureIsPreserved() {
+        ClusterHealthReport report = baseReport();
+        report.setBrokers(Collections.emptyList());
+        report.markNoBrokers("No brokers matched cluster:missing");
+
+        report.complete();
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertTrue(report.getNameServerDetail().contains("No brokers matched"));
+    }
+
+    @Test
+    public void testCompleteSortsBrokerRows() {
+        ClusterHealthReport report = baseReport();
+        report.setBrokers(Arrays.asList(
+            healthy("cluster-b", "broker-a", 0, "c:10911"),
+            healthy("cluster-a", "broker-b", 1, "b:10911"),
+            healthy("cluster-a", "broker-a", 0, "a:10911")));
+
+        report.complete();
+
+        Assert.assertEquals("a:10911", report.getBrokers().get(0).getBrokerAddr());
+        Assert.assertEquals("b:10911", report.getBrokers().get(1).getBrokerAddr());
+        Assert.assertEquals("c:10911", report.getBrokers().get(2).getBrokerAddr());
+    }
+
+    @Test
+    public void testTextContainsSummaryAndSanitizesDetail() {
+        ClusterHealthReport report = baseReport();
+        BrokerTarget target = new BrokerTarget("cluster-a", "broker-a", 0, "a:10911");
+        report.setBrokers(Collections.singletonList(
+            BrokerHealthResult.unhealthy(target, 9, "first line\nsecond line")));
+        report.setDurationMillis(17);
+        report.complete();
+
+        String text = report.toText();
+
+        Assert.assertTrue(text.contains("STATUS       UNHEALTHY"));
+        Assert.assertTrue(text.contains("0 healthy, 1 unhealthy, 1 total, 17 ms"));
+        Assert.assertTrue(text.contains("first line second line"));
+        Assert.assertFalse(text.contains("first line\nsecond line"));
+    }
+
+    @Test
+    public void testJsonContainsMachineReadableFields() {
+        ClusterHealthReport report = baseReport();
+        report.setBrokers(Collections.singletonList(healthy("cluster-a", "broker-a", 0, "a:10911")));
+        report.complete();
+
+        String json = report.toJson();
+
+        Assert.assertTrue(json.contains("\"status\":\"HEALTHY\""));
+        Assert.assertTrue(json.contains("\"nameServerStatus\":\"HEALTHY\""));
+        Assert.assertTrue(json.contains("\"brokerAddr\":\"a:10911\""));
+        Assert.assertTrue(json.contains("\"healthyBrokers\":1"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testBrokerViewCannotBeMutated() {
+        ClusterHealthReport report = baseReport();
+        report.getBrokers().add(healthy("cluster-a", "broker-a", 0, "a:10911"));
+    }
+
+    private static ClusterHealthReport baseReport() {
+        ClusterHealthReport report = new ClusterHealthReport();
+        report.setTimestamp(1);
+        report.setTarget("all-clusters");
+        report.setNameServerStatus(ClusterHealthReport.NameServerStatus.HEALTHY);
+        report.setNameServerDetail("metadata available");
+        return report;
+    }
+
+    private static BrokerHealthResult healthy(String cluster, String broker, long brokerId, String address) {
+        BrokerTarget target = new BrokerTarget(cluster, broker, brokerId, address);
+        return BrokerHealthResult.healthy(target, 3, "V5_5_0", Boolean.TRUE);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthRequestTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthRequestTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterHealthRequestTest {
+    @Test
+    public void testDefaultsDescribeAllClusters() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+
+        request.validate();
+
+        Assert.assertEquals("all-clusters", request.describeTarget());
+        Assert.assertEquals(ClusterHealthRequest.DEFAULT_TIMEOUT_MILLIS, request.getTimeoutMillis());
+        Assert.assertEquals(ClusterHealthRequest.DEFAULT_PARALLELISM, request.getParallelism());
+        Assert.assertFalse(request.isDirectBrokerCheck());
+    }
+
+    @Test
+    public void testBrokerAddressIsNormalized() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setBrokerAddr(" 127.0.0.1:10911 ");
+
+        request.validate();
+
+        Assert.assertTrue(request.isDirectBrokerCheck());
+        Assert.assertEquals("127.0.0.1:10911", request.getBrokerAddr());
+        Assert.assertEquals("broker:127.0.0.1:10911", request.describeTarget());
+    }
+
+    @Test
+    public void testClusterNameIsNormalized() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setClusterName(" production ");
+
+        request.validate();
+
+        Assert.assertEquals("production", request.getClusterName());
+        Assert.assertEquals("cluster:production", request.describeTarget());
+    }
+
+    @Test
+    public void testNameServerOnlyTarget() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setNamesrvOnly(true);
+
+        request.validate();
+
+        Assert.assertEquals("nameserver", request.describeTarget());
+    }
+
+    @Test
+    public void testRejectNonPositiveTimeout() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setTimeoutMillis(0);
+
+        assertInvalid(request, "timeoutMillis");
+    }
+
+    @Test
+    public void testRejectNonPositiveParallelism() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setParallelism(0);
+
+        assertInvalid(request, "parallelism");
+    }
+
+    @Test
+    public void testRejectExcessiveParallelism() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setParallelism(ClusterHealthRequest.MAX_PARALLELISM + 1);
+
+        assertInvalid(request, "parallelism");
+    }
+
+    @Test
+    public void testRejectBrokerAndClusterCombination() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setBrokerAddr("127.0.0.1:10911");
+        request.setClusterName("production");
+
+        assertInvalid(request, "cannot be used together");
+    }
+
+    @Test
+    public void testRejectBrokerAndNameServerOnlyCombination() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setBrokerAddr("127.0.0.1:10911");
+        request.setNamesrvOnly(true);
+
+        assertInvalid(request, "cannot be used together");
+    }
+
+    @Test
+    public void testRejectMastersForNameServerOnlyCheck() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setNamesrvOnly(true);
+        request.setMastersOnly(true);
+
+        assertInvalid(request, "mastersOnly");
+    }
+
+    @Test
+    public void testRejectActiveRequirementForNameServerOnlyCheck() {
+        ClusterHealthRequest request = new ClusterHealthRequest();
+        request.setNamesrvOnly(true);
+        request.setRequireActive(true);
+
+        assertInvalid(request, "requireActive");
+    }
+
+    private static void assertInvalid(ClusterHealthRequest request, String messagePart) {
+        try {
+            request.validate();
+            Assert.fail("Expected request validation to fail");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains(messagePart));
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthSubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/cluster/ClusterHealthSubCommandTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.cluster;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterHealthSubCommandTest {
+    @Test
+    public void testCommandIdentity() {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+
+        Assert.assertEquals("clusterHealth", command.commandName());
+        Assert.assertTrue(command.commandDesc().contains("NameServer"));
+    }
+
+    @Test
+    public void testBuildOptionsContainsScriptableControls() {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        Options options = command.buildCommandlineOptions(new Options());
+
+        Assert.assertNotNull(options.getOption("brokerAddr"));
+        Assert.assertNotNull(options.getOption("clusterName"));
+        Assert.assertNotNull(options.getOption("namesrvOnly"));
+        Assert.assertNotNull(options.getOption("mastersOnly"));
+        Assert.assertNotNull(options.getOption("requireActive"));
+        Assert.assertNotNull(options.getOption("timeoutMillis"));
+        Assert.assertNotNull(options.getOption("parallelism"));
+        Assert.assertNotNull(options.getOption("format"));
+    }
+
+    @Test
+    public void testParseAllRequestOptions() throws Exception {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        CommandLine commandLine = parse(command,
+            "-c", "production", "-m", "-a", "-t", "4500", "-p", "8", "-f", "json");
+
+        ClusterHealthRequest request = command.request(commandLine);
+
+        Assert.assertEquals("production", request.getClusterName());
+        Assert.assertTrue(request.isMastersOnly());
+        Assert.assertTrue(request.isRequireActive());
+        Assert.assertEquals(4500, request.getTimeoutMillis());
+        Assert.assertEquals(8, request.getParallelism());
+        Assert.assertEquals(ClusterHealthSubCommand.OutputFormat.JSON, command.outputFormat(commandLine));
+    }
+
+    @Test
+    public void testDefaultOutputIsText() throws Exception {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        CommandLine commandLine = parse(command, "-s");
+
+        Assert.assertEquals(ClusterHealthSubCommand.OutputFormat.TEXT, command.outputFormat(commandLine));
+    }
+
+    @Test
+    public void testOutputFormatIsCaseInsensitive() throws Exception {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        CommandLine commandLine = parse(command, "-s", "-f", "JSON");
+
+        Assert.assertEquals(ClusterHealthSubCommand.OutputFormat.JSON, command.outputFormat(commandLine));
+    }
+
+    @Test
+    public void testRejectUnknownOutputFormat() throws Exception {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        CommandLine commandLine = parse(command, "-s", "-f", "yaml");
+
+        try {
+            command.outputFormat(commandLine);
+            Assert.fail("Expected format validation to fail");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("text or json"));
+        }
+    }
+
+    @Test
+    public void testRejectNonNumericTimeout() throws Exception {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        CommandLine commandLine = parse(command, "-s", "-t", "soon");
+
+        try {
+            command.request(commandLine);
+            Assert.fail("Expected timeout validation to fail");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("timeoutMillis must be an integer"));
+        }
+    }
+
+    @Test
+    public void testRejectNonNumericParallelism() throws Exception {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        CommandLine commandLine = parse(command, "-s", "-p", "many");
+
+        try {
+            command.request(commandLine);
+            Assert.fail("Expected parallelism validation to fail");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("parallelism must be an integer"));
+        }
+    }
+
+    @Test
+    public void testRunStartsAndStopsAdminClient() throws Exception {
+        StubAdminExt adminExt = new StubAdminExt();
+        adminExt.setBrokerResponse(runtime(true));
+        final long[] factoryTimeout = new long[1];
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand((hook, timeout) -> {
+            factoryTimeout[0] = timeout;
+            return adminExt;
+        });
+        CommandLine commandLine = parse(command, "-b", "127.0.0.1:10911", "-t", "1200");
+
+        ClusterHealthReport report = command.run(commandLine, null);
+
+        Assert.assertTrue(report.isHealthy());
+        Assert.assertTrue(adminExt.isStarted());
+        Assert.assertTrue(adminExt.isShutdown());
+        Assert.assertEquals(1200, factoryTimeout[0]);
+        Assert.assertEquals("127.0.0.1:10911", adminExt.getLastBrokerAddress());
+    }
+
+    @Test
+    public void testRunStopsAdminClientWhenProbeFails() throws Exception {
+        StubAdminExt adminExt = new StubAdminExt();
+        adminExt.setBrokerFailure(new IllegalStateException("offline"));
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand((hook, timeout) -> adminExt);
+        CommandLine commandLine = parse(command, "-b", "127.0.0.1:10911");
+
+        ClusterHealthReport report = command.run(commandLine, null);
+
+        Assert.assertFalse(report.isHealthy());
+        Assert.assertTrue(adminExt.isShutdown());
+    }
+
+    @Test
+    public void testPrintTextReport() {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        ClusterHealthReport report = healthyReport();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        command.printReport(report, ClusterHealthSubCommand.OutputFormat.TEXT, new PrintStream(bytes));
+
+        Assert.assertTrue(bytes.toString().contains("STATUS       HEALTHY"));
+    }
+
+    @Test
+    public void testPrintJsonReport() {
+        ClusterHealthSubCommand command = new ClusterHealthSubCommand();
+        ClusterHealthReport report = healthyReport();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        command.printReport(report, ClusterHealthSubCommand.OutputFormat.JSON, new PrintStream(bytes));
+
+        Assert.assertTrue(bytes.toString().contains("\"status\":\"HEALTHY\""));
+    }
+
+    private static CommandLine parse(ClusterHealthSubCommand command, String... arguments) throws Exception {
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        options = command.buildCommandlineOptions(options);
+        return new DefaultParser().parse(options, arguments);
+    }
+
+    private static ClusterHealthReport healthyReport() {
+        ClusterHealthReport report = new ClusterHealthReport();
+        report.setTarget("nameserver");
+        report.setNameServerStatus(ClusterHealthReport.NameServerStatus.HEALTHY);
+        report.setBrokers(java.util.Collections.emptyList());
+        report.complete();
+        return report;
+    }
+
+    private static KVTable runtime(boolean active) {
+        KVTable table = new KVTable();
+        HashMap<String, String> values = new HashMap<>();
+        values.put("brokerActive", Boolean.toString(active));
+        values.put("brokerVersionDesc", "V5_5_0");
+        table.setTable(values);
+        return table;
+    }
+
+    private static class StubAdminExt extends DefaultMQAdminExt {
+        private boolean started;
+        private boolean shutdown;
+        private KVTable brokerResponse;
+        private RuntimeException brokerFailure;
+        private String lastBrokerAddress;
+
+        @Override
+        public void start() {
+            started = true;
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public ClusterInfo examineBrokerClusterInfo() {
+            ClusterInfo clusterInfo = new ClusterInfo();
+            clusterInfo.setBrokerAddrTable(new HashMap<>());
+            clusterInfo.setClusterAddrTable(new HashMap<>());
+            return clusterInfo;
+        }
+
+        @Override
+        public KVTable fetchBrokerRuntimeStats(String brokerAddr) {
+            lastBrokerAddress = brokerAddr;
+            if (brokerFailure != null) {
+                throw brokerFailure;
+            }
+            return brokerResponse;
+        }
+
+        boolean isStarted() {
+            return started;
+        }
+
+        boolean isShutdown() {
+            return shutdown;
+        }
+
+        void setBrokerResponse(KVTable brokerResponse) {
+            this.brokerResponse = brokerResponse;
+        }
+
+        void setBrokerFailure(RuntimeException brokerFailure) {
+            this.brokerFailure = brokerFailure;
+        }
+
+        String getLastBrokerAddress() {
+            return lastBrokerAddress;
+        }
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #9698

### Brief Description

#### Problem

RocketMQ distributions do not provide a health-check command with reliable process exit codes. Container users currently have to install tools such as nc or nmap and can only test whether a port is open, or build a producer/consumer probe that creates traffic and resources.

#### Root Cause

The existing mqadmin brokerStatus command is designed for interactive diagnostics: it prints runtime data, does not validate a cluster as a whole, and MQAdminStartup catches command failures without exposing a health-specific exit-code contract. There is also no NameServer-only probe for an empty bootstrap cluster.

#### Changes

- add mqadmin clusterHealth for direct-broker, NameServer-only, selected-cluster, and all-cluster checks
- discover brokers through NameServer and probe broker runtime RPCs concurrently with a bounded overall deadline
- support master-only checks and an optional brokerActive requirement
- provide deterministic text and JSON reports with per-broker latency, version, status, and failure details
- add mqhealthcheck and mqhealthcheck.cmd distribution launchers with stable exit codes: 0 healthy, 1 unhealthy, 2 usage or execution error
- keep checks read-only: no topics, messages, producers, or consumers are created
- add focused coverage for discovery failures, malformed responses, direct checks, filtering, master/slave selection, active-state validation, deadlines, formatting, lifecycle cleanup, and exit codes

#### Impact

Container images and orchestration systems can use the bundled command directly in Docker HEALTHCHECK or readiness scripts. Operators can distinguish a live RPC service from an open TCP port, inspect machine-readable details, and check an empty NameServer independently from broker availability. Existing mqadmin commands and behavior are unchanged.

Example uses:

- mqhealthcheck -n 127.0.0.1:9876 -s
- mqhealthcheck -b 127.0.0.1:10911
- mqhealthcheck -n 127.0.0.1:9876 -c DefaultCluster -m -a -f json

### How Did You Test This Change?

JDK 8 (Temurin 8.0.482):

- focused health-check tests: 54 tests, 0 failures, 0 errors, 0 skipped
- full rocketmq-tools suite: 201 tests, 0 failures, 0 errors, 5 existing skips; BUILD SUCCESS
- tools reactor package build: 7 modules; BUILD SUCCESS
- Checkstyle: 0 violations

Commands:

mvn -pl tools test -Dtest=ClusterHealthRequestTest,ClusterHealthReportTest,ClusterHealthCheckerTest,ClusterHealthSubCommandTest,MQHealthCheckStartupTest -Dspotbugs.skip=true -Djacoco.skip=true

mvn -pl tools test -Dspotbugs.skip=true -Djacoco.skip=true

mvn -pl tools -am package -DskipTests -Dspotbugs.skip=true -Djacoco.skip=true