### PR TITLE
[ISSUE #10698] Restore atomic producer group registration in ProducerManager

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ProducerManager.java
@@ -206,7 +206,8 @@ public class ProducerManager {
     public void registerProducer(final String group, final ClientChannelInfo clientChannelInfo) {
 
         long start = System.currentTimeMillis();
-        ClientChannelInfo clientChannelInfoFound;
+        ClientChannelInfo clientChannelInfoFound = null;
+        boolean newChannel = false;
 
         ConcurrentMap<Channel, ClientChannelInfo> channelTable = this.groupChannelTable.get(group);
         // note that we must take care of the exist groups and channels,
@@ -232,24 +233,30 @@ public class ProducerManager {
         }
 
         if (null == channelTable) {
-            channelTable = new ConcurrentHashMap<>();
-            ConcurrentMap<Channel, ClientChannelInfo> prev = this.groupChannelTable.putIfAbsent(group, channelTable);
-            channelTable = prev != null ? prev : channelTable;
+            ConcurrentMap<Channel, ClientChannelInfo> newChannelTable = new ConcurrentHashMap<>();
+            newChannelTable.put(clientChannelInfo.getChannel(), clientChannelInfo);
+            ConcurrentMap<Channel, ClientChannelInfo> prev =
+                this.groupChannelTable.putIfAbsent(group, newChannelTable);
+            if (prev == null) {
+                channelTable = newChannelTable;
+                newChannel = true;
+            } else {
+                channelTable = prev;
+            }
         }
 
-        clientChannelInfoFound = channelTable.get(clientChannelInfo.getChannel());
-        // Add client-channel info to existing producer group
-        if (null == clientChannelInfoFound) {
-            channelTable.put(clientChannelInfo.getChannel(), clientChannelInfo);
+        if (!newChannel) {
+            clientChannelInfoFound = channelTable.putIfAbsent(clientChannelInfo.getChannel(), clientChannelInfo);
+            newChannel = clientChannelInfoFound == null;
+        }
+
+        if (newChannel) {
             clientChannelTable.put(clientChannelInfo.getClientId(), clientChannelInfo.getChannel());
             log.info("new producer connected, group: {} channel: {}", group, clientChannelInfo.toString());
             if (this.brokerConfig != null && this.brokerConfig.isEnableFastChannelEventProcess()) {
                 ClientChannelAttributeHelper.addProducerGroup(clientChannelInfo.getChannel(), group);
             }
-        }
-
-        // Refresh existing client-channel-info update-timestamp
-        if (clientChannelInfoFound != null) {
+        } else {
             clientChannelInfoFound.setLastUpdateTimestamp(System.currentTimeMillis());
         }
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ProducerManagerTest.java
@@ -18,11 +18,14 @@ package org.apache.rocketmq.broker.client;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
 import java.util.Map;
-
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
 import org.junit.Before;
@@ -163,6 +166,82 @@ public class ProducerManagerTest {
         assertThat(channel1).isNotNull();
         assertThat(channelMap.get(channel)).isEqualTo(clientInfo);
         assertThat(channel1).isEqualTo(channel);
+    }
+
+    @Test
+    public void registerProducerShouldNotPublishEmptyGroupDuringConcurrentScan() throws Exception {
+        CountDownLatch hashEntered = new CountDownLatch(1);
+        CountDownLatch releaseHash = new CountDownLatch(1);
+        AtomicInteger hashCalls = new AtomicInteger();
+        Channel blockingChannel = (Channel) Proxy.newProxyInstance(
+            Channel.class.getClassLoader(), new Class<?>[] {Channel.class}, (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "hashCode":
+                        if (hashCalls.incrementAndGet() == 1) {
+                            hashEntered.countDown();
+                            if (!releaseHash.await(10, TimeUnit.SECONDS)) {
+                                throw new AssertionError("Timed out waiting to release Channel.hashCode()");
+                            }
+                        }
+                        return System.identityHashCode(proxy);
+                    case "equals":
+                        return proxy == args[0];
+                    case "toString":
+                        return "blockingChannel";
+                    default:
+                        throw new UnsupportedOperationException(method.getName());
+                }
+            });
+        String clientId = "concurrent-client";
+        ClientChannelInfo concurrentClientInfo =
+            new ClientChannelInfo(blockingChannel, clientId, LanguageCode.JAVA, 0);
+        AtomicInteger groupUnregisterCount = new AtomicInteger();
+        producerManager.appendProducerChangeListener((event, changedGroup, info) -> {
+            if (event == ProducerGroupEvent.GROUP_UNREGISTER && group.equals(changedGroup)) {
+                groupUnregisterCount.incrementAndGet();
+            }
+        });
+        AtomicReference<Throwable> registrationFailure = new AtomicReference<>();
+        Thread registerThread = new Thread(() -> {
+            try {
+                producerManager.registerProducer(group, concurrentClientInfo);
+            } catch (Throwable t) {
+                registrationFailure.set(t);
+            }
+        });
+
+        registerThread.start();
+        try {
+            assertThat(hashEntered.await(10, TimeUnit.SECONDS)).isTrue();
+            producerManager.scanNotActiveChannel();
+        } finally {
+            releaseHash.countDown();
+            registerThread.join(10_000);
+        }
+
+        assertThat(registerThread.isAlive()).isFalse();
+        assertThat(registrationFailure.get()).isNull();
+        assertThat(producerManager.getGroupChannelTable().get(group))
+            .containsEntry(blockingChannel, concurrentClientInfo);
+        assertThat(producerManager.findChannel(clientId)).isSameAs(blockingChannel);
+        assertThat(groupUnregisterCount.get()).isZero();
+    }
+
+    @Test
+    public void registerProducerShouldAddFastChannelAttributeOnlyOnce() {
+        brokerConfig.setEnableFastChannelEventProcess(true);
+        EmbeddedChannel fastChannel = new EmbeddedChannel();
+        try {
+            ClientChannelInfo fastClientInfo =
+                new ClientChannelInfo(fastChannel, "fast-client", LanguageCode.JAVA, 0);
+
+            producerManager.registerProducer(group, fastClientInfo);
+            producerManager.registerProducer(group, fastClientInfo);
+
+            assertThat(ClientChannelAttributeHelper.getProducerGroups(fastChannel)).containsExactly(group);
+        } finally {
+            fastChannel.finishAndReleaseAll();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10698

### Brief Description

Restore atomic publication of a newly registered producer group without changing the registration-gate or fast-channel behavior introduced later.

- Pre-populate a candidate group map with its first channel before publishing it.
- Fall back to `putIfAbsent` on the winning map when another registration creates the group first.
- Execute client-id indexing, connection logging, and fast-channel attributes only for the thread that inserts a new group/channel mapping.
- Refresh the winner's existing `ClientChannelInfo` timestamp for duplicate registrations.

### Root Cause

`registerProducer()` published an empty inner map to `groupChannelTable`. A concurrent inactive-channel scan could remove the empty group and emit `GROUP_UNREGISTER` before registration inserted its first channel, leaving the channel and client-id mappings detached from the producer-group index.

This is a regression of #8846 / #8847 after #9293 restored the empty-map-first ordering while adding registration gating and fast-channel processing.

### Impact

New producer groups cannot disappear during concurrent scanning, and the group/channel/client-id indexes remain consistent. The current registration switch truth table, timestamp refresh, statistics, and listener semantics are preserved. This PR intentionally does not expand into broader synchronization for already-existing empty groups.

### How Did You Test This Change?

- Deterministic red test on the previous implementation: the scanner removed `FooBar` while registration was blocked at the Channel's first `hashCode()`, and the group assertion failed.
- `ProducerManagerTest`: 9 tests passed, including latch-controlled concurrent scanning and fast-channel attribute coverage.
- Full Broker test suite: 754 tests passed, 0 failures, 0 errors, 4 skipped.
- Reactor dependency build/install: 10 modules succeeded.
- Maven Checkstyle: 0 violations.
- `git diff --check`.
