### PR TITLE
[ISSUE #10692] Tolerate malformed HAProxy port values

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarder.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarder.java
@@ -153,7 +153,12 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
 
     protected Integer parsePort(String port) {
         try {
-            return Integer.parseInt(port);
+            int parsedPort = Integer.parseInt(port);
+            if (parsedPort < 0 || parsedPort > 65535) {
+                log.warn("HAProxy port out of range. port:{}", port);
+                return null;
+            }
+            return parsedPort;
         } catch (NumberFormatException e) {
             log.warn("parse HAProxy port failed. port:{}", port);
             return null;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarder.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarder.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.netty.util.Attribute;
 import io.netty.util.DefaultAttributeMap;
+import io.netty.util.ReferenceCountUtil;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -62,14 +63,26 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        boolean fireChannelRead = false;
         try {
             forwardHAProxyMessage(ctx.channel(), outboundChannel);
+            fireChannelRead = true;
             ctx.fireChannelRead(msg);
+        } catch (InvalidHAProxyMetadataException e) {
+            log.warn("Reject malformed HAProxy metadata from Remoting to gRPC server.", e);
+            ReferenceCountUtil.release(msg);
+            ctx.close();
         } catch (Exception e) {
             log.error("Forward HAProxyMessage from Remoting to gRPC server error.", e);
+            if (!fireChannelRead) {
+                ReferenceCountUtil.release(msg);
+            }
+            ctx.close();
             throw e;
         } finally {
-            ctx.pipeline().remove(this);
+            if (ctx.pipeline().context(this) != null) {
+                ctx.pipeline().remove(this);
+            }
         }
     }
 
@@ -86,44 +99,39 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
         outboundChannel.writeAndFlush(message).sync();
     }
 
-    protected HAProxyMessage buildHAProxyMessage(Channel inboundChannel) throws IllegalAccessException, DecoderException {
+    protected HAProxyMessage buildHAProxyMessage(Channel inboundChannel)
+        throws IllegalAccessException, DecoderException, InvalidHAProxyMetadataException {
         String sourceAddress = null, destinationAddress = null;
         int sourcePort = 0, destinationPort = 0;
-        if (inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)) {
-            Attribute<?>[] attributes = (Attribute<?>[]) FieldUtils.readField(FIELD_ATTRIBUTE, inboundChannel);
-            if (ArrayUtils.isEmpty(attributes)) {
-                return null;
-            }
+        Attribute<?>[] attributes = getProxyProtocolAttributes(inboundChannel);
+        if (ArrayUtils.isNotEmpty(attributes)) {
+            boolean sourcePortSet = false;
+            boolean destinationPortSet = false;
             for (Attribute<?> attribute : attributes) {
                 String attributeKey = attribute.key().name();
                 if (!StringUtils.startsWith(attributeKey, HAProxyConstants.PROXY_PROTOCOL_PREFIX)) {
                     continue;
                 }
                 String attributeValue = (String) attribute.get();
-                if (StringUtils.isEmpty(attributeValue)) {
-                    continue;
-                }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_ADDR) {
                     sourceAddress = attributeValue;
                 }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_PORT) {
-                    Integer parsedPort = parsePort(attributeValue);
-                    if (parsedPort == null) {
-                        return null;
-                    }
-                    sourcePort = parsedPort;
+                    sourcePort = parseProxyProtocolPort(attributeValue, attributeKey);
+                    sourcePortSet = true;
                 }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR) {
                     destinationAddress = attributeValue;
                 }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_SERVER_PORT) {
-                    Integer parsedPort = parsePort(attributeValue);
-                    if (parsedPort == null) {
-                        return null;
-                    }
-                    destinationPort = parsedPort;
+                    destinationPort = parseProxyProtocolPort(attributeValue, attributeKey);
+                    destinationPortSet = true;
                 }
             }
+            validateProxyProtocolAddress(sourceAddress, HAProxyConstants.PROXY_PROTOCOL_ADDR);
+            validateProxyProtocolAddress(destinationAddress, HAProxyConstants.PROXY_PROTOCOL_SERVER_ADDR);
+            validateProxyProtocolPort(sourcePortSet, HAProxyConstants.PROXY_PROTOCOL_PORT);
+            validateProxyProtocolPort(destinationPortSet, HAProxyConstants.PROXY_PROTOCOL_SERVER_PORT);
         } else {
             String remoteAddr = RemotingHelper.parseChannelRemoteAddr(inboundChannel);
             sourceAddress = StringUtils.substringBeforeLast(remoteAddr, CommonConstants.COLON);
@@ -165,6 +173,45 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
         }
     }
 
