### PR TITLE
[ISSUE #10672] Sanitize proxy telemetry failure logs

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -25,7 +25,6 @@ import apache.rocketmq.v2.VerifyMessageCommand;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.TextFormat;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -263,22 +262,55 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
     public void writeTelemetryCommand(TelemetryCommand command) {
         StreamObserver<TelemetryCommand> observer = this.telemetryCommandRef.get();
         if (observer == null) {
-            log.warn("telemetry command observer is null when try to write data. command:{}, channel:{}", TextFormat.shortDebugString(command), this);
+            log.warn("telemetry command observer is null when try to write data. command:{}, channel:{}",
+                summarizeTelemetryCommand(command), this);
             return;
         }
         synchronized (this.telemetryWriteLock) {
             observer = this.telemetryCommandRef.get();
             if (observer == null) {
-                log.warn("telemetry command observer is null when try to write data. command:{}, channel:{}", TextFormat.shortDebugString(command), this);
+                log.warn("telemetry command observer is null when try to write data. command:{}, channel:{}",
+                    summarizeTelemetryCommand(command), this);
                 return;
             }
             try {
                 observer.onNext(command);
             } catch (StatusRuntimeException | IllegalStateException exception) {
-                log.warn("write telemetry failed. command:{}", command, exception);
+                log.warn("write telemetry failed. command:{}, channel:{}", summarizeTelemetryCommand(command), this, exception);
                 this.clearClientObserver(observer);
             }
         }
+    }
+
+    static String summarizeTelemetryCommand(TelemetryCommand command) {
+        if (command == null) {
+            return "null";
+        }
+
+        StringBuilder builder = new StringBuilder(command.getCommandCase().name());
+        switch (command.getCommandCase()) {
+            case PRINT_THREAD_STACK_TRACE_COMMAND:
+                builder.append(", nonce=").append(command.getPrintThreadStackTraceCommand().getNonce());
+                break;
+            case VERIFY_MESSAGE_COMMAND:
+                builder.append(", nonce=").append(command.getVerifyMessageCommand().getNonce());
+                break;
+            case RECOVER_ORPHANED_TRANSACTION_COMMAND:
+                builder.append(", transactionId=")
+                    .append(command.getRecoverOrphanedTransactionCommand().getTransactionId());
+                break;
+            case NOTIFY_UNSUBSCRIBE_LITE_COMMAND:
+                builder.append(", liteTopic=")
+                    .append(command.getNotifyUnsubscribeLiteCommand().getLiteTopic());
+                break;
+            case SETTINGS:
+                builder.append(", clientType=").append(command.getSettings().getClientType())
+                    .append(", pubSubCase=").append(command.getSettings().getPubSubCase());
+                break;
+            default:
+                break;
+        }
+        return builder.toString();
     }
 
     @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -297,7 +297,8 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
                 break;
             case RECOVER_ORPHANED_TRANSACTION_COMMAND:
                 builder.append(", transactionId=")
-                    .append(command.getRecoverOrphanedTransactionCommand().getTransactionId());
+                    .append(command.getRecoverOrphanedTransactionCommand().getTransactionId())
+                    .append(", details omitted");
                 break;
             case NOTIFY_UNSUBSCRIBE_LITE_COMMAND:
                 builder.append(", liteTopic=")
@@ -308,6 +309,7 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
                     .append(", pubSubCase=").append(command.getSettings().getPubSubCase());
                 break;
             default:
+                // Add explicit cases for future commands that carry sensitive payloads.
                 break;
         }
         return builder.toString();

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.proxy.grpc.v2.channel;
 
 import apache.rocketmq.v2.Message;
 import apache.rocketmq.v2.Publishing;
+import apache.rocketmq.v2.RecoverOrphanedTransactionCommand;
 import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.Settings;
 import apache.rocketmq.v2.TelemetryCommand;
