### PR TITLE
[ISSUE #10651] Upgrade DLedger to 0.3.3-SNAPSHOT

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/dledger/DLedgerRoleChangeHandler.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/dledger/DLedgerRoleChangeHandler.java
@@ -80,7 +80,7 @@ public class DLedgerRoleChangeHandler implements DLedgerLeaderElector.RoleChange
                                 if (dLegerServer.getDLedgerStore().getLedgerEndIndex() == -1) {
                                     break;
                                 }
-                                if (dLegerServer.getDLedgerStore().getLedgerEndIndex() == dLegerServer.getDLedgerStore().getCommittedIndex()
+                                if (dLegerServer.getDLedgerStore().getLedgerEndIndex() == dLegerServer.getMemberState().getCommittedIndex()
                                     && messageStore.dispatchBehindBytes() == 0) {
                                     break;
                                 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,10 +33,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>

--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/DLedgerController.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/DLedgerController.java
@@ -17,8 +17,8 @@
 package org.apache.rocketmq.controller.impl;
 
 import com.google.common.base.Stopwatch;
-import io.openmessaging.storage.dledger.AppendFuture;
 import io.openmessaging.storage.dledger.DLedgerConfig;
+import io.openmessaging.storage.dledger.common.AppendFuture;
 import io.openmessaging.storage.dledger.DLedgerLeaderElector;
 import io.openmessaging.storage.dledger.DLedgerServer;
 import io.openmessaging.storage.dledger.MemberState;

--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/DLedgerControllerStateMachine.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/DLedgerControllerStateMachine.java
@@ -20,7 +20,8 @@ import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import io.openmessaging.storage.dledger.exception.DLedgerException;
 import io.openmessaging.storage.dledger.snapshot.SnapshotReader;
 import io.openmessaging.storage.dledger.snapshot.SnapshotWriter;
-import io.openmessaging.storage.dledger.statemachine.CommittedEntryIterator;
+import io.openmessaging.storage.dledger.statemachine.ApplyEntry;
+import io.openmessaging.storage.dledger.statemachine.ApplyEntryIterator;
 import io.openmessaging.storage.dledger.statemachine.StateMachine;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.controller.impl.event.EventMessage;
@@ -51,12 +52,13 @@ public class DLedgerControllerStateMachine implements StateMachine {
     }
 
     @Override
-    public void onApply(CommittedEntryIterator iterator) {
+    public void onApply(ApplyEntryIterator iterator) {
         int applyingSize = 0;
         long firstApplyIndex = -1;
         long lastApplyIndex = -1;
         while (iterator.hasNext()) {
-            final DLedgerEntry entry = iterator.next();
+            final ApplyEntry applyEntry = iterator.next();
+            final DLedgerEntry entry = applyEntry.getEntry();
             final byte[] body = entry.getBody();
             if (body != null && body.length > 0) {
                 final EventMessage event = this.eventSerializer.deserialize(body);

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
         <netty.version>4.1.130.Final</netty.version>
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
-        <fastjson.version>1.2.83</fastjson.version>
         <fastjson2.version>2.0.59</fastjson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <jna.version>4.2.2</jna.version>
@@ -123,7 +122,7 @@
         <lz4-java.version>1.10.3</lz4-java.version>
         <opentracing.version>0.33.0</opentracing.version>
         <jaeger.version>1.8.1</jaeger.version>
-        <dleger.version>0.3.2</dleger.version>
+        <dleger.version>0.3.3-SNAPSHOT</dleger.version>
         <annotations-api.version>6.0.53</annotations-api.version>
         <extra-enforcer-rules.version>1.0-beta-4</extra-enforcer-rules.version>
         <concurrentlinkedhashmap-lru.version>1.4.2</concurrentlinkedhashmap-lru.version>
@@ -688,11 +687,6 @@
                 <scope>runtime</scope>
                 <type>jar</type>
                 <version>${bcpkix-jdk18on.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>fastjson</artifactId>
-                <version>${fastjson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableCompatTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableCompatTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.rocketmq.remoting.protocol;
 
-import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.annotation.JSONField;
 import org.apache.rocketmq.remoting.protocol.body.BatchAck;
 import org.junit.Test;
 import org.objenesis.ObjenesisStd;
@@ -408,10 +408,10 @@ public class RemotingSerializableCompatTest {
     }
     
     private boolean checkCompatible(final Object original, final Class<?> clazz) {
-        String json = com.alibaba.fastjson.JSON.toJSONString(original);
+        String json = JSON.toJSONString(original);
         Object deserialized;
         try {
-            deserialized = com.alibaba.fastjson2.JSON.parseObject(json, clazz);
+            deserialized = JSON.parseObject(json, clazz);
         } catch (Exception e) {
             System.err.printf("Deserialization failed for %s: %s\n", clazz.getName(), e.getMessage());
             return false;

--- a/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/dledger/DLedgerCommitLog.java
@@ -16,9 +16,9 @@
  */
 package org.apache.rocketmq.store.dledger;
 
-import io.openmessaging.storage.dledger.AppendFuture;
-import io.openmessaging.storage.dledger.BatchAppendFuture;
 import io.openmessaging.storage.dledger.DLedgerConfig;
+import io.openmessaging.storage.dledger.common.AppendFuture;
+import io.openmessaging.storage.dledger.common.BatchAppendFuture;
 import io.openmessaging.storage.dledger.DLedgerServer;
 import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import io.openmessaging.storage.dledger.protocol.AppendEntryRequest;
@@ -98,7 +98,7 @@ public class DLedgerCommitLog extends CommitLog {
         dLedgerConfig.setDeleteWhen(defaultMessageStore.getMessageStoreConfig().getDeleteWhen());
         dLedgerConfig.setFileReservedHours(defaultMessageStore.getMessageStoreConfig().getFileReservedTime() + 1);
         dLedgerConfig.setPreferredLeaderId(defaultMessageStore.getMessageStoreConfig().getPreferredLeaderId());
-        dLedgerConfig.setEnableBatchPush(defaultMessageStore.getMessageStoreConfig().isEnableBatchPush());
+        dLedgerConfig.setEnableBatchAppend(defaultMessageStore.getMessageStoreConfig().isEnableBatchPush());
         dLedgerConfig.setDiskSpaceRatioToCheckExpired(defaultMessageStore.getMessageStoreConfig().getDiskMaxUsedSpaceRatio() / 100f);
 
         id = Integer.parseInt(dLedgerConfig.getSelfId().substring(1)) + 1;
@@ -149,13 +149,30 @@ public class DLedgerCommitLog extends CommitLog {
 
     @Override
     public long getMaxOffset() {
-        if (dLedgerFileStore.getCommittedPos() > 0) {
-            return dLedgerFileStore.getCommittedPos();
+        long committedPos = getCommittedPos();
+        if (committedPos > 0) {
+            return committedPos;
         }
         if (dLedgerFileList.getMinOffset() > 0) {
             return dLedgerFileList.getMinOffset();
         }
         return 0;
+    }
+
+    private long getCommittedPos() {
+        long committedIndex = dLedgerServer.getMemberState().getCommittedIndex();
+        if (committedIndex < 0) {
+            return -1;
+        }
+        try {
+            DLedgerEntry committedEntry = dLedgerFileStore.get(committedIndex);
+            if (committedEntry != null) {
+                return committedEntry.getPos() + committedEntry.getSize();
+            }
+        } catch (Throwable t) {
+            log.warn("Failed to get committed dledger entry by index={}", committedIndex, t);
+        }
+        return -1;
     }
 
     @Override
@@ -232,7 +249,7 @@ public class DLedgerCommitLog extends CommitLog {
     }
 
     public SelectMmapBufferResult truncate(SelectMmapBufferResult sbr) {
-        long committedPos = dLedgerFileStore.getCommittedPos();
+        long committedPos = getCommittedPos();
         if (sbr == null || sbr.getStartOffset() == committedPos) {
             return null;
         }
@@ -257,7 +274,7 @@ public class DLedgerCommitLog extends CommitLog {
         if (offset < dividedCommitlogOffset) {
             return super.getData(offset, returnFirstOnNotFound);
         }
-        if (offset >= dLedgerFileStore.getCommittedPos()) {
+        if (offset >= getCommittedPos()) {
             return null;
         }
         int mappedFileSize = this.dLedgerServer.getdLedgerConfig().getMappedFileSizeForEntryData();
@@ -276,7 +293,7 @@ public class DLedgerCommitLog extends CommitLog {
         if (offset < dividedCommitlogOffset) {
             return super.getData(offset, size, byteBuffer);
         }
-        if (offset >= dLedgerFileStore.getCommittedPos()) {
+        if (offset >= getCommittedPos()) {
             return false;
         }
         int mappedFileSize = this.dLedgerServer.getdLedgerConfig().getMappedFileSizeForEntryData();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-that-issue-using-keywords>) to ensure automatic closure. -->

- Fixes #10651

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

This PR upgrades the DLedger dependency to `0.3.3-SNAPSHOT` and adapts RocketMQ to the related API changes:

- Update DLedger future imports to `io.openmessaging.storage.dledger.common`.
- Replace `setEnableBatchPush` with `setEnableBatchAppend`.
- Read the committed index from `MemberState` after `DLedgerStore#getCommittedIndex()` was removed.
- Adapt the DLedger controller state machine to the new `ApplyEntryIterator` API.
- Derive the committed position from the committed DLedger entry after `DLedgerMmapFileStore#getCommittedPos()` was removed.
- Remove the obsolete `fastjson1` dependency and switch the remaining compatibility test usage to `fastjson2`.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->

- `mvn -DskipTests -Dspotbugs.skip=true compile`
- `mvn -DskipTests -Dspotbugs.skip=true test-compile`
- `git diff --check`