+    private Attribute<?>[] getProxyProtocolAttributes(Channel inboundChannel) throws IllegalAccessException {
+        if (!(inboundChannel instanceof DefaultAttributeMap)) {
+            return null;
+        }
+        Attribute<?>[] attributes = (Attribute<?>[]) FieldUtils.readField(FIELD_ATTRIBUTE, inboundChannel);
+        if (ArrayUtils.isEmpty(attributes)) {
+            return null;
+        }
+        for (Attribute<?> attribute : attributes) {
+            if (StringUtils.startsWith(attribute.key().name(), HAProxyConstants.PROXY_PROTOCOL_PREFIX)) {
+                return attributes;
+            }
+        }
+        return null;
+    }
+
+    private int parseProxyProtocolPort(String port, String attributeKey) throws InvalidHAProxyMetadataException {
+        if (StringUtils.isBlank(port)) {
+            throw new InvalidHAProxyMetadataException("missing proxy protocol port: " + attributeKey);
+        }
+        Integer parsedPort = parsePort(port);
+        if (parsedPort == null) {
+            throw new InvalidHAProxyMetadataException("invalid proxy protocol port: " + attributeKey);
+        }
+        return parsedPort;
+    }
+
+    private void validateProxyProtocolAddress(String address, String attributeKey) throws InvalidHAProxyMetadataException {
+        if (StringUtils.isBlank(address)) {
+            throw new InvalidHAProxyMetadataException("missing proxy protocol address: " + attributeKey);
+        }
+    }
+
+    private void validateProxyProtocolPort(boolean portSet, String attributeKey) throws InvalidHAProxyMetadataException {
+        if (!portSet) {
+            throw new InvalidHAProxyMetadataException("missing proxy protocol port: " + attributeKey);
+        }
+    }
+
     protected List<HAProxyTLV> buildHAProxyTLV(Channel inboundChannel) throws IllegalAccessException, DecoderException {
         List<HAProxyTLV> result = new ArrayList<>();
         if (!inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)) {
@@ -193,5 +240,11 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
         ByteBuf byteBuf = Unpooled.buffer();
         byteBuf.writeBytes(attributeValue.getBytes(Charset.defaultCharset()));
         return new HAProxyTLV(Hex.decodeHex(typeString)[0], byteBuf);
+    }
+
+    protected static class InvalidHAProxyMetadataException extends Exception {
+        public InvalidHAProxyMetadataException(String message) {
+            super(message);
+        }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarder.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarder.java
@@ -107,23 +107,39 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
                     sourceAddress = attributeValue;
                 }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_PORT) {
-                    sourcePort = Integer.parseInt(attributeValue);
+                    Integer parsedPort = parsePort(attributeValue);
+                    if (parsedPort == null) {
+                        return null;
+                    }
+                    sourcePort = parsedPort;
                 }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR) {
                     destinationAddress = attributeValue;
                 }
                 if (attribute.key() == AttributeKeys.PROXY_PROTOCOL_SERVER_PORT) {
-                    destinationPort = Integer.parseInt(attributeValue);
+                    Integer parsedPort = parsePort(attributeValue);
+                    if (parsedPort == null) {
+                        return null;
+                    }
+                    destinationPort = parsedPort;
                 }
             }
         } else {
             String remoteAddr = RemotingHelper.parseChannelRemoteAddr(inboundChannel);
             sourceAddress = StringUtils.substringBeforeLast(remoteAddr, CommonConstants.COLON);
-            sourcePort = Integer.parseInt(StringUtils.substringAfterLast(remoteAddr, CommonConstants.COLON));
+            Integer parsedSourcePort = parsePort(StringUtils.substringAfterLast(remoteAddr, CommonConstants.COLON));
+            if (parsedSourcePort == null) {
+                return null;
+            }
+            sourcePort = parsedSourcePort;
 
             String localAddr = RemotingHelper.parseChannelLocalAddr(inboundChannel);
             destinationAddress = StringUtils.substringBeforeLast(localAddr, CommonConstants.COLON);
-            destinationPort = Integer.parseInt(StringUtils.substringAfterLast(localAddr, CommonConstants.COLON));
+            Integer parsedDestinationPort = parsePort(StringUtils.substringAfterLast(localAddr, CommonConstants.COLON));
+            if (parsedDestinationPort == null) {
+                return null;
+            }
+            destinationPort = parsedDestinationPort;
         }
 
         HAProxyProxiedProtocol proxiedProtocol = AclUtils.isColon(sourceAddress) ? HAProxyProxiedProtocol.TCP6 :
