### PR TITLE
[ISSUE #10685] Tolerate malformed timer properties in gRPC converter

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
@@ -251,7 +251,7 @@ public class GrpcConverter {
         return systemPropertiesBuilder.build();
     }
 
-    protected Long parseLongMessageProperty(MessageExt messageExt, String propertyName) {
+    private Long parseLongMessageProperty(MessageExt messageExt, String propertyName) {
         String value = messageExt.getProperty(propertyName);
         if (value == null) {
             return null;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverter.java
@@ -188,16 +188,14 @@ public class GrpcConverter {
         }
 
         // delivery_timestamp
-        String deliverMsString;
-        long deliverMs;
-        if (messageExt.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC) != null) {
-            long delayMs = TimeUnit.SECONDS.toMillis(Long.parseLong(messageExt.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC)));
-            deliverMs = System.currentTimeMillis() + delayMs;
+        Long delaySec = parseLongMessageProperty(messageExt, MessageConst.PROPERTY_TIMER_DELAY_SEC);
+        if (delaySec != null) {
+            long delayMs = TimeUnit.SECONDS.toMillis(delaySec);
+            long deliverMs = System.currentTimeMillis() + delayMs;
             systemPropertiesBuilder.setDeliveryTimestamp(Timestamps.fromMillis(deliverMs));
         } else {
-            deliverMsString = messageExt.getProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS);
-            if (deliverMsString != null) {
-                deliverMs = Long.parseLong(deliverMsString);
+            Long deliverMs = parseLongMessageProperty(messageExt, MessageConst.PROPERTY_TIMER_DELIVER_MS);
+            if (deliverMs != null) {
                 systemPropertiesBuilder.setDeliveryTimestamp(Timestamps.fromMillis(deliverMs));
             }
         }
@@ -251,6 +249,21 @@ public class GrpcConverter {
             systemPropertiesBuilder.setDeadLetterQueue(dlq);
         }
         return systemPropertiesBuilder.build();
+    }
+
+    protected Long parseLongMessageProperty(MessageExt messageExt, String propertyName) {
+        String value = messageExt.getProperty(propertyName);
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            log.warn("ignore invalid long message property. topic:{}, msgId:{}, property:{}, value:{}",
+                messageExt.getTopic(), messageExt.getMsgId(), propertyName, value);
+            return null;
+        }
     }
 
     public Resource buildResource(String resourceNameWithNamespace) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverterTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcConverterTest.java
@@ -19,14 +19,18 @@ package org.apache.rocketmq.proxy.grpc.v2.common;
 
 import apache.rocketmq.v2.MessageQueue;
 import apache.rocketmq.v2.MessageType;
+import apache.rocketmq.v2.SystemProperties;
+import com.google.protobuf.util.Timestamps;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -82,5 +86,70 @@ public class GrpcConverterTest {
 
         // Verify message type is LITE
         assertEquals(MessageType.LITE, grpcMessage.getSystemProperties().getMessageType());
+    }
+
+    @Test
+    public void testBuildMessageWithTimerDelaySec() {
+        MessageExt messageExt = buildMessageExt();
+        MessageAccessor.putProperty(messageExt, MessageConst.PROPERTY_TIMER_DELAY_SEC, "2");
+
+        long startMs = System.currentTimeMillis();
+        SystemProperties systemProperties = GrpcConverter.getInstance().buildMessage(messageExt).getSystemProperties();
+        long endMs = System.currentTimeMillis();
+
+        assertTrue(systemProperties.hasDeliveryTimestamp());
+        long deliveryTimestamp = Timestamps.toMillis(systemProperties.getDeliveryTimestamp());
+        assertTrue(deliveryTimestamp >= startMs + 2000);
+        assertTrue(deliveryTimestamp <= endMs + 2000);
+    }
+
+    @Test
+    public void testBuildMessageWithTimerDeliverMs() {
+        MessageExt messageExt = buildMessageExt();
+        long deliverMs = 123456789L;
+        MessageAccessor.putProperty(messageExt, MessageConst.PROPERTY_TIMER_DELIVER_MS, String.valueOf(deliverMs));
+
+        SystemProperties systemProperties = GrpcConverter.getInstance().buildMessage(messageExt).getSystemProperties();
+
+        assertTrue(systemProperties.hasDeliveryTimestamp());
+        assertEquals(deliverMs, Timestamps.toMillis(systemProperties.getDeliveryTimestamp()));
+    }
+
+    @Test
+    public void testBuildMessageIgnoresInvalidTimerDelaySec() {
+        MessageExt messageExt = buildMessageExt();
+        long deliverMs = 123456789L;
+        MessageAccessor.putProperty(messageExt, MessageConst.PROPERTY_TIMER_DELAY_SEC, "invalid-delay");
+        MessageAccessor.putProperty(messageExt, MessageConst.PROPERTY_TIMER_DELIVER_MS, String.valueOf(deliverMs));
+
+        SystemProperties systemProperties = GrpcConverter.getInstance().buildMessage(messageExt).getSystemProperties();
+
+        assertTrue(systemProperties.hasDeliveryTimestamp());
+        assertEquals(deliverMs, Timestamps.toMillis(systemProperties.getDeliveryTimestamp()));
+    }
+
+    @Test
+    public void testBuildMessageIgnoresInvalidTimerDeliverMs() {
+        MessageExt messageExt = buildMessageExt();
+        MessageAccessor.putProperty(messageExt, MessageConst.PROPERTY_TIMER_DELIVER_MS, "invalid-deliver-ms");
+
+        SystemProperties systemProperties = GrpcConverter.getInstance().buildMessage(messageExt).getSystemProperties();
+
+        assertFalse(systemProperties.hasDeliveryTimestamp());
+    }
+
+    private MessageExt buildMessageExt() {
+        MessageExt messageExt = new MessageExt();
+        messageExt.setTopic("test-topic");
+        messageExt.setBody("test-body".getBytes(StandardCharsets.UTF_8));
+        messageExt.setQueueId(1);
+        messageExt.setQueueOffset(100L);
+        messageExt.setBornTimestamp(System.currentTimeMillis());
+        messageExt.setStoreTimestamp(System.currentTimeMillis());
+        messageExt.setBornHost(new InetSocketAddress("127.0.0.1", 1234));
+        messageExt.setStoreHost(new InetSocketAddress("127.0.0.1", 5678));
+        messageExt.setReconsumeTimes(0);
+        messageExt.setMsgId("test-msg-id");
+        return messageExt;
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10685

### Brief Description

`GrpcConverter.buildSystemProperties` previously parsed `PROPERTY_TIMER_DELAY_SEC` and `PROPERTY_TIMER_DELIVER_MS` with `Long.parseLong` directly. If either optional timer property was malformed, converting a Broker `MessageExt` to the gRPC v2 `Message` response could throw `NumberFormatException`.

This PR adds safe parsing for those timer properties. Valid values still populate `delivery_timestamp`; malformed values are ignored with a warning so the message conversion can continue.

### How Did You Test This Change?

```bash
mvn -pl proxy -Dtest=GrpcConverterTest -DfailIfNoTests=false test
```

Result: `BUILD SUCCESS`, `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`.
