### PR TITLE
[ISSUE #10676] Sanitize telemetry exception logs

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -362,9 +362,37 @@ public class ClientActivity extends AbstractMessagingActivity {
             }
         }
         if (exception.getStatus().getCode().equals(io.grpc.Status.Code.INTERNAL)) {
-            log.warn("process client telemetryCommand failed. request:{}", request, t);
+            log.warn("process client telemetryCommand failed. request:{}", summarizeTelemetryCommand(request), t);
         }
         responseObserver.onError(exception);
+    }
+
+    static String summarizeTelemetryCommand(TelemetryCommand request) {
+        if (request == null) {
+            return "null";
+        }
+
+        StringBuilder builder = new StringBuilder(request.getCommandCase().name());
+        if (request.hasStatus()) {
+            builder.append(", statusCode=").append(request.getStatus().getCode());
+        }
+        switch (request.getCommandCase()) {
+            case SETTINGS:
+                builder.append(", clientType=").append(request.getSettings().getClientType())
+                    .append(", pubSubCase=").append(request.getSettings().getPubSubCase());
+                break;
+            case THREAD_STACK_TRACE:
+                builder.append(", nonce=").append(request.getThreadStackTrace().getNonce())
+                    .append(", details omitted");
+                break;
+            case VERIFY_MESSAGE_RESULT:
+                builder.append(", nonce=").append(request.getVerifyMessageResult().getNonce());
+                break;
+            default:
+                // Add explicit cases for future telemetry requests that carry sensitive details.
+                break;
+        }
+        return builder.toString();
     }
 
     protected void processAndWriteClientSettings(ProxyContext ctx, TelemetryCommand request,

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
@@ -71,6 +71,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -414,6 +415,25 @@ public class ClientActivityTest extends BaseActivityTest {
         ProxyRelayResult<ConsumeMessageDirectlyResult> result = resultArgumentCaptor.getValue();
         assertThat(result.getCode()).isEqualTo(ResponseCode.SUCCESS);
         assertThat(result.getResult().getConsumeResult()).isEqualTo(CMResult.CR_SUCCESS);
+    }
+
+    @Test
+    public void testSummarizeTelemetryCommandDoesNotIncludeThreadStackTrace() {
+        TelemetryCommand command = TelemetryCommand.newBuilder()
+            .setThreadStackTrace(ThreadStackTrace.newBuilder()
+                .setNonce("nonce-1")
+                .setThreadStackTrace("secret-stack-trace")
+                .build())
+            .setStatus(ResponseBuilder.getInstance().buildStatus(Code.OK, Code.OK.name()))
+            .build();
+
+        String summary = ClientActivity.summarizeTelemetryCommand(command);
+
+        assertTrue(summary.contains("THREAD_STACK_TRACE"));
+        assertTrue(summary.contains("statusCode=OK"));
+        assertTrue(summary.contains("nonce-1"));
+        assertTrue(summary.contains("details omitted"));
+        assertFalse(summary.contains("secret-stack-trace"));
     }
 
     protected CompletableFuture<TelemetryCommand> sendClientTelemetry(ProxyContext ctx, Settings settings) {


### PR DESCRIPTION
### Summary

- Replace full inbound `TelemetryCommand` logging in `ClientActivity.processTelemetryException` with a compact request summary.
- Preserve diagnostic fields such as command type, status code, nonce, client type, and pub/sub case.
- Add coverage to ensure thread stack trace telemetry content is omitted from summaries.

### Motivation

Closes #10676.

When client telemetry processing fails with an internal error, the previous warning log serialized the full protobuf request via `request:{}`. Client telemetry may include verbose or sensitive runtime details such as thread stack traces, so logs should stay bounded and diagnostic-focused.

### Tests

- `mvn -pl proxy -Dtest=ClientActivityTest -DfailIfNoTests=false test`

Result: BUILD SUCCESS; 16 tests passed; checkstyle reported 0 violations. The run emits existing JaCoCo instrumentation warnings under the local JDK, but tests and build completed successfully.
