### PR TITLE
[ISSUE #10696] Fix async request future cleanup on synchronous send failure

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -1659,22 +1659,31 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         RequestFutureHolder.getInstance().getRequestFutureTable().put(correlationId, requestResponseFuture);
 
         long cost = System.currentTimeMillis() - beginTimestamp;
-        this.sendDefaultImpl(msg, CommunicationMode.ASYNC, new SendCallback() {
-            @Override
-            public void onSuccess(SendResult sendResult) {
-                // Only mark the request as sent here. The user callback must fire when the reply
-                // arrives (processReplyMessage), on timeout (scanExpiredRequest), or on send
-                // failure (requestFail). Invoking it here delivers a premature onSuccess(null)
-                // and, combined with the later reply/timeout callback, causes a double callback.
-                requestResponseFuture.setSendRequestOk(true);
-            }
+        boolean sendInvocationCompleted = false;
+        try {
+            this.sendDefaultImpl(msg, CommunicationMode.ASYNC, new SendCallback() {
+                @Override
+                public void onSuccess(SendResult sendResult) {
+                    // Only mark the request as sent here. The user callback must fire when the reply
+                    // arrives (processReplyMessage), on timeout (scanExpiredRequest), or on send
+                    // failure (requestFail). Invoking it here delivers a premature onSuccess(null)
+                    // and, combined with the later reply/timeout callback, causes a double callback.
+                    requestResponseFuture.setSendRequestOk(true);
+                }
 
-            @Override
-            public void onException(Throwable e) {
-                requestResponseFuture.setCause(e);
-                requestFail(correlationId);
+                @Override
+                public void onException(Throwable e) {
+                    requestResponseFuture.setCause(e);
+                    requestFail(correlationId);
+                }
+            }, timeout - cost);
+            sendInvocationCompleted = true;
+        } finally {
+            if (!sendInvocationCompleted) {
+                RequestFutureHolder.getInstance().getRequestFutureTable()
+                    .remove(correlationId, requestResponseFuture);
             }
-        }, timeout - cost);
+        }
     }
 
     public Message request(final Message msg, final MessageQueueSelector selector, final Object arg,
@@ -1720,18 +1729,27 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         RequestFutureHolder.getInstance().getRequestFutureTable().put(correlationId, requestResponseFuture);
 
         long cost = System.currentTimeMillis() - beginTimestamp;
-        this.sendSelectImpl(msg, selector, arg, CommunicationMode.ASYNC, new SendCallback() {
-            @Override
-            public void onSuccess(SendResult sendResult) {
-                requestResponseFuture.setSendRequestOk(true);
-            }
+        boolean sendInvocationCompleted = false;
+        try {
+            this.sendSelectImpl(msg, selector, arg, CommunicationMode.ASYNC, new SendCallback() {
+                @Override
+                public void onSuccess(SendResult sendResult) {
+                    requestResponseFuture.setSendRequestOk(true);
+                }
 
-            @Override
-            public void onException(Throwable e) {
-                requestResponseFuture.setCause(e);
-                requestFail(correlationId);
+                @Override
+                public void onException(Throwable e) {
+                    requestResponseFuture.setCause(e);
+                    requestFail(correlationId);
+                }
+            }, timeout - cost);
+            sendInvocationCompleted = true;
+        } finally {
+            if (!sendInvocationCompleted) {
+                RequestFutureHolder.getInstance().getRequestFutureTable()
+                    .remove(correlationId, requestResponseFuture);
             }
-        }, timeout - cost);
+        }
 
     }
 
@@ -1790,18 +1808,27 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         RequestFutureHolder.getInstance().getRequestFutureTable().put(correlationId, requestResponseFuture);
 
         long cost = System.currentTimeMillis() - beginTimestamp;
-        this.sendKernelImpl(msg, mq, CommunicationMode.ASYNC, new SendCallback() {
-            @Override
-            public void onSuccess(SendResult sendResult) {
-                requestResponseFuture.setSendRequestOk(true);
-            }
+        boolean sendInvocationCompleted = false;
+        try {
+            this.sendKernelImpl(msg, mq, CommunicationMode.ASYNC, new SendCallback() {
+                @Override
+                public void onSuccess(SendResult sendResult) {
+                    requestResponseFuture.setSendRequestOk(true);
+                }
 
-            @Override
-            public void onException(Throwable e) {
-                requestResponseFuture.setCause(e);
-                requestFail(correlationId);
+                @Override
+                public void onException(Throwable e) {
+                    requestResponseFuture.setCause(e);
+                    requestFail(correlationId);
+                }
+            }, null, timeout - cost);
+            sendInvocationCompleted = true;
+        } finally {
+            if (!sendInvocationCompleted) {
+                RequestFutureHolder.getInstance().getRequestFutureTable()
+                    .remove(correlationId, requestResponseFuture);
             }
-        }, null, timeout - cost);
+        }
     }
 
     private void requestFail(final String correlationId) {

--- a/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/DefaultMQProducerTest.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.client.latency.MQFaultStrategy;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.compression.CompressionType;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.RPCHook;
@@ -479,9 +480,8 @@ public class DefaultMQProducerTest {
     }
 
     @Test
-    public void testAsyncRequest_OnException() throws Exception {
+    public void testAsyncRequest_SynchronousExceptionRemovesFuture() throws Exception {
         final AtomicInteger cc = new AtomicInteger(0);
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
         RequestCallback requestCallback = new RequestCallback() {
             @Override
             public void onSuccess(Message message) {
@@ -491,13 +491,6 @@ public class DefaultMQProducerTest {
             @Override
             public void onException(Throwable e) {
                 cc.incrementAndGet();
-                countDownLatch.countDown();
-            }
-        };
-        MessageQueueSelector messageQueueSelector = new MessageQueueSelector() {
-            @Override
-            public MessageQueue select(List<MessageQueue> mqs, Message msg, Object arg) {
-                return null;
             }
         };
 
@@ -506,14 +499,10 @@ public class DefaultMQProducerTest {
             failBecauseExceptionWasNotThrown(Exception.class);
         } catch (Exception e) {
             ConcurrentHashMap<String, RequestResponseFuture> responseMap = RequestFutureHolder.getInstance().getRequestFutureTable();
-            assertThat(responseMap).isNotNull();
-            for (Map.Entry<String, RequestResponseFuture> entry : responseMap.entrySet()) {
-                RequestResponseFuture future = entry.getValue();
-                future.getRequestCallback().onException(e);
-            }
+            String correlationId = message.getProperty(MessageConst.PROPERTY_CORRELATION_ID);
+            assertThat(responseMap).doesNotContainKey(correlationId);
         }
-        countDownLatch.await(defaultTimeout, TimeUnit.MILLISECONDS);
-        assertThat(cc.get()).isEqualTo(1);
+        assertThat(cc.get()).isZero();
     }
 
     @Test

--- a/client/src/test/java/org/apache/rocketmq/client/producer/selector/DefaultMQProducerImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/selector/DefaultMQProducerImplTest.java
@@ -30,6 +30,7 @@ import org.apache.rocketmq.client.impl.producer.TopicPublishInfo;
 import org.apache.rocketmq.client.producer.LocalTransactionState;
 import org.apache.rocketmq.client.producer.MessageQueueSelector;
 import org.apache.rocketmq.client.producer.RequestCallback;
+import org.apache.rocketmq.client.producer.RequestFutureHolder;
 import org.apache.rocketmq.client.producer.SendCallback;
 import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.producer.TransactionListener;
@@ -45,6 +46,7 @@ import org.apache.rocketmq.common.producer.RecallMessageHandle;
 import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.apache.rocketmq.remoting.protocol.header.CheckTransactionStateRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.EndTransactionRequestHeader;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +84,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultMQProducerImplTest {
 
+    private static final String CORRELATION_ID = "correlation-id";
+
     @Mock
     private Message message;
 
@@ -112,6 +116,7 @@ public class DefaultMQProducerImplTest {
 
     @Before
     public void init() throws Exception {
+        RequestFutureHolder.getInstance().getRequestFutureTable().remove(CORRELATION_ID);
         when(mQClientFactory.getTopicRouteTable()).thenReturn(mock(ConcurrentMap.class));
         when(mQClientFactory.getClientId()).thenReturn("client-id");
         when(mQClientFactory.getMQAdminImpl()).thenReturn(mock(MQAdminImpl.class));
@@ -123,7 +128,7 @@ public class DefaultMQProducerImplTest {
         when(mQClientFactory.getMQClientAPIImpl()).thenReturn(mQClientAPIImpl);
         when(mQClientFactory.findBrokerAddressInPublish(or(isNull(), anyString()))).thenReturn(defaultBrokerAddr);
         when(message.getTopic()).thenReturn(defaultTopic);
-        when(message.getProperty(MessageConst.PROPERTY_CORRELATION_ID)).thenReturn("correlation-id");
+        when(message.getProperty(MessageConst.PROPERTY_CORRELATION_ID)).thenReturn(CORRELATION_ID);
         when(message.getBody()).thenReturn(new byte[1]);
         TransactionMQProducer producer = new TransactionMQProducer("test-producer-group");
         producer.setTransactionListener(mock(TransactionListener.class));
@@ -136,15 +141,43 @@ public class DefaultMQProducerImplTest {
         defaultMQProducerImpl.setServiceState(ServiceState.RUNNING);
     }
 
+    @After
+    public void removeRequestFuture() {
+        RequestFutureHolder.getInstance().getRequestFutureTable().remove(CORRELATION_ID);
+    }
+
     @Test
     public void testRequest() throws Exception {
         defaultMQProducerImpl.request(message, messageQueue, requestCallback, defaultTimeout);
+        assertTrue(RequestFutureHolder.getInstance().getRequestFutureTable().containsKey(CORRELATION_ID));
         defaultMQProducerImpl.request(message, queueSelector, 1, requestCallback, defaultTimeout);
+        assertTrue(RequestFutureHolder.getInstance().getRequestFutureTable().containsKey(CORRELATION_ID));
     }
 
-    @Test(expected = MQClientException.class)
-    public void testRequestMQClientExceptionByVoid() throws Exception {
-        defaultMQProducerImpl.request(message, requestCallback, defaultTimeout);
+    @Test
+    public void testRequestCallbackRemovesFutureWhenDefaultSendThrows() {
+        assertThrows(MQClientException.class,
+            () -> defaultMQProducerImpl.request(message, requestCallback, defaultTimeout));
+        assertFalse(RequestFutureHolder.getInstance().getRequestFutureTable().containsKey(CORRELATION_ID));
+    }
+
+    @Test
+    public void testRequestCallbackRemovesFutureWhenSelectorSendThrows() {
+        when(queueSelector.select(any(), any(), any())).thenThrow(new RuntimeException("select failed"));
+
+        assertThrows(MQClientException.class,
+            () -> defaultMQProducerImpl.request(message, queueSelector, 1, requestCallback, defaultTimeout));
+        assertFalse(RequestFutureHolder.getInstance().getRequestFutureTable().containsKey(CORRELATION_ID));
+    }
+
+    @Test
+    public void testRequestCallbackRemovesFutureWhenQueueSendThrows() {
+        when(mQClientFactory.getBrokerNameFromMessageQueue(messageQueue)).thenReturn(defaultBrokerName);
+        when(mQClientFactory.findBrokerAddressInPublish(defaultBrokerName)).thenReturn(null);
+
+        assertThrows(MQClientException.class,
+            () -> defaultMQProducerImpl.request(message, messageQueue, requestCallback, defaultTimeout));
+        assertFalse(RequestFutureHolder.getInstance().getRequestFutureTable().containsKey(CORRELATION_ID));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10696

### Brief Description

The asynchronous request-reply overloads register a `RequestResponseFuture` before invoking the underlying send method. When send initiation throws synchronously, the exception reaches the caller but the future remains in `RequestFutureHolder` until timeout processing, which retains request state and can deliver a callback after the synchronous failure.

This change:

- removes the exact registered future when `sendDefaultImpl`, `sendSelectImpl`, or `sendKernelImpl` does not return normally;
- uses `remove(correlationId, requestResponseFuture)` so a concurrent replacement under the same key is not removed;
- preserves the future after a normal asynchronous handoff so reply, send-failure, and timeout paths continue to own completion;
- updates the existing synchronous-exception test semantics and adds regression coverage for the default, selector, and explicit-queue callback overloads.

### How Did You Test This Change?

Verified on 2026-09-11 at head `e340eb4d4b1372d04c9cdf3c57799a6c9724662e`, rebased onto `develop` at `1a50c6e4e35524ac22055b76fc0ff2a6d3cff99f`, using JDK 8 and Maven 3.8.1:

```bash
mvn -pl client -am -DskipITs \
  -Dtest=DefaultMQProducerTest,DefaultMQProducerImplTest \
  -Dsurefire.failIfNoSpecifiedTests=false clean test
```

- `DefaultMQProducerTest`: 41 tests passed.
- `DefaultMQProducerImplTest`: 37 tests passed.
- Total: 78 tests, 0 failures, 0 errors, 0 skips; all 4 reactor modules succeeded.
- Checkstyle: 0 violations; SpotBugs: 0 bug instances and 0 errors.
- `git diff --check`: passed.

The new regression assertion was previously verified to fail before the production fix because the correlation ID remained in `requestFutureTable`. Earlier full-client reactor evidence (995 tests, 0 failures/errors, 1 skip) predates this rebase; the latest local run above is targeted, and the full CI matrix has been triggered for the refreshed head.