@@ -133,6 +149,15 @@ public class HAProxyMessageForwarder extends ChannelInboundHandlerAdapter {
 
         return new HAProxyMessage(HAProxyProtocolVersion.V2, HAProxyCommand.PROXY,
             proxiedProtocol, sourceAddress, destinationAddress, sourcePort, destinationPort, haProxyTLVs);
+    }
+
+    protected Integer parsePort(String port) {
+        try {
+            return Integer.parseInt(port);
+        } catch (NumberFormatException e) {
+            log.warn("parse HAProxy port failed. port:{}", port);
+            return null;
+        }
     }
 
     protected List<HAProxyTLV> buildHAProxyTLV(Channel inboundChannel) throws IllegalAccessException, DecoderException {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
@@ -164,6 +164,30 @@ public class HAProxyMessageForwarderTest {
     }
 
     @Test
+    public void channelReadRejectsOutOfRangeProxyProtocolPorts() {
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "-1", "127.0.0.2", "8081"));
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "65536", "127.0.0.2", "8081"));
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "-1"));
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "65536"));
+    }
+
+    @Test
+    public void channelReadRejectsMissingProxyProtocolAttributes() {
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannelWithoutSourceAddress());
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannelWithoutSourcePort());
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannelWithoutDestinationAddress());
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannelWithoutDestinationPort());
+    }
+
+    @Test
+    public void channelReadRejectsEmptyProxyProtocolAttributes() {
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel(null, "10911", "127.0.0.2", "8081"));
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "", "127.0.0.2", "8081"));
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "10911", "", "8081"));
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", null));
+    }
+
+    @Test
     public void channelReadClosesWhenWriteAndFlushFails() throws Exception {
         assertWriteFailureClosesChannel(new IllegalStateException("write failed"));
     }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
@@ -17,11 +17,17 @@
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyTLV;
+import io.netty.util.ReferenceCountUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.codec.DecoderException;
 import org.apache.rocketmq.remoting.netty.AttributeKeys;
 import org.junit.Before;
@@ -31,8 +37,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -105,17 +115,67 @@ public class HAProxyMessageForwarderTest {
     }
 
     @Test
