### PR TITLE
[ISSUE #10683] Validate proxy metric collector address

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
@@ -140,7 +140,7 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
         return settings.toBuilder().setMetric(metric).build();
     }
 
-    protected static Address parseMetricCollectorAddress(String metricCollectorAddress) {
+    private static Address parseMetricCollectorAddress(String metricCollectorAddress) {
         if (StringUtils.isBlank(metricCollectorAddress)) {
             return null;
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.broker.client.ConsumerGroupInfo;
 import org.apache.rocketmq.common.ServiceThread;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -117,10 +118,12 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
         final Metric.Builder metricBuilder = Metric.newBuilder();
         switch (metricCollectorMode) {
             case ON:
-                final String[] split = metricCollectorAddress.split(":");
-                final String host = split[0];
-                final int port = Integer.parseInt(split[1]);
-                Address address = Address.newBuilder().setHost(host).setPort(port).build();
+                Address address = parseMetricCollectorAddress(metricCollectorAddress);
+                if (address == null) {
+                    log.warn("disable client metric collector because metricCollectorAddress is invalid: {}", metricCollectorAddress);
+                    metricBuilder.setOn(false);
+                    break;
+                }
                 final Endpoints endpoints = Endpoints.newBuilder().setScheme(AddressScheme.IPv4)
                     .addAddresses(address).build();
                 metricBuilder.setOn(true).setEndpoints(endpoints);
@@ -135,6 +138,23 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
         }
         Metric metric = metricBuilder.build();
         return settings.toBuilder().setMetric(metric).build();
+    }
+
+    protected static Address parseMetricCollectorAddress(String metricCollectorAddress) {
+        if (StringUtils.isBlank(metricCollectorAddress)) {
+            return null;
+        }
+
+        String[] split = metricCollectorAddress.split(":");
+        if (split.length != 2 || StringUtils.isBlank(split[0]) || StringUtils.isBlank(split[1])) {
+            return null;
+        }
+
+        try {
+            return Address.newBuilder().setHost(split[0]).setPort(Integer.parseInt(split[1])).build();
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     protected static Settings mergeSubscriptionData(Settings settings, SubscriptionGroupConfig groupConfig) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
@@ -42,8 +42,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -133,7 +135,7 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
 
         Settings settings = this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance());
 
-        assertEquals(true, settings.getMetric().getOn());
+        assertTrue(settings.getMetric().getOn());
         assertEquals("127.0.0.1", settings.getMetric().getEndpoints().getAddresses(0).getHost());
         assertEquals(8081, settings.getMetric().getEndpoints().getAddresses(0).getPort());
     }
@@ -143,16 +145,19 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
         ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
 
         ConfigurationManager.getProxyConfig().setMetricCollectorAddress("");
-        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+        assertFalse(this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
 
         ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1");
-        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+        assertFalse(this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
 
         ConfigurationManager.getProxyConfig().setMetricCollectorAddress(":8081");
-        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+        assertFalse(this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1: ");
+        assertFalse(this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
 
         ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1:not-a-port");
-        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+        assertFalse(this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.rocketmq.common.lite.LiteSubscriptionDTO;
 import org.apache.rocketmq.proxy.common.ContextVariable;
 import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.MetricCollectorMode;
 import org.apache.rocketmq.proxy.grpc.v2.BaseActivityTest;
 import org.apache.rocketmq.remoting.protocol.subscription.CustomizedRetryPolicy;
 import org.apache.rocketmq.remoting.protocol.subscription.ExponentialRetryPolicy;
@@ -122,6 +124,35 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
 
         assertNull(this.grpcClientSettingsManager.getClientSettings(context));
         assertNull(this.grpcClientSettingsManager.removeAndGetClientSettings(context));
+    }
+
+    @Test
+    public void testMergeMetricWithValidCollectorAddress() {
+        ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1:8081");
+
+        Settings settings = this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance());
+
+        assertEquals(true, settings.getMetric().getOn());
+        assertEquals("127.0.0.1", settings.getMetric().getEndpoints().getAddresses(0).getHost());
+        assertEquals(8081, settings.getMetric().getEndpoints().getAddresses(0).getPort());
+    }
+
+    @Test
+    public void testMergeMetricWithInvalidCollectorAddress() {
+        ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
+
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("");
+        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1");
+        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress(":8081");
+        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
+
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1:not-a-port");
+        assertEquals(false, this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance()).getMetric().getOn());
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10683

### Brief Description

`GrpcClientSettingsManager.mergeMetric` previously parsed `metricCollectorAddress` with `split(":")` and directly read `split[1]`. When `metricCollectorMode=on` but the configured address was empty, missing a port, or using a non-numeric port, the gRPC client settings path could throw a runtime exception while constructing the client metric endpoint.

This PR validates the configured collector address before building the endpoint. Invalid addresses now disable the client metric collector for the settings response and log a warning, while valid `host:port` values keep the existing behavior.

### How Did You Test This Change?

```bash
mvn -pl proxy -Dtest=GrpcClientSettingsManagerTest -DfailIfNoTests=false test
```

Result: `BUILD SUCCESS`, `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0`.