@@ -101,6 +102,27 @@ public class GrpcClientChannelTest extends InitConfigTest {
 
         assertTrue(summary.contains("VERIFY_MESSAGE_COMMAND"));
         assertTrue(summary.contains("nonce-1"));
+        assertFalse(summary.contains("secret-body"));
+        assertFalse(summary.contains("message"));
+        assertFalse(summary.contains("body"));
+    }
+
+    @Test
+    public void testSummarizeRecoverTransactionCommandDoesNotIncludeMessagePayload() {
+        TelemetryCommand command = TelemetryCommand.newBuilder()
+            .setRecoverOrphanedTransactionCommand(RecoverOrphanedTransactionCommand.newBuilder()
+                .setTransactionId("transaction-id")
+                .setMessage(Message.newBuilder()
+                    .setBody(ByteString.copyFromUtf8("secret-body"))
+                    .build())
+                .build())
+            .build();
+
+        String summary = GrpcClientChannel.summarizeTelemetryCommand(command);
+
+        assertTrue(summary.contains("RECOVER_ORPHANED_TRANSACTION_COMMAND"));
+        assertTrue(summary.contains("transaction-id"));
+        assertTrue(summary.contains("details omitted"));
         assertFalse(summary.contains("secret-body"));
         assertFalse(summary.contains("message"));
         assertFalse(summary.contains("body"));

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
@@ -18,7 +18,9 @@
 package org.apache.rocketmq.proxy.grpc.v2.channel;
 
 import apache.rocketmq.v2.Message;
+import apache.rocketmq.v2.NotifyUnsubscribeLiteCommand;
 import apache.rocketmq.v2.Publishing;
+import apache.rocketmq.v2.PrintThreadStackTraceCommand;
 import apache.rocketmq.v2.RecoverOrphanedTransactionCommand;
 import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.Settings;
@@ -126,5 +128,39 @@ public class GrpcClientChannelTest extends InitConfigTest {
         assertFalse(summary.contains("secret-body"));
         assertFalse(summary.contains("message"));
         assertFalse(summary.contains("body"));
+    }
+
+    @Test
+    public void testSummarizeTelemetryCommandDiagnosticFields() {
+        assertEquals("null", GrpcClientChannel.summarizeTelemetryCommand(null));
+        assertEquals("COMMAND_NOT_SET", GrpcClientChannel.summarizeTelemetryCommand(TelemetryCommand.getDefaultInstance()));
+
+        TelemetryCommand settingsCommand = TelemetryCommand.newBuilder()
+            .setSettings(Settings.newBuilder()
+                .setPublishing(Publishing.getDefaultInstance())
+                .build())
+            .build();
+        String settingsSummary = GrpcClientChannel.summarizeTelemetryCommand(settingsCommand);
+        assertTrue(settingsSummary.contains("SETTINGS"));
+        assertTrue(settingsSummary.contains("clientType="));
+        assertTrue(settingsSummary.contains("pubSubCase=PUBLISHING"));
+
+        TelemetryCommand threadStackCommand = TelemetryCommand.newBuilder()
+            .setPrintThreadStackTraceCommand(PrintThreadStackTraceCommand.newBuilder()
+                .setNonce("stack-nonce")
+                .build())
+            .build();
+        String threadStackSummary = GrpcClientChannel.summarizeTelemetryCommand(threadStackCommand);
+        assertTrue(threadStackSummary.contains("PRINT_THREAD_STACK_TRACE_COMMAND"));
+        assertTrue(threadStackSummary.contains("stack-nonce"));
+
+        TelemetryCommand liteCommand = TelemetryCommand.newBuilder()
+            .setNotifyUnsubscribeLiteCommand(NotifyUnsubscribeLiteCommand.newBuilder()
+                .setLiteTopic("lite-topic")
+                .build())
+            .build();
+        String liteSummary = GrpcClientChannel.summarizeTelemetryCommand(liteCommand);
+        assertTrue(liteSummary.contains("NOTIFY_UNSUBSCRIBE_LITE_COMMAND"));
+        assertTrue(liteSummary.contains("lite-topic"));
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannelTest.java
@@ -17,9 +17,13 @@
 
 package org.apache.rocketmq.proxy.grpc.v2.channel;
 
+import apache.rocketmq.v2.Message;
 import apache.rocketmq.v2.Publishing;
 import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.TelemetryCommand;
+import apache.rocketmq.v2.VerifyMessageCommand;
+import com.google.protobuf.ByteString;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.InitConfigTest;
@@ -35,7 +39,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,5 +84,25 @@ public class GrpcClientChannelTest extends InitConfigTest {
         assertEquals(clientSettings, GrpcClientChannel.parseChannelExtendAttribute(remoteChannel));
         assertEquals(clientSettings, GrpcClientChannel.parseChannelExtendAttribute(this.grpcClientChannel));
         assertNull(GrpcClientChannel.parseChannelExtendAttribute(mock(RemotingChannel.class)));
+    }
+
+    @Test
+    public void testSummarizeTelemetryCommandDoesNotIncludeMessagePayload() {
+        TelemetryCommand command = TelemetryCommand.newBuilder()
+            .setVerifyMessageCommand(VerifyMessageCommand.newBuilder()
+                .setNonce("nonce-1")
+                .setMessage(Message.newBuilder()
+                    .setBody(ByteString.copyFromUtf8("secret-body"))
+                    .build())
+                .build())
+            .build();
+
+        String summary = GrpcClientChannel.summarizeTelemetryCommand(command);
+
+        assertTrue(summary.contains("VERIFY_MESSAGE_COMMAND"));
+        assertTrue(summary.contains("nonce-1"));
+        assertFalse(summary.contains("secret-body"));
+        assertFalse(summary.contains("message"));
+        assertFalse(summary.contains("body"));
     }
 }


### PR DESCRIPTION
### Summary

- Replace full `TelemetryCommand` logging in `GrpcClientChannel.writeTelemetryCommand` with a compact command summary.
- Preserve useful runtime diagnostics such as command type, nonce, transaction ID, client type, and channel context.
- Add coverage to ensure message payloads are not included in telemetry command summaries.

### Motivation

Closes #10672.

Proxy gRPC telemetry write failures can happen after a client disconnects or when the telemetry stream is completed. The previous warning logs serialized the full protobuf command, which can include message payloads for commands such as `VerifyMessageCommand` and `RecoverOrphanedTransactionCommand`.

### Review feedback addressed

- Mark `RECOVER_ORPHANED_TRANSACTION_COMMAND` summaries with `details omitted` to make intentional field exclusion explicit.
- Add a maintenance comment for future telemetry commands that may carry sensitive payloads.
- Add a regression test for `RecoverOrphanedTransactionCommand` payload redaction.
- Improve `summarizeTelemetryCommand` coverage for null/default commands, settings commands, thread-stack trace commands, and lite unsubscribe notifications.

### Tests

- `mvn -pl proxy -Dtest=GrpcClientChannelTest -DfailIfNoTests=false test`

Result: BUILD SUCCESS; 4 tests passed; checkstyle reported 0 violations. The run emits existing JaCoCo instrumentation warnings under the local JDK, but tests and build completed successfully.