### PR TITLE
[ISSUE #10678] Reject empty ack entries

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivity.java
@@ -36,6 +36,7 @@ import org.apache.rocketmq.proxy.grpc.v2.AbstractMessagingActivity;
 import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
 import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
 import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcProxyException;
 import org.apache.rocketmq.proxy.grpc.v2.common.ResponseBuilder;
 import org.apache.rocketmq.proxy.processor.BatchAckResult;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
@@ -55,6 +56,9 @@ public class AckMessageActivity extends AbstractMessagingActivity {
             validateTopicAndConsumerGroup(request.getTopic(), request.getGroup());
             String group = request.getGroup().getName();
             String topic = request.getTopic().getName();
+            if (request.getEntriesCount() == 0) {
+                throw new GrpcProxyException(Code.BAD_REQUEST, "ack message entries cannot be empty");
+            }
             boolean isBatchAck = ConfigurationManager.getProxyConfig().isEnableBatchAck()
                 && !request.getEntries(0).hasLiteTopic();
             if (isBatchAck) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivityTest.java
@@ -28,12 +28,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.rocketmq.client.consumer.AckResult;
 import org.apache.rocketmq.client.consumer.AckStatus;
 import org.apache.rocketmq.proxy.common.ProxyException;
 import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.grpc.v2.BaseActivityTest;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcProxyException;
 import org.apache.rocketmq.proxy.processor.BatchAckResult;
 import org.apache.rocketmq.proxy.service.message.ReceiptHandleMessage;
 import org.junit.Before;
@@ -41,6 +43,7 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -151,6 +154,28 @@ public class AckMessageActivityTest extends BaseActivityTest {
             assertEquals(Code.OK, response.getEntries(1).getStatus().getCode());
             assertEquals(Code.INTERNAL_SERVER_ERROR, response.getEntries(2).getStatus().getCode());
         }
+    }
+
+    @Test
+    public void testAckMessageWithEmptyEntries() throws Throwable {
+        ConfigurationManager.getProxyConfig().setEnableBatchAck(true);
+
+        try {
+            this.ackMessageActivity.ackMessage(
+                createContext(),
+                AckMessageRequest.newBuilder()
+                    .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                    .setGroup(Resource.newBuilder().setName(GROUP).build())
+                    .build()
+            ).get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof GrpcProxyException);
+            GrpcProxyException exception = (GrpcProxyException) e.getCause();
+            assertEquals(Code.BAD_REQUEST, exception.getCode());
+            assertEquals("ack message entries cannot be empty", exception.getMessage());
+            return;
+        }
+        throw new AssertionError("empty ack entries should be rejected");
     }
 
     @Test


### PR DESCRIPTION
### Summary

- Reject empty `AckMessageRequest.entries` before checking the first entry for batch-ack routing.
- Return a structured `GrpcProxyException(Code.BAD_REQUEST, ...)` for invalid empty ack requests.
- Add a regression test covering empty entries with batch ack enabled.

### Motivation

Closes #10678.

`AckMessageActivity.ackMessage` previously evaluated `request.getEntries(0)` before validating that the request contains any entries. An empty ack request therefore triggered `IndexOutOfBoundsException`, which makes invalid client input look like an internal Proxy failure.

### Tests

- `mvn -pl proxy -Dtest=AckMessageActivityTest -DfailIfNoTests=false test`

Result: BUILD SUCCESS; 3 tests passed; checkstyle reported 0 violations. The run emits existing JaCoCo instrumentation warnings under the local JDK, but tests and build completed successfully.
