### PR TITLE
fix: correct end timestamp recovery in IndexStoreFile to read INDEX_END_TIME_STAMP instead of INDEX_BEGIN_TIME_STAMP

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreFile.java
@@ -114,7 +114,7 @@ public class IndexStoreFile implements IndexFile {
         this.fileChannel = this.mappedFile.getFileChannel();
 
         this.beginTimestamp.set(timestamp);
-        this.endTimestamp.set(byteBuffer.getLong(INDEX_BEGIN_TIME_STAMP));
+        this.endTimestamp.set(byteBuffer.getLong(INDEX_END_TIME_STAMP));
         this.hashSlotCount.set(byteBuffer.getInt(INDEX_SLOT_COUNT));
         this.indexItemCount.set(byteBuffer.getInt(INDEX_ITEM_INDEX));
         this.flushNewMetadata(byteBuffer, indexItemMaxCount == this.indexItemCount.get() + 1);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10656

### Brief Description

The recovery constructor of `IndexStoreFile` reads `endTimestamp` from `INDEX_BEGIN_TIME_STAMP` (offset 4) instead of `INDEX_END_TIME_STAMP` (offset 12).

The write path (lines 192-193) correctly stores `endTimestamp` at `INDEX_END_TIME_STAMP`:

```java
byteBuffer.putLong(INDEX_BEGIN_TIME_STAMP, this.beginTimestamp.get());
byteBuffer.putLong(INDEX_END_TIME_STAMP, this.endTimestamp.get());
```

But the recovery constructor (line 117) reads from the wrong offset:

```java
// Before (bug):
this.endTimestamp.set(byteBuffer.getLong(INDEX_BEGIN_TIME_STAMP));

// After (fix):
this.endTimestamp.set(byteBuffer.getLong(INDEX_END_TIME_STAMP));
```

This causes the end timestamp to become the begin timestamp after reopening a tiered index file, which can cause valid query results to be incorrectly skipped.

### How Did You Test This Change?

The fix is a one-line offset correction. The change is trivially verified by inspection: the constant `INDEX_END_TIME_STAMP = 12` is used correctly in the write path but was incorrectly replaced with `INDEX_BEGIN_TIME_STAMP = 4` in the recovery path. No functional logic change.