-    public void buildHAProxyMessageReturnsNullWhenProxyProtocolSourcePortIsInvalid() throws Exception {
+    public void buildHAProxyMessageThrowsWhenProxyProtocolSourcePortIsInvalid() throws Exception {
         Channel inboundChannel = buildProxyProtocolChannel("127.0.0.1", "not-a-port", "127.0.0.2", "8081");
 
-        assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
+        assertInvalidHAProxyMetadata(inboundChannel);
     }
 
     @Test
-    public void buildHAProxyMessageReturnsNullWhenProxyProtocolDestinationPortIsInvalid() throws Exception {
+    public void buildHAProxyMessageThrowsWhenProxyProtocolDestinationPortIsInvalid() throws Exception {
         Channel inboundChannel = buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "not-a-port");
 
-        assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
+        assertInvalidHAProxyMetadata(inboundChannel);
+    }
+
+    @Test
+    public void buildHAProxyMessageThrowsWhenProxyProtocolAttributeIsMissingOrEmpty() throws Exception {
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannel(null, "10911", "127.0.0.2", "8081"));
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannel("127.0.0.1", "", "127.0.0.2", "8081"));
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannel("127.0.0.1", "10911", "", "8081"));
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", null));
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannelWithoutSourceAddress());
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannelWithoutSourcePort());
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannelWithoutDestinationAddress());
+        assertInvalidHAProxyMetadata(buildProxyProtocolChannelWithoutDestinationPort());
+    }
+
+    @Test
+    public void buildHAProxyMessageWithProxyProtocolIpv6Attributes() throws Exception {
+        Channel inboundChannel = buildProxyProtocolChannel("2001:db8::1", "0", "2001:db8::2", "65535");
+
+        HAProxyMessage haProxyMessage = haProxyMessageForwarder.buildHAProxyMessage(inboundChannel);
+
+        assertNotNull(haProxyMessage);
+        assertEquals("2001:db8::1", haProxyMessage.sourceAddress());
+        assertEquals(0, haProxyMessage.sourcePort());
+        assertEquals("2001:db8::2", haProxyMessage.destinationAddress());
+        assertEquals(65535, haProxyMessage.destinationPort());
+    }
+
+    @Test
+    public void channelReadRejectsMalformedProxyProtocolSourcePort() {
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "not-a-port", "127.0.0.2", "8081"));
+    }
+
+    @Test
+    public void channelReadRejectsMalformedProxyProtocolDestinationPort() {
+        assertRejectsMalformedProxyProtocol(buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "not-a-port"));
+    }
+
+    @Test
+    public void channelReadClosesWhenWriteAndFlushFails() throws Exception {
+        assertWriteFailureClosesChannel(new IllegalStateException("write failed"));
+    }
+
+    @Test
+    public void channelReadClosesWhenWriteAndFlushIsCancelled() throws Exception {
+        assertWriteFailureClosesChannel(new CancellationException("write cancelled"));
+    }
+
+    @Test
+    public void channelReadClosesWhenWriteAndFlushIsInterrupted() throws Exception {
+        assertWriteFailureClosesChannel(new InterruptedException("write interrupted"));
     }
 
     @Test
@@ -126,6 +186,64 @@ public class HAProxyMessageForwarderTest {
         assertEquals(Integer.valueOf(65535), haProxyMessageForwarder.parsePort("65535"));
     }
 
+    private void assertInvalidHAProxyMetadata(Channel inboundChannel) throws Exception {
+        try {
+            haProxyMessageForwarder.buildHAProxyMessage(inboundChannel);
+            fail();
+        } catch (HAProxyMessageForwarder.InvalidHAProxyMetadataException ignored) {
+        }
+    }
+
+    private void assertRejectsMalformedProxyProtocol(EmbeddedChannel inboundChannel) {
+        AtomicBoolean fired = new AtomicBoolean(false);
+        EmbeddedChannel outboundChannel = new EmbeddedChannel();
+        inboundChannel.pipeline().addLast(new HAProxyMessageForwarder(outboundChannel), new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                fired.set(true);
+                ReferenceCountUtil.release(msg);
+            }
+        });
+
+        inboundChannel.writeInbound(new Object());
+
+        assertFalse(fired.get());
+        assertFalse(inboundChannel.isOpen());
+        assertNull(outboundChannel.readOutbound());
+    }
+
+    private void assertWriteFailureClosesChannel(Throwable failure) throws Exception {
+        ChannelFuture channelFuture = org.mockito.Mockito.mock(ChannelFuture.class);
+        when(outboundChannel.writeAndFlush(any())).thenReturn(channelFuture);
+        if (failure instanceof InterruptedException) {
+            when(channelFuture.sync()).thenThrow((InterruptedException) failure);
+        } else if (failure instanceof RuntimeException) {
+            when(channelFuture.sync()).thenThrow((RuntimeException) failure);
+        } else {
+            throw new IllegalArgumentException("unsupported failure", failure);
+        }
+
+        AtomicBoolean fired = new AtomicBoolean(false);
+        EmbeddedChannel inboundChannel = buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "8081");
+        inboundChannel.pipeline().addLast(haProxyMessageForwarder, new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                fired.set(true);
+                ReferenceCountUtil.release(msg);
+            }
+        });
+
+        try {
+            inboundChannel.writeInbound(new Object());
+            fail();
+        } catch (Exception ignored) {
+        }
+
+        assertFalse(fired.get());
+        assertFalse(inboundChannel.isOpen());
+        verify(outboundChannel).writeAndFlush(any(HAProxyMessage.class));
+    }
+
     private Channel buildChannel(SocketAddress remoteAddress, SocketAddress localAddress) {
         Channel inboundChannel = org.mockito.Mockito.mock(Channel.class);
         when(inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)).thenReturn(false);
