### PR TITLE
[ISSUE #10674] Fix integer overflow in three long-to-int comparators

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopRequest.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopRequest.java
@@ -92,12 +92,14 @@ public class PopRequest {
     }
 
     public static final Comparator<PopRequest> COMPARATOR = (o1, o2) -> {
-        int ret = (int) (o1.getExpired() - o2.getExpired());
+        // Avoid long-subtraction-cast-to-int overflow (op starts at Long.MIN_VALUE,
+        // expired is a long timestamp) — mirrors the #10579 fix in DefaultElectPolicy.
+        int ret = Long.compare(o1.getExpired(), o2.getExpired());
 
         if (ret != 0) {
             return ret;
         }
-        ret = (int) (o1.op - o2.op);
+        ret = Long.compare(o1.op, o2.op);
         if (ret != 0) {
             return ret;
         }

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -725,7 +725,7 @@ public class PopReviveService extends ServiceThread {
                 return sortList;
             }
             sortList = new ArrayList<>(map.values());
-            sortList.sort((o1, o2) -> (int) (o1.getReviveOffset() - o2.getReviveOffset()));
+            sortList.sort((o1, o2) -> Long.compare(o1.getReviveOffset(), o2.getReviveOffset()));
             return sortList;
         }
     }

--- a/broker/src/test/java/org/apache/rocketmq/broker/longpolling/PopRequestComparatorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/longpolling/PopRequestComparatorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.broker.longpolling;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.apache.rocketmq.store.MessageFilter;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Regression tests for the long-to-int comparator overflow fixed in PopRequest.COMPARATOR.
+ *
+ * <p>The {@code op} counter starts at {@link Long#MIN_VALUE}, so a delta between two
+ * PopRequests can easily exceed {@link Integer#MAX_VALUE} and would overflow when
+ * the old code cast a {@code long} subtraction to {@code int}. The {@code expired}
+ * timestamp has the same hazard for requests far apart in time.
+ */
+public class PopRequestComparatorTest {
+
+    private PopRequest newPopRequest(long expired) throws Exception {
+        return new PopRequest(
+            mock(RemotingCommand.class),
+            mock(ChannelHandlerContext.class),
+            expired,
+            mock(SubscriptionData.class),
+            mock(MessageFilter.class));
+    }
+
+    /**
+     * Reflectively set the {@code op} field (assigned from a static AtomicLong
+     * starting at {@link Long#MIN_VALUE}) so two PopRequests' op values differ by
+     * more than {@link Integer#MAX_VALUE}.
+     *
+     * <p>The old {@code (int)(o1.op - o2.op)} cast truncated this delta to int and
+     * flipped the sign, corrupting the {@code ConcurrentSkipListSet} ordering.
+     * The fix uses {@link Long#compare} to preserve the correct sign.
+     */
+    @Test
+    public void comparatorDoesNotOverflowOnOpDelta() throws Exception {
+        resetOpCounterTo(Long.MIN_VALUE);
+        PopRequest a = newPopRequest(1000L);
+        PopRequest c = newPopRequest(1000L);
+
+        // Force op delta beyond Integer.MAX_VALUE: a.op = MIN_VALUE,
+        // c.op = MIN_VALUE + (MAX_VALUE + 2) -> delta = MAX_VALUE + 2 > int range.
+        setOp(a, Long.MIN_VALUE);
+        setOp(c, Long.MIN_VALUE + (long) Integer.MAX_VALUE + 2L);
+
+        // a.op < c.op by more than 2^31. Old (int)(a.op - c.op) overflowed to a
+        // positive value (wrongly a > c); Long.compare returns negative (a < c).
+        assertThat(PopRequest.COMPARATOR.compare(a, c)).isNegative();
+        assertThat(PopRequest.COMPARATOR.compare(c, a)).isPositive();
+    }
+
+    /**
+     * Two requests whose {@code expired} timestamps differ by more than
+     * {@link Integer#MAX_VALUE} must be ordered by the earlier expiry first.
+     */
+    @Test
+    public void comparatorDoesNotOverflowOnExpiredDelta() throws Exception {
+        resetOpCounterTo(Long.MIN_VALUE);
+        long base = 0L;
+        PopRequest earlier = newPopRequest(base);
+        PopRequest later = newPopRequest(base + (long) Integer.MAX_VALUE + 2L);
+
+        // earlier should compare before later
+        assertThat(PopRequest.COMPARATOR.compare(earlier, later)).isNegative();
+        assertThat(PopRequest.COMPARATOR.compare(later, earlier)).isPositive();
+    }
+
+    /**
+     * The comparator must be consistent for equal {@code expired}: the one with
+     * the smaller {@code op} comes first (FIFO by creation order).
+     */
+    @Test
+    public void comparatorIsConsistentForEqualExpired() throws Exception {
+        resetOpCounterTo(Long.MIN_VALUE);
+        PopRequest first = newPopRequest(5000L);
+        PopRequest second = newPopRequest(5000L);
+
+        // equal expired -> tie-broken by op (first created is smaller) -> first < second
+        assertThat(PopRequest.COMPARATOR.compare(first, second)).isNegative();
+    }
+
+    /**
+     * Reflectively reset the static op counter so the overflow window is
+     * deterministic and does not depend on how many PopRequests tests before
+     * this one have created.
+     */
+    private static void resetOpCounterTo(long value) throws Exception {
+        Field counterField = PopRequest.class.getDeclaredField("COUNTER");
+        counterField.setAccessible(true);
+        AtomicLong counter = (AtomicLong) counterField.get(null);
+        counter.set(value);
+    }
+
+    /**
+     * Reflectively set the {@code op} field on a PopRequest to force an op delta
+     * that exceeds {@link Integer#MAX_VALUE} without having to create 2^31
+     * real PopRequests.
+     */
+    private static void setOp(PopRequest pr, long value) throws Exception {
+        Field opField = PopRequest.class.getDeclaredField("op");
+        opField.setAccessible(true);
+        opField.setLong(pr, value);
+    }
+}

--- a/store/src/main/java/org/apache/rocketmq/store/pop/PopCheckPoint.java
+++ b/store/src/main/java/org/apache/rocketmq/store/pop/PopCheckPoint.java
@@ -212,6 +212,7 @@ public class PopCheckPoint implements Comparable<PopCheckPoint> {
 
     @Override
     public int compareTo(PopCheckPoint o) {
-        return (int) (this.getStartOffset() - o.getStartOffset());
+        // Avoid long-subtraction-cast-to-int overflow — mirrors the #10579 fix.
+        return Long.compare(this.getStartOffset(), o.getStartOffset());
     }
 }

--- a/store/src/test/java/org/apache/rocketmq/store/pop/PopCheckPointComparatorTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/pop/PopCheckPointComparatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.pop;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the long-to-int comparator overflow fixed in
+ * {@link PopCheckPoint#compareTo(PopCheckPoint)}.
+ *
+ * <p>When two {@code startOffset} values differ by more than
+ * {@link Integer#MAX_VALUE}, the old cast-{@code (int)(a - b)} overflowed
+ * and produced the wrong sign.
+ */
+public class PopCheckPointComparatorTest {
+
+    private PopCheckPoint newCheckPoint(long startOffset) {
+        PopCheckPoint cp = new PopCheckPoint();
+        cp.setStartOffset(startOffset);
+        return cp;
+    }
+
+    /**
+     * The delta between the two startOffset values exceeds Integer.MAX_VALUE.
+     * The old code: {@code (int)(a - b)} would overflow and return the wrong sign.
+     * The fix: {@code Long.compare(a, b)} returns the correct ordering.
+     */
+    @Test
+    public void compareToDoesNotOverflowOnLargeOffsetDelta() {
+        long small = 0L;
+        long large = (long) Integer.MAX_VALUE + 2L;
+
+        PopCheckPoint cpSmall = newCheckPoint(small);
+        PopCheckPoint cpLarge = newCheckPoint(large);
+
+        // small offset should compare before large offset
+        assertThat(cpSmall.compareTo(cpLarge)).isNegative();
+        assertThat(cpLarge.compareTo(cpSmall)).isPositive();
+    }
+
+    /**
+     * Offsets near Long.MIN_VALUE should also be ordered correctly.
+     */
+    @Test
+    public void compareToOrdersNearMinValue() {
+        PopCheckPoint a = newCheckPoint(Long.MIN_VALUE);
+        PopCheckPoint b = newCheckPoint(Long.MIN_VALUE + 100);
+
+        assertThat(a.compareTo(b)).isNegative();
+        assertThat(b.compareTo(a)).isPositive();
+    }
+
+    /**
+     * Equal offsets should compare as zero.
+     */
+    @Test
+    public void compareToReturnsZeroForEqualOffsets() {
+        PopCheckPoint a = newCheckPoint(12345L);
+        PopCheckPoint b = newCheckPoint(12345L);
+
+        assertThat(a.compareTo(b)).isZero();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

PR #10579 fixed a long-to-int subtraction overflow in `DefaultElectPolicy`'s comparator. A systematic scan found **three more comparators** with the same `(int)(longA - longB)` overflow pattern. When the `long` delta exceeds `Integer.MAX_VALUE`, the cast truncates the result and flips the sign, corrupting sort/ordered-set invariants.

This PR fixes all three by replacing the subtraction-cast-to-`int` idiom with `Long.compare`, mirroring the #10579 fix.

## Brief changelog

### 1. `PopRequest.COMPARATOR` — broker, long-polling (most severe)
- `expired` is a `long` timestamp; `op` is a `long` counter starting at `Long.MIN_VALUE`.
- **Overflow is essentially guaranteed** for any non-trivial run: the `op` counter walks from `Long.MIN_VALUE` upward, so deltas between early and late requests easily exceed `Integer.MAX_VALUE`.
- This comparator backs a `ConcurrentSkipListSet` for pop long-polling. A broken comparator corrupts the set's ordering invariants, causing requests to be misplaced, starved, or delivered out of order.
- Fix: `Long.compare(o1.getExpired(), o2.getExpired())` + `Long.compare(o1.op, o2.op)`.

### 2. `PopCheckPoint.compareTo` — store, pop checkpoint
- `startOffset` is a `long` queue offset. Long-running brokers can produce offsets whose delta exceeds `Integer.MAX_VALUE`.
- Fix: `Long.compare(this.getStartOffset(), o.getStartOffset())`.

### 3. `PopReviveService.genSortList` — broker, pop revival
- `reviveOffset` is a `long` commit-log offset (same class as #10579).
- Fix: `Long.compare(o1.getReviveOffset(), o2.getReviveOffset())`.

## How to test

Added regression tests covering the overflow condition:

- `PopRequestComparatorTest` (broker module, 3 tests):
  - `comparatorDoesNotOverflowOnOpDelta` — reflects `op` field to force a delta beyond `Integer.MAX_VALUE`; verifies correct ordering.
  - `comparatorDoesNotOverflowOnExpiredDelta` — `expired` timestamps differ by more than `Integer.MAX_VALUE`.
  - `comparatorIsConsistentForEqualExpired` — equal `expired` tie-broken by `op` (FIFO).

- `PopCheckPointComparatorTest` (store module, 3 tests):
  - `compareToDoesNotOverflowOnLargeOffsetDelta` — `startOffset` delta exceeds `Integer.MAX_VALUE`.
  - `compareToOrdersNearMinValue` — offsets near `Long.MIN_VALUE`.
  - `compareToReturnsZeroForEqualOffsets` — equal offsets compare as zero.

All 6 tests pass with the fix; the old code fails the overflow tests.

## Verifying this change

- [x] Make sure there is a GitHub issue field for the change (usually something like `#10674`).

Closes #10674