### PR TITLE
[ISSUE #10644] Add LMQ number gauge metric to Broker observability

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsConstant.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsConstant.java
@@ -25,6 +25,7 @@ public class BrokerMetricsConstant {
     public static final String GAUGE_BROKER_PERMISSION = "rocketmq_broker_permission";
     public static final String GAUGE_TOPIC_NUM = "rocketmq_topic_number";
     public static final String GAUGE_CONSUMER_GROUP_NUM = "rocketmq_consumer_group_number";
+    public static final String GAUGE_LMQ_NUM = "rocketmq_lmq_number";
 
     public static final String COUNTER_MESSAGES_IN_TOTAL = "rocketmq_messages_in_total";
     public static final String COUNTER_MESSAGES_OUT_TOTAL = "rocketmq_messages_out_total";

--- a/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
@@ -93,6 +93,7 @@ import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_CON
 import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_CONSUMER_QUEUEING_LATENCY;
 import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_CONSUMER_READY_MESSAGES;
 import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_HALF_MESSAGES;
+import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_LMQ_NUM;
 import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_PROCESSOR_WATERMARK;
 import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.GAUGE_PRODUCER_CONNECTIONS;
 import static org.apache.rocketmq.broker.metrics.BrokerMetricsConstant.HISTOGRAM_FINISH_MSG_LATENCY;
@@ -138,6 +139,7 @@ public class BrokerMetricsManager {
     private ObservableLongGauge brokerPermission = new NopObservableLongGauge();
     private ObservableLongGauge topicNum = new NopObservableLongGauge();
     private ObservableLongGauge consumerGroupNum = new NopObservableLongGauge();
+    private ObservableLongGauge lmqNum = new NopObservableLongGauge();
 
     // request metrics
     private LongCounter messagesInTotal = new NopLongCounter();
@@ -602,6 +604,13 @@ public class BrokerMetricsManager {
             .setDescription("Active subscription group number")
             .ofLongs()
             .buildWithCallback(measurement -> measurement.record(brokerController.getSubscriptionGroupManager().getSubscriptionGroupTable().size(), newAttributesBuilder().build()));
+
+        if (messageStore.getMessageStoreConfig().isEnableLmq()) {
+            lmqNum = brokerMeter.gaugeBuilder(GAUGE_LMQ_NUM)
+                .setDescription("Current LMQ number")
+                .ofLongs()
+                .buildWithCallback(measurement -> measurement.record(messageStore.getQueueStore().getLmqNum(), newAttributesBuilder().build()));
+        }
     }
 
     private void initRequestMetrics() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10644

### Brief Description

Add a new gauge metric `rocketmq_lmq_number` to the Broker's OpenTelemetry metrics, reporting the current LMQ count via `messageStore.getQueueStore().getLmqNum()`. This gives operators continuous visibility into LMQ resource usage for monitoring and alerting.

### How Did You Test This Change?

Verified locally by starting Broker with metrics enabled and confirming the new gauge appears in the OTLP/Prometheus exporter output.