### PR TITLE
[ISSUE #10641] Deprecate legacy Broker DLedger mode

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -44,6 +44,10 @@ import org.apache.rocketmq.store.config.MessageStoreConfig;
 
 public class BrokerStartup {
 
+    static final String DLEDGER_COMMIT_LOG_DEPRECATION_WARNING =
+        "Broker DLedger mode is deprecated and may be removed in a future release. " +
+            "Use Controller mode for new deployments.";
+
     public static Logger log;
 
     public static void main(String[] args) {
@@ -228,6 +232,7 @@ public class BrokerStartup {
         }
 
         log = LoggerFactory.getLogger(LoggerName.BROKER_LOGGER_NAME);
+        warnIfDLedgerCommitLogEnabled(messageStoreConfig, log);
         MixAll.printObjectProperties(log, brokerConfig);
         MixAll.printObjectProperties(log, nettyServerConfig);
         MixAll.printObjectProperties(log, nettyClientConfig);
@@ -246,6 +251,12 @@ public class BrokerStartup {
         controller.setConfigContext(configContext);
 
         return controller;
+    }
+
+    static void warnIfDLedgerCommitLogEnabled(MessageStoreConfig messageStoreConfig, Logger logger) {
+        if (messageStoreConfig.isEnableDLegerCommitLog()) {
+            logger.warn(DLEDGER_COMMIT_LOG_DEPRECATION_WARNING);
+        }
     }
 
     public static Runnable buildShutdownHook(BrokerController brokerController) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerStartupTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerStartupTest.java
@@ -21,8 +21,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Properties;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class BrokerStartupTest {
 
@@ -51,5 +54,26 @@ public class BrokerStartupTest {
         }
 
 
+    }
+
+    @Test
+    public void testWarnIfDLedgerCommitLogEnabled() {
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setEnableDLegerCommitLog(true);
+        Logger logger = Mockito.mock(Logger.class);
+
+        BrokerStartup.warnIfDLedgerCommitLogEnabled(messageStoreConfig, logger);
+
+        Mockito.verify(logger).warn(BrokerStartup.DLEDGER_COMMIT_LOG_DEPRECATION_WARNING);
+    }
+
+    @Test
+    public void testDoesNotWarnIfDLedgerCommitLogDisabled() {
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        Logger logger = Mockito.mock(Logger.class);
+
+        BrokerStartup.warnIfDLedgerCommitLogEnabled(messageStoreConfig, logger);
+
+        Mockito.verifyNoInteractions(logger);
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -892,10 +892,18 @@ public class MessageStoreConfig {
         this.storePathCommitLog = storePathCommitLog;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public String getStorePathDLedgerCommitLog() {
         return storePathDLedgerCommitLog;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setStorePathDLedgerCommitLog(String storePathDLedgerCommitLog) {
         this.storePathDLedgerCommitLog = storePathDLedgerCommitLog;
     }
@@ -1364,50 +1372,98 @@ public class MessageStoreConfig {
         this.readOnlyCommitLogStorePaths = readOnlyCommitLogStorePaths;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public String getdLegerGroup() {
         return dLegerGroup;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setdLegerGroup(String dLegerGroup) {
         this.dLegerGroup = dLegerGroup;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public String getdLegerPeers() {
         return dLegerPeers;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setdLegerPeers(String dLegerPeers) {
         this.dLegerPeers = dLegerPeers;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public String getdLegerSelfId() {
         return dLegerSelfId;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setdLegerSelfId(String dLegerSelfId) {
         this.dLegerSelfId = dLegerSelfId;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public boolean isEnableDLegerCommitLog() {
         return enableDLegerCommitLog;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setEnableDLegerCommitLog(boolean enableDLegerCommitLog) {
         this.enableDLegerCommitLog = enableDLegerCommitLog;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public String getPreferredLeaderId() {
         return preferredLeaderId;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setPreferredLeaderId(String preferredLeaderId) {
         this.preferredLeaderId = preferredLeaderId;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public boolean isEnableBatchPush() {
         return enableBatchPush;
     }
 
+    /**
+     * @deprecated Broker DLedger mode is deprecated. Use Controller mode for new deployments.
+     */
+    @Deprecated
     public void setEnableBatchPush(boolean enableBatchPush) {
         this.enableBatchPush = enableBatchPush;
     }

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -58,7 +58,10 @@ import org.rocksdb.RocksDBException;
 
 /**
  * Store all metadata downtime for recovery, data protection reliability
+ *
+ * @deprecated Use Controller mode for automatic Broker failover in new deployments.
  */
+@Deprecated
 public class DLedgerCommitLog extends CommitLog {
 
     static {

--- a/store/src/test/java/org/apache/rocketmq/store/dledger/DLedgerDeprecationTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/dledger/DLedgerDeprecationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.dledger;
+
+import java.lang.reflect.Method;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DLedgerDeprecationTest {
+
+    @Test
+    public void testDLedgerCommitLogIsDeprecated() {
+        Assert.assertTrue(DLedgerCommitLog.class.isAnnotationPresent(Deprecated.class));
+    }
+
+    @Test
+    public void testDLedgerMessageStoreConfigAccessorsAreDeprecated() throws Exception {
+        assertDeprecated(MessageStoreConfig.class.getMethod("getStorePathDLedgerCommitLog"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setStorePathDLedgerCommitLog", String.class));
+        assertDeprecated(MessageStoreConfig.class.getMethod("getdLegerGroup"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setdLegerGroup", String.class));
+        assertDeprecated(MessageStoreConfig.class.getMethod("getdLegerPeers"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setdLegerPeers", String.class));
+        assertDeprecated(MessageStoreConfig.class.getMethod("getdLegerSelfId"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setdLegerSelfId", String.class));
+        assertDeprecated(MessageStoreConfig.class.getMethod("isEnableDLegerCommitLog"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setEnableDLegerCommitLog", boolean.class));
+        assertDeprecated(MessageStoreConfig.class.getMethod("getPreferredLeaderId"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setPreferredLeaderId", String.class));
+        assertDeprecated(MessageStoreConfig.class.getMethod("isEnableBatchPush"));
+        assertDeprecated(MessageStoreConfig.class.getMethod("setEnableBatchPush", boolean.class));
+    }
+
+    private void assertDeprecated(Method method) {
+        Assert.assertTrue(method.getName() + " should be deprecated",
+            method.isAnnotationPresent(Deprecated.class));
+    }
+}


### PR DESCRIPTION
## Summary

- deprecate the legacy Broker DLedger commit log and its `MessageStoreConfig` accessors
- log a startup warning when `enableDLegerCommitLog=true`
- preserve existing Broker DLedger behavior and leave the DLedger-backed Controller implementation unchanged

## Motivation

Controller mode is the recommended automatic failover path for new deployments. Existing Broker DLedger deployments remain compatible; this change only adds API annotations and an opt-in startup warning.

Closes #10641

## Test Plan

- [x] `mvn -pl broker,store -am -DskipITs -Dtest=BrokerStartupTest,DLedgerDeprecationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] 5 focused tests passed across 10 reactor modules
- [x] Checkstyle reported 0 violations
- [x] SpotBugs reported 0 findings