### PR TITLE
[ISSUE #9987] Fix bracketed IPv6 address parsing with scope id

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.nio.channels.Selector;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.ArrayList;
@@ -192,28 +193,45 @@ public class NetworkUtil {
     }
 
     public static SocketAddress string2SocketAddress(final String addr) {
+        if (addr == null) {
+            throw new IllegalArgumentException("Socket address must not be null");
+        }
+
+        String host;
+        int port;
+
         if (addr.startsWith("[")) {
             int end = addr.indexOf(']');
-            if (end > 0 && end + 1 < addr.length() && addr.charAt(end + 1) == ':') {
-                String host = addr.substring(1, end);
-                int scope = host.indexOf('%');
-                if (scope > 0) {
-                    host = host.substring(0, scope);
-                }
-                String port = addr.substring(end + 2);
-                return new InetSocketAddress(host, Integer.parseInt(port));
+            if (end <= 0 || end + 1 >= addr.length() || addr.charAt(end + 1) != ':') {
+                throw new IllegalArgumentException("Invalid socket address: " + addr);
+            }
+
+            host = addr.substring(1, end);
+            port = Integer.parseInt(addr.substring(end + 2));
+        } else {
+            int index = addr.lastIndexOf(':');
+            if (index <= 0 || index == addr.length() - 1) {
+                throw new IllegalArgumentException("Invalid socket address: " + addr);
+            }
+
+            host = addr.substring(0, index);
+            port = Integer.parseInt(addr.substring(index + 1));
+        }
+
+        if (host.indexOf(':') >= 0) {
+            try {
+                return new InetSocketAddress(InetAddress.getByName(host), port);
+            } catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Invalid socket address: " + addr, e);
             }
         }
-        int split = addr.lastIndexOf(":");
-        String host = addr.substring(0, split);
-        String port = addr.substring(split + 1);
-        return new InetSocketAddress(host, Integer.parseInt(port));
+        return new InetSocketAddress(host, port);
     }
 
     public static String socketAddress2String(final SocketAddress addr) {
         StringBuilder sb = new StringBuilder();
         InetSocketAddress inetSocketAddress = (InetSocketAddress) addr;
-        sb.append(normalizeHostAddress(inetSocketAddress.getAddress()));
+        sb.append(inetSocketAddress.getAddress().getHostAddress());
         sb.append(":");
         sb.append(inetSocketAddress.getPort());
         return sb.toString();

--- a/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
@@ -192,6 +192,18 @@ public class NetworkUtil {
     }
 
     public static SocketAddress string2SocketAddress(final String addr) {
+        if (addr.startsWith("[")) {
+            int end = addr.indexOf(']');
+            if (end > 0 && end + 1 < addr.length() && addr.charAt(end + 1) == ':') {
+                String host = addr.substring(1, end);
+                int scope = host.indexOf('%');
+                if (scope > 0) {
+                    host = host.substring(0, scope);
+                }
+                String port = addr.substring(end + 2);
+                return new InetSocketAddress(host, Integer.parseInt(port));
+            }
+        }
         int split = addr.lastIndexOf(":");
         String host = addr.substring(0, split);
         String port = addr.substring(split + 1);
@@ -201,7 +213,7 @@ public class NetworkUtil {
     public static String socketAddress2String(final SocketAddress addr) {
         StringBuilder sb = new StringBuilder();
         InetSocketAddress inetSocketAddress = (InetSocketAddress) addr;
-        sb.append(inetSocketAddress.getAddress().getHostAddress());
+        sb.append(normalizeHostAddress(inetSocketAddress.getAddress()));
         sb.append(":");
         sb.append(inetSocketAddress.getPort());
         return sb.toString();

--- a/common/src/test/java/org/apache/rocketmq/common/NetworkUtilTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/NetworkUtilTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.common;
 
+import java.net.InetSocketAddress;
+
 import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.junit.Test;
 
@@ -39,5 +41,32 @@ public class NetworkUtilTest {
     public void testConvert2IpStringWithHost() {
         String result = NetworkUtil.convert2IpString("localhost:9876");
         assertThat(result).isEqualTo("127.0.0.1:9876");
+    }
+
+    @Test
+    public void testString2SocketAddressWithBracketedIPv6Scope() {
+        InetSocketAddress result = (InetSocketAddress) NetworkUtil.string2SocketAddress(
+            "[202:202:0:0:0:0:81:1811%enp1s0]:9876");
+
+        assertThat(result.getPort()).isEqualTo(9876);
+        assertThat(result.getAddress()).isNotNull();
+        assertThat(result.getAddress().getHostAddress()).isEqualTo("202:202:0:0:0:0:81:1811");
+    }
+
+    @Test
+    public void testString2SocketAddressWithBracketedIPv6() {
+        InetSocketAddress result = (InetSocketAddress) NetworkUtil.string2SocketAddress(
+            "[202:202:0:0:0:0:81:1811]:9876");
+
+        assertThat(result.getPort()).isEqualTo(9876);
+        assertThat(result.getAddress()).isNotNull();
+        assertThat(result.getAddress().getHostAddress()).isEqualTo("202:202:0:0:0:0:81:1811");
+    }
+
+    @Test
+    public void testConvert2IpStringWithBracketedIPv6Scope() {
+        String result = NetworkUtil.convert2IpString("[202:202:0:0:0:0:81:1811%enp1s0]:9876");
+
+        assertThat(result).isEqualTo("[202:202:0:0:0:0:81:1811]:9876");
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/NetworkUtilTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/NetworkUtilTest.java
@@ -16,12 +16,19 @@
  */
 package org.apache.rocketmq.common;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
 
 import org.apache.rocketmq.common.utils.NetworkUtil;
+import org.junit.Assume;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class NetworkUtilTest {
     @Test
@@ -35,22 +42,31 @@ public class NetworkUtilTest {
     public void testConvert2IpStringWithIp() {
         String result = NetworkUtil.convert2IpString("127.0.0.1:9876");
         assertThat(result).isEqualTo("127.0.0.1:9876");
+        assertParseFormatParse("127.0.0.1:9876");
     }
 
     @Test
     public void testConvert2IpStringWithHost() {
         String result = NetworkUtil.convert2IpString("localhost:9876");
         assertThat(result).isEqualTo("127.0.0.1:9876");
+        assertParseFormatParse("localhost:9876");
     }
 
     @Test
     public void testString2SocketAddressWithBracketedIPv6Scope() {
         InetSocketAddress result = (InetSocketAddress) NetworkUtil.string2SocketAddress(
-            "[202:202:0:0:0:0:81:1811%enp1s0]:9876");
+            "[fe80::1%1]:9876");
 
         assertThat(result.getPort()).isEqualTo(9876);
         assertThat(result.getAddress()).isNotNull();
-        assertThat(result.getAddress().getHostAddress()).isEqualTo("202:202:0:0:0:0:81:1811");
+        assertThat(result.getAddress()).isInstanceOf(Inet6Address.class);
+        assertThat(((Inet6Address) result.getAddress()).getScopeId()).isEqualTo(1);
+
+        InetSocketAddress reparsed = (InetSocketAddress) NetworkUtil.string2SocketAddress(
+            NetworkUtil.socketAddress2String(result));
+        assertThat(reparsed.getAddress().getHostAddress()).isEqualTo(result.getAddress().getHostAddress());
+        assertThat(reparsed.getPort()).isEqualTo(result.getPort());
+        assertParseFormatParse("[fe80::1%1]:9876");
     }
 
     @Test
@@ -61,12 +77,96 @@ public class NetworkUtilTest {
         assertThat(result.getPort()).isEqualTo(9876);
         assertThat(result.getAddress()).isNotNull();
         assertThat(result.getAddress().getHostAddress()).isEqualTo("202:202:0:0:0:0:81:1811");
+        assertParseFormatParse("[202:202:0:0:0:0:81:1811]:9876");
     }
 
     @Test
-    public void testConvert2IpStringWithBracketedIPv6Scope() {
-        String result = NetworkUtil.convert2IpString("[202:202:0:0:0:0:81:1811%enp1s0]:9876");
+    public void testString2SocketAddressWithRealLinkLocalIPv6Scope() throws SocketException {
+        Inet6Address linkLocalAddress = getLinkLocalAddressWithInterfaceScope();
+        Assume.assumeTrue("No link-local IPv6 address with interface scope is available", linkLocalAddress != null);
 
-        assertThat(result).isEqualTo("[202:202:0:0:0:0:81:1811]:9876");
+        String scopedHost = linkLocalAddress.getHostAddress().split("%", 2)[0]
+            + "%" + linkLocalAddress.getScopedInterface().getName();
+        InetSocketAddress parsed = (InetSocketAddress) NetworkUtil.string2SocketAddress(
+            "[" + scopedHost + "]:9876");
+
+        assertThat(parsed.getAddress()).isInstanceOf(Inet6Address.class);
+        Inet6Address parsedAddress = (Inet6Address) parsed.getAddress();
+        assertThat(parsedAddress.isLinkLocalAddress()).isTrue();
+        assertThat(parsedAddress.getScopedInterface()).isNotNull();
+        assertThat(parsedAddress.getScopedInterface().getName()).isEqualTo(linkLocalAddress.getScopedInterface().getName());
+        assertThat(parsed.getPort()).isEqualTo(9876);
+
+        InetSocketAddress reparsed = (InetSocketAddress) NetworkUtil.string2SocketAddress(
+            NetworkUtil.socketAddress2String(parsed));
+        assertThat(reparsed.getAddress().getHostAddress()).isEqualTo(parsed.getAddress().getHostAddress());
+        assertThat(reparsed.getPort()).isEqualTo(parsed.getPort());
+        assertParseFormatParse("[" + scopedHost + "]:9876");
+    }
+
+    @Test
+    public void testString2SocketAddressWithLegacyUnbracketedIPv6() {
+        InetSocketAddress result = (InetSocketAddress) NetworkUtil.string2SocketAddress(
+            "202:202:0:0:0:0:81:1811:9876");
+
+        assertThat(result.getPort()).isEqualTo(9876);
+        assertThat(result.getAddress()).isNotNull();
+        assertThat(result.getAddress().getHostAddress()).isEqualTo("202:202:0:0:0:0:81:1811");
+        assertParseFormatParse("202:202:0:0:0:0:81:1811:9876");
+    }
+
+    @Test
+    public void testConvert2IpStringWithBracketedIPv6PreservesLegacyOutputFormat() {
+        String result = NetworkUtil.convert2IpString("[202:202:0:0:0:0:81:1811]:9876");
+
+        assertThat(result).isEqualTo("202:202:0:0:0:0:81:1811:9876");
+    }
+
+    @Test
+    public void testString2SocketAddressWithMalformedAddress() {
+        for (String address : new String[] {
+            "[202:202:0:0:0:0:81:1811:9876",
+            "[202:202:0:0:0:0:81:1811]9876",
+            "[202:202:0:0:0:0:81:1811]:",
+            "[fe80::1%invalid-interface-name]:9876",
+            "127.0.0.1",
+            "127.0.0.1:",
+            "127.0.0.1:not-a-port",
+            "127.0.0.1:-1",
+            "127.0.0.1:65536"
+        }) {
+            assertThatThrownBy(() -> NetworkUtil.string2SocketAddress(address))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    private void assertParseFormatParse(String address) {
+        InetSocketAddress parsed = (InetSocketAddress) NetworkUtil.string2SocketAddress(address);
+        String formatted = NetworkUtil.socketAddress2String(parsed);
+        InetSocketAddress reparsed = (InetSocketAddress) NetworkUtil.string2SocketAddress(formatted);
+
+        assertThat(reparsed.getAddress().getHostAddress()).isEqualTo(parsed.getAddress().getHostAddress());
+        assertThat(reparsed.getPort()).isEqualTo(parsed.getPort());
+    }
+
+    private Inet6Address getLinkLocalAddressWithInterfaceScope() throws SocketException {
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            if (!networkInterface.isUp()) {
+                continue;
+            }
+            Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                InetAddress address = addresses.nextElement();
+                if (address instanceof Inet6Address) {
+                    Inet6Address inet6Address = (Inet6Address) address;
+                    if (inet6Address.isLinkLocalAddress() && inet6Address.getScopedInterface() != null) {
+                        return inet6Address;
+                    }
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Related to [#9987](https://github.com/apache/rocketmq/issues/9987)

### Brief Description

`NetworkUtil.string2SocketAddress` currently parses socket addresses by using `lastIndexOf(":")`.

This works fine for normal `host:port` addresses, but it doesn't handle bracketed IPv6 addresses correctly. For example, with `[2001:db8::1]:9876`, the brackets may remain in the host part after parsing.

This PR adds handling for the standard `[IPv6]:port` format before using the existing parser logic.

For IPv6 addresses with a scope id, the scope part is removed before creating `InetSocketAddress`. Also, `socketAddress2String` is updated to always output IPv6 addresses in `[IPv6]:port` format.

The issue was reported as fixed after upgrading to 5.3.1, but this change focuses on fixing the remaining parsing problem in `NetworkUtil` and does not change the existing IPv4 or hostname behavior.

### How Did You Test This Change?

```bash
mvn -pl common -Dtest=NetworkUtilTest test
```

Result:
BUILD SUCCESS
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0

I also verified the regression case by temporarily reverting the parser implementation to the old version while keeping the new test. The test testString2SocketAddressWithBracketedIPv6Scope fails because the parsed address becomes null.