### PR TITLE
[ISSUE #9881] Increase broker notification timeout

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java
@@ -73,6 +73,8 @@ public class NamesrvConfig {
 
     private volatile boolean notifyMinBrokerIdChanged = false;
 
+    private long notifyMinBrokerIdChangeTimeoutMillis = 3000;
+
     /**
      * Is startup the controller in this name-srv
      */
@@ -239,6 +241,14 @@ public class NamesrvConfig {
 
     public void setNotifyMinBrokerIdChanged(boolean notifyMinBrokerIdChanged) {
         this.notifyMinBrokerIdChanged = notifyMinBrokerIdChanged;
+    }
+
+    public long getNotifyMinBrokerIdChangeTimeoutMillis() {
+        return notifyMinBrokerIdChangeTimeoutMillis;
+    }
+
+    public void setNotifyMinBrokerIdChangeTimeoutMillis(long notifyMinBrokerIdChangeTimeoutMillis) {
+        this.notifyMinBrokerIdChangeTimeoutMillis = notifyMinBrokerIdChangeTimeoutMillis;
     }
 
     public boolean isEnableControllerInNamesrv() {

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -931,7 +931,8 @@ public class RouteInfoManager {
         RemotingCommand request =
             RemotingCommand.createRequestCommand(RequestCode.NOTIFY_MIN_BROKER_ID_CHANGE, requestHeader);
         for (String brokerAddr : brokerAddrsNotify) {
-            this.namesrvController.getRemotingClient().invokeOneway(brokerAddr, request, 300);
+            this.namesrvController.getRemotingClient().invokeOneway(brokerAddr, request,
+                this.namesrvConfig.getNotifyMinBrokerIdChangeTimeoutMillis());
         }
     }
 

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerNewTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerNewTest.java
@@ -19,11 +19,14 @@ package org.apache.rocketmq.namesrv.routeinfo;
 
 import com.google.common.collect.Sets;
 import io.netty.channel.Channel;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -31,7 +34,10 @@ import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.constant.PermName;
 import org.apache.rocketmq.common.namesrv.NamesrvConfig;
+import org.apache.rocketmq.namesrv.NamesrvController;
+import org.apache.rocketmq.remoting.RemotingClient;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
@@ -47,8 +53,12 @@ import org.mockito.Spy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RouteInfoManagerNewTest {
     private RouteInfoManager routeInfoManager;
@@ -600,6 +610,29 @@ public class RouteInfoManagerNewTest {
         await().atMost(Duration.ofSeconds(5)).until(() -> routeInfoManager.blockedUnRegisterRequests() == 0);
         assertThat(routeInfoManager.pickupTopicRouteData("TestTopic")).isNull();
         assertThat(routeInfoManager.pickupTopicRouteData("TestTopic1")).isNull();
+    }
+
+    @Test
+    public void notifyMinBrokerIdChangedUsesBrokerNotificationTimeout() throws Exception {
+        NamesrvController namesrvController = mock(NamesrvController.class);
+        RemotingClient remotingClient = mock(RemotingClient.class);
+        when(namesrvController.getRemotingClient()).thenReturn(remotingClient);
+
+        RouteInfoManager manager = new RouteInfoManager(config, namesrvController);
+        HashMap<Long, String> brokerAddrs = new HashMap<>();
+        brokerAddrs.put(0L, DEFAULT_ADDR);
+
+        Method notifyMinBrokerIdChanged = RouteInfoManager.class.getDeclaredMethod("notifyMinBrokerIdChanged",
+            Map.class, String.class, String.class);
+        notifyMinBrokerIdChanged.setAccessible(true);
+        notifyMinBrokerIdChanged.invoke(manager, brokerAddrs, null, null);
+
+        verify(remotingClient).invokeOneway(eq(DEFAULT_ADDR), any(RemotingCommand.class), eq(3000L));
+
+        config.setNotifyMinBrokerIdChangeTimeoutMillis(1234L);
+        notifyMinBrokerIdChanged.invoke(manager, brokerAddrs, null, null);
+
+        verify(remotingClient).invokeOneway(eq(DEFAULT_ADDR), any(RemotingCommand.class), eq(1234L));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #9881

### Brief Description

Increase the timeout for `NOTIFY_MIN_BROKER_ID_CHANGE` broker notification requests from 300ms to 3000ms. This gives the NameServer broker notification path the timeout requested in the issue while keeping the change scoped to that notification.

### How Did You Test This Change?

- `mvn -pl namesrv -Dtest=RouteInfoManagerNewTest#notifyMinBrokerIdChangedUsesBrokerNotificationTimeout test -DfailIfNoTests=false -Djacoco.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drat.skip=true`
- `mvn -pl namesrv -Dtest=RouteInfoManagerNewTest test -DfailIfNoTests=false -Djacoco.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drat.skip=true`
- `git diff --check`