### PR TITLE
[ISSUE #10700] Make consumer offset commits concurrency-safe

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConsumerOffsetManager.java
@@ -192,26 +192,44 @@ public class RocksDBConsumerOffsetManager extends ConsumerOffsetManager {
         ConcurrentMap<Integer, Long> map = this.offsetTable.get(key);
         if (null == map) {
             map = MixAll.isLmq(topic) ? new ConcurrentHashMap<>(1, 1.0F) : new ConcurrentHashMap<>();
-            map.put(queueId, offset);
-            this.offsetTable.put(key, map);
-        } else {
-            Long storeOffset = map.put(queueId, offset);
-            if (storeOffset != null && offset < storeOffset) {
-                LOG.warn("[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, requestOffset={}, storeOffset={}", clientHost, key, queueId, offset, storeOffset);
+            ConcurrentMap<Integer, Long> previous = this.offsetTable.putIfAbsent(key, map);
+            if (null != previous) {
+                map = previous;
             }
         }
-        if (versionChangeCounter.incrementAndGet() % brokerController.getBrokerConfig().getConsumerOffsetUpdateVersionStep() == 0) {
-            updateDataVersion();
-        }
+
         if (!brokerController.getBrokerConfig().isPersistConsumerOffsetIncrementally()) {
+            updateOffset(clientHost, key, queueId, offset, map);
+            updateDataVersionIfNeeded();
             return;
         }
 
-        try (WriteBatch writeBatch = new WriteBatch()) {
-            putWriteBatch(writeBatch, key, map);
-            this.rocksDBConfigManager.batchPutWithWal(writeBatch);
-        } catch (Exception e) {
-            log.error("consumer offset persist Failed", e);
+        // Keep the in-memory update, whole-map snapshot, and WAL write ordered for the same RocksDB key.
+        // Otherwise, an older concurrent snapshot can be persisted after a newer one and overwrite offsets.
+        synchronized (map) {
+            updateOffset(clientHost, key, queueId, offset, map);
+            updateDataVersionIfNeeded();
+            try (WriteBatch writeBatch = new WriteBatch()) {
+                putWriteBatch(writeBatch, key, map);
+                this.rocksDBConfigManager.batchPutWithWal(writeBatch);
+            } catch (Exception e) {
+                log.error("consumer offset persist Failed", e);
+            }
+        }
+    }
+
+    private void updateOffset(String clientHost, String key, int queueId, long offset,
+        ConcurrentMap<Integer, Long> map) {
+        Long storeOffset = map.put(queueId, offset);
+        if (storeOffset != null && offset < storeOffset) {
+            LOG.warn("[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, requestOffset={}, storeOffset={}", clientHost, key, queueId, offset, storeOffset);
+        }
+    }
+
+    private void updateDataVersionIfNeeded() {
+        if (versionChangeCounter.incrementAndGet()
+            % brokerController.getBrokerConfig().getConsumerOffsetUpdateVersionStep() == 0) {
+            updateDataVersion();
         }
     }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
@@ -206,13 +206,14 @@ public class ConsumerOffsetManager extends ConfigManager {
         ConcurrentMap<Integer, Long> map = this.offsetTable.get(key);
         if (null == map) {
             map = new ConcurrentHashMap<>(2);
-            map.put(queueId, offset);
-            this.offsetTable.put(key, map);
-        } else {
-            Long storeOffset = map.put(queueId, offset);
-            if (storeOffset != null && offset < storeOffset) {
-                LOG.warn("[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, requestOffset={}, storeOffset={}", clientHost, key, queueId, offset, storeOffset);
+            ConcurrentMap<Integer, Long> previous = this.offsetTable.putIfAbsent(key, map);
+            if (null != previous) {
+                map = previous;
             }
+        }
+        Long storeOffset = map.put(queueId, offset);
+        if (storeOffset != null && offset < storeOffset) {
+            LOG.warn("[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, requestOffset={}, storeOffset={}", clientHost, key, queueId, offset, storeOffset);
         }
         if (versionChangeCounter.incrementAndGet() % brokerController.getBrokerConfig().getConsumerOffsetUpdateVersionStep() == 0) {
             updateDataVersion();

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
@@ -17,15 +17,20 @@
 
 package org.apache.rocketmq.broker.offset;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.mockito.Mockito;
 
 import static org.apache.rocketmq.broker.offset.ConsumerOffsetManager.TOPIC_GROUP_SEPARATOR;
@@ -34,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConsumerOffsetManagerTest {
 
     private static final String KEY = "FooBar@FooBarGroup";
+    private static final long TIMEOUT_SECONDS = 10;
 
     private BrokerController brokerController;
 
@@ -47,6 +53,7 @@ public class ConsumerOffsetManagerTest {
 
         MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
         Mockito.when(brokerController.getMessageStoreConfig()).thenReturn(messageStoreConfig);
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
 
         ConcurrentHashMap<String, ConcurrentMap<Integer, Long>> offsetTable = new ConcurrentHashMap<>(512);
         offsetTable.put(KEY,new ConcurrentHashMap<Integer, Long>() {{
@@ -72,7 +79,6 @@ public class ConsumerOffsetManagerTest {
     public void removeOffsetByGroupTest() {
         String topic = "TopicName";
         String group = "GroupName";
-        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
         consumerOffsetManager.commitOffset("Commit", group, topic, 0, 100);
         consumerOffsetManager.assignResetOffset(topic, group, 0, 100);
         consumerOffsetManager.commitPullOffset("Pull", group, topic, 0, 100);
@@ -120,5 +126,75 @@ public class ConsumerOffsetManagerTest {
         consumerOffsetManager.eraseResetOffset(topic, group, 1);
         Assert.assertFalse(consumerOffsetManager.hasOffsetReset(topic, group, 1));
         Assert.assertFalse(consumerOffsetManager.resetOffsetTable.containsKey(key));
+    }
+
+    @Test
+    public void testConcurrentFirstCommitsPreserveAllQueuesDuringJsonRoundTrip() throws Exception {
+        String topic = "ConcurrentTopic";
+        String group = "ConcurrentGroup";
+        String key = topic + TOPIC_GROUP_SEPARATOR + group;
+        FirstReadBarrierMap offsetTable = new FirstReadBarrierMap(key);
+        consumerOffsetManager.setOffsetTable(offsetTable);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> firstCommit = executor.submit(
+                () -> consumerOffsetManager.commitOffset("ClientA", group, topic, 0, 100L));
+            Future<?> secondCommit = executor.submit(
+                () -> consumerOffsetManager.commitOffset("ClientB", group, topic, 1, 200L));
+
+            firstCommit.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            secondCommit.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } finally {
+            offsetTable.releaseReaders();
+            executor.shutdownNow();
+            Assert.assertTrue(executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+
+        assertOffsets(offsetTable.get(key));
+
+        ConsumerOffsetManager decodedManager = new ConsumerOffsetManager(brokerController);
+        decodedManager.decode(consumerOffsetManager.encode());
+        assertOffsets(decodedManager.getOffsetTable().get(key));
+    }
+
+    private static void assertOffsets(ConcurrentMap<Integer, Long> offsets) {
+        Assert.assertNotNull(offsets);
+        Assert.assertEquals(2, offsets.size());
+        Assert.assertEquals(Long.valueOf(100L), offsets.get(0));
+        Assert.assertEquals(Long.valueOf(200L), offsets.get(1));
+    }
+
+    private static class FirstReadBarrierMap
+        extends ConcurrentHashMap<String, ConcurrentMap<Integer, Long>> {
+        private final String targetKey;
+        private final AtomicInteger targetReads = new AtomicInteger();
+        private final CountDownLatch firstReads = new CountDownLatch(2);
+
+        FirstReadBarrierMap(String targetKey) {
+            this.targetKey = targetKey;
+        }
+
+        @Override
+        public ConcurrentMap<Integer, Long> get(Object key) {
+            ConcurrentMap<Integer, Long> storedValue = super.get(key);
+            if (targetKey.equals(key) && targetReads.getAndIncrement() < 2) {
+                firstReads.countDown();
+                try {
+                    Assert.assertTrue("Timed out waiting for both initial reads",
+                        firstReads.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return storedValue;
+        }
+
+        void releaseReaders() {
+            while (firstReads.getCount() > 0) {
+                firstReads.countDown();
+            }
+        }
     }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/RocksDBConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/RocksDBConsumerOffsetManagerTest.java
@@ -21,9 +21,18 @@ import java.io.File;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.config.v1.RocksDBConsumerOffsetManager;
+import org.apache.rocketmq.broker.config.v1.RocksDBConfigManager;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
@@ -34,6 +43,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.rocksdb.WriteBatch;
 
 import static org.apache.rocketmq.broker.offset.ConsumerOffsetManager.TOPIC_GROUP_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +53,7 @@ public class RocksDBConsumerOffsetManagerTest {
     private static final String SKIP_MAC_KEY = "skipMac";
 
     private static final String KEY = "FooBar@FooBarGroup";
+    private static final long TIMEOUT_SECONDS = 10;
 
     private BrokerController brokerController;
 
@@ -152,6 +163,122 @@ public class RocksDBConsumerOffsetManagerTest {
         consumerOffsetManager.getOffsetTable().clear();
         consumerOffsetManager.load();
         Assert.assertTrue(consumerOffsetManager.getOffsetTable().containsKey(key)); // reload from kv
+    }
+
+    @Test
+    public void testConcurrentFirstCommitsPersistAllLmqQueuesPeriodically() throws Exception {
+        brokerConfig.setPersistConsumerOffsetIncrementally(false);
+        String group = UUID.randomUUID().toString();
+        String topic = MixAll.LMQ_PREFIX + UUID.randomUUID();
+        String key = topic + TOPIC_GROUP_SEPARATOR + group;
+        FirstReadBarrierMap offsetTable = new FirstReadBarrierMap(key);
+        consumerOffsetManager.setOffsetTable(offsetTable);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> firstCommit = executor.submit(
+                () -> consumerOffsetManager.commitOffset("ClientA", group, topic, 0, 100L));
+            Future<?> secondCommit = executor.submit(
+                () -> consumerOffsetManager.commitOffset("ClientB", group, topic, 1, 200L));
+
+            firstCommit.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            secondCommit.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } finally {
+            offsetTable.releaseReaders();
+            executor.shutdownNow();
+            Assert.assertTrue(executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        }
+
+        assertOffsets(offsetTable.get(key));
+        consumerOffsetManager.persist();
+        consumerOffsetManager.stop();
+        consumerOffsetManager.getOffsetTable().clear();
+        Assert.assertTrue(consumerOffsetManager.load());
+        assertOffsets(consumerOffsetManager.getOffsetTable().get(key));
+    }
+
+    @Test
+    public void testIncrementalConcurrentCommitsPersistLatestSnapshot() throws Exception {
+        brokerConfig.setPersistConsumerOffsetIncrementally(true);
+        String group = UUID.randomUUID().toString();
+        String topic = UUID.randomUUID().toString();
+        String key = topic + TOPIC_GROUP_SEPARATOR + group;
+        ConcurrentMap<Integer, Long> offsets = new ConcurrentHashMap<>();
+        ConcurrentMap<String, ConcurrentMap<Integer, Long>> offsetTable = new ConcurrentHashMap<>();
+        offsetTable.put(key, offsets);
+        consumerOffsetManager.setOffsetTable(offsetTable);
+
+        RocksDBConsumerOffsetManager rocksDBConsumerOffsetManager =
+            (RocksDBConsumerOffsetManager) consumerOffsetManager;
+        RocksDBConfigManager realConfigManager = (RocksDBConfigManager) FieldUtils.readDeclaredField(
+            rocksDBConsumerOffsetManager, "rocksDBConfigManager", true);
+        RocksDBConfigManager configManagerSpy = Mockito.spy(realConfigManager);
+        FieldUtils.writeDeclaredField(
+            rocksDBConsumerOffsetManager, "rocksDBConfigManager", configManagerSpy, true);
+
+        CountDownLatch firstBatchReady = new CountDownLatch(1);
+        CountDownLatch releaseFirstBatch = new CountDownLatch(1);
+        CountDownLatch secondBatchWritten = new CountDownLatch(1);
+        AtomicInteger batchWriteCount = new AtomicInteger();
+        Mockito.doAnswer(invocation -> {
+            int batchNumber = batchWriteCount.incrementAndGet();
+            if (batchNumber == 1) {
+                firstBatchReady.countDown();
+                try {
+                    Assert.assertTrue("Timed out waiting to release the first batch",
+                        releaseFirstBatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            Object result = invocation.callRealMethod();
+            if (batchNumber == 2) {
+                secondBatchWritten.countDown();
+            }
+            return result;
+        }).when(configManagerSpy).batchPutWithWal(Mockito.any(WriteBatch.class));
+
+        FutureTask<Void> firstCommit = new FutureTask<>(() -> {
+            consumerOffsetManager.commitOffset("ClientA", group, topic, 0, 100L);
+            return null;
+        });
+        FutureTask<Void> secondCommit = new FutureTask<>(() -> {
+            consumerOffsetManager.commitOffset("ClientB", group, topic, 1, 200L);
+            return null;
+        });
+        Thread firstThread = new Thread(firstCommit, "first-incremental-offset-commit");
+        Thread secondThread = new Thread(secondCommit, "second-incremental-offset-commit");
+        boolean secondWriteCompletedBeforeRelease;
+        try {
+            firstThread.start();
+            Assert.assertTrue("First batch was not ready",
+                firstBatchReady.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            secondThread.start();
+            awaitSecondWriteOrBlocked(secondThread, secondBatchWritten);
+            secondWriteCompletedBeforeRelease = secondBatchWritten.getCount() == 0;
+            if (!secondWriteCompletedBeforeRelease) {
+                Assert.assertEquals(Thread.State.BLOCKED, secondThread.getState());
+            }
+
+            releaseFirstBatch.countDown();
+            firstCommit.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            secondCommit.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } finally {
+            releaseFirstBatch.countDown();
+            firstThread.interrupt();
+            secondThread.interrupt();
+            firstThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            secondThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        }
+
+        Assert.assertEquals(2, batchWriteCount.get());
+        consumerOffsetManager.stop();
+        consumerOffsetManager.getOffsetTable().clear();
+        Assert.assertTrue(consumerOffsetManager.load());
+        assertOffsets(consumerOffsetManager.getOffsetTable().get(key));
+        Assert.assertFalse("Commits for one topic and group must be serialized",
+            secondWriteCompletedBeforeRelease);
     }
 
     @Test
@@ -327,6 +454,58 @@ public class RocksDBConsumerOffsetManagerTest {
         consumerOffsetManager.stop();
         consumerOffsetManager.load();
         Assert.assertEquals(10, consumerOffsetManager.getDataVersion().getCounter().get());
+    }
+
+    private static void awaitSecondWriteOrBlocked(Thread secondThread, CountDownLatch secondBatchWritten)
+        throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (System.nanoTime() < deadline) {
+            if (secondBatchWritten.await(10, TimeUnit.MILLISECONDS)
+                || secondThread.getState() == Thread.State.BLOCKED) {
+                return;
+            }
+        }
+        Assert.fail("Second commit neither wrote its batch nor blocked on the offset map");
+    }
+
+    private static void assertOffsets(ConcurrentMap<Integer, Long> offsets) {
+        Assert.assertNotNull(offsets);
+        Assert.assertEquals(2, offsets.size());
+        Assert.assertEquals(Long.valueOf(100L), offsets.get(0));
+        Assert.assertEquals(Long.valueOf(200L), offsets.get(1));
+    }
+
+    private static class FirstReadBarrierMap
+        extends ConcurrentHashMap<String, ConcurrentMap<Integer, Long>> {
+        private final String targetKey;
+        private final AtomicInteger targetReads = new AtomicInteger();
+        private final CountDownLatch firstReads = new CountDownLatch(2);
+
+        FirstReadBarrierMap(String targetKey) {
+            this.targetKey = targetKey;
+        }
+
+        @Override
+        public ConcurrentMap<Integer, Long> get(Object key) {
+            ConcurrentMap<Integer, Long> storedValue = super.get(key);
+            if (targetKey.equals(key) && targetReads.getAndIncrement() < 2) {
+                firstReads.countDown();
+                try {
+                    Assert.assertTrue("Timed out waiting for both initial reads",
+                        firstReads.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return storedValue;
+        }
+
+        void releaseReaders() {
+            while (firstReads.getCount() > 0) {
+                firstReads.countDown();
+            }
+        }
     }
 
     private static void skipMacIfNecessary() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10700

### Brief Description

Make first offset-map initialization atomic in the classic and RocksDB v1 consumer offset managers, and serialize incremental whole-map persistence for the same `topic@group`.

- Publish one shared inner queue-offset map with outer `putIfAbsent`, then update the selected winner map.
- Preserve the RocksDB v1 LMQ-specific map construction.
- In incremental mode, order the queue update, version update, whole-map serialization, and WAL batch write under the inner map monitor.
- Keep non-incremental commits lock-free across the existing concurrent map and allow different `topic@group` keys to proceed independently.
- Leave RocksDB v2 unchanged because it already initializes atomically and persists each queue under an independent key.

### Root Cause

Classic and RocksDB v1 used check-then-act initialization followed by unconditional outer `put`, so two first commits could publish different inner maps and overwrite one queue. RocksDB v1 incremental mode additionally allowed an older serialized whole-map batch to be written after a newer batch for the same RocksDB key.

Historical unmerged PR #1427 identified the classic initialization race. This PR preserves that analysis while extending coverage to RocksDB v1, incremental WAL ordering, and deterministic persistence/reload tests. PRs #10625, #9602, and #9877 touch related files but do not change these commit paths.

### Related PR coordination

PR #10992 independently addresses the classic-manager subset of #10700 using `computeIfAbsent` and a multi-queue concurrency test. This PR also covers RocksDB v1 initialization, LMQ map construction, and same-key incremental WAL ordering, including restart verification. Its classic-manager regression controls the conflicting first reads with latches and verifies a JSON round trip.

The author of #10992 has offered to consolidate in favor of this PR. Maintainers can review the broader fix here; if the narrower classic fix is preferred first, the remaining RocksDB v1 changes still need review and this PR can be adjusted accordingly. Neither implementation is merged as of 2026-09-11.

### Impact

Concurrent first commits retain every queue in memory and after persistence. Incremental restart recovery cannot regress to an older same-key snapshot. Existing rollback warnings, version semantics, LMQ allocation, and v2 behavior are preserved.

### How Did You Test This Change?

- Deterministic red tests on the previous implementation:
  - classic concurrent first commits: expected 2 queues, reloaded 1;
  - RocksDB v1 periodic LMQ commits: expected 2 queues, retained 1;
  - RocksDB v1 incremental delayed old batch: expected 2 queues after restart, reloaded 1.
- `ConsumerOffsetManagerTest` + `RocksDBConsumerOffsetManagerTest`: 21 tests passed.
- Full `broker` test suite: 755 tests passed, 0 failures, 0 errors, 4 skipped.
- Maven Checkstyle: 0 violations.
- SpotBugs: 0 findings.
- `git diff --check`.
- Current PR head `03695c8703aa26d52f7d2b999935a5a8513c8224`: all 10 GitHub checks passed (checked 2026-09-11). This evidence is for the existing head, not a new run against current `develop`.