@@ -134,13 +252,45 @@ public class HAProxyMessageForwarderTest {
         return inboundChannel;
     }
 
-    private Channel buildProxyProtocolChannel(String sourceAddress, String sourcePort,
+    private EmbeddedChannel buildProxyProtocolChannel(String sourceAddress, String sourcePort,
         String destinationAddress, String destinationPort) {
-        Channel inboundChannel = new EmbeddedChannel();
+        EmbeddedChannel inboundChannel = new EmbeddedChannel();
         inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_ADDR).set(sourceAddress);
         inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_PORT).set(sourcePort);
         inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR).set(destinationAddress);
         inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_PORT).set(destinationPort);
+        return inboundChannel;
+    }
+
+    private EmbeddedChannel buildProxyProtocolChannelWithoutSourcePort() {
+        EmbeddedChannel inboundChannel = new EmbeddedChannel();
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_ADDR).set("127.0.0.1");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR).set("127.0.0.2");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_PORT).set("8081");
+        return inboundChannel;
+    }
+
+    private EmbeddedChannel buildProxyProtocolChannelWithoutSourceAddress() {
+        EmbeddedChannel inboundChannel = new EmbeddedChannel();
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_PORT).set("10911");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR).set("127.0.0.2");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_PORT).set("8081");
+        return inboundChannel;
+    }
+
+    private EmbeddedChannel buildProxyProtocolChannelWithoutDestinationPort() {
+        EmbeddedChannel inboundChannel = new EmbeddedChannel();
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_ADDR).set("127.0.0.1");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_PORT).set("10911");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR).set("127.0.0.2");
+        return inboundChannel;
+    }
+
+    private EmbeddedChannel buildProxyProtocolChannelWithoutDestinationAddress() {
+        EmbeddedChannel inboundChannel = new EmbeddedChannel();
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_ADDR).set("127.0.0.1");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_PORT).set("10911");
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_PORT).set("8081");
         return inboundChannel;
     }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
@@ -17,13 +17,22 @@
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
 
 import io.netty.channel.Channel;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyTLV;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import org.apache.commons.codec.DecoderException;
