### PR TITLE
fix(proxy): unregister all publishing topics on gRPC producer termination

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -156,11 +156,11 @@ public class ClientActivity extends AbstractMessagingActivity {
 
             switch (clientSettings.getClientType()) {
                 case PRODUCER:
-                    for (Resource topic : clientSettings.getPublishing().getTopicsList()) {
-                        String topicName = topic.getName();
-                        GrpcClientChannel channel = this.grpcChannelManager.removeChannel(clientId);
-                        if (channel != null) {
-                            ClientChannelInfo clientChannelInfo = new ClientChannelInfo(channel, clientId, languageCode, MQVersion.Version.V5_0_0.ordinal());
+                    GrpcClientChannel producerChannel = this.grpcChannelManager.removeChannel(clientId);
+                    if (producerChannel != null) {
+                        ClientChannelInfo clientChannelInfo = new ClientChannelInfo(producerChannel, clientId, languageCode, MQVersion.Version.V5_0_0.ordinal());
+                        for (Resource topic : clientSettings.getPublishing().getTopicsList()) {
+                            String topicName = topic.getName();
                             this.messagingProcessor.unRegisterProducer(ctx, topicName, clientChannelInfo);
                         }
                     }


### PR DESCRIPTION
## 痛点

gRPC producer 终止时，notifyClientTermination 中 grpcChannelManager.removeChannel(clientId) 被放在 for 循环内部。removeChannel 第一次调用时移除并返回 channel，后续迭代返回 null，导致只有第一个 publishing topic 被注销，其余 topic 的 producer 注册信息残留在 broker 端。

Fixes #10661

## 已实现

- 将 grpcChannelManager.removeChannel(clientId) 移到 for 循环之前
- channel 只移除一次，所有 publishing topic 均正确调用 unRegisterProducer

## 验证

- 改动仅调整控制流顺序，不改变单次注销的语义
- 本地无 Java 编译环境，依赖 CI 验证编译和测试
- 改动文件：ClientActivity.java（5 行增 5 行删）

Signed-off-by: btlqql <2977859784@qq.com>