### PR TITLE
fix: handle invalid namesrv instance endpoints

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NameServerAddressUtils.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NameServerAddressUtils.java
@@ -28,11 +28,11 @@ public class NameServerAddressUtils {
     }
 
     public static boolean validateInstanceEndpoint(String endpoint) {
-        return INST_ENDPOINT_PATTERN.matcher(endpoint).matches();
+        return StringUtils.isNotEmpty(endpoint) && INST_ENDPOINT_PATTERN.matcher(endpoint).matches();
     }
 
     public static String parseInstanceIdFromEndpoint(String endpoint) {
-        if (StringUtils.isEmpty(endpoint)) {
+        if (!validateInstanceEndpoint(endpoint)) {
             return null;
         }
         return endpoint.substring(endpoint.lastIndexOf("/") + 1, endpoint.indexOf('.'));

--- a/common/src/test/java/org/apache/rocketmq/common/utils/NameServerAddressUtilsTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/NameServerAddressUtilsTest.java
@@ -31,6 +31,7 @@ public class NameServerAddressUtilsTest {
 
     @Test
     public void testValidateInstanceEndpoint() {
+        assertThat(NameServerAddressUtils.validateInstanceEndpoint(null)).isEqualTo(false);
         assertThat(NameServerAddressUtils.validateInstanceEndpoint(endpoint1)).isEqualTo(false);
         assertThat(NameServerAddressUtils.validateInstanceEndpoint(endpoint2)).isEqualTo(false);
         assertThat(NameServerAddressUtils.validateInstanceEndpoint(endpoint3)).isEqualTo(true);
@@ -43,6 +44,8 @@ public class NameServerAddressUtilsTest {
             "MQ_INST_123456789_BXXUzaee");
         assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint(endpoint4)).isEqualTo(
             "MQ_INST_123456789_BXXUzaee");
+        assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint(endpoint1)).isNull();
+        assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint(endpoint2)).isNull();
     }
 
     @Test

--- a/common/src/test/java/org/apache/rocketmq/common/utils/NameServerAddressUtilsTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/NameServerAddressUtilsTest.java
@@ -40,6 +40,7 @@ public class NameServerAddressUtilsTest {
 
     @Test
     public void testParseInstanceIdFromEndpoint() {
+        assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint(null)).isNull();
         assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint(endpoint3)).isEqualTo(
             "MQ_INST_123456789_BXXUzaee");
         assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint(endpoint4)).isEqualTo(


### PR DESCRIPTION
## Summary

- make `validateInstanceEndpoint` return `false` for a null endpoint
- return `null` when `parseInstanceIdFromEndpoint` receives an invalid non-empty endpoint
- cover null and normal NameServer endpoints with unit tests

## Why

The parser previously used string indexes on any non-empty input. A normal NameServer address that is not an instance endpoint could therefore throw `StringIndexOutOfBoundsException`.

## Impact

Valid instance endpoints retain their existing parsed instance ID. Invalid or non-instance endpoints now fail safely with `null`.

## Validation

- `git diff --check`
- Attempted: `mvn -pl common -Dtest=NameServerAddressUtilsTest test`
- The first Maven dependency resolution exceeded the local command timeout; upstream CI is still needed for the full test result.
