### PR TITLE
[ISSUE #10681] Skip lite offline cleanup without subscriptions

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
@@ -236,6 +236,9 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
             && ClientType.LITE_SIMPLE_CONSUMER != settings.getClientType()) {
             return;
         }
+        if (!settings.hasSubscription() || settings.getSubscription().getSubscriptionsCount() == 0) {
+            return;
+        }
         try {
             String topic = settings.getSubscription().getSubscriptions(0).getTopic().getName();
             String group = settings.getSubscription().getGroup().getName();

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
@@ -157,6 +157,20 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
     }
 
     @Test
+    public void testOfflineClientLiteSubscription_LiteConsumerWithoutSubscriptions() {
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.LITE_PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("testGroup").build())
+                .build())
+            .build();
+
+        grpcClientSettingsManager.offlineClientLiteSubscription(ctx, clientId, settings);
+
+        verify(messagingProcessor, never()).syncLiteSubscription(any(), any(), anyLong());
+    }
+
+    @Test
     public void testOfflineClientLiteSubscription_ValidLiteConsumer_Success() {
         Subscription subscription = Subscription.newBuilder()
             .setGroup(Resource.newBuilder().setName("testGroup").build())


### PR DESCRIPTION
### Summary

- Skip lite-client offline cleanup when settings have no subscription section or no subscription entries.
- Avoid indexing `subscriptions(0)` for incomplete lite-consumer settings.
- Add a regression test for lite consumers without subscription entries.

### Motivation

Closes #10681.

`GrpcClientSettingsManager.offlineClientLiteSubscription` previously assumed lite-consumer settings always contain at least one subscription entry. Incomplete settings could throw `IndexOutOfBoundsException` and fall into the broad error log path, including the full settings object.

### Tests

- `mvn -pl proxy -Dtest=GrpcClientSettingsManagerTest -DfailIfNoTests=false test`

Result: BUILD SUCCESS; 8 tests passed; checkstyle reported 0 violations. The run emits existing JaCoCo instrumentation warnings under the local JDK, and one existing test intentionally logs a simulated sync failure, but tests and build completed successfully.
