### PR TITLE
[ISSUE #10656] Fix incorrect end timestamp recovery in tiered index files

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -114,7 +114,7 @@ public class IndexStoreFile implements IndexFile {
         this.fileChannel = this.mappedFile.getFileChannel();
 
         this.beginTimestamp.set(timestamp);
-        this.endTimestamp.set(byteBuffer.getLong(INDEX_BEGIN_TIME_STAMP));
+        this.endTimestamp.set(byteBuffer.getLong(INDEX_END_TIME_STAMP));
         this.hashSlotCount.set(byteBuffer.getInt(INDEX_SLOT_COUNT));
         this.indexItemCount.set(byteBuffer.getInt(INDEX_ITEM_INDEX));
         this.flushNewMetadata(byteBuffer, indexItemMaxCount == this.indexItemCount.get() + 1);

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreFileTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreFileTest.java
@@ -230,6 +230,21 @@ public class IndexStoreFileTest {
     }
 
     @Test
+    public void recoverEndTimestampTest() throws IOException {
+        long beginTimestamp = indexStoreFile.getTimestamp();
+        long endTimestamp = beginTimestamp + 10000L;
+        Assert.assertEquals(AppendResult.SUCCESS, indexStoreFile.putKey(
+            TOPIC_NAME, TOPIC_ID, QUEUE_ID, KEY_SET, MESSAGE_OFFSET, MESSAGE_SIZE, endTimestamp));
+        Assert.assertEquals(endTimestamp, indexStoreFile.getEndTimestamp());
+
+        indexStoreFile.shutdown();
+        indexStoreFile = new IndexStoreFile(storeConfig, beginTimestamp);
+
+        Assert.assertEquals(beginTimestamp, indexStoreFile.getTimestamp());
+        Assert.assertEquals(endTimestamp, indexStoreFile.getEndTimestamp());
+    }
+
+    @Test
     public void doCompactionTest() {
         long timestamp = indexStoreFile.getTimestamp();
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10656 

### Brief Description

Fix `IndexStoreFile` to restore `endTimestamp` from `INDEX_END_TIME_STAMP` and add a regression test.

### How Did You Test This Change?

Added a test that writes an index, reopens the file, and verifies that its end timestamp is recovered correctly with and without mmap writes.
