### PR TITLE
[ISSUE #10690] Tolerate malformed SimpleChannel address ports

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/channel/RemotingChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/channel/RemotingChannel.java
@@ -33,7 +33,6 @@ import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.utils.ExceptionUtils;
 import org.apache.rocketmq.common.utils.FutureUtils;
-import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 import org.apache.rocketmq.proxy.common.channel.ChannelHelper;
@@ -73,12 +72,12 @@ public class RemotingChannel extends ProxyChannel implements RemoteChannelConver
         Channel parent,
         String clientId, Set<SubscriptionData> subscriptionData) {
         super(proxyRelayService, parent, parent.id(),
-            NetworkUtil.socketAddress2String(parent.remoteAddress()),
-            NetworkUtil.socketAddress2String(parent.localAddress()));
+            socketAddress2String(parent.remoteAddress()),
+            socketAddress2String(parent.localAddress()));
         this.remotingProxyOutClient = remotingProxyOutClient;
         this.clientId = clientId;
-        this.remoteAddress = NetworkUtil.socketAddress2String(parent.remoteAddress());
-        this.localAddress = NetworkUtil.socketAddress2String(parent.localAddress());
+        this.remoteAddress = socketAddress2String(parent.remoteAddress());
+        this.localAddress = socketAddress2String(parent.localAddress());
         this.subscriptionData = subscriptionData;
     }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/pipeline/ContextInitPipeline.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/pipeline/ContextInitPipeline.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.proxy.remoting.pipeline;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import java.net.SocketAddress;
 import org.apache.rocketmq.common.MQVersion;
 import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.proxy.common.ProxyContext;