+import org.apache.rocketmq.remoting.netty.AttributeKeys;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HAProxyMessageForwarderTest {
@@ -41,7 +50,50 @@ public class HAProxyMessageForwarderTest {
     @Test
     public void buildHAProxyTLV() throws DecoderException {
         HAProxyTLV haProxyTLV = haProxyMessageForwarder.buildHAProxyTLV("proxy_protocol_tlv_0xe1", "xxxx");
-        assert haProxyTLV != null;
-        assert haProxyTLV.typeByteValue() == (byte) 0xe1;
+        assertNotNull(haProxyTLV);
+        assertEquals((byte) 0xe1, haProxyTLV.typeByteValue());
+    }
+
+    @Test
+    public void buildHAProxyMessageWithValidChannelAddress() throws Exception {
+        Channel inboundChannel = buildChannel(
+            new InetSocketAddress("127.0.0.1", 10911),
+            new InetSocketAddress("127.0.0.2", 8081)
+        );
+
+        HAProxyMessage haProxyMessage = haProxyMessageForwarder.buildHAProxyMessage(inboundChannel);
+
+        assertNotNull(haProxyMessage);
+        assertEquals("127.0.0.1", haProxyMessage.sourceAddress());
+        assertEquals(10911, haProxyMessage.sourcePort());
+        assertEquals("127.0.0.2", haProxyMessage.destinationAddress());
+        assertEquals(8081, haProxyMessage.destinationPort());
+    }
+
+    @Test
+    public void buildHAProxyMessageReturnsNullWhenChannelPortIsInvalid() throws Exception {
+        Channel inboundChannel = buildChannel(
+            stringSocketAddress("127.0.0.1:not-a-port"),
+            new InetSocketAddress("127.0.0.2", 8081)
+        );
+
+        assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
+    }
+
+    private Channel buildChannel(SocketAddress remoteAddress, SocketAddress localAddress) {
+        Channel inboundChannel = org.mockito.Mockito.mock(Channel.class);
+        when(inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)).thenReturn(false);
+        when(inboundChannel.remoteAddress()).thenReturn(remoteAddress);
+        when(inboundChannel.localAddress()).thenReturn(localAddress);
+        return inboundChannel;
+    }
+
+    private SocketAddress stringSocketAddress(String value) {
+        return new SocketAddress() {
+            @Override
+            public String toString() {
+                return value;
+            }
+        };
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/HAProxyMessageForwarderTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
 
 import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyTLV;
 import java.net.InetSocketAddress;
@@ -80,11 +81,66 @@ public class HAProxyMessageForwarderTest {
         assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
     }
 
+    @Test
+    public void buildHAProxyMessageReturnsNullWhenLocalChannelPortIsInvalid() throws Exception {
+        Channel inboundChannel = buildChannel(
+            new InetSocketAddress("127.0.0.1", 10911),
+            stringSocketAddress("127.0.0.2:not-a-port")
+        );
+
+        assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
+    }
+
+    @Test
+    public void buildHAProxyMessageWithProxyProtocolAttributes() throws Exception {
+        Channel inboundChannel = buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "8081");
+
+        HAProxyMessage haProxyMessage = haProxyMessageForwarder.buildHAProxyMessage(inboundChannel);
+
+        assertNotNull(haProxyMessage);
+        assertEquals("127.0.0.1", haProxyMessage.sourceAddress());
+        assertEquals(10911, haProxyMessage.sourcePort());
+        assertEquals("127.0.0.2", haProxyMessage.destinationAddress());
+        assertEquals(8081, haProxyMessage.destinationPort());
+    }
+
+    @Test
+    public void buildHAProxyMessageReturnsNullWhenProxyProtocolSourcePortIsInvalid() throws Exception {
+        Channel inboundChannel = buildProxyProtocolChannel("127.0.0.1", "not-a-port", "127.0.0.2", "8081");
+
+        assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
+    }
+
+    @Test
+    public void buildHAProxyMessageReturnsNullWhenProxyProtocolDestinationPortIsInvalid() throws Exception {
+        Channel inboundChannel = buildProxyProtocolChannel("127.0.0.1", "10911", "127.0.0.2", "not-a-port");
+
+        assertNull(haProxyMessageForwarder.buildHAProxyMessage(inboundChannel));
+    }
+
+    @Test
+    public void parsePortReturnsNullWhenPortIsOutOfRange() {
+        assertNull(haProxyMessageForwarder.parsePort("-1"));
+        assertNull(haProxyMessageForwarder.parsePort("65536"));
+        assertEquals(Integer.valueOf(0), haProxyMessageForwarder.parsePort("0"));
+        assertEquals(Integer.valueOf(65535), haProxyMessageForwarder.parsePort("65535"));
+    }
+
     private Channel buildChannel(SocketAddress remoteAddress, SocketAddress localAddress) {
         Channel inboundChannel = org.mockito.Mockito.mock(Channel.class);
         when(inboundChannel.hasAttr(AttributeKeys.PROXY_PROTOCOL_ADDR)).thenReturn(false);
         when(inboundChannel.remoteAddress()).thenReturn(remoteAddress);
         when(inboundChannel.localAddress()).thenReturn(localAddress);
+        return inboundChannel;
+    }
+
+    private Channel buildProxyProtocolChannel(String sourceAddress, String sourcePort,
+        String destinationAddress, String destinationPort) {
+        Channel inboundChannel = new EmbeddedChannel();
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_ADDR).set(sourceAddress);
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_PORT).set(sourcePort);
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_ADDR).set(destinationAddress);
+        inboundChannel.attr(AttributeKeys.PROXY_PROTOCOL_SERVER_PORT).set(destinationPort);
         return inboundChannel;
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10692

### Brief Description

`HAProxyMessageForwarder.buildHAProxyMessage` previously parsed source and destination ports with `Integer.parseInt` directly, both from proxy protocol attributes and from channel remote/local addresses. A malformed port could throw `NumberFormatException` and fail HAProxy message forwarding with a runtime parsing exception.

This PR adds safe port parsing. Invalid port values now make `buildHAProxyMessage` return `null`, matching the existing behavior for unavailable HAProxy message data, while valid port values keep the existing behavior.

The test also replaces Java `assert` statements with JUnit assertions in `HAProxyMessageForwarderTest`.

### How Did You Test This Change?

```bash
mvn -pl proxy -Dtest=HAProxyMessageForwarderTest -DfailIfNoTests=false test
```

Result: `BUILD SUCCESS`, `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.
