### PR TITLE
[ISSUE #10025] Treat blank local serve address as unset

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -296,7 +296,7 @@ public class ProxyConfig implements ConfigFile {
     @Override
     public void initData() {
         parseDelayLevel();
-        if (StringUtils.isEmpty(localServeAddr)) {
+        if (StringUtils.isBlank(localServeAddr)) {
             this.localServeAddr = NetworkUtil.getLocalAddress();
         }
         if (StringUtils.isBlank(localServeAddr)) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxyConfigTest {
+
+    @Test
+    public void initDataShouldResolveBlankLocalServeAddr() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+        proxyConfig.setLocalServeAddr(" \t ");
+        proxyConfig.setRemotingAccessAddr(" ");
+
+        proxyConfig.initData();
+
+        assertThat(StringUtils.isBlank(proxyConfig.getLocalServeAddr())).isFalse();
+        assertThat(proxyConfig.getRemotingAccessAddr()).isEqualTo(proxyConfig.getLocalServeAddr());
+    }
+}


### PR DESCRIPTION
## Summary
- treat blank `localServeAddr` as unset in `ProxyConfig.initData()`
- add coverage for whitespace-only local address fallback and remoting access address fallback

## Tests
- `mvn -pl proxy -Dtest=ProxyConfigTest test`

Fixes #10025