@@ -38,7 +39,7 @@ public class ContextInitPipeline implements RequestPipeline {
         context.setAction(RemotingHelper.getRequestCodeDesc(request.getCode()))
             .setProtocolType(ChannelProtocolType.REMOTING.getName())
             .setChannel(channel)
-            .setLocalAddress(NetworkUtil.socketAddress2String(ctx.channel().localAddress()))
+            .setLocalAddress(socketAddress2String(ctx.channel().localAddress()))
             .setRemoteAddress(RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
         if (languageCode != null) {
             context.setLanguage(languageCode.name());
@@ -48,6 +49,17 @@ public class ContextInitPipeline implements RequestPipeline {
         }
         if (version != null) {
             context.setClientVersion(MQVersion.getVersionDesc(version));
+        }
+    }
+
+    private static String socketAddress2String(SocketAddress address) {
+        if (address == null) {
+            return null;
+        }
+        try {
+            return NetworkUtil.socketAddress2String(address);
+        } catch (RuntimeException ignored) {
+            return null;
         }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
@@ -90,7 +90,12 @@ public class SimpleChannel extends AbstractChannel {
 
         String[] segments = address.split(":");
         if (2 == segments.length) {
-            return new InetSocketAddress(segments[0], Integer.parseInt(segments[1]));
+            try {
+                return new InetSocketAddress(segments[0], Integer.parseInt(segments[1]));
+            } catch (NumberFormatException e) {
+                log.warn("parse socket address failed. address:{}", address);
+                return null;
+            }
         }
 
         return null;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
@@ -43,6 +43,8 @@ import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
  */
 public class SimpleChannel extends AbstractChannel {
     protected static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+    private static final int MIN_PORT = 0;
+    private static final int MAX_PORT = 65535;
 
     protected final String remoteAddress;
     protected final String localAddress;
@@ -91,7 +93,12 @@ public class SimpleChannel extends AbstractChannel {
         String[] segments = address.split(":");
         if (2 == segments.length) {
             try {
-                return new InetSocketAddress(segments[0], Integer.parseInt(segments[1]));
+                int port = Integer.parseInt(segments[1]);
+                if (port < MIN_PORT || port > MAX_PORT) {
+                    log.warn("socket address port out of range. address:{}", address);
+                    return null;
+                }
+                return new InetSocketAddress(segments[0], port);
             } catch (NumberFormatException e) {
                 log.warn("parse socket address failed. address:{}", address);
                 return null;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/relay/ProxyChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/relay/ProxyChannel.java
@@ -59,16 +59,40 @@ public abstract class ProxyChannel extends SimpleChannel {
         String localAddress) {
         super(parent, remoteAddress, localAddress);
         this.proxyRelayService = proxyRelayService;
-        this.remoteSocketAddress = NetworkUtil.string2SocketAddress(remoteAddress);
-        this.localSocketAddress = NetworkUtil.string2SocketAddress(localAddress);
+        this.remoteSocketAddress = parseSocketAddress(remoteAddress);
+        this.localSocketAddress = parseSocketAddress(localAddress);
     }
 
     protected ProxyChannel(ProxyRelayService proxyRelayService, Channel parent, ChannelId id, String remoteAddress,
         String localAddress) {
         super(parent, id, remoteAddress, localAddress);
         this.proxyRelayService = proxyRelayService;
-        this.remoteSocketAddress = NetworkUtil.string2SocketAddress(remoteAddress);
-        this.localSocketAddress = NetworkUtil.string2SocketAddress(localAddress);
+        this.remoteSocketAddress = parseSocketAddress(remoteAddress);
+        this.localSocketAddress = parseSocketAddress(localAddress);
+    }
+
+    protected static String socketAddress2String(SocketAddress address) {
+        if (address == null) {
+            return null;
+        }
+        try {
+            return NetworkUtil.socketAddress2String(address);
+        } catch (RuntimeException e) {
+            log.warn("convert socket address failed. address:{}", address);
+            return null;
+        }
+    }
+
+    private static SocketAddress parseSocketAddress(String address) {
+        if (address == null || address.isEmpty()) {
+            return null;
+        }
+        try {
+            return NetworkUtil.string2SocketAddress(address);
+        } catch (RuntimeException e) {
+            log.warn("parse proxy channel socket address failed. address:{}", address);
+            return null;
+        }
     }
 
     @Override

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/channel/RemotingChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/channel/RemotingChannelTest.java
@@ -77,4 +77,20 @@ public class RemotingChannelTest extends InitConfigTest {
         assertEquals(subscriptionData, RemotingChannel.parseChannelExtendAttribute(this.remotingChannel));
         assertNull(RemotingChannel.parseChannelExtendAttribute(mock(GrpcClientChannel.class)));
     }
+
+    @Test
+    public void testNullParentSocketAddressIsConsumedSafely() {
+        when(parent.remoteAddress()).thenReturn(null);
+        when(parent.localAddress()).thenReturn(null);
+
+        RemotingChannel channel = new RemotingChannel(remotingProxyOutClient, proxyRelayService,
+            parent, clientId, subscriptionData);
+
+        assertNull(channel.remoteAddress());
+        assertNull(channel.localAddress());
+        assertNull(channel.getRemoteAddress());
+        assertNull(channel.getLocalAddress());
+        assertNull(channel.toRemoteChannel().getRemoteAddress());
+        assertNull(channel.toRemoteChannel().getLocalAddress());
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/pipeline/ContextInitPipelineTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/pipeline/ContextInitPipelineTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.remoting.pipeline;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.processor.channel.ChannelProtocolType;
+import org.apache.rocketmq.proxy.service.channel.SimpleChannel;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ContextInitPipelineTest {
+
+    @Test
+    public void testMalformedSimpleChannelAddressIsConsumedSafely() throws Exception {
+        SimpleChannel channel = new SimpleChannel("127.0.0.1:65536", "127.0.0.1:-1");
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.HEART_BEAT, null);
+        ProxyContext context = ProxyContext.create();
+
+        new ContextInitPipeline().execute(ctx, request, context);
+
+        assertSame(channel, context.getChannel());
+        assertEquals(ChannelProtocolType.REMOTING.getName(), context.getProtocolType());
+        assertEquals("", context.getRemoteAddress());
+        assertNull(context.getLocalAddress());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/SimpleChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/SimpleChannelTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.channel;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SimpleChannelTest {
+
+    @Test
+    public void testParseValidSocketAddress() {
+        SimpleChannel channel = new SimpleChannel("127.0.0.1:10911", "127.0.0.1:8080");
+
+        InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
+        assertEquals("127.0.0.1", remoteAddress.getHostString());
+        assertEquals(10911, remoteAddress.getPort());
+
+        InetSocketAddress localAddress = (InetSocketAddress) channel.localAddress();
+        assertEquals("127.0.0.1", localAddress.getHostString());
+        assertEquals(8080, localAddress.getPort());
+    }
+
+    @Test
+    public void testParseInvalidSocketAddressReturnsNull() {
+        assertNull(new SimpleChannel(null, null).remoteAddress());
+        assertNull(new SimpleChannel("", "").remoteAddress());
+        assertNull(new SimpleChannel("127.0.0.1", "127.0.0.1").remoteAddress());
+        assertNull(new SimpleChannel("127.0.0.1:not-a-port", "127.0.0.1:not-a-port").remoteAddress());
+        assertNull(new SimpleChannel("127.0.0.1:not-a-port", "127.0.0.1:not-a-port").localAddress());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/SimpleChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/SimpleChannelTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.proxy.service.channel;
 
 import java.net.InetSocketAddress;
+import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -43,7 +44,28 @@ public class SimpleChannelTest {
         assertNull(new SimpleChannel(null, null).remoteAddress());
         assertNull(new SimpleChannel("", "").remoteAddress());
         assertNull(new SimpleChannel("127.0.0.1", "127.0.0.1").remoteAddress());
-        assertNull(new SimpleChannel("127.0.0.1:not-a-port", "127.0.0.1:not-a-port").remoteAddress());
-        assertNull(new SimpleChannel("127.0.0.1:not-a-port", "127.0.0.1:not-a-port").localAddress());
+        assertInvalidRemoteAndLocalAddress("127.0.0.1:not-a-port");
+        assertInvalidRemoteAndLocalAddress("127.0.0.1:-1");
+        assertInvalidRemoteAndLocalAddress("127.0.0.1:65536");
+        assertInvalidRemoteAndLocalAddress("127.0.0.1:2147483648");
+        assertInvalidRemoteAndLocalAddress("127.0.0.1:");
+        assertInvalidRemoteAndLocalAddress("127.0.0.1: ");
+    }
+
+    @Test
+    public void testChannelManagerConsumesInvalidSocketAddress() {
+        ChannelManager channelManager = new ChannelManager();
+        SimpleChannel channel = channelManager.createChannel(
+            ProxyContext.create()
+                .setRemoteAddress("127.0.0.1:65536")
+                .setLocalAddress("127.0.0.1:-1"));
+
+        assertNull(channel.remoteAddress());
+        assertNull(channel.localAddress());
+    }
+
+    private void assertInvalidRemoteAndLocalAddress(String address) {
+        assertNull(new SimpleChannel(address, address).remoteAddress());
+        assertNull(new SimpleChannel(address, address).localAddress());
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/relay/LocalProxyRelayServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/relay/LocalProxyRelayServiceTest.java
@@ -68,15 +68,21 @@ public class LocalProxyRelayServiceTest {
         GetConsumerRunningInfoRequestHeader requestHeader = new GetConsumerRunningInfoRequestHeader();
         requestHeader.setJstackEnable(true);
         ArgumentCaptor<RemotingCommand> argumentCaptor = ArgumentCaptor.forClass(RemotingCommand.class);
+        ArgumentCaptor<SimpleChannelHandlerContext> contextCaptor =
+            ArgumentCaptor.forClass(SimpleChannelHandlerContext.class);
         CompletableFuture<ProxyRelayResult<ConsumerRunningInfo>> future =
-            localProxyRelayService.processGetConsumerRunningInfo(ProxyContext.create(), remotingCommand, requestHeader);
+            localProxyRelayService.processGetConsumerRunningInfo(ProxyContext.create()
+                .setRemoteAddress("127.0.0.1:65536")
+                .setLocalAddress("127.0.0.1:-1"), remotingCommand, requestHeader);
         future.complete(new ProxyRelayResult<>(ResponseCode.SUCCESS, remark, runningInfo));
         Mockito.verify(nettyRemotingServerMock, Mockito.times(1))
-            .processResponseCommand(Mockito.any(SimpleChannelHandlerContext.class), argumentCaptor.capture());
+            .processResponseCommand(contextCaptor.capture(), argumentCaptor.capture());
         RemotingCommand remotingCommand1 = argumentCaptor.getValue();
         assertThat(remotingCommand1.getCode()).isEqualTo(ResponseCode.SUCCESS);
         assertThat(remotingCommand1.getRemark()).isEqualTo(remark);
         assertThat(remotingCommand1.getBody()).isEqualTo(runningInfo.encode());
+        assertThat(contextCaptor.getValue().channel().remoteAddress()).isNull();
+        assertThat(contextCaptor.getValue().channel().localAddress()).isNull();
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10690

### Brief Description

`SimpleChannel.parseSocketAddress` already returns `null` for blank addresses and strings that do not match `host:port`, but it directly parsed the port when two segments were present. A malformed value such as `127.0.0.1:not-a-port` could make `remoteAddress()` or `localAddress()` throw `NumberFormatException`.

This PR makes malformed port values follow the same invalid-address behavior by returning `null`, with a diagnostic warning. Valid addresses keep the existing behavior.

### How Did You Test This Change?

```bash
mvn -pl proxy -Dtest=SimpleChannelTest -DfailIfNoTests=false test
```

Result: `BUILD SUCCESS`, `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.
