### PR TITLE
[Studio] feat: Feature/rip 2 pr3 security interceptor

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,6 +158,22 @@ load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_jav
 rules_java_dependencies()
 rules_java_toolchains()
 
+# rules_proto 5.3.0-21.7 — last 5.x release, WORKSPACE-compatible (avoids
+# bazel_features Bzlmod requirement introduced in 6.0.0).
+# Uses git archive URL because the GitHub Release asset was removed (returns 404).
+http_archive(
+    name = "rules_proto",
+    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+    strip_prefix = "rules_proto-5.3.0-21.7",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
 load("@rules_java//toolchains:local_java_repository.bzl", "local_java_repository")
 local_java_repository(
   name = "jdk8",

--- a/common/src/main/java/org/apache/rocketmq/common/constant/GrpcConstants.java
+++ b/common/src/main/java/org/apache/rocketmq/common/constant/GrpcConstants.java
@@ -73,4 +73,11 @@ public class GrpcConstants {
 
     public static final Metadata.Key<String> CHANNEL_ID
         = Metadata.Key.of("x-mq-channel-id", Metadata.ASCII_STRING_MARSHALLER);
+
+    /**
+     * SSL/TLS state key in gRPC metadata, indicating whether the connection uses SSL.
+     * Value is "true" or "false".
+     */
+    public static final Metadata.Key<String> SSL_ENABLED
+        = Metadata.Key.of("x-mq-ssl-enabled", Metadata.ASCII_STRING_MARSHALLER);
 }

--- a/common/src/test/java/org/apache/rocketmq/common/ServiceThreadTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/ServiceThreadTest.java
@@ -161,8 +161,11 @@ public class ServiceThreadTest {
     public void serviceThreadShouldNotLoseWakeupUnderStress() throws Exception {
         final int stressIterations = 10000;
         final int wakerThreads = 4;
-        final long waitTimeoutMs = 20;
-        final long lostWakeupThresholdMs = 18;
+        // A delivered wakeup returns in microseconds while a lost one blocks for the whole
+        // interval. Keep the interval and the threshold far above CI scheduler/GC jitter
+        // (which can easily exceed tens of milliseconds) so the two cases stay distinguishable.
+        final long waitTimeoutMs = 2000;
+        final long lostWakeupThresholdMs = 1000;
 
         StressServiceThread service = new StressServiceThread();
         AtomicInteger activeIteration = new AtomicInteger(-1);

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -15,12 +15,26 @@
 # limitations under the License.
 #
 load("//bazel:GenTestRules.bzl", "GenTestRules")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "proxy_admin_proto",
+    srcs = ["src/main/proto/proxy_admin.proto"],
+)
+
+# java_proto_library: native rule in Bazel 6.x; rules_java 7.x does not export it.
+java_proto_library(
+    name = "proxy_admin_java_proto",
+    deps = [":proxy_admin_proto"],
+    visibility = ["//visibility:public"],
+)
 
 java_library(
     name = "proxy",
     srcs = glob(["src/main/java/**/*.java"]),
     visibility = ["//visibility:public"],
     deps = [
+        ":proxy_admin_java_proto",
         "//auth",
         "//broker",
         "//client",
@@ -80,6 +94,7 @@ java_library(
     deps = [
 	    "//auth",
         ":proxy",
+        ":proxy_admin_java_proto",
         "//:test_deps",
         "//broker",
         "//client",

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -32,7 +32,46 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.root>${basedir}/..</project.root>
+        <protobuf.version>3.20.1</protobuf.version>
+        <grpc.version>1.53.0</grpc.version>
     </properties>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
+                    <outputDirectory>${basedir}/target/generated-sources/protobuf/java</outputDirectory>
+                    <clearOutputDirectory>false</clearOutputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>**/generated-sources/**/*.java</excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnostics.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnostics.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import java.util.Map;
+
+/**
+ * Diagnostic information for batch consumption, aggregated per client channel.
+ * <p>
+ * Combines data from ReceiptHandleManager (unacked message statistics)
+ * with enrichment from ConsumerManager and GrpcClientSettingsManager.
+ * <p>
+ * Key diagnostic use cases:
+ * - Identify clients with excessive unacked messages (batch too large)
+ * - Detect clients with high expired handle counts (timeout issues)
+ * - Monitor renewal patterns per client (ChangeInvisibleTime frequency)
+ * - Correlate unacked count with configured receiveBatchSize
+ */
+public class BatchConsumeClientDiagnostics {
+    private final String clientId;
+    private final String channelId;
+    private final int unackedMessageCount;
+    private final int unackedHandleCount;
+    private final long totalRenewTimes;
+    private final long totalRenewRetryTimes;
+    private final int expiredHandleCount;
+    private final Map<String, Integer> topicDistribution;
+    private final String consumeType;
+    private final String messageModel;
+    private final int receiveBatchSize;
+    private final long longPollingTimeoutMs;
+    private final long lastRttMs;
+    private final long connectTime;
+
+    public BatchConsumeClientDiagnostics(String clientId, String channelId,
+        int unackedMessageCount, int unackedHandleCount,
+        long totalRenewTimes, long totalRenewRetryTimes, int expiredHandleCount,
+        Map<String, Integer> topicDistribution,
+        String consumeType, String messageModel,
+        int receiveBatchSize, long longPollingTimeoutMs,
+        long lastRttMs, long connectTime) {
+        this.clientId = clientId;
+        this.channelId = channelId;
+        this.unackedMessageCount = unackedMessageCount;
+        this.unackedHandleCount = unackedHandleCount;
+        this.totalRenewTimes = totalRenewTimes;
+        this.totalRenewRetryTimes = totalRenewRetryTimes;
+        this.expiredHandleCount = expiredHandleCount;
+        this.topicDistribution = topicDistribution;
+        this.consumeType = consumeType;
+        this.messageModel = messageModel;
+        this.receiveBatchSize = receiveBatchSize;
+        this.longPollingTimeoutMs = longPollingTimeoutMs;
+        this.lastRttMs = lastRttMs;
+        this.connectTime = connectTime;
+    }
+
+    public String getClientId() { return clientId; }
+    public String getChannelId() { return channelId; }
+    public int getUnackedMessageCount() { return unackedMessageCount; }
+    public int getUnackedHandleCount() { return unackedHandleCount; }
+    public long getTotalRenewTimes() { return totalRenewTimes; }
+    public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+    public int getExpiredHandleCount() { return expiredHandleCount; }
+    public Map<String, Integer> getTopicDistribution() { return topicDistribution; }
+    public String getConsumeType() { return consumeType; }
+    public String getMessageModel() { return messageModel; }
+    public int getReceiveBatchSize() { return receiveBatchSize; }
+    public long getLongPollingTimeoutMs() { return longPollingTimeoutMs; }
+    public long getLastRttMs() { return lastRttMs; }
+    public long getConnectTime() { return connectTime; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummary.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+/**
+ * Aggregated summary statistics for batch consumption diagnostics across a consumer group.
+ * <p>
+ * Provides a high-level view of the batch consumption state for a group,
+ * useful for quickly identifying groups with excessive unacked messages,
+ * high renewal rates, or expired handles across all clients.
+ */
+public class BatchConsumeGroupSummary {
+    private final String group;
+    private final int totalClients;
+    private final int totalUnackedMessages;
+    private final int totalUnackedHandles;
+    private final int totalExpiredHandles;
+    private final long totalRenewTimes;
+    private final long totalRenewRetryTimes;
+
+    public BatchConsumeGroupSummary(String group, int totalClients,
+        int totalUnackedMessages, int totalUnackedHandles, int totalExpiredHandles,
+        long totalRenewTimes, long totalRenewRetryTimes) {
+        this.group = group;
+        this.totalClients = totalClients;
+        this.totalUnackedMessages = totalUnackedMessages;
+        this.totalUnackedHandles = totalUnackedHandles;
+        this.totalExpiredHandles = totalExpiredHandles;
+        this.totalRenewTimes = totalRenewTimes;
+        this.totalRenewRetryTimes = totalRenewRetryTimes;
+    }
+
+    public String getGroup() { return group; }
+    public int getTotalClients() { return totalClients; }
+    public int getTotalUnackedMessages() { return totalUnackedMessages; }
+    public int getTotalUnackedHandles() { return totalUnackedHandles; }
+    public int getTotalExpiredHandles() { return totalExpiredHandles; }
+    public long getTotalRenewTimes() { return totalRenewTimes; }
+    public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummary.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummary.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+/**
+ * Aggregated summary statistics for POP receipt handles in a consumer group.
+ * <p>
+ * Provides a high-level view of the POP consumption state for a group,
+ * useful for quickly identifying groups with excessive unacked messages,
+ * high renewal rates, or expired handles.
+ */
+public class PopReceiptHandleGroupSummary {
+    private final String group;
+    private final int totalHandles;
+    private final int totalMessages;
+    private final long totalRenewTimes;
+    private final long totalRenewRetryTimes;
+    private final int expiredHandles;
+
+    public PopReceiptHandleGroupSummary(String group, int totalHandles, int totalMessages,
+        long totalRenewTimes, long totalRenewRetryTimes, int expiredHandles) {
+        this.group = group;
+        this.totalHandles = totalHandles;
+        this.totalMessages = totalMessages;
+        this.totalRenewTimes = totalRenewTimes;
+        this.totalRenewRetryTimes = totalRenewRetryTimes;
+        this.expiredHandles = expiredHandles;
+    }
+
+    public String getGroup() { return group; }
+    public int getTotalHandles() { return totalHandles; }
+    public int getTotalMessages() { return totalMessages; }
+    public long getTotalRenewTimes() { return totalRenewTimes; }
+    public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+    public int getExpiredHandles() { return expiredHandles; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfo.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+/**
+ * Diagnostic information for a single POP receipt handle.
+ * <p>
+ * Contains all relevant fields for diagnosing POP consumption issues:
+ * - Message identification (group, topic, queueId, messageId, queueOffset)
+ * - Consumption state (reconsumeTimes, renewTimes, renewRetryTimes, consumeTimestamp)
+ * - Invisible time management (receiptHandle, nextVisibleTime, invisibleTime, isExpired)
+ * - Broker location (brokerName)
+ */
+public class PopReceiptHandleInfo {
+    private final String group;
+    private final String topic;
+    private final int queueId;
+    private final String messageId;
+    private final long queueOffset;
+    private final int reconsumeTimes;
+    private final int renewTimes;
+    private final int renewRetryTimes;
+    private final long consumeTimestamp;
+    private final String receiptHandle;
+    private final long nextVisibleTime;
+    private final long invisibleTime;
+    private final String brokerName;
+    private final boolean expired;
+
+    public PopReceiptHandleInfo(String group, String topic, int queueId, String messageId,
+        long queueOffset, int reconsumeTimes, int renewTimes, int renewRetryTimes,
+        long consumeTimestamp, String receiptHandle, long nextVisibleTime,
+        long invisibleTime, String brokerName, boolean expired) {
+        this.group = group;
+        this.topic = topic;
+        this.queueId = queueId;
+        this.messageId = messageId;
+        this.queueOffset = queueOffset;
+        this.reconsumeTimes = reconsumeTimes;
+        this.renewTimes = renewTimes;
+        this.renewRetryTimes = renewRetryTimes;
+        this.consumeTimestamp = consumeTimestamp;
+        this.receiptHandle = receiptHandle;
+        this.nextVisibleTime = nextVisibleTime;
+        this.invisibleTime = invisibleTime;
+        this.brokerName = brokerName;
+        this.expired = expired;
+    }
+
+    public String getGroup() { return group; }
+    public String getTopic() { return topic; }
+    public int getQueueId() { return queueId; }
+    public String getMessageId() { return messageId; }
+    public long getQueueOffset() { return queueOffset; }
+    public int getReconsumeTimes() { return reconsumeTimes; }
+    public int getRenewTimes() { return renewTimes; }
+    public int getRenewRetryTimes() { return renewRetryTimes; }
+    public long getConsumeTimestamp() { return consumeTimestamp; }
+    public String getReceiptHandle() { return receiptHandle; }
+    public long getNextVisibleTime() { return nextVisibleTime; }
+    public long getInvisibleTime() { return invisibleTime; }
+    public String getBrokerName() { return brokerName; }
+    public boolean isExpired() { return expired; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
@@ -156,4 +156,22 @@ public class ProxyContext {
             || ClientType.LITE_SIMPLE_CONSUMER.name().equals(clientType);
     }
 
+    public ProxyContext setSslEnabled(Boolean sslEnabled) {
+        this.withVal(ContextVariable.SSL_ENABLED, sslEnabled);
+        return this;
+    }
+
+    public Boolean isSslEnabled() {
+        return this.getVal(ContextVariable.SSL_ENABLED);
+    }
+
+    public ProxyContext setAuthUsername(String username) {
+        this.withVal(ContextVariable.AUTH_USERNAME, username);
+        return this;
+    }
+
+    public String getAuthUsername() {
+        return this.getVal(ContextVariable.AUTH_USERNAME);
+    }
+
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -112,6 +112,40 @@ public class ProxyConfig implements ConfigFile {
      * 130M = 4M * 32 messages + 2M attributes
      */
     private int grpcMaxInboundMessageSize = 130 * 1024 * 1024;
+
+    /**
+     * Proxy Admin gRPC configuration (RIP-2)
+     * Admin interface runs on a separate port from the data plane.
+     */
+    private boolean proxyAdminEnabled = true;
+    private Integer proxyAdminServerPort = 8082;
+    private int proxyAdminThreadPoolNums = 4;
+    private int proxyAdminMaxPageSize = 100;
+    /**
+     * Sampling concurrency limit for DescribeClient diagnostic queries (RIP-2 §8.5).
+     * When concurrent DescribeClient requests exceed this value, new requests are rejected.
+     * Default: 8
+     */
+    private int proxyAdminDescribeClientConcurrencyLimit = 8;
+    /**
+     * Sampling rate under medium load (RIP-2 §8.5).
+     * When concurrency is between half the limit and the full limit, this fraction of
+     * DescribeClient requests are accepted. Value between 0.0 and 1.0.
+     * Default: 0.5
+     */
+    private double proxyAdminSamplingRateUnderLoad = 0.5;
+    /**
+     * Maximum heartbeat history records per client (RIP-2 §5.2.2).
+     * Controls memory usage for heartbeat tracking.
+     * Default: 10
+     */
+    private int proxyAdminHeartbeatHistorySize = 10;
+    /**
+     * Sampling threshold for client count (RIP-2 §8.5).
+     * When total client count exceeds this value, diagnostic interfaces may apply sampling.
+     * Default: 100000
+     */
+    private long proxyAdminSamplingThreshold = 100000L;
     /**
      * max message body size, 0 or negative number means no limit for proxy
      */
@@ -481,6 +515,70 @@ public class ProxyConfig implements ConfigFile {
 
     public void setGrpcServerPort(Integer grpcServerPort) {
         this.grpcServerPort = grpcServerPort;
+    }
+
+    public boolean isProxyAdminEnabled() {
+        return proxyAdminEnabled;
+    }
+
+    public void setProxyAdminEnabled(boolean proxyAdminEnabled) {
+        this.proxyAdminEnabled = proxyAdminEnabled;
+    }
+
+    public Integer getProxyAdminServerPort() {
+        return proxyAdminServerPort;
+    }
+
+    public void setProxyAdminServerPort(Integer proxyAdminServerPort) {
+        this.proxyAdminServerPort = proxyAdminServerPort;
+    }
+
+    public int getProxyAdminThreadPoolNums() {
+        return proxyAdminThreadPoolNums;
+    }
+
+    public void setProxyAdminThreadPoolNums(int proxyAdminThreadPoolNums) {
+        this.proxyAdminThreadPoolNums = proxyAdminThreadPoolNums;
+    }
+
+    public int getProxyAdminMaxPageSize() {
+        return proxyAdminMaxPageSize;
+    }
+
+    public void setProxyAdminMaxPageSize(int proxyAdminMaxPageSize) {
+        this.proxyAdminMaxPageSize = proxyAdminMaxPageSize;
+    }
+
+    public int getProxyAdminDescribeClientConcurrencyLimit() {
+        return proxyAdminDescribeClientConcurrencyLimit;
+    }
+
+    public void setProxyAdminDescribeClientConcurrencyLimit(int proxyAdminDescribeClientConcurrencyLimit) {
+        this.proxyAdminDescribeClientConcurrencyLimit = proxyAdminDescribeClientConcurrencyLimit;
+    }
+
+    public double getProxyAdminSamplingRateUnderLoad() {
+        return proxyAdminSamplingRateUnderLoad;
+    }
+
+    public void setProxyAdminSamplingRateUnderLoad(double proxyAdminSamplingRateUnderLoad) {
+        this.proxyAdminSamplingRateUnderLoad = proxyAdminSamplingRateUnderLoad;
+    }
+
+    public int getProxyAdminHeartbeatHistorySize() {
+        return proxyAdminHeartbeatHistorySize;
+    }
+
+    public void setProxyAdminHeartbeatHistorySize(int proxyAdminHeartbeatHistorySize) {
+        this.proxyAdminHeartbeatHistorySize = proxyAdminHeartbeatHistorySize;
+    }
+
+    public long getProxyAdminSamplingThreshold() {
+        return proxyAdminSamplingThreshold;
+    }
+
+    public void setProxyAdminSamplingThreshold(long proxyAdminSamplingThreshold) {
+        this.proxyAdminSamplingThreshold = proxyAdminSamplingThreshold;
     }
 
     public long getGrpcShutdownTimeSeconds() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/AdminCode.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/AdminCode.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+/**
+ * Admin API response codes (RIP-2 §5.2.3).
+ * Mirrors the AdminCode enum defined in proxy_admin.proto.
+ * <p>
+ * These codes provide structured error information in the response body,
+ * complementing gRPC status codes with application-level semantics.
+ */
+public enum AdminCode {
+    /**
+     * Success.
+     */
+    OK(1, "OK"),
+
+    /**
+     * Internal server error.
+     */
+    INTERNAL_ERROR(2, "Internal error"),
+
+    /**
+     * Bad request - invalid parameters.
+     */
+    BAD_REQUEST(3, "Bad request"),
+
+    /**
+     * Unauthorized - authentication required.
+     */
+    UNAUTHORIZED(4, "Unauthorized"),
+
+    /**
+     * Forbidden - insufficient permissions.
+     */
+    FORBIDDEN(5, "Forbidden"),
+
+    /**
+     * Resource not found.
+     */
+    NOT_FOUND(6, "Not found"),
+
+    /**
+     * Too many requests - rate limited.
+     */
+    TOO_MANY_REQUESTS(7, "Too many requests"),
+
+    /**
+     * Conflict - client already disconnected or in transition.
+     */
+    CONFLICT(8, "Conflict");
+
+    private final int code;
+    private final String description;
+
+    AdminCode(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Convert a numeric code to the corresponding AdminCode.
+     *
+     * @param code the numeric code
+     * @return the AdminCode, or null if not found
+     */
+    public static AdminCode fromCode(int code) {
+        for (AdminCode ac : values()) {
+            if (ac.code == code) {
+                return ac;
+            }
+        }
+        return null;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminAuthInterceptor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminAuthInterceptor.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.auth.authentication.AuthenticationEvaluator;
+import org.apache.rocketmq.auth.authentication.context.DefaultAuthenticationContext;
+import org.apache.rocketmq.auth.authentication.exception.AuthenticationException;
+import org.apache.rocketmq.auth.authentication.factory.AuthenticationFactory;
+import org.apache.rocketmq.auth.authentication.model.User;
+import org.apache.rocketmq.auth.authorization.AuthorizationEvaluator;
+import org.apache.rocketmq.auth.authorization.context.AuthorizationContext;
+import org.apache.rocketmq.auth.authorization.context.DefaultAuthorizationContext;
+import org.apache.rocketmq.auth.authorization.exception.AuthorizationException;
+import org.apache.rocketmq.auth.authorization.factory.AuthorizationFactory;
+import org.apache.rocketmq.auth.authorization.model.Resource;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.common.action.Action;
+import org.apache.rocketmq.common.constant.CommonConstants;
+import org.apache.rocketmq.common.constant.GrpcConstants;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.resource.ResourcePattern;
+import org.apache.rocketmq.common.resource.ResourceType;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+
+/**
+ * gRPC server interceptor for Proxy Admin ACL 2.0 authentication and authorization.
+ * <p>
+ * RIP-2 defines the ACL resource pattern as: proxy.admin.client
+ * - ListClients: proxy.admin.client read
+ * - DescribeClient: proxy.admin.client read
+ * - ListClientsByGroup: proxy.admin.client read
+ * - ListClientsByTopic: proxy.admin.client read
+ * - GetConfig: proxy.admin.client read
+ * - UpdateConfig: proxy.admin.client write
+ * <p>
+ * All admin RPCs require read permission on the proxy.admin.client resource.
+ * UpdateConfig requires write permission.
+ */
+public class ProxyAdminAuthInterceptor implements ServerInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+
+    /** ACL 2.0 resource prefix for proxy admin operations */
+    public static final String ADMIN_RESOURCE_PREFIX = "proxy.admin";
+
+    /** Resource for client admin operations */
+    public static final String CLIENT_ADMIN_RESOURCE = "proxy.admin.client";
+
+    private final AuthConfig authConfig;
+    private final AuthenticationEvaluator authenticationEvaluator;
+    private final AuthorizationEvaluator authorizationEvaluator;
+
+    public ProxyAdminAuthInterceptor(AuthConfig authConfig, MessagingProcessor messagingProcessor) {
+        this.authConfig = authConfig;
+        if (authConfig.isAuthenticationEnabled() || authConfig.isAuthorizationEnabled()) {
+            this.authenticationEvaluator = AuthenticationFactory.getEvaluator(authConfig, messagingProcessor::getMetadataService);
+            this.authorizationEvaluator = AuthorizationFactory.getEvaluator(authConfig, messagingProcessor::getMetadataService);
+        } else {
+            this.authenticationEvaluator = null;
+            this.authorizationEvaluator = null;
+        }
+    }
+
+    @Override
+    public <REQT, RESPT> ServerCall.Listener<REQT> interceptCall(
+        ServerCall<REQT, RESPT> call, Metadata headers, ServerCallHandler<REQT, RESPT> next) {
+
+        if (!authConfig.isAuthenticationEnabled() && !authConfig.isAuthorizationEnabled()) {
+            return next.startCall(call, headers);
+        }
+
+        String methodName = call.getMethodDescriptor().getFullMethodName();
+
+        try {
+            // Step 1: Authentication
+            if (authConfig.isAuthenticationEnabled()) {
+                authenticate(headers, methodName);
+            }
+
+            // Step 2: Authorization
+            if (authConfig.isAuthorizationEnabled()) {
+                authorize(headers, methodName);
+            }
+
+        } catch (AuthenticationException e) {
+            log.warn("Admin authentication failed for method:{}, user:{}, error:{}",
+                methodName, extractUsername(headers), e.getMessage());
+            call.close(Status.UNAUTHENTICATED
+                .withDescription("Authentication failed: " + e.getMessage()), headers);
+            return new ServerCall.Listener<REQT>() { };
+        } catch (AuthorizationException e) {
+            log.warn("Admin authorization failed for method:{}, user:{}, error:{}",
+                methodName, extractUsername(headers), e.getMessage());
+            call.close(Status.PERMISSION_DENIED
+                .withDescription("Authorization failed: " + e.getMessage()), headers);
+            return new ServerCall.Listener<REQT>() { };
+        } catch (Exception e) {
+            log.error("Admin auth error for method:{}", methodName, e);
+            call.close(Status.INTERNAL
+                .withDescription("Internal auth error: " + e.getMessage()), headers);
+            return new ServerCall.Listener<REQT>() { };
+        }
+
+        return next.startCall(call, headers);
+    }
+
+    /**
+     * Perform authentication using ACL 2.0 evaluator.
+     * Manually constructs the authentication context from gRPC headers
+     * since admin requests are not protobuf GeneratedMessageV3 types.
+     */
+    private void authenticate(Metadata headers, String methodName) {
+        DefaultAuthenticationContext authContext = new DefaultAuthenticationContext();
+        authContext.setChannelId(headers.get(GrpcConstants.CHANNEL_ID));
+        authContext.setRpcCode(methodName);
+
+        // Parse Authorization header for credentials
+        String authorization = headers.get(GrpcConstants.AUTHORIZATION);
+        if (StringUtils.isNotBlank(authorization)) {
+            String datetime = headers.get(GrpcConstants.DATE_TIME);
+            if (StringUtils.isNotBlank(datetime)) {
+                String[] result = authorization.split(CommonConstants.SPACE, 2);
+                if (result.length == 2) {
+                    String[] keyValues = result[1].split(CommonConstants.COMMA);
+                    for (String keyValue : keyValues) {
+                        String[] kv = keyValue.trim().split(CommonConstants.EQUAL, 2);
+                        if (kv.length == 2) {
+                            if ("Credential".equals(kv[0])) {
+                                String[] credential = kv[1].split(CommonConstants.SLASH);
+                                if (credential.length > 0) {
+                                    authContext.setUsername(credential[0]);
+                                }
+                            } else if ("Signature".equals(kv[0])) {
+                                authContext.setSignature(kv[1]);
+                            }
+                        }
+                    }
+                    authContext.setContent(datetime.getBytes(StandardCharsets.UTF_8));
+                }
+            }
+        }
+
+        authenticationEvaluator.evaluate(authContext);
+    }
+
+    /**
+     * Perform authorization using ACL 2.0 evaluator.
+     * Admin operations require read permission on proxy.admin.client resource.
+     * <p>
+     * RIP-2 §7.2: read covers list/describe/get operations.
+     * - DescribeClient uses Action.GET (single resource read)
+     * - List* operations use Action.LIST (collection read)
+     */
+    private void authorize(Metadata headers, String methodName) {
+        // Extract subject (username) from headers
+        String username = extractUsername(headers);
+        User subject = User.of(username);
+
+        // Build resource: use ANY type with the admin resource name
+        Resource resource = Resource.of(ResourceType.ANY, CLIENT_ADMIN_RESOURCE, ResourcePattern.LITERAL);
+
+        // Determine action based on method type (RIP-2 §7.2)
+        Action action = resolveAction(methodName);
+
+        // Build authorization context
+        DefaultAuthorizationContext context = DefaultAuthorizationContext.of(
+            subject, resource, action, extractSourceIp(headers));
+
+        List<AuthorizationContext> contexts = Collections.singletonList(context);
+        authorizationEvaluator.evaluate(contexts);
+    }
+
+    /**
+     * Resolve the authorization action for the given admin RPC method.
+     * RIP-2 §7.2: read = list/describe/get, write = update
+     * - DescribeClient → GET (single resource read)
+     * - GetConfig → GET (single config read)
+     * - UpdateConfig → UPDATE (config write)
+     * - ListClients / ListClientsByGroup / ListClientsByTopic → LIST (collection read)
+     */
+    private Action resolveAction(String methodName) {
+        if (methodName != null && methodName.contains("UpdateConfig")) {
+            return Action.UPDATE;
+        }
+        if (methodName != null && (methodName.contains("DescribeClient")
+            || methodName.contains("GetConfig"))) {
+            return Action.GET;
+        }
+        return Action.LIST;
+    }
+
+    /**
+     * Extract username from gRPC headers for logging and authorization.
+     */
+    private String extractUsername(Metadata headers) {
+        if (headers == null) {
+            return "unknown";
+        }
+        String ak = headers.get(GrpcConstants.AUTHORIZATION_AK);
+        return StringUtils.isNotBlank(ak) ? ak : "unknown";
+    }
+
+    /**
+     * Extract source IP from gRPC headers.
+     */
+    private String extractSourceIp(Metadata headers) {
+        if (headers == null) {
+            return null;
+        }
+        // Try to get source IP from the gRPC metadata
+        String sourceIp = headers.get(Metadata.Key.of("x-forwarded-for", Metadata.ASCII_STRING_MARSHALLER));
+        return StringUtils.isNotBlank(sourceIp) ? sourceIp : null;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshaller.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshaller.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * The License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
+import apache.rocketmq.proxy.admin.v1.ListClientsRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsResponse;
+import apache.rocketmq.proxy.admin.v1.DescribeClientRequest;
+import apache.rocketmq.proxy.admin.v1.DescribeClientResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicResponse;
+import apache.rocketmq.proxy.admin.v1.GetConfigRequest;
+import apache.rocketmq.proxy.admin.v1.GetConfigResponse;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigRequest;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigResponse;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientRequest;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientResponse;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesRequest;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesResponse;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsRequest;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsResponse;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsRequest;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsResponse;
+
+/**
+ * Protobuf-based Marshallers for Proxy Admin gRPC requests and responses.
+ * <p>
+ * Uses protobuf binary serialization as the wire format for admin RPCs,
+ * replacing the previous JSON-based marshalling. This is the standard
+ * approach for gRPC services defined via .proto files.
+ * <p>
+ * The proto definitions are compiled by protobuf-maven-plugin from
+ * src/main/proto/proxy_admin.proto into Java classes in the
+ * apache.rocketmq.proxy.admin.v1 package.
+ */
+public class ProxyAdminMarshaller {
+
+    private ProxyAdminMarshaller() {
+        // Utility class
+    }
+
+    // Request marshallers
+    public static final MethodDescriptor.Marshaller<ListClientsRequest>
+        LIST_CLIENTS_REQ_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeClientRequest>
+        DESCRIBE_CLIENT_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DescribeClientRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByGroupRequest>
+        LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByGroupRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByTopicRequest>
+        LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByTopicRequest.getDefaultInstance());
+
+    // Response marshallers
+    public static final MethodDescriptor.Marshaller<ListClientsResponse>
+        LIST_CLIENTS_RESP_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeClientResponse>
+        DESCRIBE_CLIENT_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DescribeClientResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByGroupResponse>
+        LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByGroupResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByTopicResponse>
+        LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByTopicResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<GetConfigRequest>
+        GET_CONFIG_REQ_MARSHALLER = ProtoLiteUtils.marshaller(GetConfigRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<GetConfigResponse>
+        GET_CONFIG_RESP_MARSHALLER = ProtoLiteUtils.marshaller(GetConfigResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<UpdateConfigRequest>
+        UPDATE_CONFIG_REQ_MARSHALLER = ProtoLiteUtils.marshaller(UpdateConfigRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<UpdateConfigResponse>
+        UPDATE_CONFIG_RESP_MARSHALLER = ProtoLiteUtils.marshaller(UpdateConfigResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DisconnectClientRequest>
+        DISCONNECT_CLIENT_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DisconnectClientRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DisconnectClientResponse>
+        DISCONNECT_CLIENT_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DisconnectClientResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribePopReceiptHandlesRequest>
+        DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DescribePopReceiptHandlesRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribePopReceiptHandlesResponse>
+        DESCRIBE_POP_RECEIPT_HANDLES_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DescribePopReceiptHandlesResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeBatchConsumeDiagnosticsRequest>
+        DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DescribeBatchConsumeDiagnosticsRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeBatchConsumeDiagnosticsResponse>
+        DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DescribeBatchConsumeDiagnosticsResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<SubscribeRouteEventsRequest>
+        SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER = ProtoLiteUtils.marshaller(SubscribeRouteEventsRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<SubscribeRouteEventsResponse>
+        SUBSCRIBE_ROUTE_EVENTS_RESP_MARSHALLER = ProtoLiteUtils.marshaller(SubscribeRouteEventsResponse.getDefaultInstance());
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminProtoConverter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminProtoConverter.java
@@ -1,0 +1,1016 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * The License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientDetailInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientInstanceInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ListClientsFilter;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEvent;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEventType;
+import org.apache.rocketmq.proxy.grpc.admin.model.TopicRouteSnapshot;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService.BatchConsumeDiagnosticResult;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService.ListClientsResult;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager.PopReceiptHandleDiagnosticResult;
+import apache.rocketmq.proxy.admin.v1.AdminCode;
+import apache.rocketmq.proxy.admin.v1.AuthStatus;
+import apache.rocketmq.proxy.admin.v1.BatchConsumeClientDiagnostics;
+import apache.rocketmq.proxy.admin.v1.BatchConsumeGroupSummary;
+import apache.rocketmq.proxy.admin.v1.BrokerInfo;
+import apache.rocketmq.proxy.admin.v1.ClientDetail;
+import apache.rocketmq.proxy.admin.v1.ClientInstance;
+import apache.rocketmq.proxy.admin.v1.ClientLanguage;
+import apache.rocketmq.proxy.admin.v1.ClientProtocol;
+import apache.rocketmq.proxy.admin.v1.ClientRole;
+import apache.rocketmq.proxy.admin.v1.ClientSettings;
+import apache.rocketmq.proxy.admin.v1.ConsumeProgress;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsResponse;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesResponse;
+import apache.rocketmq.proxy.admin.v1.HeartbeatRecord;
+import apache.rocketmq.proxy.admin.v1.ListClientsRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsResponse;
+import apache.rocketmq.proxy.admin.v1.DescribeClientResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicResponse;
+import apache.rocketmq.proxy.admin.v1.GetConfigResponse;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigResponse;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientResponse;
+import apache.rocketmq.proxy.admin.v1.NetworkInfo;
+import apache.rocketmq.proxy.admin.v1.Pagination;
+import apache.rocketmq.proxy.admin.v1.PopReceiptHandleGroupSummary;
+import apache.rocketmq.proxy.admin.v1.PopReceiptHandleInfo;
+import apache.rocketmq.proxy.admin.v1.ProxyRuntimeConfig;
+import apache.rocketmq.proxy.admin.v1.QueueInfo;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsResponse;
+import apache.rocketmq.proxy.admin.v1.TopicConsumeProgress;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
+
+/**
+ * Converter between internal model classes and protobuf-generated types.
+ * <p>
+ * Since the service layer uses internal model classes (ClientInstanceInfo, ClientDetailInfo, etc.)
+ * and the gRPC layer uses protobuf-generated types, this converter bridges the two representations.
+ */
+public class ProxyAdminProtoConverter {
+
+    private ProxyAdminProtoConverter() {
+        // Utility class
+    }
+
+    // ==================== Request Converters ====================
+
+    /**
+     * Convert proto ListClientsRequest to internal ListClientsFilter.
+     */
+    public static ListClientsFilter toFilter(ListClientsRequest request) {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup(request.getGroup());
+        filter.setTopic(request.getTopic());
+        filter.setClientIdPrefix(request.getClientIdPrefix());
+        if (request.getLanguage() != null && request.getLanguage() != ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED) {
+            filter.setLanguage(fromClientLanguage(request.getLanguage()));
+        }
+        if (request.getConnectTimeStart() > 0) {
+            filter.setConnectTimeStart(request.getConnectTimeStart());
+        }
+        if (request.getConnectTimeEnd() > 0) {
+            filter.setConnectTimeEnd(request.getConnectTimeEnd());
+        }
+        return filter;
+    }
+
+    // ==================== Response Converters ====================
+
+    /**
+     * Build a ListClientsResponse from service result.
+     */
+    public static ListClientsResponse toListClientsResponse(ListClientsResult result) {
+        ListClientsResponse.Builder builder = ListClientsResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setPagination(Pagination.newBuilder()
+                .setTotal(result.getTotal())
+                .setPageNum(result.getPageNum())
+                .setPageSize(result.getPageSize())
+                .build());
+
+        for (ClientInstanceInfo info : result.getList()) {
+            builder.addList(toClientInstance(info));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Build a ListClientsResponse for error cases.
+     */
+    public static ListClientsResponse toListClientsError(AdminCode code, String message) {
+        return ListClientsResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Build a DescribeClientResponse from ClientDetailInfo.
+     */
+    public static DescribeClientResponse toDescribeClientResponse(ClientDetailInfo detail) {
+        return DescribeClientResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setClientDetail(toClientDetail(detail))
+            .build();
+    }
+
+    /**
+     * Build a DescribeClientResponse for error cases.
+     */
+    public static DescribeClientResponse toDescribeClientError(AdminCode code, String message) {
+        return DescribeClientResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Build a ListClientsByGroupResponse from service result.
+     */
+    public static ListClientsByGroupResponse toListClientsByGroupResponse(ListClientsResult result) {
+        ListClientsByGroupResponse.Builder builder = ListClientsByGroupResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setPagination(Pagination.newBuilder()
+                .setTotal(result.getTotal())
+                .setPageNum(result.getPageNum())
+                .setPageSize(result.getPageSize())
+                .build());
+
+        for (ClientInstanceInfo info : result.getList()) {
+            builder.addList(toClientInstance(info));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Build a ListClientsByGroupResponse for error cases.
+     */
+    public static ListClientsByGroupResponse toListClientsByGroupError(AdminCode code, String message) {
+        return ListClientsByGroupResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Build a ListClientsByTopicResponse from service result.
+     */
+    public static ListClientsByTopicResponse toListClientsByTopicResponse(ListClientsResult result) {
+        ListClientsByTopicResponse.Builder builder = ListClientsByTopicResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setPagination(Pagination.newBuilder()
+                .setTotal(result.getTotal())
+                .setPageNum(result.getPageNum())
+                .setPageSize(result.getPageSize())
+                .build());
+
+        for (ClientInstanceInfo info : result.getList()) {
+            builder.addList(toClientInstance(info));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Build a ListClientsByTopicResponse for error cases.
+     */
+    public static ListClientsByTopicResponse toListClientsByTopicError(AdminCode code, String message) {
+        return ListClientsByTopicResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Build a GetConfigResponse from ProxyConfig.
+     */
+    public static GetConfigResponse toGetConfigResponse(ProxyConfig config) {
+        return GetConfigResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setConfig(toProxyRuntimeConfig(config))
+            .build();
+    }
+
+    /**
+     * Build a GetConfigResponse for error cases.
+     */
+    public static GetConfigResponse toGetConfigError(AdminCode code, String message) {
+        return GetConfigResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Build an UpdateConfigResponse from updated ProxyConfig and list of changed field names.
+     */
+    public static UpdateConfigResponse toUpdateConfigResponse(ProxyConfig config, List<String> changedFields) {
+        return UpdateConfigResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setConfig(toProxyRuntimeConfig(config))
+            .addAllChangedFields(changedFields)
+            .build();
+    }
+
+    /**
+     * Build an UpdateConfigResponse for error cases.
+     */
+    public static UpdateConfigResponse toUpdateConfigError(AdminCode code, String message) {
+        return UpdateConfigResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Build a DisconnectClientResponse for successful disconnection.
+     */
+    public static DisconnectClientResponse toDisconnectClientResponse(boolean disconnected) {
+        return DisconnectClientResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setDisconnected(disconnected)
+            .build();
+    }
+
+    /**
+     * Build a DisconnectClientResponse for error cases.
+     */
+    public static DisconnectClientResponse toDisconnectClientError(AdminCode code, String message) {
+        return DisconnectClientResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    // ==================== POP Diagnostics Converters ====================
+
+    /**
+     * Build a DescribePopReceiptHandlesResponse from diagnostic result.
+     */
+    public static DescribePopReceiptHandlesResponse toDescribePopReceiptHandlesResponse(
+        PopReceiptHandleDiagnosticResult result) {
+        DescribePopReceiptHandlesResponse.Builder builder = DescribePopReceiptHandlesResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setSummary(toPopReceiptHandleGroupSummary(result.getSummary()))
+            .setPagination(Pagination.newBuilder()
+                .setTotal(result.getTotal())
+                .setPageNum(result.getPageNum())
+                .setPageSize(result.getPageSize())
+                .build());
+
+        for (org.apache.rocketmq.proxy.common.PopReceiptHandleInfo info : result.getHandles()) {
+            builder.addHandles(toPopReceiptHandleInfo(info));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Build a DescribePopReceiptHandlesResponse for error cases.
+     */
+    public static DescribePopReceiptHandlesResponse toDescribePopReceiptHandlesError(
+        AdminCode code, String message) {
+        return DescribePopReceiptHandlesResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Convert internal PopReceiptHandleGroupSummary to proto.
+     */
+    public static PopReceiptHandleGroupSummary toPopReceiptHandleGroupSummary(
+        org.apache.rocketmq.proxy.common.PopReceiptHandleGroupSummary summary) {
+        return PopReceiptHandleGroupSummary.newBuilder()
+            .setGroup(summary.getGroup() != null ? summary.getGroup() : "")
+            .setTotalHandles(summary.getTotalHandles())
+            .setTotalMessages(summary.getTotalMessages())
+            .setTotalRenewTimes(summary.getTotalRenewTimes())
+            .setTotalRenewRetryTimes(summary.getTotalRenewRetryTimes())
+            .setExpiredHandles(summary.getExpiredHandles())
+            .build();
+    }
+
+    /**
+     * Convert internal PopReceiptHandleInfo to proto.
+     */
+    public static PopReceiptHandleInfo toPopReceiptHandleInfo(
+        org.apache.rocketmq.proxy.common.PopReceiptHandleInfo info) {
+        return PopReceiptHandleInfo.newBuilder()
+            .setGroup(info.getGroup() != null ? info.getGroup() : "")
+            .setTopic(info.getTopic() != null ? info.getTopic() : "")
+            .setQueueId(info.getQueueId())
+            .setMessageId(info.getMessageId() != null ? info.getMessageId() : "")
+            .setQueueOffset(info.getQueueOffset())
+            .setReconsumeTimes(info.getReconsumeTimes())
+            .setRenewTimes(info.getRenewTimes())
+            .setRenewRetryTimes(info.getRenewRetryTimes())
+            .setConsumeTimestamp(info.getConsumeTimestamp())
+            .setReceiptHandle(info.getReceiptHandle() != null ? info.getReceiptHandle() : "")
+            .setNextVisibleTime(info.getNextVisibleTime())
+            .setInvisibleTime(info.getInvisibleTime())
+            .setBrokerName(info.getBrokerName() != null ? info.getBrokerName() : "")
+            .setIsExpired(info.isExpired())
+            .build();
+    }
+
+    // ==================== Batch Consume Diagnostics Converters ====================
+
+    /**
+     * Build a DescribeBatchConsumeDiagnosticsResponse from diagnostic result.
+     */
+    public static DescribeBatchConsumeDiagnosticsResponse toDescribeBatchConsumeDiagnosticsResponse(
+        BatchConsumeDiagnosticResult result) {
+        DescribeBatchConsumeDiagnosticsResponse.Builder builder = DescribeBatchConsumeDiagnosticsResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name())
+            .setSummary(toBatchConsumeGroupSummary(result.getSummary()))
+            .setPagination(Pagination.newBuilder()
+                .setTotal(result.getTotal())
+                .setPageNum(result.getPageNum())
+                .setPageSize(result.getPageSize())
+                .build());
+
+        for (org.apache.rocketmq.proxy.common.BatchConsumeClientDiagnostics diag : result.getDiagnostics()) {
+            builder.addDiagnostics(toBatchConsumeClientDiagnostics(diag));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Build a DescribeBatchConsumeDiagnosticsResponse for error cases.
+     */
+    public static DescribeBatchConsumeDiagnosticsResponse toDescribeBatchConsumeDiagnosticsError(
+        AdminCode code, String message) {
+        return DescribeBatchConsumeDiagnosticsResponse.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+    }
+
+    /**
+     * Convert internal BatchConsumeGroupSummary to proto.
+     */
+    public static BatchConsumeGroupSummary toBatchConsumeGroupSummary(
+        org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary summary) {
+        return BatchConsumeGroupSummary.newBuilder()
+            .setGroup(summary.getGroup() != null ? summary.getGroup() : "")
+            .setTotalClients(summary.getTotalClients())
+            .setTotalUnackedMessages(summary.getTotalUnackedMessages())
+            .setTotalUnackedHandles(summary.getTotalUnackedHandles())
+            .setTotalExpiredHandles(summary.getTotalExpiredHandles())
+            .setTotalRenewTimes(summary.getTotalRenewTimes())
+            .setTotalRenewRetryTimes(summary.getTotalRenewRetryTimes())
+            .build();
+    }
+
+    /**
+     * Convert internal BatchConsumeClientDiagnostics to proto.
+     */
+    public static BatchConsumeClientDiagnostics toBatchConsumeClientDiagnostics(
+        org.apache.rocketmq.proxy.common.BatchConsumeClientDiagnostics diag) {
+        BatchConsumeClientDiagnostics.Builder builder = BatchConsumeClientDiagnostics.newBuilder()
+            .setClientId(diag.getClientId() != null ? diag.getClientId() : "")
+            .setChannelId(diag.getChannelId() != null ? diag.getChannelId() : "")
+            .setUnackedMessageCount(diag.getUnackedMessageCount())
+            .setUnackedHandleCount(diag.getUnackedHandleCount())
+            .setTotalRenewTimes(diag.getTotalRenewTimes())
+            .setTotalRenewRetryTimes(diag.getTotalRenewRetryTimes())
+            .setExpiredHandleCount(diag.getExpiredHandleCount())
+            .setConsumeType(diag.getConsumeType() != null ? diag.getConsumeType() : "")
+            .setMessageModel(diag.getMessageModel() != null ? diag.getMessageModel() : "")
+            .setReceiveBatchSize(diag.getReceiveBatchSize())
+            .setLongPollingTimeoutMs(diag.getLongPollingTimeoutMs())
+            .setLastRttMs(diag.getLastRttMs())
+            .setConnectTime(diag.getConnectTime());
+
+        if (diag.getTopicDistribution() != null) {
+            builder.putAllTopicDistribution(diag.getTopicDistribution());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Compare requested config with current config and apply changes for fields that differ.
+     * Returns the list of field names (snake_case) that were actually changed.
+     * <p>
+     * Due to proto3 default value semantics, fields set to their default value (0, "", false, 0.0)
+     * in the request will be treated as "not set" and will NOT be updated. This means the API
+     * cannot be used to explicitly set a field to its default value; use a config file reset for that.
+     * <p>
+     * Configuration changes take effect immediately for operations that read config at invocation time
+     * (e.g., message size limits, timeout values, rate limiting thresholds). Some settings such as
+     * network ports and cluster names cannot be hot-updated and require a restart.
+     */
+    public static List<String> applyConfigChanges(ProxyConfig config, ProxyRuntimeConfig req) {
+        List<String> changed = new ArrayList<>();
+
+        // === gRPC data plane ===
+        ifInt(changed, "grpc_server_port", req.getGrpcServerPort(), config.getGrpcServerPort(), v -> config.setGrpcServerPort(v));
+        ifInt(changed, "grpc_boss_loop_num", req.getGrpcBossLoopNum(), config.getGrpcBossLoopNum(), v -> config.setGrpcBossLoopNum(v));
+        ifInt(changed, "grpc_worker_loop_num", req.getGrpcWorkerLoopNum(), config.getGrpcWorkerLoopNum(), v -> config.setGrpcWorkerLoopNum(v));
+        ifInt(changed, "grpc_thread_pool_nums", req.getGrpcThreadPoolNums(), config.getGrpcThreadPoolNums(), v -> config.setGrpcThreadPoolNums(v));
+        ifInt(changed, "grpc_thread_pool_queue_capacity", req.getGrpcThreadPoolQueueCapacity(), config.getGrpcThreadPoolQueueCapacity(), v -> config.setGrpcThreadPoolQueueCapacity(v));
+        ifInt(changed, "grpc_max_inbound_message_size", req.getGrpcMaxInboundMessageSize(), config.getGrpcMaxInboundMessageSize(), v -> config.setGrpcMaxInboundMessageSize(v));
+        ifInt(changed, "grpc_max_concurrent_calls_per_connection", req.getGrpcMaxConcurrentCallsPerConnection(), config.getGrpcMaxConcurrentCallsPerConnection(), v -> config.setGrpcMaxConcurrentCallsPerConnection(v));
+
+        // === Admin interface ===
+        ifBool(changed, "proxy_admin_enabled", req.getProxyAdminEnabled(), config.isProxyAdminEnabled(), v -> config.setProxyAdminEnabled(v));
+        ifInt(changed, "proxy_admin_server_port", req.getProxyAdminServerPort(), config.getProxyAdminServerPort(), v -> config.setProxyAdminServerPort(v));
+        ifInt(changed, "proxy_admin_thread_pool_nums", req.getProxyAdminThreadPoolNums(), config.getProxyAdminThreadPoolNums(), v -> config.setProxyAdminThreadPoolNums(v));
+        ifInt(changed, "proxy_admin_max_page_size", req.getProxyAdminMaxPageSize(), config.getProxyAdminMaxPageSize(), v -> config.setProxyAdminMaxPageSize(v));
+        ifInt(changed, "proxy_admin_describe_client_concurrency_limit", req.getProxyAdminDescribeClientConcurrencyLimit(), config.getProxyAdminDescribeClientConcurrencyLimit(), v -> config.setProxyAdminDescribeClientConcurrencyLimit(v));
+        ifDouble(changed, "proxy_admin_sampling_rate_under_load", req.getProxyAdminSamplingRateUnderLoad(), config.getProxyAdminSamplingRateUnderLoad(), v -> config.setProxyAdminSamplingRateUnderLoad(v));
+        ifInt(changed, "proxy_admin_heartbeat_history_size", req.getProxyAdminHeartbeatHistorySize(), config.getProxyAdminHeartbeatHistorySize(), v -> config.setProxyAdminHeartbeatHistorySize(v));
+        ifLong(changed, "proxy_admin_sampling_threshold", req.getProxyAdminSamplingThreshold(), config.getProxyAdminSamplingThreshold(), v -> config.setProxyAdminSamplingThreshold(v));
+
+        // === Thread pools - gRPC activities ===
+        ifInt(changed, "grpc_producer_thread_pool_nums", req.getGrpcProducerThreadPoolNums(), config.getGrpcProducerThreadPoolNums(), v -> config.setGrpcProducerThreadPoolNums(v));
+        ifInt(changed, "grpc_producer_thread_queue_capacity", req.getGrpcProducerThreadQueueCapacity(), config.getGrpcProducerThreadQueueCapacity(), v -> config.setGrpcProducerThreadQueueCapacity(v));
+        ifInt(changed, "grpc_consumer_thread_pool_nums", req.getGrpcConsumerThreadPoolNums(), config.getGrpcConsumerThreadPoolNums(), v -> config.setGrpcConsumerThreadPoolNums(v));
+        ifInt(changed, "grpc_consumer_thread_queue_capacity", req.getGrpcConsumerThreadQueueCapacity(), config.getGrpcConsumerThreadQueueCapacity(), v -> config.setGrpcConsumerThreadQueueCapacity(v));
+        ifInt(changed, "grpc_route_thread_pool_nums", req.getGrpcRouteThreadPoolNums(), config.getGrpcRouteThreadPoolNums(), v -> config.setGrpcRouteThreadPoolNums(v));
+        ifInt(changed, "grpc_route_thread_queue_capacity", req.getGrpcRouteThreadQueueCapacity(), config.getGrpcRouteThreadQueueCapacity(), v -> config.setGrpcRouteThreadQueueCapacity(v));
+        ifInt(changed, "grpc_client_manager_thread_pool_nums", req.getGrpcClientManagerThreadPoolNums(), config.getGrpcClientManagerThreadPoolNums(), v -> config.setGrpcClientManagerThreadPoolNums(v));
+        ifInt(changed, "grpc_client_manager_thread_queue_capacity", req.getGrpcClientManagerThreadQueueCapacity(), config.getGrpcClientManagerThreadQueueCapacity(), v -> config.setGrpcClientManagerThreadQueueCapacity(v));
+        ifInt(changed, "grpc_transaction_thread_pool_nums", req.getGrpcTransactionThreadPoolNums(), config.getGrpcTransactionThreadPoolNums(), v -> config.setGrpcTransactionThreadPoolNums(v));
+        ifInt(changed, "grpc_transaction_thread_queue_capacity", req.getGrpcTransactionThreadQueueCapacity(), config.getGrpcTransactionThreadQueueCapacity(), v -> config.setGrpcTransactionThreadQueueCapacity(v));
+
+        // === Thread pools - remoting ===
+        ifInt(changed, "remoting_heartbeat_thread_pool_nums", req.getRemotingHeartbeatThreadPoolNums(), config.getRemotingHeartbeatThreadPoolNums(), v -> config.setRemotingHeartbeatThreadPoolNums(v));
+        ifInt(changed, "remoting_send_message_thread_pool_nums", req.getRemotingSendMessageThreadPoolNums(), config.getRemotingSendMessageThreadPoolNums(), v -> config.setRemotingSendMessageThreadPoolNums(v));
+        ifInt(changed, "remoting_pull_message_thread_pool_nums", req.getRemotingPullMessageThreadPoolNums(), config.getRemotingPullMessageThreadPoolNums(), v -> config.setRemotingPullMessageThreadPoolNums(v));
+
+        // === Message limits ===
+        ifInt(changed, "max_message_size", req.getMaxMessageSize(), config.getMaxMessageSize(), v -> config.setMaxMessageSize(v));
+        ifInt(changed, "max_user_property_size", req.getMaxUserPropertySize(), config.getMaxUserPropertySize(), v -> config.setMaxUserPropertySize(v));
+        ifInt(changed, "user_property_max_num", req.getUserPropertyMaxNum(), config.getUserPropertyMaxNum(), v -> config.setUserPropertyMaxNum(v));
+        ifInt(changed, "max_message_group_size", req.getMaxMessageGroupSize(), config.getMaxMessageGroupSize(), v -> config.setMaxMessageGroupSize(v));
+
+        // === Timeout and polling ===
+        ifLong(changed, "default_invisible_time_mills", req.getDefaultInvisibleTimeMills(), config.getDefaultInvisibleTimeMills(), v -> config.setDefaultInvisibleTimeMills(v));
+        ifLong(changed, "max_invisible_time_mills", req.getMaxInvisibleTimeMills(), config.getMaxInvisibleTimeMills(), v -> config.setMaxInvisibleTimeMills(v));
+        ifLong(changed, "min_invisible_time_mills_for_recv", req.getMinInvisibleTimeMillsForRecv(), config.getMinInvisibleTimeMillsForRecv(), v -> config.setMinInvisibleTimeMillsForRecv(v));
+        ifLong(changed, "max_delay_time_mills", req.getMaxDelayTimeMills(), config.getMaxDelayTimeMills(), v -> config.setMaxDelayTimeMills(v));
+        ifLong(changed, "grpc_client_consumer_min_long_polling_timeout_millis", req.getGrpcClientConsumerMinLongPollingTimeoutMillis(), config.getGrpcClientConsumerMinLongPollingTimeoutMillis(), v -> config.setGrpcClientConsumerMinLongPollingTimeoutMillis(v));
+        ifLong(changed, "grpc_client_consumer_max_long_polling_timeout_millis", req.getGrpcClientConsumerMaxLongPollingTimeoutMillis(), config.getGrpcClientConsumerMaxLongPollingTimeoutMillis(), v -> config.setGrpcClientConsumerMaxLongPollingTimeoutMillis(v));
+        ifInt(changed, "grpc_client_consumer_long_polling_batch_size", req.getGrpcClientConsumerLongPollingBatchSize(), config.getGrpcClientConsumerLongPollingBatchSize(), v -> config.setGrpcClientConsumerLongPollingBatchSize(v));
+        ifInt(changed, "grpc_client_producer_max_attempts", req.getGrpcClientProducerMaxAttempts(), config.getGrpcClientProducerMaxAttempts(), v -> config.setGrpcClientProducerMaxAttempts(v));
+        ifLong(changed, "grpc_client_producer_backoff_initial_millis", req.getGrpcClientProducerBackoffInitialMillis(), config.getGrpcClientProducerBackoffInitialMillis(), v -> config.setGrpcClientProducerBackoffInitialMillis(v));
+        ifLong(changed, "grpc_client_producer_backoff_max_millis", req.getGrpcClientProducerBackoffMaxMillis(), config.getGrpcClientProducerBackoffMaxMillis(), v -> config.setGrpcClientProducerBackoffMaxMillis(v));
+        ifInt(changed, "grpc_client_producer_backoff_multiplier", req.getGrpcClientProducerBackoffMultiplier(), config.getGrpcClientProducerBackoffMultiplier(), v -> config.setGrpcClientProducerBackoffMultiplier(v));
+
+        // === Cache ===
+        ifInt(changed, "topic_route_service_cache_expired_seconds", req.getTopicRouteServiceCacheExpiredSeconds(), config.getTopicRouteServiceCacheExpiredSeconds(), v -> config.setTopicRouteServiceCacheExpiredSeconds(v));
+        ifInt(changed, "topic_route_service_cache_refresh_seconds", req.getTopicRouteServiceCacheRefreshSeconds(), config.getTopicRouteServiceCacheRefreshSeconds(), v -> config.setTopicRouteServiceCacheRefreshSeconds(v));
+        ifInt(changed, "topic_route_service_cache_max_num", req.getTopicRouteServiceCacheMaxNum(), config.getTopicRouteServiceCacheMaxNum(), v -> config.setTopicRouteServiceCacheMaxNum(v));
+
+        // === Metrics ===
+        ifInt(changed, "metrics_prom_exporter_port", req.getMetricsPromExporterPort(), config.getMetricsPromExporterPort(), v -> config.setMetricsPromExporterPort(v));
+        ifBool(changed, "trace_on", req.getTraceOn(), config.isTraceOn(), v -> config.setTraceOn(v));
+
+        return changed;
+    }
+
+    // ==================== Config Update Helpers ====================
+
+    private interface IntSetter { void set(int value); }
+    private interface LongSetter { void set(long value); }
+    private interface BoolSetter { void set(boolean value); }
+    private interface DoubleSetter { void set(double value); }
+
+    private static void ifInt(List<String> changed, String name, int reqVal, int curVal, IntSetter setter) {
+        if (reqVal != 0 && reqVal != curVal) {
+            setter.set(reqVal);
+            changed.add(name);
+        }
+    }
+
+    private static void ifLong(List<String> changed, String name, long reqVal, long curVal, LongSetter setter) {
+        if (reqVal != 0 && reqVal != curVal) {
+            setter.set(reqVal);
+            changed.add(name);
+        }
+    }
+
+    private static void ifBool(List<String> changed, String name, boolean reqVal, boolean curVal, BoolSetter setter) {
+        // For booleans, we always compare (both true and false are meaningful)
+        // but only update if different. Since proto3 default for bool is false,
+        // we can't distinguish "not set" from "set to false". To avoid accidentally
+        // resetting booleans to false, we only update when reqVal is true and differs.
+        if (reqVal && reqVal != curVal) {
+            setter.set(reqVal);
+            changed.add(name);
+        }
+    }
+
+    private static void ifDouble(List<String> changed, String name, double reqVal, double curVal, DoubleSetter setter) {
+        if (reqVal != 0.0 && Double.compare(reqVal, curVal) != 0) {
+            setter.set(reqVal);
+            changed.add(name);
+        }
+    }
+
+    /**
+     * Convert ProxyConfig to ProxyRuntimeConfig proto message.
+     * Maps the most important runtime configuration fields that Dashboard
+     * needs to display for monitoring and diagnostics.
+     */
+    public static ProxyRuntimeConfig toProxyRuntimeConfig(ProxyConfig config) {
+        return ProxyRuntimeConfig.newBuilder()
+            // Basic info
+            .setProxyMode(nullSafe(config.getProxyMode()))
+            .setRocketmqClusterName(nullSafe(config.getRocketMQClusterName()))
+            .setProxyClusterName(nullSafe(config.getProxyClusterName()))
+            .setProxyName(nullSafe(config.getProxyName()))
+            .setLocalServeAddr(nullSafe(config.getLocalServeAddr()))
+            .setNamesrvAddr(nullSafe(config.getNamesrvAddr()))
+            // gRPC data plane
+            .setGrpcServerPort(config.getGrpcServerPort())
+            .setGrpcBossLoopNum(config.getGrpcBossLoopNum())
+            .setGrpcWorkerLoopNum(config.getGrpcWorkerLoopNum())
+            .setGrpcThreadPoolNums(config.getGrpcThreadPoolNums())
+            .setGrpcThreadPoolQueueCapacity(config.getGrpcThreadPoolQueueCapacity())
+            .setGrpcMaxInboundMessageSize(config.getGrpcMaxInboundMessageSize())
+            .setGrpcMaxConcurrentCallsPerConnection(config.getGrpcMaxConcurrentCallsPerConnection())
+            // Admin interface
+            .setProxyAdminEnabled(config.isProxyAdminEnabled())
+            .setProxyAdminServerPort(config.getProxyAdminServerPort())
+            .setProxyAdminThreadPoolNums(config.getProxyAdminThreadPoolNums())
+            .setProxyAdminMaxPageSize(config.getProxyAdminMaxPageSize())
+            .setProxyAdminDescribeClientConcurrencyLimit(config.getProxyAdminDescribeClientConcurrencyLimit())
+            .setProxyAdminSamplingRateUnderLoad(config.getProxyAdminSamplingRateUnderLoad())
+            .setProxyAdminHeartbeatHistorySize(config.getProxyAdminHeartbeatHistorySize())
+            .setProxyAdminSamplingThreshold(config.getProxyAdminSamplingThreshold())
+            // Thread pools - gRPC activities
+            .setGrpcProducerThreadPoolNums(config.getGrpcProducerThreadPoolNums())
+            .setGrpcProducerThreadQueueCapacity(config.getGrpcProducerThreadQueueCapacity())
+            .setGrpcConsumerThreadPoolNums(config.getGrpcConsumerThreadPoolNums())
+            .setGrpcConsumerThreadQueueCapacity(config.getGrpcConsumerThreadQueueCapacity())
+            .setGrpcRouteThreadPoolNums(config.getGrpcRouteThreadPoolNums())
+            .setGrpcRouteThreadQueueCapacity(config.getGrpcRouteThreadQueueCapacity())
+            .setGrpcClientManagerThreadPoolNums(config.getGrpcClientManagerThreadPoolNums())
+            .setGrpcClientManagerThreadQueueCapacity(config.getGrpcClientManagerThreadQueueCapacity())
+            .setGrpcTransactionThreadPoolNums(config.getGrpcTransactionThreadPoolNums())
+            .setGrpcTransactionThreadQueueCapacity(config.getGrpcTransactionThreadQueueCapacity())
+            // Thread pools - remoting
+            .setRemotingHeartbeatThreadPoolNums(config.getRemotingHeartbeatThreadPoolNums())
+            .setRemotingSendMessageThreadPoolNums(config.getRemotingSendMessageThreadPoolNums())
+            .setRemotingPullMessageThreadPoolNums(config.getRemotingPullMessageThreadPoolNums())
+            // Message limits
+            .setMaxMessageSize(config.getMaxMessageSize())
+            .setMaxUserPropertySize(config.getMaxUserPropertySize())
+            .setUserPropertyMaxNum(config.getUserPropertyMaxNum())
+            .setMaxMessageGroupSize(config.getMaxMessageGroupSize())
+            // Timeout and polling
+            .setDefaultInvisibleTimeMills(config.getDefaultInvisibleTimeMills())
+            .setMaxInvisibleTimeMills(config.getMaxInvisibleTimeMills())
+            .setMinInvisibleTimeMillsForRecv(config.getMinInvisibleTimeMillsForRecv())
+            .setMaxDelayTimeMills(config.getMaxDelayTimeMills())
+            .setGrpcClientConsumerMinLongPollingTimeoutMillis(config.getGrpcClientConsumerMinLongPollingTimeoutMillis())
+            .setGrpcClientConsumerMaxLongPollingTimeoutMillis(config.getGrpcClientConsumerMaxLongPollingTimeoutMillis())
+            .setGrpcClientConsumerLongPollingBatchSize(config.getGrpcClientConsumerLongPollingBatchSize())
+            .setGrpcClientProducerMaxAttempts(config.getGrpcClientProducerMaxAttempts())
+            .setGrpcClientProducerBackoffInitialMillis(config.getGrpcClientProducerBackoffInitialMillis())
+            .setGrpcClientProducerBackoffMaxMillis(config.getGrpcClientProducerBackoffMaxMillis())
+            .setGrpcClientProducerBackoffMultiplier(config.getGrpcClientProducerBackoffMultiplier())
+            // Cache
+            .setTopicRouteServiceCacheExpiredSeconds(config.getTopicRouteServiceCacheExpiredSeconds())
+            .setTopicRouteServiceCacheRefreshSeconds(config.getTopicRouteServiceCacheRefreshSeconds())
+            .setTopicRouteServiceCacheMaxNum(config.getTopicRouteServiceCacheMaxNum())
+            // TLS
+            .setTlsTestModeEnable(config.isTlsTestModeEnable())
+            .setTlsKeyPath(nullSafe(config.getTlsKeyPath()))
+            .setTlsCertPath(nullSafe(config.getTlsCertPath()))
+            // Metrics
+            .setMetricsExporterType(config.getMetricsExporterType() != null ? config.getMetricsExporterType().name() : "")
+            .setMetricsPromExporterPort(config.getMetricsPromExporterPort())
+            .setTraceOn(config.isTraceOn())
+            .build();
+    }
+
+    /**
+     * Null-safe string helper for proto string fields.
+     */
+    private static String nullSafe(String value) {
+        return value != null ? value : "";
+    }
+
+    // ==================== Model Converters ====================
+
+    /**
+     * Convert ClientInstanceInfo model to ClientInstance proto.
+     */
+    public static ClientInstance toClientInstance(ClientInstanceInfo info) {
+        ClientInstance.Builder builder = ClientInstance.newBuilder()
+            .setClientId(info.getClientId() != null ? info.getClientId() : "")
+            .setClientVersion(info.getClientVersion() != null ? info.getClientVersion() : "")
+            .setAccessPoint(info.getAccessPoint() != null ? info.getAccessPoint() : "")
+            .setConnectAt(info.getConnectAt())
+            .setLastActiveAt(info.getLastActiveAt());
+
+        if (info.getLanguage() != null) {
+            builder.setLanguage(toClientLanguage(info.getLanguage()));
+        }
+        if (info.getProtocol() != null) {
+            builder.setProtocol(toClientProtocol(info.getProtocol()));
+        }
+        if (info.getRole() != null) {
+            builder.setRole(toClientRole(info.getRole()));
+        }
+        if (info.getGroup() != null) {
+            builder.setGroup(info.getGroup());
+        }
+        if (info.getTopics() != null) {
+            builder.addAllTopics(info.getTopics());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert ClientDetailInfo model to ClientDetail proto.
+     */
+    public static ClientDetail toClientDetail(ClientDetailInfo info) {
+        ClientDetail.Builder builder = ClientDetail.newBuilder();
+
+        if (info.getClientInstance() != null) {
+            builder.setClientInstance(toClientInstance(info.getClientInstance()));
+        }
+        if (info.getSettings() != null) {
+            builder.setSettings(toClientSettings(info.getSettings()));
+        }
+        if (info.getHeartbeatHistory() != null) {
+            for (ClientDetailInfo.HeartbeatRecordInfo record : info.getHeartbeatHistory()) {
+                builder.addHeartbeatHistory(toHeartbeatRecord(record));
+            }
+        }
+        if (info.getAuthStatus() != null) {
+            builder.setAuthStatus(toAuthStatus(info.getAuthStatus()));
+        }
+        if (info.getConsumeProgress() != null) {
+            builder.setConsumeProgress(toConsumeProgress(info.getConsumeProgress()));
+        }
+        if (info.getNetworkInfo() != null) {
+            builder.setNetworkInfo(toNetworkInfo(info.getNetworkInfo()));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert ClientSettingsInfo to ClientSettings proto.
+     */
+    public static ClientSettings toClientSettings(ClientDetailInfo.ClientSettingsInfo info) {
+        ClientSettings.Builder builder = ClientSettings.newBuilder()
+            .setReceiveBatchSize(info.getReceiveBatchSize())
+            .setLongPollingTimeoutMs(info.getLongPollingTimeoutMs())
+            .setFifo(info.isFifo());
+
+        if (info.getSubscriptionMode() != null) {
+            builder.setSubscriptionMode(info.getSubscriptionMode());
+        }
+        if (info.getSubscriptionTopics() != null) {
+            builder.addAllSubscriptionTopics(info.getSubscriptionTopics());
+        }
+        if (info.getPublishingTopics() != null) {
+            builder.addAllPublishingTopics(info.getPublishingTopics());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert HeartbeatRecordInfo to HeartbeatRecord proto.
+     */
+    public static HeartbeatRecord toHeartbeatRecord(ClientDetailInfo.HeartbeatRecordInfo info) {
+        return HeartbeatRecord.newBuilder()
+            .setTimestamp(info.getTimestamp())
+            .setSuccess(info.isSuccess())
+            .setRemark(info.getRemark() != null ? info.getRemark() : "")
+            .build();
+    }
+
+    /**
+     * Convert AuthStatusInfo to AuthStatus proto.
+     */
+    public static AuthStatus toAuthStatus(ClientDetailInfo.AuthStatusInfo info) {
+        return AuthStatus.newBuilder()
+            .setAuthenticated(info.isAuthenticated())
+            .setUsername(info.getUsername() != null ? info.getUsername() : "")
+            .setLastAuthTime(info.getLastAuthTime())
+            .setFailureReason(info.getFailureReason() != null ? info.getFailureReason() : "")
+            .build();
+    }
+
+    /**
+     * Convert ConsumeProgressInfo to ConsumeProgress proto.
+     */
+    public static ConsumeProgress toConsumeProgress(ClientDetailInfo.ConsumeProgressInfo info) {
+        ConsumeProgress.Builder builder = ConsumeProgress.newBuilder()
+            .setLag(info.getLag())
+            .setLatencyMs(info.getLatencyMs());
+
+        if (info.getTopicProgress() != null) {
+            for (ClientDetailInfo.TopicConsumeProgressInfo topicProgress : info.getTopicProgress()) {
+                builder.addTopicProgress(toTopicConsumeProgress(topicProgress));
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert TopicConsumeProgressInfo to TopicConsumeProgress proto.
+     */
+    public static TopicConsumeProgress toTopicConsumeProgress(ClientDetailInfo.TopicConsumeProgressInfo info) {
+        return TopicConsumeProgress.newBuilder()
+            .setTopic(info.getTopic() != null ? info.getTopic() : "")
+            .setLag(info.getLag())
+            .setLatencyMs(info.getLatencyMs())
+            .build();
+    }
+
+    /**
+     * Convert NetworkInfoInfo to NetworkInfo proto.
+     */
+    public static NetworkInfo toNetworkInfo(ClientDetailInfo.NetworkInfoInfo info) {
+        return NetworkInfo.newBuilder()
+            .setLocalAddress(info.getLocalAddress() != null ? info.getLocalAddress() : "")
+            .setRemoteAddress(info.getRemoteAddress() != null ? info.getRemoteAddress() : "")
+            .setRttMs(info.getRttMs())
+            .setSslEnabled(info.isSslEnabled() ? "true" : "false")
+            .build();
+    }
+
+    // ==================== Enum Converters ====================
+
+    /**
+     * Convert ClientLanguage proto enum to internal string format.
+     * This is the reverse of toClientLanguage(), converting proto enum values
+     * like CLIENT_LANGUAGE_JAVA to the internal format "JAVA" used by
+     * FilterContext.matchesLanguage().
+     */
+    public static String fromClientLanguage(ClientLanguage language) {
+        if (language == null || language == ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED) {
+            return null;
+        }
+        switch (language) {
+            case CLIENT_LANGUAGE_JAVA:
+                return "JAVA";
+            case CLIENT_LANGUAGE_GOLANG:
+                return "GOLANG";
+            case CLIENT_LANGUAGE_CPP:
+                return "CPP";
+            case CLIENT_LANGUAGE_RUST:
+                return "RUST";
+            case CLIENT_LANGUAGE_PYTHON:
+                return "PYTHON";
+            case CLIENT_LANGUAGE_NODEJS:
+                return "NODE_JS";
+            case CLIENT_LANGUAGE_CSHARP:
+                return "DOTNET";
+            case CLIENT_LANGUAGE_PHP:
+                return "PHP";
+            default:
+                return language.name().replace("CLIENT_LANGUAGE_", "");
+        }
+    }
+
+    /**
+     * Convert string language to ClientLanguage proto enum.
+     */
+    public static ClientLanguage toClientLanguage(String language) {
+        if (language == null) {
+            return ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED;
+        }
+        switch (language.toUpperCase()) {
+            case "JAVA":
+                return ClientLanguage.CLIENT_LANGUAGE_JAVA;
+            case "GOLANG":
+            case "GO":
+                return ClientLanguage.CLIENT_LANGUAGE_GOLANG;
+            case "CPP":
+                return ClientLanguage.CLIENT_LANGUAGE_CPP;
+            case "RUST":
+                return ClientLanguage.CLIENT_LANGUAGE_RUST;
+            case "PYTHON":
+                return ClientLanguage.CLIENT_LANGUAGE_PYTHON;
+            case "NODEJS":
+            case "NODE_JS":
+                return ClientLanguage.CLIENT_LANGUAGE_NODEJS;
+            case "CSHARP":
+            case "DOTNET":
+                return ClientLanguage.CLIENT_LANGUAGE_CSHARP;
+            case "PHP":
+                return ClientLanguage.CLIENT_LANGUAGE_PHP;
+            default:
+                return ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED;
+        }
+    }
+
+    /**
+     * Convert string protocol to ClientProtocol proto enum.
+     */
+    public static ClientProtocol toClientProtocol(String protocol) {
+        if (protocol == null) {
+            return ClientProtocol.CLIENT_PROTOCOL_UNSPECIFIED;
+        }
+        switch (protocol.toUpperCase()) {
+            case "GRPC":
+            case "GRPC_V2":
+                return ClientProtocol.CLIENT_PROTOCOL_GRPC;
+            case "REMOTING":
+                return ClientProtocol.CLIENT_PROTOCOL_REMOTING;
+            default:
+                return ClientProtocol.CLIENT_PROTOCOL_UNSPECIFIED;
+        }
+    }
+
+    /**
+     * Convert string role to ClientRole proto enum.
+     */
+    public static ClientRole toClientRole(String role) {
+        if (role == null) {
+            return ClientRole.CLIENT_ROLE_UNSPECIFIED;
+        }
+        switch (role.toUpperCase()) {
+            case "PRODUCER":
+                return ClientRole.CLIENT_ROLE_PRODUCER;
+            case "PUSH_CONSUMER":
+                return ClientRole.CLIENT_ROLE_PUSH_CONSUMER;
+            case "SIMPLE_CONSUMER":
+                return ClientRole.CLIENT_ROLE_SIMPLE_CONSUMER;
+            default:
+                return ClientRole.CLIENT_ROLE_UNSPECIFIED;
+        }
+    }
+
+    /**
+     * Convert AdminCode enum to proto AdminCode.
+     */
+    public static AdminCode toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode code) {
+        if (code == null) {
+            return AdminCode.ADMIN_CODE_UNSPECIFIED;
+        }
+        switch (code) {
+            case OK:
+                return AdminCode.ADMIN_CODE_OK;
+            case INTERNAL_ERROR:
+                return AdminCode.ADMIN_CODE_INTERNAL_ERROR;
+            case BAD_REQUEST:
+                return AdminCode.ADMIN_CODE_BAD_REQUEST;
+            case UNAUTHORIZED:
+                return AdminCode.ADMIN_CODE_UNAUTHORIZED;
+            case FORBIDDEN:
+                return AdminCode.ADMIN_CODE_FORBIDDEN;
+            case NOT_FOUND:
+                return AdminCode.ADMIN_CODE_NOT_FOUND;
+            case TOO_MANY_REQUESTS:
+                return AdminCode.ADMIN_CODE_TOO_MANY_REQUESTS;
+            default:
+                return AdminCode.ADMIN_CODE_UNSPECIFIED;
+        }
+    }
+
+    // ==================== Route Event Converters ====================
+
+    /**
+     * Convert internal RouteChangeEvent model to SubscribeRouteEventsResponse proto.
+     */
+    public static SubscribeRouteEventsResponse toSubscribeRouteEventsResponse(RouteChangeEvent event) {
+        SubscribeRouteEventsResponse.Builder responseBuilder = SubscribeRouteEventsResponse.newBuilder()
+            .setCode(AdminCode.ADMIN_CODE_OK)
+            .setMessage(AdminCode.ADMIN_CODE_OK.name());
+
+        apache.rocketmq.proxy.admin.v1.RouteChangeEvent.Builder eventBuilder =
+            apache.rocketmq.proxy.admin.v1.RouteChangeEvent.newBuilder()
+                .setEventType(toProtoRouteChangeEventType(event.getEventType()))
+                .setTimestamp(event.getTimestamp())
+                .setTopic(event.getTopic() != null ? event.getTopic() : "");
+
+        if (event.getCluster() != null) {
+            eventBuilder.setCluster(event.getCluster());
+        }
+        if (event.getBrokerName() != null) {
+            eventBuilder.setBrokerName(event.getBrokerName());
+        }
+        if (event.getBrokerId() != 0) {
+            eventBuilder.setBrokerId(event.getBrokerId());
+        }
+        if (event.getBrokerAddress() != null) {
+            eventBuilder.setBrokerAddress(event.getBrokerAddress());
+        }
+        if (event.getPreviousReadQueueNums() != 0) {
+            eventBuilder.setPreviousReadQueueNums(event.getPreviousReadQueueNums());
+        }
+        if (event.getCurrentReadQueueNums() != 0) {
+            eventBuilder.setCurrentReadQueueNums(event.getCurrentReadQueueNums());
+        }
+        if (event.getPreviousWriteQueueNums() != 0) {
+            eventBuilder.setPreviousWriteQueueNums(event.getPreviousWriteQueueNums());
+        }
+        if (event.getCurrentWriteQueueNums() != 0) {
+            eventBuilder.setCurrentWriteQueueNums(event.getCurrentWriteQueueNums());
+        }
+        if (event.getRouteSnapshot() != null) {
+            eventBuilder.setRouteSnapshot(toProtoTopicRouteSnapshot(event.getRouteSnapshot()));
+        }
+
+        responseBuilder.setEvent(eventBuilder.build());
+        return responseBuilder.build();
+    }
+
+    /**
+     * Convert internal RouteChangeEventType enum to proto RouteChangeEventType.
+     */
+    public static apache.rocketmq.proxy.admin.v1.RouteChangeEventType toProtoRouteChangeEventType(RouteChangeEventType type) {
+        if (type == null) {
+            return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.ROUTE_CHANGE_EVENT_TYPE_UNSPECIFIED;
+        }
+        switch (type) {
+            case BROKER_ONLINE:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_ONLINE;
+            case BROKER_OFFLINE:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_OFFLINE;
+            case QUEUE_SCALE:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.QUEUE_SCALE;
+            case TOPIC_CREATE:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_CREATE;
+            case TOPIC_DELETE:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_DELETE;
+            case ROUTE_SNAPSHOT:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.ROUTE_SNAPSHOT;
+            default:
+                return apache.rocketmq.proxy.admin.v1.RouteChangeEventType.ROUTE_CHANGE_EVENT_TYPE_UNSPECIFIED;
+        }
+    }
+
+    /**
+     * Convert internal TopicRouteSnapshot model to proto TopicRouteSnapshot.
+     */
+    public static apache.rocketmq.proxy.admin.v1.TopicRouteSnapshot toProtoTopicRouteSnapshot(TopicRouteSnapshot snapshot) {
+        apache.rocketmq.proxy.admin.v1.TopicRouteSnapshot.Builder builder = apache.rocketmq.proxy.admin.v1.TopicRouteSnapshot.newBuilder()
+            .setTopic(snapshot.getTopic() != null ? snapshot.getTopic() : "");
+
+        if (snapshot.getBrokers() != null) {
+            for (TopicRouteSnapshot.BrokerInfo broker : snapshot.getBrokers()) {
+                builder.addBrokers(toProtoBrokerInfo(broker));
+            }
+        }
+        if (snapshot.getQueues() != null) {
+            for (TopicRouteSnapshot.QueueInfo queue : snapshot.getQueues()) {
+                builder.addQueues(toProtoQueueInfo(queue));
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert internal BrokerInfo model to proto BrokerInfo.
+     */
+    public static BrokerInfo toProtoBrokerInfo(TopicRouteSnapshot.BrokerInfo info) {
+        BrokerInfo.Builder builder = BrokerInfo.newBuilder()
+            .setCluster(info.getCluster() != null ? info.getCluster() : "")
+            .setBrokerName(info.getBrokerName() != null ? info.getBrokerName() : "");
+        if (info.getBrokerAddrs() != null) {
+            builder.putAllBrokerAddrs(info.getBrokerAddrs());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Convert internal QueueInfo model to proto QueueInfo.
+     */
+    public static QueueInfo toProtoQueueInfo(TopicRouteSnapshot.QueueInfo info) {
+        return QueueInfo.newBuilder()
+            .setBrokerName(info.getBrokerName() != null ? info.getBrokerName() : "")
+            .setReadQueueNums(info.getReadQueueNums())
+            .setWriteQueueNums(info.getWriteQueueNums())
+            .setPerm(info.getPerm())
+            .build();
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeEventDetector.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeEventDetector.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEvent;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEventType;
+import org.apache.rocketmq.proxy.grpc.admin.model.TopicRouteSnapshot;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+
+/**
+ * Detects route changes by comparing old and new TopicRouteData.
+ * <p>
+ * Used by {@link RouteChangeNotifier} during TopicRouteService cache refresh
+ * to identify broker online/offline, queue scaling, and topic create/delete events.
+ * <p>
+ * Detection strategy (Method A from design):
+ * - Compare brokerDatas: detect new/removed brokers (BROKER_ONLINE / BROKER_OFFLINE)
+ * - Compare queueDatas: detect read/write queue count changes (QUEUE_SCALE)
+ * - Detect topic creation: old route was empty, new route has data (TOPIC_CREATE)
+ * - Detect topic deletion: old route had data, new route is empty (TOPIC_DELETE)
+ */
+public class RouteChangeEventDetector {
+
+    /**
+     * Detect route changes between old and new TopicRouteData for a given topic.
+     *
+     * @param topic the topic name
+     * @param oldRoute the previous route data (may be null if topic was not cached)
+     * @param newRoute the new route data (may be null/empty if topic was deleted)
+     * @return list of detected route change events (empty if no changes)
+     */
+    public List<RouteChangeEvent> detectChanges(String topic, TopicRouteData oldRoute, TopicRouteData newRoute) {
+        List<RouteChangeEvent> events = new ArrayList<>();
+        long now = System.currentTimeMillis();
+
+        boolean oldEmpty = isRouteEmpty(oldRoute);
+        boolean newEmpty = isRouteEmpty(newRoute);
+
+        // Topic creation: was empty, now has data
+        if (oldEmpty && !newEmpty) {
+            RouteChangeEvent event = new RouteChangeEvent();
+            event.setEventType(RouteChangeEventType.TOPIC_CREATE);
+            event.setTimestamp(now);
+            event.setTopic(topic);
+            event.setRouteSnapshot(buildSnapshot(topic, newRoute));
+            events.add(event);
+            // Also generate broker online events for all brokers in the new route
+            events.addAll(detectBrokerOnlineEvents(topic, newRoute, now));
+            return events;
+        }
+
+        // Topic deletion: had data, now empty
+        if (!oldEmpty && newEmpty) {
+            RouteChangeEvent event = new RouteChangeEvent();
+            event.setEventType(RouteChangeEventType.TOPIC_DELETE);
+            event.setTimestamp(now);
+            event.setTopic(topic);
+            events.add(event);
+            // Also generate broker offline events for all brokers in the old route
+            events.addAll(detectBrokerOfflineEvents(topic, oldRoute, now));
+            return events;
+        }
+
+        // Both empty or both null - no changes
+        if (oldEmpty && newEmpty) {
+            return events;
+        }
+
+        // Both have data - compare broker and queue changes
+        events.addAll(detectBrokerChanges(topic, oldRoute, newRoute, now));
+        events.addAll(detectQueueChanges(topic, oldRoute, newRoute, now));
+
+        return events;
+    }
+
+    /**
+     * Detect broker online/offline changes.
+     */
+    private List<RouteChangeEvent> detectBrokerChanges(String topic,
+        TopicRouteData oldRoute, TopicRouteData newRoute, long timestamp) {
+        List<RouteChangeEvent> events = new ArrayList<>();
+
+        // Build broker address maps: brokerName -> (brokerId -> address)
+        Map<String, Map<Long, String>> oldBrokers = buildBrokerMap(oldRoute);
+        Map<String, Map<Long, String>> newBrokers = buildBrokerMap(newRoute);
+
+        // Find new brokers (broker online)
+        Set<String> oldBrokerNames = oldBrokers.keySet();
+        Set<String> newBrokerNames = newBrokers.keySet();
+
+        // New broker names
+        for (String brokerName : newBrokerNames) {
+            if (!oldBrokerNames.contains(brokerName)) {
+                // Entirely new broker cluster
+                Map<Long, String> addrs = newBrokers.get(brokerName);
+                for (Map.Entry<Long, String> entry : addrs.entrySet()) {
+                    RouteChangeEvent event = createBrokerEvent(topic, newRoute, brokerName,
+                        entry.getKey(), entry.getValue(), RouteChangeEventType.BROKER_ONLINE, timestamp);
+                    events.add(event);
+                }
+            } else {
+                // Same broker name, check for new broker instances (new brokerId)
+                Map<Long, String> oldAddrs = oldBrokers.get(brokerName);
+                Map<Long, String> newAddrs = newBrokers.get(brokerName);
+                for (Map.Entry<Long, String> entry : newAddrs.entrySet()) {
+                    if (!oldAddrs.containsKey(entry.getKey())) {
+                        RouteChangeEvent event = createBrokerEvent(topic, newRoute, brokerName,
+                            entry.getKey(), entry.getValue(), RouteChangeEventType.BROKER_ONLINE, timestamp);
+                        events.add(event);
+                    } else if (!oldAddrs.get(entry.getKey()).equals(entry.getValue())) {
+                        // Address changed - treat as offline + online
+                        RouteChangeEvent offlineEvent = createBrokerEvent(topic, oldRoute, brokerName,
+                            entry.getKey(), oldAddrs.get(entry.getKey()), RouteChangeEventType.BROKER_OFFLINE, timestamp);
+                        events.add(offlineEvent);
+                        RouteChangeEvent onlineEvent = createBrokerEvent(topic, newRoute, brokerName,
+                            entry.getKey(), entry.getValue(), RouteChangeEventType.BROKER_ONLINE, timestamp);
+                        events.add(onlineEvent);
+                    }
+                }
+            }
+        }
+
+        // Removed broker names or instances
+        for (String brokerName : oldBrokerNames) {
+            if (!newBrokerNames.contains(brokerName)) {
+                // Entirely removed broker cluster
+                Map<Long, String> addrs = oldBrokers.get(brokerName);
+                for (Map.Entry<Long, String> entry : addrs.entrySet()) {
+                    RouteChangeEvent event = createBrokerEvent(topic, oldRoute, brokerName,
+                        entry.getKey(), entry.getValue(), RouteChangeEventType.BROKER_OFFLINE, timestamp);
+                    events.add(event);
+                }
+            } else {
+                // Same broker name, check for removed broker instances
+                Map<Long, String> oldAddrs = oldBrokers.get(brokerName);
+                Map<Long, String> newAddrs = newBrokers.get(brokerName);
+                for (Map.Entry<Long, String> entry : oldAddrs.entrySet()) {
+                    if (!newAddrs.containsKey(entry.getKey())) {
+                        RouteChangeEvent event = createBrokerEvent(topic, oldRoute, brokerName,
+                            entry.getKey(), entry.getValue(), RouteChangeEventType.BROKER_OFFLINE, timestamp);
+                        events.add(event);
+                    }
+                }
+            }
+        }
+
+        return events;
+    }
+
+    /**
+     * Detect queue count changes (QUEUE_SCALE).
+     */
+    private List<RouteChangeEvent> detectQueueChanges(String topic,
+        TopicRouteData oldRoute, TopicRouteData newRoute, long timestamp) {
+        List<RouteChangeEvent> events = new ArrayList<>();
+
+        // Build queue maps: brokerName -> QueueData
+        Map<String, QueueData> oldQueues = buildQueueMap(oldRoute);
+        Map<String, QueueData> newQueues = buildQueueMap(newRoute);
+
+        Set<String> allBrokerNames = new HashSet<>();
+        allBrokerNames.addAll(oldQueues.keySet());
+        allBrokerNames.addAll(newQueues.keySet());
+
+        for (String brokerName : allBrokerNames) {
+            QueueData oldQ = oldQueues.get(brokerName);
+            QueueData newQ = newQueues.get(brokerName);
+
+            int oldRead = oldQ != null ? oldQ.getReadQueueNums() : 0;
+            int newRead = newQ != null ? newQ.getReadQueueNums() : 0;
+            int oldWrite = oldQ != null ? oldQ.getWriteQueueNums() : 0;
+            int newWrite = newQ != null ? newQ.getWriteQueueNums() : 0;
+
+            if (oldRead != newRead || oldWrite != newWrite) {
+                RouteChangeEvent event = new RouteChangeEvent();
+                event.setEventType(RouteChangeEventType.QUEUE_SCALE);
+                event.setTimestamp(timestamp);
+                event.setTopic(topic);
+                event.setBrokerName(brokerName);
+                event.setPreviousReadQueueNums(oldRead);
+                event.setCurrentReadQueueNums(newRead);
+                event.setPreviousWriteQueueNums(oldWrite);
+                event.setCurrentWriteQueueNums(newWrite);
+                events.add(event);
+            }
+        }
+
+        return events;
+    }
+
+    /**
+     * Generate broker online events for all brokers in a route (used for TOPIC_CREATE).
+     */
+    private List<RouteChangeEvent> detectBrokerOnlineEvents(String topic, TopicRouteData route, long timestamp) {
+        List<RouteChangeEvent> events = new ArrayList<>();
+        if (route == null || route.getBrokerDatas() == null) {
+            return events;
+        }
+        for (BrokerData brokerData : route.getBrokerDatas()) {
+            if (brokerData.getBrokerAddrs() != null) {
+                for (Map.Entry<Long, String> entry : brokerData.getBrokerAddrs().entrySet()) {
+                    RouteChangeEvent event = createBrokerEvent(topic, route,
+                        brokerData.getBrokerName(), entry.getKey(), entry.getValue(),
+                        RouteChangeEventType.BROKER_ONLINE, timestamp);
+                    events.add(event);
+                }
+            }
+        }
+        return events;
+    }
+
+    /**
+     * Generate broker offline events for all brokers in a route (used for TOPIC_DELETE).
+     */
+    private List<RouteChangeEvent> detectBrokerOfflineEvents(String topic, TopicRouteData route, long timestamp) {
+        List<RouteChangeEvent> events = new ArrayList<>();
+        if (route == null || route.getBrokerDatas() == null) {
+            return events;
+        }
+        for (BrokerData brokerData : route.getBrokerDatas()) {
+            if (brokerData.getBrokerAddrs() != null) {
+                for (Map.Entry<Long, String> entry : brokerData.getBrokerAddrs().entrySet()) {
+                    RouteChangeEvent event = createBrokerEvent(topic, route,
+                        brokerData.getBrokerName(), entry.getKey(), entry.getValue(),
+                        RouteChangeEventType.BROKER_OFFLINE, timestamp);
+                    events.add(event);
+                }
+            }
+        }
+        return events;
+    }
+
+    private RouteChangeEvent createBrokerEvent(String topic, TopicRouteData route,
+        String brokerName, long brokerId, String brokerAddress,
+        RouteChangeEventType eventType, long timestamp) {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(eventType);
+        event.setTimestamp(timestamp);
+        event.setTopic(topic);
+        event.setBrokerName(brokerName);
+        event.setBrokerId(brokerId);
+        event.setBrokerAddress(brokerAddress);
+        // Find cluster name from brokerDatas
+        if (route != null && route.getBrokerDatas() != null) {
+            for (BrokerData bd : route.getBrokerDatas()) {
+                if (bd.getBrokerName().equals(brokerName)) {
+                    event.setCluster(bd.getCluster());
+                    break;
+                }
+            }
+        }
+        return event;
+    }
+
+    private boolean isRouteEmpty(TopicRouteData route) {
+        if (route == null) {
+            return true;
+        }
+        return (route.getBrokerDatas() == null || route.getBrokerDatas().isEmpty())
+            && (route.getQueueDatas() == null || route.getQueueDatas().isEmpty());
+    }
+
+    private Map<String, Map<Long, String>> buildBrokerMap(TopicRouteData route) {
+        Map<String, Map<Long, String>> result = new HashMap<>();
+        if (route == null || route.getBrokerDatas() == null) {
+            return result;
+        }
+        for (BrokerData brokerData : route.getBrokerDatas()) {
+            Map<Long, String> addrs = brokerData.getBrokerAddrs();
+            if (addrs != null) {
+                result.put(brokerData.getBrokerName(), new HashMap<>(addrs));
+            } else {
+                result.put(brokerData.getBrokerName(), new HashMap<>());
+            }
+        }
+        return result;
+    }
+
+    private Map<String, QueueData> buildQueueMap(TopicRouteData route) {
+        Map<String, QueueData> result = new HashMap<>();
+        if (route == null || route.getQueueDatas() == null) {
+            return result;
+        }
+        for (QueueData queueData : route.getQueueDatas()) {
+            result.put(queueData.getBrokerName(), queueData);
+        }
+        return result;
+    }
+
+    /**
+     * Build a TopicRouteSnapshot from TopicRouteData.
+     */
+    public TopicRouteSnapshot buildSnapshot(String topic, TopicRouteData route) {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic(topic);
+
+        if (route == null) {
+            snapshot.setBrokers(new ArrayList<>());
+            snapshot.setQueues(new ArrayList<>());
+            return snapshot;
+        }
+
+        // Build broker info list
+        List<TopicRouteSnapshot.BrokerInfo> brokers = new ArrayList<>();
+        if (route.getBrokerDatas() != null) {
+            for (BrokerData bd : route.getBrokerDatas()) {
+                TopicRouteSnapshot.BrokerInfo info = new TopicRouteSnapshot.BrokerInfo();
+                info.setCluster(bd.getCluster());
+                info.setBrokerName(bd.getBrokerName());
+                if (bd.getBrokerAddrs() != null) {
+                    info.setBrokerAddrs(new HashMap<>(bd.getBrokerAddrs()));
+                }
+                brokers.add(info);
+            }
+        }
+        snapshot.setBrokers(brokers);
+
+        // Build queue info list
+        List<TopicRouteSnapshot.QueueInfo> queues = new ArrayList<>();
+        if (route.getQueueDatas() != null) {
+            for (QueueData qd : route.getQueueDatas()) {
+                TopicRouteSnapshot.QueueInfo info = new TopicRouteSnapshot.QueueInfo();
+                info.setBrokerName(qd.getBrokerName());
+                info.setReadQueueNums(qd.getReadQueueNums());
+                info.setWriteQueueNums(qd.getWriteQueueNums());
+                info.setPerm(qd.getPerm());
+                queues.add(info);
+            }
+        }
+        snapshot.setQueues(queues);
+
+        return snapshot;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeNotifier.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeNotifier.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEvent;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEventType;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.proxy.service.route.TopicRouteService;
+import org.apache.rocketmq.proxy.service.route.MessageQueueView;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsResponse;
+
+/**
+ * Manages route change event subscriptions and broadcasts events to subscribers.
+ * <p>
+ * Integrates with {@link TopicRouteService} Caffeine cache refresh mechanism:
+ * when the cache reloads route data (every 20s by default), this notifier
+ * compares old and new route data using {@link RouteChangeEventDetector}
+ * and pushes detected changes to all active subscribers.
+ * <p>
+ * Subscription management:
+ * - Subscribers are tracked in a CopyOnWriteArrayList for thread safety
+ * - Each subscriber can filter by topics and event types
+ * - Client disconnection is handled via ServerCallStreamObserver.setOnCancelHandler
+ * - Initial route snapshot is sent on subscription for immediate state sync
+ */
+public class RouteChangeNotifier implements TopicRouteService.RouteRefreshListener {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+
+    private final RouteChangeEventDetector detector;
+    private final CopyOnWriteArrayList<RouteEventSubscription> subscriptions;
+    private final TopicRouteService topicRouteService;
+
+    public RouteChangeNotifier(TopicRouteService topicRouteService) {
+        this.topicRouteService = topicRouteService;
+        this.detector = new RouteChangeEventDetector();
+        this.subscriptions = new CopyOnWriteArrayList<>();
+    }
+
+    /**
+     * Subscribe to route change events.
+     * Sends an initial route snapshot for all subscribed topics, then pushes
+     * incremental changes as they are detected.
+     *
+     * @param topics filter: only receive events for these topics (empty = all topics)
+     * @param eventTypes filter: only receive these event types (empty = all types)
+     * @param responseObserver the gRPC stream observer for pushing events
+     */
+    public void subscribe(List<String> topics, List<RouteChangeEventType> eventTypes,
+        StreamObserver<SubscribeRouteEventsResponse> responseObserver) {
+        RouteEventSubscription subscription = new RouteEventSubscription(topics, eventTypes, responseObserver);
+
+        // Register cancellation handler for client disconnect
+        if (responseObserver instanceof ServerCallStreamObserver) {
+            ServerCallStreamObserver<SubscribeRouteEventsResponse> serverObserver =
+                (ServerCallStreamObserver<SubscribeRouteEventsResponse>) responseObserver;
+            serverObserver.setOnCancelHandler(() -> {
+                subscriptions.remove(subscription);
+                log.info("Route event subscriber disconnected. Active subscribers: {}", subscriptions.size());
+            });
+        }
+
+        subscriptions.add(subscription);
+        log.info("New route event subscriber registered. Topics filter: {}, Event types filter: {}, Active subscribers: {}",
+            topics, eventTypes, subscriptions.size());
+
+        // Send initial route snapshot for all cached topics
+        try {
+            sendInitialSnapshot(subscription);
+        } catch (Exception e) {
+            log.error("Failed to send initial route snapshot to new subscriber", e);
+        }
+    }
+
+    /**
+     * Called by TopicRouteService cache reload listener when route data changes.
+     * Compares old and new route data, detects changes, and broadcasts to subscribers.
+     *
+     * @param topic the topic whose route was refreshed
+     * @param oldView the previous MessageQueueView (may be null)
+     * @param newView the new MessageQueueView (may be null/empty)
+     */
+    public void onRouteRefreshed(String topic, MessageQueueView oldView, MessageQueueView newView) {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+
+        TopicRouteData oldRoute = oldView != null ? oldView.getTopicRouteData() : null;
+        TopicRouteData newRoute = newView != null ? newView.getTopicRouteData() : null;
+
+        List<RouteChangeEvent> events = detector.detectChanges(topic, oldRoute, newRoute);
+        if (events.isEmpty()) {
+            return;
+        }
+
+        log.debug("Detected {} route change events for topic {}", events.size(), topic);
+        broadcastEvents(events);
+    }
+
+    /**
+     * Broadcast detected events to all matching subscribers.
+     */
+    private void broadcastEvents(List<RouteChangeEvent> events) {
+        for (RouteChangeEvent event : events) {
+            for (RouteEventSubscription subscription : subscriptions) {
+                if (!subscription.matches(event)) {
+                    continue;
+                }
+                try {
+                    SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+                    subscription.getResponseObserver().onNext(response);
+                } catch (Exception e) {
+                    log.warn("Failed to push route event to subscriber, removing. Error: {}", e.getMessage());
+                    subscriptions.remove(subscription);
+                }
+            }
+        }
+    }
+
+    /**
+     * Send initial route snapshot to a newly subscribed client.
+     * Iterates all cached topics and sends ROUTE_SNAPSHOT events.
+     */
+    private void sendInitialSnapshot(RouteEventSubscription subscription) {
+        if (topicRouteService == null) {
+            return;
+        }
+
+        // Get all cached topic names
+        Set<String> cachedTopics = topicRouteService.getAllTopicNames();
+        Set<String> topicFilter = subscription.getTopicFilter();
+
+        for (String topic : cachedTopics) {
+            // Apply topic filter
+            if (!topicFilter.isEmpty() && !topicFilter.contains(topic)) {
+                continue;
+            }
+
+            try {
+                MessageQueueView view = topicRouteService.getCachedTopicRouteData(topic);
+                if (view == null) {
+                    continue;
+                }
+
+                RouteChangeEvent snapshotEvent = new RouteChangeEvent();
+                snapshotEvent.setEventType(RouteChangeEventType.ROUTE_SNAPSHOT);
+                snapshotEvent.setTimestamp(System.currentTimeMillis());
+                snapshotEvent.setTopic(topic);
+                snapshotEvent.setRouteSnapshot(detector.buildSnapshot(topic, view.getTopicRouteData()));
+
+                // Check event type filter
+                if (!subscription.matchesEventType(snapshotEvent.getEventType())) {
+                    continue;
+                }
+
+                SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(snapshotEvent);
+                subscription.getResponseObserver().onNext(response);
+            } catch (Exception e) {
+                log.warn("Failed to send initial snapshot for topic {}: {}", topic, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Get the number of active subscribers.
+     */
+    public int getSubscriberCount() {
+        return subscriptions.size();
+    }
+
+    /**
+     * Shutdown the notifier and close all subscriber streams.
+     */
+    public void shutdown() {
+        for (RouteEventSubscription subscription : subscriptions) {
+            try {
+                subscription.getResponseObserver().onCompleted();
+            } catch (Exception e) {
+                log.debug("Error closing subscriber stream during shutdown", e);
+            }
+        }
+        subscriptions.clear();
+        log.info("RouteChangeNotifier shutdown complete");
+    }
+
+    /**
+     * Internal representation of a route event subscription.
+     */
+    private static class RouteEventSubscription {
+        private final Set<String> topicFilter;
+        private final Set<RouteChangeEventType> eventTypeFilter;
+        private final StreamObserver<SubscribeRouteEventsResponse> responseObserver;
+
+        RouteEventSubscription(List<String> topics, List<RouteChangeEventType> eventTypes,
+            StreamObserver<SubscribeRouteEventsResponse> responseObserver) {
+            this.topicFilter = topics != null && !topics.isEmpty() ? new HashSet<>(topics) : new HashSet<>();
+            this.eventTypeFilter = eventTypes != null && !eventTypes.isEmpty() ? new HashSet<>(eventTypes) : new HashSet<>();
+            this.responseObserver = responseObserver;
+        }
+
+        Set<String> getTopicFilter() {
+            return topicFilter;
+        }
+
+        StreamObserver<SubscribeRouteEventsResponse> getResponseObserver() {
+            return responseObserver;
+        }
+
+        boolean matchesEventType(RouteChangeEventType eventType) {
+            return eventTypeFilter.isEmpty() || eventTypeFilter.contains(eventType);
+        }
+
+        boolean matches(RouteChangeEvent event) {
+            // Check topic filter
+            if (!topicFilter.isEmpty() && !topicFilter.contains(event.getTopic())) {
+                return false;
+            }
+            // Check event type filter
+            return matchesEventType(event.getEventType());
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfo.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfo.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.List;
+
+/**
+ * Client detail information model.
+ * Extends ClientInstanceInfo with additional diagnostic data.
+ * Maps to the ClientDetail proto message.
+ */
+public class ClientDetailInfo {
+    private ClientInstanceInfo clientInstance;
+    private ClientSettingsInfo settings;
+    private List<HeartbeatRecordInfo> heartbeatHistory;
+    private AuthStatusInfo authStatus;
+    private ConsumeProgressInfo consumeProgress;
+    private NetworkInfoInfo networkInfo;
+
+    public ClientDetailInfo() {
+    }
+
+    public ClientInstanceInfo getClientInstance() {
+        return clientInstance;
+    }
+
+    public void setClientInstance(ClientInstanceInfo clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public ClientSettingsInfo getSettings() {
+        return settings;
+    }
+
+    public void setSettings(ClientSettingsInfo settings) {
+        this.settings = settings;
+    }
+
+    public List<HeartbeatRecordInfo> getHeartbeatHistory() {
+        return heartbeatHistory;
+    }
+
+    public void setHeartbeatHistory(List<HeartbeatRecordInfo> heartbeatHistory) {
+        this.heartbeatHistory = heartbeatHistory;
+    }
+
+    public AuthStatusInfo getAuthStatus() {
+        return authStatus;
+    }
+
+    public void setAuthStatus(AuthStatusInfo authStatus) {
+        this.authStatus = authStatus;
+    }
+
+    public ConsumeProgressInfo getConsumeProgress() {
+        return consumeProgress;
+    }
+
+    public void setConsumeProgress(ConsumeProgressInfo consumeProgress) {
+        this.consumeProgress = consumeProgress;
+    }
+
+    public NetworkInfoInfo getNetworkInfo() {
+        return networkInfo;
+    }
+
+    public void setNetworkInfo(NetworkInfoInfo networkInfo) {
+        this.networkInfo = networkInfo;
+    }
+
+    /**
+     * Client settings information.
+     */
+    public static class ClientSettingsInfo {
+        private String subscriptionMode;
+        private int receiveBatchSize;
+        private long longPollingTimeoutMs;
+        private boolean fifo;
+        private List<String> subscriptionTopics;
+        private List<String> publishingTopics;
+
+        public String getSubscriptionMode() { return subscriptionMode; }
+        public void setSubscriptionMode(String subscriptionMode) { this.subscriptionMode = subscriptionMode; }
+        public int getReceiveBatchSize() { return receiveBatchSize; }
+        public void setReceiveBatchSize(int receiveBatchSize) { this.receiveBatchSize = receiveBatchSize; }
+        public long getLongPollingTimeoutMs() { return longPollingTimeoutMs; }
+        public void setLongPollingTimeoutMs(long longPollingTimeoutMs) { this.longPollingTimeoutMs = longPollingTimeoutMs; }
+        public boolean isFifo() { return fifo; }
+        public void setFifo(boolean fifo) { this.fifo = fifo; }
+        public List<String> getSubscriptionTopics() { return subscriptionTopics; }
+        public void setSubscriptionTopics(List<String> subscriptionTopics) { this.subscriptionTopics = subscriptionTopics; }
+        public List<String> getPublishingTopics() { return publishingTopics; }
+        public void setPublishingTopics(List<String> publishingTopics) { this.publishingTopics = publishingTopics; }
+    }
+
+    /**
+     * Heartbeat record information.
+     */
+    public static class HeartbeatRecordInfo {
+        private long timestamp;
+        private boolean success;
+        private String remark;
+
+        public long getTimestamp() { return timestamp; }
+        public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
+        public boolean isSuccess() { return success; }
+        public void setSuccess(boolean success) { this.success = success; }
+        public String getRemark() { return remark; }
+        public void setRemark(String remark) { this.remark = remark; }
+    }
+
+    /**
+     * Auth status information.
+     */
+    public static class AuthStatusInfo {
+        private boolean authenticated;
+        private String username;
+        private long lastAuthTime;
+        private String failureReason;
+
+        public boolean isAuthenticated() { return authenticated; }
+        public void setAuthenticated(boolean authenticated) { this.authenticated = authenticated; }
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public long getLastAuthTime() { return lastAuthTime; }
+        public void setLastAuthTime(long lastAuthTime) { this.lastAuthTime = lastAuthTime; }
+        public String getFailureReason() { return failureReason; }
+        public void setFailureReason(String failureReason) { this.failureReason = failureReason; }
+    }
+
+    /**
+     * Consume progress information.
+     */
+    public static class ConsumeProgressInfo {
+        private long lag;
+        private long latencyMs;
+        private List<TopicConsumeProgressInfo> topicProgress;
+
+        public long getLag() { return lag; }
+        public void setLag(long lag) { this.lag = lag; }
+        public long getLatencyMs() { return latencyMs; }
+        public void setLatencyMs(long latencyMs) { this.latencyMs = latencyMs; }
+        public List<TopicConsumeProgressInfo> getTopicProgress() { return topicProgress; }
+        public void setTopicProgress(List<TopicConsumeProgressInfo> topicProgress) { this.topicProgress = topicProgress; }
+    }
+
+    /**
+     * Topic consume progress information.
+     */
+    public static class TopicConsumeProgressInfo {
+        private String topic;
+        private long lag;
+        private long latencyMs;
+
+        public String getTopic() { return topic; }
+        public void setTopic(String topic) { this.topic = topic; }
+        public long getLag() { return lag; }
+        public void setLag(long lag) { this.lag = lag; }
+        public long getLatencyMs() { return latencyMs; }
+        public void setLatencyMs(long latencyMs) { this.latencyMs = latencyMs; }
+    }
+
+    /**
+     * Network information.
+     */
+    public static class NetworkInfoInfo {
+        private String localAddress;
+        private String remoteAddress;
+        private long rttMs;
+        private boolean sslEnabled;
+
+        public String getLocalAddress() { return localAddress; }
+        public void setLocalAddress(String localAddress) { this.localAddress = localAddress; }
+        public String getRemoteAddress() { return remoteAddress; }
+        public void setRemoteAddress(String remoteAddress) { this.remoteAddress = remoteAddress; }
+        public long getRttMs() { return rttMs; }
+        public void setRttMs(long rttMs) { this.rttMs = rttMs; }
+        public boolean isSslEnabled() { return sslEnabled; }
+        public void setSslEnabled(boolean sslEnabled) { this.sslEnabled = sslEnabled; }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfo.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfo.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.List;
+
+/**
+ * Client instance basic information model.
+ * Maps to the ClientInstance proto message.
+ */
+public class ClientInstanceInfo {
+    private String clientId;
+    private String language;
+    private String clientVersion;
+    private String protocol;
+    private String accessPoint;
+    private long connectAt;
+    private long lastActiveAt;
+    private String role;
+    private String group;
+    private List<String> topics;
+
+    public ClientInstanceInfo() {
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getClientVersion() {
+        return clientVersion;
+    }
+
+    public void setClientVersion(String clientVersion) {
+        this.clientVersion = clientVersion;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getAccessPoint() {
+        return accessPoint;
+    }
+
+    public void setAccessPoint(String accessPoint) {
+        this.accessPoint = accessPoint;
+    }
+
+    public long getConnectAt() {
+        return connectAt;
+    }
+
+    public void setConnectAt(long connectAt) {
+        this.connectAt = connectAt;
+    }
+
+    public long getLastActiveAt() {
+        return lastActiveAt;
+    }
+
+    public void setLastActiveAt(long lastActiveAt) {
+        this.lastActiveAt = lastActiveAt;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public List<String> getTopics() {
+        return topics;
+    }
+
+    public void setTopics(List<String> topics) {
+        this.topics = topics;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientInstanceInfo{" +
+            "clientId='" + clientId + '\'' +
+            ", language='" + language + '\'' +
+            ", clientVersion='" + clientVersion + '\'' +
+            ", protocol='" + protocol + '\'' +
+            ", accessPoint='" + accessPoint + '\'' +
+            ", connectAt=" + connectAt +
+            ", lastActiveAt=" + lastActiveAt +
+            ", role='" + role + '\'' +
+            ", group='" + group + '\'' +
+            ", topics=" + topics +
+            '}';
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilter.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+/**
+ * Filter criteria for ListClients query.
+ * Supports filter pushdown to avoid full memory traversal.
+ */
+public class ListClientsFilter {
+    private String group;
+    private String topic;
+    private String clientIdPrefix;
+    private String language;
+    private long connectTimeStart;
+    private long connectTimeEnd;
+
+    public ListClientsFilter() {
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getClientIdPrefix() {
+        return clientIdPrefix;
+    }
+
+    public void setClientIdPrefix(String clientIdPrefix) {
+        this.clientIdPrefix = clientIdPrefix;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public long getConnectTimeStart() {
+        return connectTimeStart;
+    }
+
+    public void setConnectTimeStart(long connectTimeStart) {
+        this.connectTimeStart = connectTimeStart;
+    }
+
+    public long getConnectTimeEnd() {
+        return connectTimeEnd;
+    }
+
+    public void setConnectTimeEnd(long connectTimeEnd) {
+        this.connectTimeEnd = connectTimeEnd;
+    }
+
+    /**
+     * Check if any filter criteria is set.
+     *
+     * @return true if at least one filter criterion is set
+     */
+    public boolean hasFilter() {
+        return group != null || topic != null || clientIdPrefix != null
+            || language != null || connectTimeStart > 0 || connectTimeEnd > 0;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEvent.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEvent.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+/**
+ * Route change event model.
+ * Represents a single route change detected by the proxy.
+ */
+public class RouteChangeEvent {
+    private RouteChangeEventType eventType;
+    private long timestamp;
+    private String topic;
+    private String cluster;
+    private String brokerName;
+    private long brokerId;
+    private String brokerAddress;
+    private int previousReadQueueNums;
+    private int currentReadQueueNums;
+    private int previousWriteQueueNums;
+    private int currentWriteQueueNums;
+    private TopicRouteSnapshot routeSnapshot;
+
+    public RouteChangeEvent() {
+    }
+
+    public RouteChangeEventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(RouteChangeEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
+    }
+
+    public String getBrokerName() {
+        return brokerName;
+    }
+
+    public void setBrokerName(String brokerName) {
+        this.brokerName = brokerName;
+    }
+
+    public long getBrokerId() {
+        return brokerId;
+    }
+
+    public void setBrokerId(long brokerId) {
+        this.brokerId = brokerId;
+    }
+
+    public String getBrokerAddress() {
+        return brokerAddress;
+    }
+
+    public void setBrokerAddress(String brokerAddress) {
+        this.brokerAddress = brokerAddress;
+    }
+
+    public int getPreviousReadQueueNums() {
+        return previousReadQueueNums;
+    }
+
+    public void setPreviousReadQueueNums(int previousReadQueueNums) {
+        this.previousReadQueueNums = previousReadQueueNums;
+    }
+
+    public int getCurrentReadQueueNums() {
+        return currentReadQueueNums;
+    }
+
+    public void setCurrentReadQueueNums(int currentReadQueueNums) {
+        this.currentReadQueueNums = currentReadQueueNums;
+    }
+
+    public int getPreviousWriteQueueNums() {
+        return previousWriteQueueNums;
+    }
+
+    public void setPreviousWriteQueueNums(int previousWriteQueueNums) {
+        this.previousWriteQueueNums = previousWriteQueueNums;
+    }
+
+    public int getCurrentWriteQueueNums() {
+        return currentWriteQueueNums;
+    }
+
+    public void setCurrentWriteQueueNums(int currentWriteQueueNums) {
+        this.currentWriteQueueNums = currentWriteQueueNums;
+    }
+
+    public TopicRouteSnapshot getRouteSnapshot() {
+        return routeSnapshot;
+    }
+
+    public void setRouteSnapshot(TopicRouteSnapshot routeSnapshot) {
+        this.routeSnapshot = routeSnapshot;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventType.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+/**
+ * Route change event type enum.
+ * Maps to the RouteChangeEventType proto enum.
+ */
+public enum RouteChangeEventType {
+    BROKER_ONLINE,
+    BROKER_OFFLINE,
+    QUEUE_SCALE,
+    TOPIC_CREATE,
+    TOPIC_DELETE,
+    ROUTE_SNAPSHOT
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshot.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshot.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.List;
+
+/**
+ * Topic route snapshot model.
+ * Contains the complete route data for a topic at a point in time.
+ */
+public class TopicRouteSnapshot {
+    private String topic;
+    private List<BrokerInfo> brokers;
+    private List<QueueInfo> queues;
+
+    public TopicRouteSnapshot() {
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public List<BrokerInfo> getBrokers() {
+        return brokers;
+    }
+
+    public void setBrokers(List<BrokerInfo> brokers) {
+        this.brokers = brokers;
+    }
+
+    public List<QueueInfo> getQueues() {
+        return queues;
+    }
+
+    public void setQueues(List<QueueInfo> queues) {
+        this.queues = queues;
+    }
+
+    /**
+     * Broker info in route snapshot.
+     */
+    public static class BrokerInfo {
+        private String cluster;
+        private String brokerName;
+        private java.util.Map<Long, String> brokerAddrs;
+
+        public BrokerInfo() {
+        }
+
+        public String getCluster() {
+            return cluster;
+        }
+
+        public void setCluster(String cluster) {
+            this.cluster = cluster;
+        }
+
+        public String getBrokerName() {
+            return brokerName;
+        }
+
+        public void setBrokerName(String brokerName) {
+            this.brokerName = brokerName;
+        }
+
+        public java.util.Map<Long, String> getBrokerAddrs() {
+            return brokerAddrs;
+        }
+
+        public void setBrokerAddrs(java.util.Map<Long, String> brokerAddrs) {
+            this.brokerAddrs = brokerAddrs;
+        }
+    }
+
+    /**
+     * Queue info in route snapshot.
+     */
+    public static class QueueInfo {
+        private String brokerName;
+        private int readQueueNums;
+        private int writeQueueNums;
+        private int perm;
+
+        public QueueInfo() {
+        }
+
+        public String getBrokerName() {
+            return brokerName;
+        }
+
+        public void setBrokerName(String brokerName) {
+            this.brokerName = brokerName;
+        }
+
+        public int getReadQueueNums() {
+            return readQueueNums;
+        }
+
+        public void setReadQueueNums(int readQueueNums) {
+            this.readQueueNums = readQueueNums;
+        }
+
+        public int getWriteQueueNums() {
+            return writeQueueNums;
+        }
+
+        public void setWriteQueueNums(int writeQueueNums) {
+            this.writeQueueNums = writeQueueNums;
+        }
+
+        public int getPerm() {
+            return perm;
+        }
+
+        public void setPerm(int perm) {
+            this.perm = perm;
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/interceptor/HeaderInterceptor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/interceptor/HeaderInterceptor.java
@@ -66,6 +66,10 @@ public class HeaderInterceptor implements ServerInterceptor {
             GrpcUtils.putHeaderIfNotExist(headers, GrpcConstants.CHANNEL_ID, channelId);
         }
 
+        // Detect per-connection SSL state from gRPC transport attributes (RIP-2 §5.2.1)
+        boolean sslEnabled = isSslEnabled(call.getAttributes());
+        GrpcUtils.putHeaderIfNotExist(headers, GrpcConstants.SSL_ENABLED, String.valueOf(sslEnabled));
+
         return next.startCall(call, headers);
     }
 
@@ -89,5 +93,18 @@ public class HeaderInterceptor implements ServerInterceptor {
             return null;
         }
         return proxyProtocolAddr + ":" + proxyProtocolPort;
+    }
+
+    /**
+     * Detect whether the gRPC connection uses SSL/TLS by checking the transport SSL session.
+     * A non-null SSLSession indicates TLS is active for this connection.
+     */
+    private boolean isSslEnabled(Attributes attributes) {
+        try {
+            javax.net.ssl.SSLSession sslSession = attributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
+            return sslSession != null;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/pipeline/AuthenticationPipeline.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/pipeline/AuthenticationPipeline.java
@@ -75,6 +75,8 @@ public class AuthenticationPipeline implements RequestPipeline {
             DefaultAuthenticationContext defaultAuthenticationContext = (DefaultAuthenticationContext) result;
             if (StringUtils.isNotBlank(defaultAuthenticationContext.getUsername())) {
                 GrpcUtils.putHeaderIfNotExist(headers, GrpcConstants.AUTHORIZATION_AK, defaultAuthenticationContext.getUsername());
+                // Also store in ProxyContext for per-connection tracking (RIP-2 §5.2.2)
+                context.setAuthUsername(defaultAuthenticationContext.getUsername());
             }
         }
         return result;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/pipeline/ContextInitPipeline.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/pipeline/ContextInitPipeline.java
@@ -37,6 +37,19 @@ public class ContextInitPipeline implements RequestPipeline {
             .setClientVersion(getDefaultStringMetadataInfo(headers, GrpcConstants.CLIENT_VERSION))
             .setAction(getDefaultStringMetadataInfo(headers, GrpcConstants.SIMPLE_RPC_NAME))
             .setNamespace(getDefaultStringMetadataInfo(headers, GrpcConstants.NAMESPACE_ID));
+
+        // Extract per-connection SSL state from gRPC metadata (RIP-2 §5.2.1)
+        String sslEnabledStr = getDefaultStringMetadataInfo(headers, GrpcConstants.SSL_ENABLED);
+        if (StringUtils.isNotBlank(sslEnabledStr)) {
+            context.setSslEnabled(Boolean.parseBoolean(sslEnabledStr));
+        }
+
+        // Extract authenticated username from gRPC metadata (RIP-2 §5.2.2)
+        String authUsername = getDefaultStringMetadataInfo(headers, GrpcConstants.AUTHORIZATION_AK);
+        if (StringUtils.isNotBlank(authUsername)) {
+            context.setAuthUsername(authUsername);
+        }
+
         if (ctx.getDeadline() != null) {
             context.setRemainingMs(ctx.getDeadline().timeRemaining(TimeUnit.MILLISECONDS));
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/DefaultGrpcMessagingActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/DefaultGrpcMessagingActivity.java
@@ -60,6 +60,7 @@ import org.apache.rocketmq.proxy.grpc.v2.producer.SendMessageActivity;
 import org.apache.rocketmq.proxy.grpc.v2.route.RouteActivity;
 import org.apache.rocketmq.proxy.grpc.v2.transaction.EndTransactionActivity;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService;
 
 public class DefaultGrpcMessagingActivity extends AbstractStartAndShutdown implements GrpcMessagingActivity {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
@@ -95,6 +96,26 @@ public class DefaultGrpcMessagingActivity extends AbstractStartAndShutdown imple
         this.clientActivity = new ClientActivity(messagingProcessor, grpcClientSettingsManager, grpcChannelManager);
 
         this.appendStartAndShutdown(this.grpcClientSettingsManager);
+    }
+
+    @Override
+    public GrpcChannelManager getGrpcChannelManager() {
+        return this.grpcChannelManager;
+    }
+
+    @Override
+    public GrpcClientSettingsManager getGrpcClientSettingsManager() {
+        return this.grpcClientSettingsManager;
+    }
+
+    /**
+     * Set the proxy admin client service for heartbeat recording (RIP-2 §5.2.2).
+     * Delegates to ClientActivity to enable telemetry heartbeat tracking.
+     *
+     * @param proxyAdminClientService the admin service
+     */
+    public void setProxyAdminClientService(ProxyAdminClientService proxyAdminClientService) {
+        this.clientActivity.setProxyAdminClientService(proxyAdminClientService);
     }
 
     @Override

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/GrpcMessagingActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/GrpcMessagingActivity.java
@@ -46,8 +46,14 @@ import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.common.utils.StartAndShutdown;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
 
 public interface GrpcMessagingActivity extends StartAndShutdown {
+
+    GrpcChannelManager getGrpcChannelManager();
+
+    GrpcClientSettingsManager getGrpcClientSettingsManager();
 
     CompletableFuture<QueryRouteResponse> queryRoute(ProxyContext ctx, QueryRouteRequest request);
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/GrpcMessagingApplication.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/GrpcMessagingApplication.java
@@ -71,7 +71,10 @@ import org.apache.rocketmq.proxy.grpc.pipeline.RequestPipeline;
 import org.apache.rocketmq.proxy.grpc.v2.common.GrpcProxyException;
 import org.apache.rocketmq.proxy.grpc.v2.common.ResponseBuilder;
 import org.apache.rocketmq.proxy.grpc.v2.common.ResponseWriter;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService;
 
 public class GrpcMessagingApplication extends MessagingServiceGrpc.MessagingServiceImplBase implements StartAndShutdown {
     private final static Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
@@ -143,6 +146,27 @@ public class GrpcMessagingApplication extends MessagingServiceGrpc.MessagingServ
         this.consumerThreadPoolExecutor.setRejectedExecutionHandler(rejectedExecutionHandler);
         this.clientManagerThreadPoolExecutor.setRejectedExecutionHandler(rejectedExecutionHandler);
         this.transactionThreadPoolExecutor.setRejectedExecutionHandler(rejectedExecutionHandler);
+    }
+
+    public GrpcChannelManager getGrpcChannelManager() {
+        return this.grpcMessagingActivity.getGrpcChannelManager();
+    }
+
+    public GrpcClientSettingsManager getGrpcClientSettingsManager() {
+        return this.grpcMessagingActivity.getGrpcClientSettingsManager();
+    }
+
+    /**
+     * Set the proxy admin client service for heartbeat recording (RIP-2 §5.2.2).
+     * This enables the telemetry pipeline to record heartbeat events
+     * for the admin client query interface.
+     *
+     * @param proxyAdminClientService the admin service
+     */
+    public void setProxyAdminClientService(ProxyAdminClientService proxyAdminClientService) {
+        if (this.grpcMessagingActivity instanceof DefaultGrpcMessagingActivity) {
+            ((DefaultGrpcMessagingActivity) this.grpcMessagingActivity).setProxyAdminClientService(proxyAdminClientService);
+        }
     }
 
     public static GrpcMessagingApplication create(MessagingProcessor messagingProcessor) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.proxy.grpc.v2.channel;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -71,6 +72,16 @@ public class GrpcChannelManager implements StartAndShutdown {
 
     public GrpcClientChannel removeChannel(String clientId) {
         return this.clientIdChannelMap.remove(clientId);
+    }
+
+    /**
+     * Get all client channel mappings for admin queries.
+     * Returns an unmodifiable view of the clientId-channel map.
+     *
+     * @return unmodifiable map of clientId to GrpcClientChannel
+     */
+    public Map<String, GrpcClientChannel> getClientIdChannelMap() {
+        return java.util.Collections.unmodifiableMap(this.clientIdChannelMap);
     }
 
     public <T> String addResponseFuture(CompletableFuture<ProxyRelayResult<T>> responseFuture) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcClientChannel.java
@@ -34,6 +34,7 @@ import io.netty.channel.ChannelId;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
@@ -68,6 +69,31 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
     private final AtomicReference<StreamObserver<TelemetryCommand>> telemetryCommandRef = new AtomicReference<>();
     private final Object telemetryWriteLock = new Object();
     private final String clientId;
+    private final long createTime;
+
+    /**
+     * Last measured RTT in milliseconds, estimated from telemetry command round-trip.
+     * A value of -1 means no RTT measurement is available yet.
+     */
+    private volatile long lastRttMs = -1;
+
+    /**
+     * Timestamp (millis) when the proxy last sent a telemetry command to this client.
+     * Used to estimate RTT when the next telemetry command is received.
+     */
+    private volatile long lastTelemetrySendTimeMs = 0;
+
+    /**
+     * Whether this client connection uses SSL/TLS.
+     * Detected from gRPC transport security level at channel creation time.
+     */
+    private volatile boolean sslEnabled = false;
+
+    /**
+     * Authenticated username for this client connection.
+     * Extracted from auth metadata (AUTHORIZATION_AK) at channel creation time.
+     */
+    private volatile String authUsername = null;
 
     public GrpcClientChannel(ProxyRelayService proxyRelayService, GrpcClientSettingsManager grpcClientSettingsManager,
         GrpcChannelManager grpcChannelManager, ProxyContext ctx, String clientId) {
@@ -77,6 +103,68 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
         this.grpcChannelManager = grpcChannelManager;
         this.grpcClientSettingsManager = grpcClientSettingsManager;
         this.clientId = clientId;
+        this.createTime = System.currentTimeMillis();
+        // Detect per-connection SSL state from ProxyContext (RIP-2 §5.2.1)
+        Boolean ssl = ctx.isSslEnabled();
+        if (ssl != null) {
+            this.sslEnabled = ssl;
+        }
+        // Store authenticated username from ProxyContext (RIP-2 §5.2.2)
+        String username = ctx.getAuthUsername();
+        if (StringUtils.isNotBlank(username)) {
+            this.authUsername = username;
+        }
+    }
+
+    public long getCreateTime() {
+        return this.createTime;
+    }
+
+    /**
+     * Get the last measured RTT in milliseconds.
+     * @return RTT in ms, or -1 if no measurement is available
+     */
+    public long getLastRttMs() {
+        return this.lastRttMs;
+    }
+
+    /**
+     * Check whether this client connection uses SSL/TLS.
+     * @return true if SSL/TLS is enabled for this connection
+     */
+    public boolean isSslEnabled() {
+        return this.sslEnabled;
+    }
+
+    /**
+     * Get the authenticated username for this client connection.
+     * @return the username, or null if not available
+     */
+    public String getAuthUsername() {
+        return this.authUsername;
+    }
+
+    /**
+     * Update RTT measurement based on telemetry command round-trip.
+     * Called when a telemetry command is received from the client after
+     * the proxy sent a telemetry command.
+     */
+    public void updateRttMeasurement() {
+        long sendTime = this.lastTelemetrySendTimeMs;
+        if (sendTime > 0) {
+            long now = System.currentTimeMillis();
+            long rtt = now - sendTime;
+            if (rtt > 0) {
+                this.lastRttMs = rtt;
+            }
+        }
+    }
+
+    /**
+     * Record the timestamp when the proxy sends a telemetry command.
+     */
+    public void recordTelemetrySendTime() {
+        this.lastTelemetrySendTimeMs = System.currentTimeMillis();
     }
 
     @Override
@@ -163,6 +251,37 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
 
     protected void clearClientObserver(StreamObserver<TelemetryCommand> future) {
         this.telemetryCommandRef.compareAndSet(future, null);
+    }
+
+    /**
+     * Forcibly close this client channel from the server side.
+     * Sends an error status to the client via the telemetry stream observer,
+     * then clears the observer reference so the channel is marked as inactive.
+     * <p>
+     * After this call:
+     * - The client receives a gRPC error on its telemetry stream
+     * - isOpen()/isActive()/isWritable() return false
+     * - The caller should also remove the channel from GrpcChannelManager
+     *   and clean up settings to complete the disconnection.
+     *
+     * @param reason human-readable reason for the forced disconnection
+     * @return true if the stream was successfully closed, false if already closed
+     */
+    public boolean forceClose(String reason) {
+        StreamObserver<TelemetryCommand> observer = this.telemetryCommandRef.get();
+        if (observer == null) {
+            return false;
+        }
+        try {
+            observer.onError(io.grpc.Status.UNAVAILABLE
+                .withDescription("Connection force closed by admin: " + reason)
+                .asRuntimeException());
+        } catch (Exception e) {
+            log.warn("forceClose: failed to send error to client {}, clearing observer directly", clientId, e);
+        }
+        this.clearClientObserver(observer);
+        log.info("forceClose: client {} disconnected, reason: {}", clientId, reason);
+        return true;
     }
 
     @Override
@@ -274,6 +393,8 @@ public class GrpcClientChannel extends ProxyChannel implements ChannelExtendAttr
             }
             try {
                 observer.onNext(command);
+                // Record send time for RTT measurement (RIP-2 §5.2.1)
+                recordTelemetrySendTime();
             } catch (StatusRuntimeException | IllegalStateException exception) {
                 log.warn("write telemetry failed. command:{}", command, exception);
                 this.clearClientObserver(observer);

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -68,6 +68,7 @@ import org.apache.rocketmq.proxy.grpc.v2.common.GrpcConverter;
 import org.apache.rocketmq.proxy.grpc.v2.common.GrpcProxyException;
 import org.apache.rocketmq.proxy.grpc.v2.common.ResponseBuilder;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService;
 import org.apache.rocketmq.proxy.service.relay.ProxyRelayResult;
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
@@ -83,11 +84,28 @@ public class ClientActivity extends AbstractMessagingActivity {
 
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
+    /**
+     * Optional admin service for heartbeat recording (RIP-2 §5.2.2).
+     * Set after construction to avoid circular dependency.
+     */
+    private volatile ProxyAdminClientService proxyAdminClientService;
+
     public ClientActivity(MessagingProcessor messagingProcessor,
         GrpcClientSettingsManager grpcClientSettingsManager,
         GrpcChannelManager grpcChannelManager) {
         super(messagingProcessor, grpcClientSettingsManager, grpcChannelManager);
         this.init();
+    }
+
+    /**
+     * Set the proxy admin client service for heartbeat recording.
+     * This is called after construction to break the circular dependency
+     * between the telemetry pipeline and the admin service.
+     *
+     * @param proxyAdminClientService the admin service
+     */
+    public void setProxyAdminClientService(ProxyAdminClientService proxyAdminClientService) {
+        this.proxyAdminClientService = proxyAdminClientService;
     }
 
     protected void init() {
@@ -130,6 +148,9 @@ public class ClientActivity extends AbstractMessagingActivity {
                     return future;
                 }
             }
+            // Record heartbeat for admin telemetry tracking (RIP-2 §5.2.2)
+            recordHeartbeat(ctx.getClientID());
+
             future.complete(HeartbeatResponse.newBuilder()
                 .setStatus(ResponseBuilder.getInstance().buildStatus(Code.OK, Code.OK.name()))
                 .build());
@@ -283,9 +304,13 @@ public class ClientActivity extends AbstractMessagingActivity {
             public void onNext(ProxyContext ctx, TelemetryCommand request) {
                 this.proxyCtx = ctx;
                 try {
+                    // Update RTT measurement for this client channel (RIP-2 §5.2.1)
+                    updateRttMeasurement(ctx);
                     switch (request.getCommandCase()) {
                         case SETTINGS: {
                             processAndWriteClientSettings(ctx, request, responseObserver);
+                            // Record heartbeat for admin telemetry tracking (RIP-2 §5.2.2)
+                            recordHeartbeat(ctx.getClientID());
                             break;
                         }
                         case THREAD_STACK_TRACE: {
@@ -327,6 +352,42 @@ public class ClientActivity extends AbstractMessagingActivity {
                 return LiteSubscriptionAction.COMPLETE_REMOVE;
         }
         throw new IllegalArgumentException("unknown LiteSubscriptionAction: " + gRpcAction);
+    }
+
+    /**
+     * Record a heartbeat event via the admin service.
+     * Safely handles the case where admin service is not yet initialized.
+     *
+     * @param clientId the client identifier
+     */
+    private void recordHeartbeat(String clientId) {
+        ProxyAdminClientService service = this.proxyAdminClientService;
+        if (service != null && StringUtils.isNotBlank(clientId)) {
+            try {
+                service.recordHeartbeat(clientId);
+            } catch (Throwable t) {
+                log.warn("Failed to record heartbeat for clientId: {}", clientId, t);
+            }
+        }
+    }
+
+    /**
+     * Update RTT measurement for the client channel.
+     * Called when a telemetry command is received from the client,
+     * estimating RTT from the time since the proxy last sent a telemetry command.
+     */
+    private void updateRttMeasurement(ProxyContext ctx) {
+        try {
+            String clientId = ctx.getClientID();
+            if (StringUtils.isNotBlank(clientId)) {
+                GrpcClientChannel channel = this.grpcChannelManager.getChannel(clientId);
+                if (channel != null) {
+                    channel.updateRttMeasurement();
+                }
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to update RTT measurement for clientId: {}", ctx.getClientID(), t);
+        }
     }
 
     private void handleGrpcCancel(ProxyContext ctx, Throwable t) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
@@ -55,8 +55,10 @@ import org.apache.rocketmq.proxy.service.ServiceManager;
 import org.apache.rocketmq.proxy.service.ServiceManagerFactory;
 import org.apache.rocketmq.proxy.service.message.ReceiptHandleMessage;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
 import org.apache.rocketmq.proxy.service.relay.ProxyRelayService;
 import org.apache.rocketmq.proxy.service.route.ProxyTopicRouteData;
+import org.apache.rocketmq.proxy.service.route.TopicRouteService;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumeType;
@@ -399,5 +401,15 @@ public class DefaultMessagingProcessor extends AbstractStartAndShutdown implemen
 
     @Override public int getUnackedMessageCount(ProxyContext ctx, Channel channel, String group) {
         return receiptHandleProcessor.getUnackedMessageCount(ctx, channel, group);
+    }
+
+    @Override
+    public ReceiptHandleManager getReceiptHandleManager() {
+        return receiptHandleProcessor.getReceiptHandleManager();
+    }
+
+    @Override
+    public TopicRouteService getTopicRouteService() {
+        return this.serviceManager.getTopicRouteService();
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/MessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/MessagingProcessor.java
@@ -40,8 +40,10 @@ import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.service.message.ReceiptHandleMessage;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
 import org.apache.rocketmq.proxy.service.relay.ProxyRelayService;
 import org.apache.rocketmq.proxy.service.route.ProxyTopicRouteData;
+import org.apache.rocketmq.proxy.service.route.TopicRouteService;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumeType;
 import org.apache.rocketmq.remoting.protocol.heartbeat.MessageModel;
@@ -420,4 +422,18 @@ public interface MessagingProcessor extends StartAndShutdown {
         String receiptHandle);
 
     int getUnackedMessageCount(ProxyContext ctx, Channel channel, String group);
+
+    /**
+     * Get the ReceiptHandleManager for POP diagnostics.
+     *
+     * @return the receipt handle manager instance
+     */
+    ReceiptHandleManager getReceiptHandleManager();
+
+    /**
+     * Get the TopicRouteService for route change event subscriptions.
+     *
+     * @return the topic route service instance
+     */
+    TopicRouteService getTopicRouteService();
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ReceiptHandleProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ReceiptHandleProcessor.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.common.RenewEvent;
 import org.apache.rocketmq.proxy.service.ServiceManager;
 import org.apache.rocketmq.proxy.service.receipt.DefaultReceiptHandleManager;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
 
 public class ReceiptHandleProcessor extends AbstractProcessor {
     protected final static Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
@@ -70,6 +71,15 @@ public class ReceiptHandleProcessor extends AbstractProcessor {
 
     public int getUnackedMessageCount(ProxyContext ctx, Channel channel, String group) {
         return receiptHandleManager.getUnackedMessageCount(ctx, channel, group);
+    }
+
+    /**
+     * Get the ReceiptHandleManager for POP diagnostics.
+     *
+     * @return the receipt handle manager instance
+     */
+    public ReceiptHandleManager getReceiptHandleManager() {
+        return receiptHandleManager;
     }
 
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultProxyAdminClientService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultProxyAdminClientService.java
@@ -1,0 +1,932 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.admin;
+
+import apache.rocketmq.v2.ClientType;
+import apache.rocketmq.v2.Language;
+import apache.rocketmq.v2.Resource;
+import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.UA;
+import io.netty.channel.Channel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.common.BatchConsumeClientDiagnostics;
+import org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientDetailInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientInstanceInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ListClientsFilter;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleGroupSummary;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager.ChannelBatchConsumeData;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager.PopReceiptHandleDiagnosticResult;
+
+/**
+ * Default implementation of ProxyAdminClientService.
+ * <p>
+ * All client data comes from the internal ClientManager module (GrpcChannelManager and GrpcClientSettingsManager),
+ * based on gRPC Telemetry long-connection reported information.
+ * <p>
+ * Performance considerations (RIP-2 §8):
+ * - Filter pushdown: filters are applied during iteration, avoiding full collection before filtering
+ * - Pagination is enforced with max page size of 100
+ * - Data is weakly consistent (near real-time snapshot)
+ * - Sampling support for high-concurrency scenarios
+ */
+public class DefaultProxyAdminClientService implements ProxyAdminClientService {
+    private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
+    private static final int MAX_PAGE_SIZE = 100;
+
+    /**
+     * Maximum heartbeat history records per client (RIP-2 §5.2.2).
+     */
+    private static final int MAX_HEARTBEAT_HISTORY_SIZE = 10;
+
+    /**
+     * Sampling threshold: when total client count exceeds this value,
+     * DescribeClient diagnostics may return sampled data (RIP-2 §8.5).
+     */
+    private static final long SAMPLING_THRESHOLD = 100_000;
+
+    private final GrpcChannelManager grpcChannelManager;
+    private final GrpcClientSettingsManager grpcClientSettingsManager;
+    private volatile ReceiptHandleManager receiptHandleManager;
+
+    /**
+     * Heartbeat history tracker: clientId -> deque of heartbeat timestamps.
+     * Tracks the most recent heartbeat records for each client.
+     */
+    private final ConcurrentLinkedDeque<HeartbeatRecord> heartbeatLog = new ConcurrentLinkedDeque<>();
+    private final AtomicLong heartbeatLogCounter = new AtomicLong(0);
+
+    public DefaultProxyAdminClientService(GrpcChannelManager grpcChannelManager,
+        GrpcClientSettingsManager grpcClientSettingsManager) {
+        this.grpcChannelManager = grpcChannelManager;
+        this.grpcClientSettingsManager = grpcClientSettingsManager;
+    }
+
+    /**
+     * Set the ReceiptHandleManager for POP diagnostics.
+     * Called during startup after the MessagingProcessor is initialized.
+     *
+     * @param receiptHandleManager the receipt handle manager instance
+     */
+    public void setReceiptHandleManager(ReceiptHandleManager receiptHandleManager) {
+        this.receiptHandleManager = receiptHandleManager;
+    }
+
+    @Override
+    public ListClientsResult listClients(ListClientsFilter filter, int pageNum, int pageSize) {
+        pageNum = Math.max(pageNum, 1);
+        pageSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
+
+        // Filter pushdown (RIP-2 §8.1): apply filters during iteration
+        // instead of collecting all clients first then filtering
+        FilterContext filterCtx = new FilterContext(filter);
+        List<ClientInstanceInfo> allClients = collectAndFilterClients(filterCtx);
+
+        // Paginate
+        long total = allClients.size();
+        int fromIndex = (pageNum - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, allClients.size());
+
+        List<ClientInstanceInfo> pageList;
+        if (fromIndex >= allClients.size()) {
+            pageList = Collections.emptyList();
+        } else {
+            pageList = allClients.subList(fromIndex, toIndex);
+        }
+
+        return new ListClientsResult(total, pageNum, pageSize, new ArrayList<>(pageList));
+    }
+
+    @Override
+    public ClientDetailInfo describeClient(String clientId) {
+        if (StringUtils.isBlank(clientId)) {
+            return null;
+        }
+
+        GrpcClientChannel channel = grpcChannelManager.getChannel(clientId);
+        if (channel == null) {
+            return null;
+        }
+
+        Settings settings = grpcClientSettingsManager.getRawClientSettings(clientId);
+        if (settings == null) {
+            return null;
+        }
+
+        ClientDetailInfo detail = new ClientDetailInfo();
+
+        // Build basic client instance info
+        ClientInstanceInfo instanceInfo = buildClientInstanceInfo(clientId, channel, settings);
+        detail.setClientInstance(instanceInfo);
+
+        // Build client settings info
+        ClientDetailInfo.ClientSettingsInfo settingsInfo = buildClientSettingsInfo(settings);
+        detail.setSettings(settingsInfo);
+
+        // Build heartbeat history from tracked records
+        detail.setHeartbeatHistory(buildHeartbeatHistory(clientId, channel));
+
+        // Build auth status with username extraction from settings
+        detail.setAuthStatus(buildAuthStatus(clientId, channel, settings));
+
+        // Build consume progress (only for consumers)
+        if (isConsumer(settings)) {
+            detail.setConsumeProgress(buildConsumeProgress(clientId, settings));
+        }
+
+        // Build network info with full details
+        detail.setNetworkInfo(buildNetworkInfo(channel));
+
+        return detail;
+    }
+
+    @Override
+    public ListClientsResult listClientsByGroup(String group, int pageNum, int pageSize) {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup(group);
+        return listClients(filter, pageNum, pageSize);
+    }
+
+    @Override
+    public ListClientsResult listClientsByTopic(String topic, int pageNum, int pageSize) {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setTopic(topic);
+        return listClients(filter, pageNum, pageSize);
+    }
+
+    /**
+     * Record a heartbeat event for a client.
+     * Called by the telemetry processing pipeline when a heartbeat is received.
+     * This enables real heartbeat history tracking (RIP-2 §5.2.2).
+     *
+     * @param clientId the client identifier
+     */
+    public void recordHeartbeat(String clientId) {
+        long now = System.currentTimeMillis();
+        heartbeatLog.addFirst(new HeartbeatRecord(clientId, now, true));
+        heartbeatLogCounter.incrementAndGet();
+
+        // Evict old entries to bound memory usage.
+        // removeLast() is safe here because the while-loop condition
+        // (size() > MAX_HEARTBEAT_HISTORY_SIZE * 1000) guarantees the deque is non-empty.
+        while (heartbeatLog.size() > MAX_HEARTBEAT_HISTORY_SIZE * 1000) {
+            heartbeatLog.removeLast();
+        }
+    }
+
+    @Override
+    public boolean forceDisconnectClient(String clientId, String reason) {
+        if (StringUtils.isBlank(clientId)) {
+            log.warn("forceDisconnectClient: clientId is blank, ignoring");
+            return false;
+        }
+
+        GrpcClientChannel channel = grpcChannelManager.getChannel(clientId);
+        if (channel == null) {
+            log.warn("forceDisconnectClient: client {} not found in channel manager", clientId);
+            return false;
+        }
+
+        // Step 1: Force close the gRPC telemetry stream
+        // This sends a UNAVAILABLE error to the client, triggering reconnection
+        boolean closed = channel.forceClose(reason);
+        if (!closed) {
+            log.warn("forceDisconnectClient: client {} stream already closed, proceeding with cleanup", clientId);
+        }
+
+        // Step 2: Remove the channel from GrpcChannelManager
+        GrpcClientChannel removed = grpcChannelManager.removeChannel(clientId);
+        if (removed != null) {
+            log.info("forceDisconnectClient: removed channel for client {} from channel manager", clientId);
+        }
+
+        // Step 3: Remove client settings from GrpcClientSettingsManager
+        Settings removedSettings = grpcClientSettingsManager.removeAndGetRawClientSettings(clientId);
+        if (removedSettings != null) {
+            log.info("forceDisconnectClient: removed settings for client {}", clientId);
+        }
+
+        log.info("forceDisconnectClient: client {} disconnected. reason: {}, streamClosed: {}, channelRemoved: {}, settingsRemoved: {}",
+            clientId, reason, closed, removed != null, removedSettings != null);
+        return true;
+    }
+
+    /**
+     * Check if sampling should be applied for the current load level.
+     * RIP-2 §8.5: When client count exceeds SAMPLING_THRESHOLD,
+     * diagnostic interfaces should sample to protect system stability.
+     *
+     * @return true if sampling should be applied
+     */
+    public boolean shouldSample() {
+        return grpcChannelManager.getClientIdChannelMap().size() > SAMPLING_THRESHOLD;
+    }
+
+    // ==================== Filter Pushdown Implementation (RIP-2 §8.1) ====================
+
+    /**
+     * Collect and filter clients in a single pass.
+     * Implements filter pushdown by applying filters during iteration
+     * rather than collecting all clients first then filtering.
+     * <p>
+     * This avoids creating a full ClientInstanceInfo list for all clients
+     * when only a subset matches the filter criteria, significantly reducing
+     * memory pressure under high connection counts.
+     */
+    private List<ClientInstanceInfo> collectAndFilterClients(FilterContext filterCtx) {
+        List<ClientInstanceInfo> clients = new ArrayList<>();
+        Map<String, GrpcClientChannel> channelMap = grpcChannelManager.getClientIdChannelMap();
+
+        for (Map.Entry<String, GrpcClientChannel> entry : channelMap.entrySet()) {
+            String clientId = entry.getKey();
+
+            // Pushdown filter: clientId prefix (cheapest check first)
+            if (!filterCtx.matchesClientIdPrefix(clientId)) {
+                continue;
+            }
+
+            GrpcClientChannel channel = entry.getValue();
+
+            // Pushdown filter: connect time range (cheap, no Settings needed)
+            if (!filterCtx.matchesConnectTimeRange(channel.getCreateTime())) {
+                continue;
+            }
+
+            Settings settings = grpcClientSettingsManager.getRawClientSettings(clientId);
+            if (settings == null) {
+                continue;
+            }
+
+            // Pushdown filter: language (requires Settings)
+            if (!filterCtx.matchesLanguage(settings)) {
+                continue;
+            }
+
+            // Build partial info for remaining filter checks
+            ClientInstanceInfo info = buildClientInstanceInfo(clientId, channel, settings);
+
+            // Pushdown filter: group (requires built info)
+            if (!filterCtx.matchesGroup(info.getGroup())) {
+                continue;
+            }
+
+            // Pushdown filter: topic (requires built info)
+            if (!filterCtx.matchesTopic(info.getTopics())) {
+                continue;
+            }
+
+            clients.add(info);
+        }
+        return clients;
+    }
+
+    /**
+     * Filter context that encapsulates filter criteria and provides
+     * pushdown matching methods for each filter dimension.
+     * Each method returns true if the item passes the filter (or if the
+     * filter criterion is not set), enabling early elimination.
+     */
+    private static class FilterContext {
+        private final ListClientsFilter filter;
+
+        FilterContext(ListClientsFilter filter) {
+            this.filter = filter != null ? filter : new ListClientsFilter();
+        }
+
+        boolean matchesClientIdPrefix(String clientId) {
+            if (StringUtils.isBlank(filter.getClientIdPrefix())) {
+                return true;
+            }
+            return clientId != null && clientId.startsWith(filter.getClientIdPrefix());
+        }
+
+        boolean matchesConnectTimeRange(long connectTime) {
+            if (filter.getConnectTimeStart() > 0 && connectTime < filter.getConnectTimeStart()) {
+                return false;
+            }
+            if (filter.getConnectTimeEnd() > 0 && connectTime > filter.getConnectTimeEnd()) {
+                return false;
+            }
+            return true;
+        }
+
+        boolean matchesLanguage(Settings settings) {
+            if (StringUtils.isBlank(filter.getLanguage())) {
+                return true;
+            }
+            if (settings == null || !settings.hasUserAgent()) {
+                return false;
+            }
+            String clientLanguage = convertLanguageToString(settings.getUserAgent().getLanguage());
+            return filter.getLanguage().equalsIgnoreCase(clientLanguage);
+        }
+
+        boolean matchesGroup(String group) {
+            if (StringUtils.isBlank(filter.getGroup())) {
+                return true;
+            }
+            return filter.getGroup().equals(group);
+        }
+
+        boolean matchesTopic(List<String> topics) {
+            if (StringUtils.isBlank(filter.getTopic())) {
+                return true;
+            }
+            return topics != null && topics.contains(filter.getTopic());
+        }
+
+        private String convertLanguageToString(Language language) {
+            if (language == null || language == Language.LANGUAGE_UNSPECIFIED) {
+                return "UNSPECIFIED";
+            }
+            switch (language) {
+                case JAVA: return "JAVA";
+                case CPP: return "CPP";
+                case DOT_NET: return "DOTNET";
+                case GOLANG: return "GOLANG";
+                case RUST: return "RUST";
+                case PYTHON: return "PYTHON";
+                case PHP: return "PHP";
+                case NODE_JS: return "NODE_JS";
+                case RUBY: return "RUBY";
+                case OBJECTIVE_C: return "OBJECTIVE_C";
+                case DART: return "DART";
+                case KOTLIN: return "KOTLIN";
+                default: return language.name();
+            }
+        }
+    }
+
+    // ==================== Build Methods ====================
+
+    /**
+     * Build a ClientInstanceInfo from channel and settings data.
+     */
+    private ClientInstanceInfo buildClientInstanceInfo(String clientId, GrpcClientChannel channel,
+        Settings settings) {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId(clientId);
+        info.setProtocol("GRPC_V2");
+        info.setConnectAt(channel.getCreateTime());
+        info.setLastActiveAt(channel.getLastAccessTime());
+
+        // Extract remote address as access point
+        info.setAccessPoint(channel.getRemoteAddress());
+
+        // Extract role, group, and topics from settings
+        if (settings != null) {
+            ClientType clientType = settings.getClientType();
+            info.setRole(convertClientType(clientType));
+
+            // Extract language and clientVersion from Settings.user_agent (RIP-2 §5.2.1)
+            if (settings.hasUserAgent()) {
+                UA userAgent = settings.getUserAgent();
+                info.setLanguage(convertLanguage(userAgent.getLanguage()));
+                info.setClientVersion(userAgent.getVersion());
+            } else {
+                info.setLanguage(convertLanguage(Language.LANGUAGE_UNSPECIFIED));
+            }
+
+            if (settings.hasPublishing()) {
+                // Producer
+                List<String> topics = settings.getPublishing().getTopicsList().stream()
+                    .map(Resource::getName)
+                    .collect(Collectors.toList());
+                info.setTopics(topics);
+            } else if (settings.hasSubscription()) {
+                // Consumer
+                String group = settings.getSubscription().getGroup().getName();
+                info.setGroup(group);
+                List<String> topics = settings.getSubscription().getSubscriptionsList().stream()
+                    .map(entry -> entry.getTopic().getName())
+                    .collect(Collectors.toList());
+                info.setTopics(topics);
+            }
+        }
+
+        return info;
+    }
+
+    /**
+     * Convert proto Language enum to display string.
+     * Maps the gRPC v2 Language enum values to the string representation
+     * required by RIP-2 §5.2.1 ClientInstance.language field.
+     */
+    private String convertLanguage(Language language) {
+        if (language == null || language == Language.LANGUAGE_UNSPECIFIED) {
+            return "UNSPECIFIED";
+        }
+        switch (language) {
+            case JAVA:
+                return "JAVA";
+            case CPP:
+                return "CPP";
+            case DOT_NET:
+                return "DOTNET";
+            case GOLANG:
+                return "GOLANG";
+            case RUST:
+                return "RUST";
+            case PYTHON:
+                return "PYTHON";
+            case PHP:
+                return "PHP";
+            case NODE_JS:
+                return "NODE_JS";
+            case RUBY:
+                return "RUBY";
+            case OBJECTIVE_C:
+                return "OBJECTIVE_C";
+            case DART:
+                return "DART";
+            case KOTLIN:
+                return "KOTLIN";
+            default:
+                return language.name();
+        }
+    }
+
+    /**
+     * Convert ClientType to role string.
+     */
+    private String convertClientType(ClientType clientType) {
+        if (clientType == null) {
+            return "UNSPECIFIED";
+        }
+        switch (clientType) {
+            case PRODUCER:
+                return "PRODUCER";
+            case PUSH_CONSUMER:
+            case LITE_PUSH_CONSUMER:
+                return "PUSH_CONSUMER";
+            case SIMPLE_CONSUMER:
+                return "SIMPLE_CONSUMER";
+            default:
+                return clientType.name();
+        }
+    }
+
+    /**
+     * Build client settings info from Settings proto.
+     */
+    private ClientDetailInfo.ClientSettingsInfo buildClientSettingsInfo(Settings settings) {
+        ClientDetailInfo.ClientSettingsInfo info = new ClientDetailInfo.ClientSettingsInfo();
+        if (settings == null) {
+            return info;
+        }
+
+        if (settings.hasSubscription()) {
+            info.setSubscriptionMode(settings.getSubscription().getFifo() ? "FIFO" : "STANDARD");
+            info.setReceiveBatchSize(settings.getSubscription().getReceiveBatchSize());
+            info.setLongPollingTimeoutMs(settings.getSubscription().getLongPollingTimeout().getSeconds() * 1000
+                + settings.getSubscription().getLongPollingTimeout().getNanos() / 1_000_000L);
+            info.setFifo(settings.getSubscription().getFifo());
+            info.setSubscriptionTopics(settings.getSubscription().getSubscriptionsList().stream()
+                .map(entry -> entry.getTopic().getName())
+                .collect(Collectors.toList()));
+        }
+
+        if (settings.hasPublishing()) {
+            info.setPublishingTopics(settings.getPublishing().getTopicsList().stream()
+                .map(Resource::getName)
+                .collect(Collectors.toList()));
+        }
+
+        return info;
+    }
+
+    /**
+     * Build heartbeat history from tracked records and channel last access time.
+     * RIP-2 §5.2.2: Returns recent heartbeat records with timestamps and status.
+     * <p>
+     * If tracked heartbeat records are available, returns those.
+     * Otherwise, falls back to a synthetic record based on lastAccessTime.
+     */
+    private List<ClientDetailInfo.HeartbeatRecordInfo> buildHeartbeatHistory(String clientId,
+        GrpcClientChannel channel) {
+        List<ClientDetailInfo.HeartbeatRecordInfo> history = new ArrayList<>();
+
+        // Collect tracked heartbeat records for this client
+        for (HeartbeatRecord record : heartbeatLog) {
+            if (record.clientId.equals(clientId)) {
+                ClientDetailInfo.HeartbeatRecordInfo info = new ClientDetailInfo.HeartbeatRecordInfo();
+                info.setTimestamp(record.timestamp);
+                info.setSuccess(record.success);
+                info.setRemark(record.success ? "Heartbeat OK" : "Heartbeat timeout");
+                history.add(info);
+                if (history.size() >= MAX_HEARTBEAT_HISTORY_SIZE) {
+                    break;
+                }
+            }
+        }
+
+        // Fallback: if no tracked records, use lastAccessTime as synthetic heartbeat
+        if (history.isEmpty()) {
+            ClientDetailInfo.HeartbeatRecordInfo record = new ClientDetailInfo.HeartbeatRecordInfo();
+            record.setTimestamp(channel.getLastAccessTime());
+            record.setSuccess(true);
+            record.setRemark("Last activity (synthetic)");
+            history.add(record);
+        }
+
+        return history;
+    }
+
+    /**
+     * Build auth status from channel and settings.
+     * RIP-2 §5.2.2: Extracts authentication information including username
+     * from the auth metadata (AUTHORIZATION_AK) stored in GrpcClientChannel.
+     * <p>
+     * The username is obtained from per-connection auth metadata captured
+     * during the authentication pipeline, stored in GrpcClientChannel.
+     * Falls back to user agent platform field or clientId convention.
+     */
+    private ClientDetailInfo.AuthStatusInfo buildAuthStatus(String clientId,
+        GrpcClientChannel channel, Settings settings) {
+        ClientDetailInfo.AuthStatusInfo authStatus = new ClientDetailInfo.AuthStatusInfo();
+
+        // Channel is established, so authentication was successful
+        authStatus.setAuthenticated(true);
+        authStatus.setLastAuthTime(channel.getCreateTime());
+
+        // Priority 1: Use authenticated username from auth metadata (RIP-2 §5.2.2)
+        String authUsername = channel.getAuthUsername();
+        if (StringUtils.isNotBlank(authUsername)) {
+            authStatus.setUsername(authUsername);
+        }
+
+        // Priority 2: Extract username from user agent platform field
+        if (StringUtils.isBlank(authStatus.getUsername()) && settings != null && settings.hasUserAgent()) {
+            UA userAgent = settings.getUserAgent();
+            String platform = userAgent.getPlatform();
+            if (StringUtils.isNotBlank(platform)) {
+                authStatus.setUsername(platform);
+            }
+        }
+
+        // Priority 3: Try to extract from clientId convention
+        if (StringUtils.isBlank(authStatus.getUsername())) {
+            authStatus.setUsername(extractUsernameFromClientId(clientId));
+        }
+
+        return authStatus;
+    }
+
+    /**
+     * Extract username from clientId following common naming conventions.
+     * ClientId format typically: hostname@processId@timestamp or user@hostname@processId
+     */
+    private String extractUsernameFromClientId(String clientId) {
+        if (clientId == null || clientId.isEmpty()) {
+            return null;
+        }
+        // ClientId format: typically "hostname-processId-timestamp"
+        // or for authenticated clients: "user@hostname-processId-timestamp"
+        int atIndex = clientId.indexOf('@');
+        if (atIndex > 0) {
+            String prefix = clientId.substring(0, atIndex);
+            // Check if the prefix looks like a username (not an IP or hostname)
+            if (!prefix.matches(".*[.\\d]+.*") && prefix.length() < 64) {
+                return prefix;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Check if the client type is a consumer.
+     */
+    private boolean isConsumer(Settings settings) {
+        if (settings == null) {
+            return false;
+        }
+        ClientType clientType = settings.getClientType();
+        return clientType == ClientType.PUSH_CONSUMER
+            || clientType == ClientType.LITE_PUSH_CONSUMER
+            || clientType == ClientType.SIMPLE_CONSUMER;
+    }
+
+    /**
+     * Build consume progress for consumer clients.
+     * In local view mode, consume progress requires broker-side data
+     * which is not directly available from the proxy's local state.
+     * <p>
+     * M1 implementation: returns available local data (subscription info).
+     * Full implementation with broker-side lag/latency data planned for M2.
+     */
+    private ClientDetailInfo.ConsumeProgressInfo buildConsumeProgress(String clientId, Settings settings) {
+        ClientDetailInfo.ConsumeProgressInfo progress = new ClientDetailInfo.ConsumeProgressInfo();
+        if (!settings.hasSubscription()) {
+            return progress;
+        }
+
+        // Build per-topic progress entries with available local data
+        // Lag and latency require broker-side queries (M2 scope)
+        List<ClientDetailInfo.TopicConsumeProgressInfo> topicProgressList = new ArrayList<>();
+        for (apache.rocketmq.v2.SubscriptionEntry entry : settings.getSubscription().getSubscriptionsList()) {
+            ClientDetailInfo.TopicConsumeProgressInfo topicProgress = new ClientDetailInfo.TopicConsumeProgressInfo();
+            topicProgress.setTopic(entry.getTopic().getName());
+            // Lag and latency are not available from proxy local state
+            // These require broker-side queries planned for M2
+            topicProgress.setLag(-1);
+            topicProgress.setLatencyMs(-1);
+            topicProgressList.add(topicProgress);
+        }
+        progress.setTopicProgress(topicProgressList);
+
+        // Overall lag/latency not available from local state
+        progress.setLag(-1);
+        progress.setLatencyMs(-1);
+
+        return progress;
+    }
+
+    /**
+     * Build network info from channel with full details.
+     * RIP-2 §5.2.2: Extracts local/remote addresses, RTT, and SSL state.
+     */
+    private ClientDetailInfo.NetworkInfoInfo buildNetworkInfo(GrpcClientChannel channel) {
+        ClientDetailInfo.NetworkInfoInfo networkInfo = new ClientDetailInfo.NetworkInfoInfo();
+
+        // Remote address
+        if (channel.getRemoteAddress() != null) {
+            networkInfo.setRemoteAddress(channel.getRemoteAddress());
+        }
+
+        // Local address - extracted from SimpleChannel.localAddress field
+        String localAddress = channel.getLocalAddress();
+        if (localAddress != null) {
+            networkInfo.setLocalAddress(localAddress);
+        }
+
+        // SSL state detection from the underlying Netty channel pipeline
+        networkInfo.setSslEnabled(detectSslState(channel));
+
+        // RTT measurement from telemetry command round-trip (RIP-2 §5.2.1)
+        networkInfo.setRttMs(channel.getLastRttMs());
+
+        return networkInfo;
+    }
+
+    /**
+     * Detect SSL state for a specific client connection.
+     * <p>
+     * First checks the per-connection SSL state stored in GrpcClientChannel,
+     * which is detected from gRPC transport security level at channel creation time.
+     * Falls back to global TlsSystemConfig.tlsMode if per-connection state is unavailable.
+     */
+    private boolean detectSslState(GrpcClientChannel channel) {
+        try {
+            // Prefer per-connection SSL state from GrpcClientChannel (RIP-2 §5.2.1)
+            if (channel.isSslEnabled()) {
+                return true;
+            }
+            // Fallback: infer from global TLS configuration
+            org.apache.rocketmq.remoting.common.TlsMode tlsMode = org.apache.rocketmq.remoting.netty.TlsSystemConfig.tlsMode;
+            return tlsMode == org.apache.rocketmq.remoting.common.TlsMode.PERMISSIVE
+                || tlsMode == org.apache.rocketmq.remoting.common.TlsMode.ENFORCING;
+        } catch (Exception e) {
+            log.debug("Failed to detect SSL state for channel: {}", channel.getClientId(), e);
+        }
+        return false;
+    }
+
+    // ==================== POP Diagnostics ====================
+
+    @Override
+    public PopReceiptHandleDiagnosticResult describePopReceiptHandles(String group, String topic,
+        int pageNum, int pageSize) {
+        if (receiptHandleManager == null) {
+            log.warn("ReceiptHandleManager not initialized, POP diagnostics unavailable");
+            return new PopReceiptHandleDiagnosticResult(
+                new PopReceiptHandleGroupSummary(group, 0, 0, 0, 0, 0),
+                Collections.emptyList(), 0, 1, 1);
+        }
+        pageNum = Math.max(pageNum, 1);
+        pageSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
+        return receiptHandleManager.describePopReceiptHandles(group, topic, pageNum, pageSize);
+    }
+
+    // ==================== Batch Consume Diagnostics ====================
+
+    @Override
+    public ProxyAdminClientService.BatchConsumeDiagnosticResult describeBatchConsumeDiagnostics(
+        String group, String topic, String clientId, int pageNum, int pageSize) {
+        if (receiptHandleManager == null) {
+            log.warn("ReceiptHandleManager not initialized, batch consume diagnostics unavailable");
+            return new ProxyAdminClientService.BatchConsumeDiagnosticResult(
+                new BatchConsumeGroupSummary(group, 0, 0, 0, 0, 0, 0),
+                Collections.emptyList(), 0, 1, 1);
+        }
+        if (StringUtils.isBlank(group)) {
+            return new ProxyAdminClientService.BatchConsumeDiagnosticResult(
+                new BatchConsumeGroupSummary("", 0, 0, 0, 0, 0, 0),
+                Collections.emptyList(), 0, 1, 1);
+        }
+
+        pageNum = Math.max(pageNum, 1);
+        pageSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
+
+        // Step 1: Get all channel-level raw data from ReceiptHandleManager
+        // We fetch all data (no server-side pagination) because we need to:
+        //   a) Enrich with clientId from GrpcClientChannel
+        //   b) Apply clientId filter if specified
+        //   c) Re-paginate after enrichment and filtering
+        ReceiptHandleManager.BatchConsumeDiagnosticResult rawResult = receiptHandleManager.describeBatchConsumeDiagnostics(
+            group, topic, 1, Integer.MAX_VALUE);
+
+        // Step 2: Enrich each ChannelBatchConsumeData with gRPC channel/settings data
+        List<BatchConsumeClientDiagnostics> enriched = new ArrayList<>();
+        for (ChannelBatchConsumeData channelData : rawResult.getChannelData()) {
+            BatchConsumeClientDiagnostics diagnostic = enrichChannelData(channelData);
+            if (diagnostic == null) {
+                continue;
+            }
+
+            // Step 3: Apply clientId filter if specified
+            if (StringUtils.isNotBlank(clientId) && !clientId.equals(diagnostic.getClientId())) {
+                continue;
+            }
+
+            enriched.add(diagnostic);
+        }
+
+        // Step 4: Re-paginate after enrichment and filtering
+        long total = enriched.size();
+        int fromIndex = (pageNum - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, enriched.size());
+
+        List<BatchConsumeClientDiagnostics> pageList;
+        if (fromIndex >= enriched.size()) {
+            pageList = Collections.emptyList();
+        } else {
+            pageList = enriched.subList(fromIndex, toIndex);
+        }
+
+        // Step 5: Recalculate summary for the filtered set
+        BatchConsumeGroupSummary summary = recalculateSummary(group, enriched);
+
+        return new ProxyAdminClientService.BatchConsumeDiagnosticResult(
+            summary, new ArrayList<>(pageList), total, pageNum, pageSize);
+    }
+
+    /**
+     * Enrich a ChannelBatchConsumeData with gRPC channel and settings information.
+     * <p>
+     * The Channel stored in ReceiptHandleGroupKey is the GrpcClientChannel itself
+     * (passed from ReceiveMessageActivity), so we can directly cast and extract:
+     * - clientId, lastRttMs, createTime from GrpcClientChannel
+     * - receiveBatchSize, longPollingTimeout from Settings
+     * - consumeType from Settings.clientType
+     * - messageModel defaults to CLUSTERING for gRPC v2 proxy clients
+     *
+     * @param channelData raw per-channel data from ReceiptHandleManager
+     * @return enriched diagnostics, or null if channel cannot be identified
+     */
+    private BatchConsumeClientDiagnostics enrichChannelData(ChannelBatchConsumeData channelData) {
+        Channel channel = channelData.getChannel();
+
+        // Extract clientId and channel info from GrpcClientChannel
+        String clientId = null;
+        long lastRttMs = -1;
+        long connectTime = -1;
+
+        // The Channel in ReceiptHandleGroupKey IS the GrpcClientChannel (set in ReceiveMessageActivity)
+        if (channel instanceof GrpcClientChannel) {
+            GrpcClientChannel grpcChannel = (GrpcClientChannel) channel;
+            clientId = grpcChannel.getClientId();
+            lastRttMs = grpcChannel.getLastRttMs();
+            connectTime = grpcChannel.getCreateTime();
+        } else {
+            // Fallback: reverse-lookup from GrpcChannelManager's clientIdChannelMap
+            // This handles edge cases where the channel type differs
+            for (Map.Entry<String, GrpcClientChannel> entry : grpcChannelManager.getClientIdChannelMap().entrySet()) {
+                if (entry.getValue().equals(channel)) {
+                    clientId = entry.getKey();
+                    lastRttMs = entry.getValue().getLastRttMs();
+                    connectTime = entry.getValue().getCreateTime();
+                    break;
+                }
+            }
+        }
+
+        if (clientId == null) {
+            // Channel no longer exists in gRPC channel manager, skip this entry
+            log.debug("Batch diagnostics: channel {} not found in GrpcChannelManager, skipping", channel);
+            return null;
+        }
+
+        // Get Settings for receiveBatchSize, longPollingTimeout, and consumeType
+        int receiveBatchSize = -1;
+        long longPollingTimeoutMs = -1;
+        String consumeType = "UNSPECIFIED";
+        String messageModel = "CLUSTERING"; // Default for gRPC v2 proxy clients
+
+        Settings settings = grpcClientSettingsManager.getRawClientSettings(clientId);
+        if (settings != null) {
+            consumeType = convertClientType(settings.getClientType());
+
+            if (settings.hasSubscription()) {
+                receiveBatchSize = settings.getSubscription().getReceiveBatchSize();
+                longPollingTimeoutMs = settings.getSubscription().getLongPollingTimeout().getSeconds() * 1000
+                    + settings.getSubscription().getLongPollingTimeout().getNanos() / 1_000_000L;
+            }
+        }
+
+        String channelId = channel.id().asShortText();
+
+        return new BatchConsumeClientDiagnostics(
+            clientId,
+            channelId,
+            channelData.getUnackedMessageCount(),
+            channelData.getUnackedHandleCount(),
+            channelData.getTotalRenewTimes(),
+            channelData.getTotalRenewRetryTimes(),
+            channelData.getExpiredHandleCount(),
+            channelData.getTopicDistribution(),
+            consumeType,
+            messageModel,
+            receiveBatchSize,
+            longPollingTimeoutMs,
+            lastRttMs,
+            connectTime
+        );
+    }
+
+    /**
+     * Recalculate the group summary from the enriched (and possibly filtered) diagnostics list.
+     * This is necessary because:
+     * 1. The raw summary from ReceiptHandleManager covers ALL channels in the group
+     * 2. We may have filtered by clientId, reducing the set
+     * 3. Some channels may have been removed (not found in GrpcChannelManager)
+     *
+     * @param group      consumer group name
+     * @param diagnostics enriched and filtered diagnostics list
+     * @return recalculated group summary
+     */
+    private BatchConsumeGroupSummary recalculateSummary(String group, List<BatchConsumeClientDiagnostics> diagnostics) {
+        int totalClients = diagnostics.size();
+        int totalUnackedMessages = 0;
+        int totalUnackedHandles = 0;
+        int totalExpiredHandles = 0;
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+
+        for (BatchConsumeClientDiagnostics diag : diagnostics) {
+            totalUnackedMessages += diag.getUnackedMessageCount();
+            totalUnackedHandles += diag.getUnackedHandleCount();
+            totalExpiredHandles += diag.getExpiredHandleCount();
+            totalRenewTimes += diag.getTotalRenewTimes();
+            totalRenewRetryTimes += diag.getTotalRenewRetryTimes();
+        }
+
+        return new BatchConsumeGroupSummary(group, totalClients, totalUnackedMessages,
+            totalUnackedHandles, totalExpiredHandles, totalRenewTimes, totalRenewRetryTimes);
+    }
+
+    // ==================== Inner Classes ====================
+
+    /**
+     * Heartbeat record for tracking client heartbeat history.
+     */
+    private static class HeartbeatRecord {
+        final String clientId;
+        final long timestamp;
+        final boolean success;
+
+        HeartbeatRecord(String clientId, long timestamp, boolean success) {
+            this.clientId = clientId;
+            this.timestamp = timestamp;
+            this.success = success;
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/ProxyAdminClientService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/ProxyAdminClientService.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.admin;
+
+import java.util.List;
+import org.apache.rocketmq.proxy.common.BatchConsumeClientDiagnostics;
+import org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientInstanceInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientDetailInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ListClientsFilter;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager.PopReceiptHandleDiagnosticResult;
+
+/**
+ * Proxy Admin Client Service interface.
+ * Provides online client query capabilities for the Proxy Admin interface.
+ * <p>
+ * This is the core service layer for RIP-2 M1 (Online Client Query).
+ * All data comes from the internal ClientManager module.
+ */
+public interface ProxyAdminClientService {
+
+    /**
+     * List online gRPC clients with filtering and pagination.
+     * Supports filter pushdown to avoid full memory traversal.
+     *
+     * @param filter  filter criteria including group, topic, clientIdPrefix, language, time range
+     * @param pageNum page number starting from 1
+     * @param pageSize page size, max 100
+     * @return paginated list of client instances
+     */
+    ListClientsResult listClients(ListClientsFilter filter, int pageNum, int pageSize);
+
+    /**
+     * Describe a single client's detailed information.
+     * Returns the complete Telemetry view and diagnostic info.
+     *
+     * @param clientId the unique client identifier
+     * @return detailed client information
+     */
+    ClientDetailInfo describeClient(String clientId);
+
+    /**
+     * List online clients by consumer group.
+     * High-frequency shortcut interface for operations.
+     *
+     * @param group    consumer group name
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return paginated list of client instances in the group
+     */
+    ListClientsResult listClientsByGroup(String group, int pageNum, int pageSize);
+
+    /**
+     * List online clients by topic.
+     * High-frequency shortcut interface for operations.
+     *
+     * @param topic    topic name
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return paginated list of client instances associated with the topic
+     */
+    ListClientsResult listClientsByTopic(String topic, int pageNum, int pageSize);
+
+    /**
+     * Record a heartbeat event for a client.
+     * Called by the telemetry processing pipeline when a heartbeat is received.
+     * This enables real heartbeat history tracking (RIP-2 §5.2.2).
+     *
+     * @param clientId the client identifier
+     */
+    void recordHeartbeat(String clientId);
+
+    /**
+     * Force disconnect a specific client connection.
+     * Closes the gRPC telemetry stream, removes the channel and settings,
+     * triggering client reconnection and consumer group rebalance.
+     * <p>
+     * Use cases:
+     * - Malicious client detection and isolation
+     * - Stuck consumer triggering rebalance
+     * - Zombie connection cleanup
+     *
+     * @param clientId the unique client identifier to disconnect
+     * @param reason   human-readable reason for audit logging
+     * @return true if the client was found and disconnected, false if not found
+     */
+    boolean forceDisconnectClient(String clientId, String reason);
+
+    /**
+     * Query POP receipt handles for diagnostics.
+     * <p>
+     * Provides diagnostic information for POP consumption mode, including:
+     * - Unacked message receipt handles with renewal statistics
+     * - Messages with expired invisible time (about to be redelivered)
+     * - Frequent ChangeInvisibleTime (renewal) patterns
+     * - Consumption timeout detection
+     * <p>
+     * This is the core service method for RIP-2 M3 (POP Diagnostics).
+     *
+     * @param group    consumer group name (required)
+     * @param topic    optional topic filter, null or empty means no filter
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return diagnostic result containing summary and paginated handle details
+     */
+    PopReceiptHandleDiagnosticResult describePopReceiptHandles(String group, String topic, int pageNum, int pageSize);
+
+    /**
+     * Query batch consumption diagnostics, aggregated per client.
+     * <p>
+     * Provides diagnostic information for batch consumption mode, including:
+     * - Per-client unacked message counts and handle counts
+     * - Clients with expired handles (messages about to be redelivered)
+     * - Renewal patterns per client (ChangeInvisibleTime frequency)
+     * - Topic distribution of unacked messages per client
+     * - Client configuration correlation (receiveBatchSize, longPollingTimeout)
+     * <p>
+     * This is the core service method for RIP-2 M4 (Batch Consume Diagnostics).
+     *
+     * @param group    consumer group name (required)
+     * @param topic    optional topic filter, null or empty means no filter
+     * @param clientId optional client ID filter for exact match
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return diagnostic result containing summary and paginated per-client diagnostics
+     */
+    BatchConsumeDiagnosticResult describeBatchConsumeDiagnostics(String group, String topic, String clientId, int pageNum, int pageSize);
+
+    /**
+     * Result of batch consumption diagnostic query.
+     */
+    class BatchConsumeDiagnosticResult {
+        private final BatchConsumeGroupSummary summary;
+        private final List<BatchConsumeClientDiagnostics> diagnostics;
+        private final long total;
+        private final int pageNum;
+        private final int pageSize;
+
+        public BatchConsumeDiagnosticResult(BatchConsumeGroupSummary summary,
+            List<BatchConsumeClientDiagnostics> diagnostics, long total, int pageNum, int pageSize) {
+            this.summary = summary;
+            this.diagnostics = diagnostics;
+            this.total = total;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+        }
+
+        public BatchConsumeGroupSummary getSummary() { return summary; }
+        public List<BatchConsumeClientDiagnostics> getDiagnostics() { return diagnostics; }
+        public long getTotal() { return total; }
+        public int getPageNum() { return pageNum; }
+        public int getPageSize() { return pageSize; }
+    }
+
+    /**
+     * Result of list clients query with pagination info.
+     */
+    class ListClientsResult {
+        private final long total;
+        private final int pageNum;
+        private final int pageSize;
+        private final List<ClientInstanceInfo> list;
+
+        public ListClientsResult(long total, int pageNum, int pageSize, List<ClientInstanceInfo> list) {
+            this.total = total;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+            this.list = list;
+        }
+
+        public long getTotal() {
+            return total;
+        }
+
+        public int getPageNum() {
+            return pageNum;
+        }
+
+        public int getPageSize() {
+            return pageSize;
+        }
+
+        public List<ClientInstanceInfo> getList() {
+            return list;
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
@@ -204,6 +204,10 @@ public class SimpleChannel extends AbstractChannel {
         return localAddress;
     }
 
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
     public ChannelHandlerContext getChannelHandlerContext() {
         return channelHandlerContext;
     }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -19,6 +19,9 @@ package org.apache.rocketmq.proxy.service.receipt;
 
 import com.google.common.base.Stopwatch;
 import io.netty.channel.Channel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +48,10 @@ import org.apache.rocketmq.common.utils.StartAndShutdown;
 import org.apache.rocketmq.common.utils.ThreadUtils;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary;
 import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleGroupSummary;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleInfo;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.common.ProxyException;
 import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
@@ -302,5 +308,215 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
 
     protected ProxyContext createContext(String actionName) {
         return ProxyContext.createForInner(this.getClass().getSimpleName() + actionName);
+    }
+
+    /**
+     * Query POP receipt handles for diagnostics.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group name,
+     * collects diagnostic information for each unacked message handle,
+     * and returns a summary with paginated handle details.
+     * <p>
+     * This method is thread-safe: it iterates over the ConcurrentHashMap without
+     * locking, providing a weakly consistent snapshot of the current state.
+     */
+    @Override
+    public PopReceiptHandleDiagnosticResult describePopReceiptHandles(String group, String topic, int pageNum, int pageSize) {
+        List<PopReceiptHandleInfo> allHandles = new ArrayList<>();
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+        int expiredHandles = 0;
+        int totalHandleCount = 0;
+        int totalMessageCount = 0;
+
+        long currentTime = System.currentTimeMillis();
+
+        // Scan all receipt handle groups matching the group name
+        for (Map.Entry<ReceiptHandleGroupKey, ReceiptHandleGroup> entry : receiptHandleGroupMap.entrySet()) {
+            ReceiptHandleGroupKey key = entry.getKey();
+            if (!key.getGroup().equals(group)) {
+                continue;
+            }
+
+            ReceiptHandleGroup handleGroup = entry.getValue();
+            totalHandleCount += (int) handleGroup.getHandleNum();
+            totalMessageCount += handleGroup.getMsgCount();
+
+            // Scan handles in this group
+            handleGroup.scan((msgID, handleStr, messageReceiptHandle) -> {
+                // Apply topic filter if specified
+                if (topic != null && !topic.isEmpty() && !topic.equals(messageReceiptHandle.getTopic())) {
+                    return;
+                }
+
+                // Decode receipt handle to get invisible time info
+                ReceiptHandle receiptHandle = ReceiptHandle.decode(messageReceiptHandle.getReceiptHandleStr());
+                boolean isExpired = receiptHandle.getNextVisibleTime() <= currentTime;
+
+                PopReceiptHandleInfo info = new PopReceiptHandleInfo(
+                    messageReceiptHandle.getGroup(),
+                    messageReceiptHandle.getTopic(),
+                    messageReceiptHandle.getQueueId(),
+                    messageReceiptHandle.getMessageId(),
+                    messageReceiptHandle.getQueueOffset(),
+                    messageReceiptHandle.getReconsumeTimes(),
+                    messageReceiptHandle.getRenewTimes(),
+                    messageReceiptHandle.getRenewRetryTimes(),
+                    messageReceiptHandle.getConsumeTimestamp(),
+                    messageReceiptHandle.getReceiptHandleStr(),
+                    receiptHandle.getNextVisibleTime(),
+                    receiptHandle.getInvisibleTime(),
+                    receiptHandle.getBrokerName(),
+                    isExpired
+                );
+                allHandles.add(info);
+            });
+        }
+
+        // Aggregate summary statistics
+        for (PopReceiptHandleInfo info : allHandles) {
+            totalRenewTimes += info.getRenewTimes();
+            totalRenewRetryTimes += info.getRenewRetryTimes();
+            if (info.isExpired()) {
+                expiredHandles++;
+            }
+        }
+
+        PopReceiptHandleGroupSummary summary = new PopReceiptHandleGroupSummary(
+            group, totalHandleCount, totalMessageCount,
+            totalRenewTimes, totalRenewRetryTimes, expiredHandles
+        );
+
+        // Apply pagination
+        long total = allHandles.size();
+        int fromIndex = (pageNum - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, allHandles.size());
+        List<PopReceiptHandleInfo> pagedHandles;
+        if (fromIndex >= allHandles.size()) {
+            pagedHandles = new ArrayList<>();
+        } else {
+            pagedHandles = allHandles.subList(fromIndex, toIndex);
+        }
+
+        return new PopReceiptHandleDiagnosticResult(summary, pagedHandles, total, pageNum, pageSize);
+    }
+
+    /**
+     * Query batch consumption diagnostics, aggregated per client channel.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group,
+     * aggregates unacked message statistics per Channel, and returns
+     * a summary with paginated per-channel diagnostic data.
+     * <p>
+     * This method is thread-safe: it iterates over the ConcurrentHashMap without
+     * locking, providing a weakly consistent snapshot of the current state.
+     */
+    @Override
+    public BatchConsumeDiagnosticResult describeBatchConsumeDiagnostics(String group, String topic, int pageNum, int pageSize) {
+        long currentTime = System.currentTimeMillis();
+
+        // Aggregate per-channel data: Channel -> aggregated stats
+        Map<Channel, ChannelAggregator> channelAggregators = new HashMap<>();
+
+        // Scan all receipt handle groups matching the group name
+        for (Map.Entry<ReceiptHandleGroupKey, ReceiptHandleGroup> entry : receiptHandleGroupMap.entrySet()) {
+            ReceiptHandleGroupKey key = entry.getKey();
+            if (!key.getGroup().equals(group)) {
+                continue;
+            }
+
+            Channel channel = key.getChannel();
+            ReceiptHandleGroup handleGroup = entry.getValue();
+            ChannelAggregator aggregator = channelAggregators.computeIfAbsent(channel, ChannelAggregator::new);
+
+            // Scan handles in this group
+            handleGroup.scan((msgID, handleStr, messageReceiptHandle) -> {
+                // Apply topic filter if specified
+                if (topic != null && !topic.isEmpty() && !topic.equals(messageReceiptHandle.getTopic())) {
+                    return;
+                }
+
+                // Decode receipt handle to check expiration
+                ReceiptHandle receiptHandle = ReceiptHandle.decode(messageReceiptHandle.getReceiptHandleStr());
+                boolean isExpired = receiptHandle.getNextVisibleTime() <= currentTime;
+
+                aggregator.unackedMessageCount++;
+                aggregator.totalRenewTimes += messageReceiptHandle.getRenewTimes();
+                aggregator.totalRenewRetryTimes += messageReceiptHandle.getRenewRetryTimes();
+                if (isExpired) {
+                    aggregator.expiredHandleCount++;
+                }
+                aggregator.topicDistribution.merge(messageReceiptHandle.getTopic(), 1, Integer::sum);
+            });
+
+            // Handle count is per-group (one ReceiptHandleGroup per Channel+group key)
+            aggregator.unackedHandleCount += (int) handleGroup.getHandleNum();
+        }
+
+        // Build per-channel data list
+        List<ChannelBatchConsumeData> allChannelData = new ArrayList<>();
+        int totalUnackedMessages = 0;
+        int totalUnackedHandles = 0;
+        int totalExpiredHandles = 0;
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+
+        for (ChannelAggregator aggregator : channelAggregators.values()) {
+            // Skip channels with no unacked messages (after topic filter)
+            if (aggregator.unackedMessageCount == 0) {
+                continue;
+            }
+
+            allChannelData.add(new ChannelBatchConsumeData(
+                aggregator.channel,
+                aggregator.unackedMessageCount,
+                aggregator.unackedHandleCount,
+                aggregator.totalRenewTimes,
+                aggregator.totalRenewRetryTimes,
+                aggregator.expiredHandleCount,
+                new HashMap<>(aggregator.topicDistribution)
+            ));
+
+            totalUnackedMessages += aggregator.unackedMessageCount;
+            totalUnackedHandles += aggregator.unackedHandleCount;
+            totalExpiredHandles += aggregator.expiredHandleCount;
+            totalRenewTimes += aggregator.totalRenewTimes;
+            totalRenewRetryTimes += aggregator.totalRenewRetryTimes;
+        }
+
+        BatchConsumeGroupSummary summary = new BatchConsumeGroupSummary(
+            group, allChannelData.size(), totalUnackedMessages,
+            totalUnackedHandles, totalExpiredHandles, totalRenewTimes, totalRenewRetryTimes
+        );
+
+        // Apply pagination
+        long total = allChannelData.size();
+        int fromIndex = (pageNum - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, allChannelData.size());
+        List<ChannelBatchConsumeData> pagedData;
+        if (fromIndex >= allChannelData.size()) {
+            pagedData = new ArrayList<>();
+        } else {
+            pagedData = allChannelData.subList(fromIndex, toIndex);
+        }
+
+        return new BatchConsumeDiagnosticResult(summary, pagedData, total, pageNum, pageSize);
+    }
+
+    /**
+     * Internal aggregator for per-channel statistics during batch diagnostics scan.
+     */
+    private static class ChannelAggregator {
+        final Channel channel;
+        int unackedMessageCount = 0;
+        int unackedHandleCount = 0;
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+        int expiredHandleCount = 0;
+        final Map<String, Integer> topicDistribution = new HashMap<>();
+
+        ChannelAggregator(Channel channel) {
+            this.channel = channel;
+        }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/ReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/ReceiptHandleManager.java
@@ -18,7 +18,12 @@
 package org.apache.rocketmq.proxy.service.receipt;
 
 import io.netty.channel.Channel;
+import java.util.List;
+import java.util.Map;
+import org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary;
 import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleInfo;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleGroupSummary;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 
 public interface ReceiptHandleManager {
@@ -27,4 +32,139 @@ public interface ReceiptHandleManager {
     MessageReceiptHandle removeReceiptHandle(ProxyContext context, Channel channel, String group, String msgID, String receiptHandle);
 
     int getUnackedMessageCount(ProxyContext context, Channel channel, String group);
+
+    /**
+     * Query POP receipt handles for diagnostics.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group,
+     * collects diagnostic information for each unacked message handle,
+     * and returns a summary with paginated handle details.
+     *
+     * @param group    consumer group name (required)
+     * @param topic    optional topic filter, null or empty means no filter
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return diagnostic result containing summary and paginated handle details
+     */
+    PopReceiptHandleDiagnosticResult describePopReceiptHandles(String group, String topic, int pageNum, int pageSize);
+
+    /**
+     * Result of POP receipt handle diagnostic query.
+     */
+    class PopReceiptHandleDiagnosticResult {
+        private final PopReceiptHandleGroupSummary summary;
+        private final List<PopReceiptHandleInfo> handles;
+        private final long total;
+        private final int pageNum;
+        private final int pageSize;
+
+        public PopReceiptHandleDiagnosticResult(PopReceiptHandleGroupSummary summary, List<PopReceiptHandleInfo> handles,
+            long total, int pageNum, int pageSize) {
+            this.summary = summary;
+            this.handles = handles;
+            this.total = total;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+        }
+
+        public PopReceiptHandleGroupSummary getSummary() {
+            return summary;
+        }
+
+        public List<PopReceiptHandleInfo> getHandles() {
+            return handles;
+        }
+
+        public long getTotal() {
+            return total;
+        }
+
+        public int getPageNum() {
+            return pageNum;
+        }
+
+        public int getPageSize() {
+            return pageSize;
+        }
+    }
+
+    /**
+     * Query batch consumption diagnostics, aggregated per client channel.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group,
+     * aggregates unacked message statistics per Channel, and returns
+     * a summary with paginated per-client diagnostic details.
+     * <p>
+     * This method only returns raw data from ReceiptHandleManager.
+     * The caller (DefaultProxyAdminClientService) is responsible for
+     * enriching with GrpcChannelManager/GrpcClientSettingsManager data.
+     *
+     * @param group    consumer group name (required)
+     * @param topic    optional topic filter, null or empty means no filter
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return diagnostic result containing summary and paginated per-channel diagnostics
+     */
+    BatchConsumeDiagnosticResult describeBatchConsumeDiagnostics(String group, String topic, int pageNum, int pageSize);
+
+    /**
+     * Per-channel raw data for batch consumption diagnostics.
+     * Used internally to transfer data from ReceiptHandleManager to DefaultProxyAdminClientService
+     * for enrichment with gRPC channel/settings data.
+     */
+    class ChannelBatchConsumeData {
+        private final Channel channel;
+        private final int unackedMessageCount;
+        private final int unackedHandleCount;
+        private final long totalRenewTimes;
+        private final long totalRenewRetryTimes;
+        private final int expiredHandleCount;
+        private final Map<String, Integer> topicDistribution;
+
+        public ChannelBatchConsumeData(Channel channel, int unackedMessageCount, int unackedHandleCount,
+            long totalRenewTimes, long totalRenewRetryTimes, int expiredHandleCount,
+            Map<String, Integer> topicDistribution) {
+            this.channel = channel;
+            this.unackedMessageCount = unackedMessageCount;
+            this.unackedHandleCount = unackedHandleCount;
+            this.totalRenewTimes = totalRenewTimes;
+            this.totalRenewRetryTimes = totalRenewRetryTimes;
+            this.expiredHandleCount = expiredHandleCount;
+            this.topicDistribution = topicDistribution;
+        }
+
+        public Channel getChannel() { return channel; }
+        public int getUnackedMessageCount() { return unackedMessageCount; }
+        public int getUnackedHandleCount() { return unackedHandleCount; }
+        public long getTotalRenewTimes() { return totalRenewTimes; }
+        public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+        public int getExpiredHandleCount() { return expiredHandleCount; }
+        public Map<String, Integer> getTopicDistribution() { return topicDistribution; }
+    }
+
+    /**
+     * Result of batch consumption diagnostic query.
+     */
+    class BatchConsumeDiagnosticResult {
+        private final BatchConsumeGroupSummary summary;
+        private final List<ChannelBatchConsumeData> channelData;
+        private final long total;
+        private final int pageNum;
+        private final int pageSize;
+
+        public BatchConsumeDiagnosticResult(BatchConsumeGroupSummary summary,
+            List<ChannelBatchConsumeData> channelData, long total, int pageNum, int pageSize) {
+            this.summary = summary;
+            this.channelData = channelData;
+            this.total = total;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+        }
+
+        public BatchConsumeGroupSummary getSummary() { return summary; }
+        public List<ChannelBatchConsumeData> getChannelData() { return channelData; }
+        public long getTotal() { return total; }
+        public int getPageNum() { return pageNum; }
+        public int getPageSize() { return pageSize; }
+    }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/TopicRouteService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/TopicRouteService.java
@@ -23,9 +23,12 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
@@ -51,11 +54,28 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public abstract class TopicRouteService extends AbstractStartAndShutdown {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
+    /**
+     * Listener interface for route refresh events.
+     * Implementations are notified when the Caffeine cache reloads route data for a topic,
+     * enabling detection and propagation of route changes (broker online/offline, queue scaling, etc.).
+     */
+    public interface RouteRefreshListener {
+        /**
+         * Called when a topic's route data has been refreshed in the cache.
+         *
+         * @param topic the topic whose route was refreshed
+         * @param oldView the previous MessageQueueView (may be null if not previously cached)
+         * @param newView the new MessageQueueView (may be WRAPPED_EMPTY_QUEUE if topic was deleted)
+         */
+        void onRouteRefreshed(String topic, MessageQueueView oldView, MessageQueueView newView);
+    }
+
     private final MQFaultStrategy mqFaultStrategy;
     protected final LoadingCache<String /* topicName */, MessageQueueView> topicCache;
     protected final ThreadPoolExecutor cacheRefreshExecutor;
     protected final List<MessageQueuePenalizer<AddressableMessageQueue>> penalizers = new ArrayList<>();
     protected MessageQueuePriorityProvider<AddressableMessageQueue> priorityProvider = new DefaultMessageQueuePriorityProvider();
+    protected final CopyOnWriteArrayList<RouteRefreshListener> routeRefreshListeners = new CopyOnWriteArrayList<>();
 
     public TopicRouteService(MQClientAPIFactory mqClientAPIFactory) {
         ProxyConfig config = ConfigurationManager.getProxyConfig();
@@ -91,7 +111,18 @@ public abstract class TopicRouteService extends AbstractStartAndShutdown {
                 public @Nullable MessageQueueView reload(@NonNull String key,
                     @NonNull MessageQueueView oldValue) throws Exception {
                     try {
-                        return load(key);
+                        MessageQueueView newValue = load(key);
+                        // Notify route refresh listeners if the new value differs from old
+                        if (!routeRefreshListeners.isEmpty()) {
+                            for (RouteRefreshListener listener : routeRefreshListeners) {
+                                try {
+                                    listener.onRouteRefreshed(key, oldValue, newValue);
+                                } catch (Exception e) {
+                                    log.warn("Route refresh listener error for topic {}: {}", key, e.getMessage());
+                                }
+                            }
+                        }
+                        return newValue;
                     } catch (Exception e) {
                         log.warn(String.format("reload topic route from namesrv. topic: %s", key), e);
                         return oldValue;
@@ -213,6 +244,47 @@ public abstract class TopicRouteService extends AbstractStartAndShutdown {
 
     public void addPenalizer(MessageQueuePenalizer<AddressableMessageQueue> penalizer) {
         this.penalizers.add(penalizer);
+    }
+
+    /**
+     * Add a route refresh listener that will be notified when route data is refreshed in the cache.
+     *
+     * @param listener the listener to add
+     */
+    public void addRouteRefreshListener(RouteRefreshListener listener) {
+        this.routeRefreshListeners.add(listener);
+    }
+
+    /**
+     * Get all topic names currently in the route cache.
+     * Topics with empty route data (WRAPPED_EMPTY_QUEUE) are excluded.
+     *
+     * @return set of topic names with valid route data
+     */
+    public Set<String> getAllTopicNames() {
+        Set<String> result = new java.util.HashSet<>();
+        for (Map.Entry<String, MessageQueueView> entry : topicCache.asMap().entrySet()) {
+            MessageQueueView view = entry.getValue();
+            if (view != null && !view.isEmptyCachedQueue()) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get cached MessageQueueView for a topic without triggering a cache load.
+     * Returns null if the topic is not in the cache.
+     *
+     * @param topic the topic name
+     * @return the cached MessageQueueView, or null if not cached
+     */
+    public MessageQueueView getCachedTopicRouteData(String topic) {
+        MessageQueueView view = topicCache.getIfPresent(topic);
+        if (view != null && !view.isEmptyCachedQueue()) {
+            return view;
+        }
+        return null;
     }
 
     @VisibleForTesting

--- a/proxy/src/main/proto/proxy_admin.proto
+++ b/proxy/src/main/proto/proxy_admin.proto
@@ -1,0 +1,606 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package apache.rocketmq.proxy.admin.v1;
+
+option java_multiple_files = true;
+option java_package = "apache.rocketmq.proxy.admin.v1";
+option java_outer_classname = "ProxyAdminProto";
+
+// Client language enum
+enum ClientLanguage {
+  CLIENT_LANGUAGE_UNSPECIFIED = 0;
+  CLIENT_LANGUAGE_JAVA = 1;
+  CLIENT_LANGUAGE_GOLANG = 2;
+  CLIENT_LANGUAGE_CPP = 3;
+  CLIENT_LANGUAGE_RUST = 4;
+  CLIENT_LANGUAGE_PYTHON = 5;
+  CLIENT_LANGUAGE_NODEJS = 6;
+  CLIENT_LANGUAGE_CSHARP = 7;
+  CLIENT_LANGUAGE_PHP = 8;
+}
+
+// Client protocol enum
+enum ClientProtocol {
+  CLIENT_PROTOCOL_UNSPECIFIED = 0;
+  CLIENT_PROTOCOL_GRPC = 1;
+  CLIENT_PROTOCOL_REMOTING = 2;
+}
+
+// Client role enum
+enum ClientRole {
+  CLIENT_ROLE_UNSPECIFIED = 0;
+  CLIENT_ROLE_PRODUCER = 1;
+  CLIENT_ROLE_PUSH_CONSUMER = 2;
+  CLIENT_ROLE_SIMPLE_CONSUMER = 3;
+}
+
+// Status code for admin responses
+enum AdminCode {
+  ADMIN_CODE_UNSPECIFIED = 0;
+  ADMIN_CODE_OK = 1;
+  ADMIN_CODE_INTERNAL_ERROR = 2;
+  ADMIN_CODE_BAD_REQUEST = 3;
+  ADMIN_CODE_UNAUTHORIZED = 4;
+  ADMIN_CODE_FORBIDDEN = 5;
+  ADMIN_CODE_NOT_FOUND = 6;
+  ADMIN_CODE_TOO_MANY_REQUESTS = 7;
+}
+
+// Client instance basic information
+message ClientInstance {
+  string client_id = 1;
+  ClientLanguage language = 2;
+  string client_version = 3;
+  ClientProtocol protocol = 4;
+  string access_point = 5;
+  int64 connect_at = 6;
+  int64 last_active_at = 7;
+  ClientRole role = 8;
+  string group = 9;
+  repeated string topics = 10;
+}
+
+// Client detail information (extends ClientInstance)
+message ClientDetail {
+  ClientInstance client_instance = 1;
+  ClientSettings settings = 2;
+  repeated HeartbeatRecord heartbeat_history = 3;
+  AuthStatus auth_status = 4;
+  ConsumeProgress consume_progress = 5;
+  NetworkInfo network_info = 6;
+}
+
+// Client settings
+message ClientSettings {
+  string subscription_mode = 1;
+  int32 receive_batch_size = 2;
+  int64 long_polling_timeout_ms = 3;
+  bool fifo = 4;
+  repeated string subscription_topics = 5;
+  repeated string publishing_topics = 6;
+}
+
+// Heartbeat record
+message HeartbeatRecord {
+  int64 timestamp = 1;
+  bool success = 2;
+  string remark = 3;
+}
+
+// Auth status
+message AuthStatus {
+  bool authenticated = 1;
+  string username = 2;
+  int64 last_auth_time = 3;
+  string failure_reason = 4;
+}
+
+// Consume progress
+message ConsumeProgress {
+  int64 lag = 1;
+  int64 latency_ms = 2;
+  repeated TopicConsumeProgress topic_progress = 3;
+}
+
+// Topic consume progress
+message TopicConsumeProgress {
+  string topic = 1;
+  int64 lag = 2;
+  int64 latency_ms = 3;
+}
+
+// Network info
+message NetworkInfo {
+  string local_address = 1;
+  string remote_address = 2;
+  int64 rtt_ms = 3;
+  string ssl_enabled = 4;
+}
+
+// Pagination metadata
+message Pagination {
+  int64 total = 1;
+  int32 page_num = 2;
+  int32 page_size = 3;
+}
+
+// ListClients request
+message ListClientsRequest {
+  string group = 1;
+  string topic = 2;
+  string client_id_prefix = 3;
+  ClientLanguage language = 4;
+  int64 connect_time_start = 5;
+  int64 connect_time_end = 6;
+  int32 page_num = 7;
+  int32 page_size = 8;
+}
+
+// ListClients response
+message ListClientsResponse {
+  AdminCode code = 1;
+  string message = 2;
+  Pagination pagination = 3;
+  repeated ClientInstance list = 4;
+}
+
+// DescribeClient request
+message DescribeClientRequest {
+  string client_id = 1;
+}
+
+// DescribeClient response
+message DescribeClientResponse {
+  AdminCode code = 1;
+  string message = 2;
+  ClientDetail client_detail = 3;
+}
+
+// ListClientsByGroup request
+message ListClientsByGroupRequest {
+  string group = 1;
+  int32 page_num = 2;
+  int32 page_size = 3;
+}
+
+// ListClientsByGroup response
+message ListClientsByGroupResponse {
+  AdminCode code = 1;
+  string message = 2;
+  Pagination pagination = 3;
+  repeated ClientInstance list = 4;
+}
+
+// ListClientsByTopic request
+message ListClientsByTopicRequest {
+  string topic = 1;
+  int32 page_num = 2;
+  int32 page_size = 3;
+}
+
+// ListClientsByTopic response
+message ListClientsByTopicResponse {
+  AdminCode code = 1;
+  string message = 2;
+  Pagination pagination = 3;
+  repeated ClientInstance list = 4;
+}
+
+// GetConfig request - no parameters needed, returns current runtime config
+message GetConfigRequest {
+}
+
+// Proxy runtime configuration snapshot
+message ProxyRuntimeConfig {
+  // Basic info
+  string proxy_mode = 1;
+  string rocketmq_cluster_name = 2;
+  string proxy_cluster_name = 3;
+  string proxy_name = 4;
+  string local_serve_addr = 5;
+  string namesrv_addr = 6;
+
+  // gRPC data plane
+  int32 grpc_server_port = 10;
+  int32 grpc_boss_loop_num = 11;
+  int32 grpc_worker_loop_num = 12;
+  int32 grpc_thread_pool_nums = 13;
+  int32 grpc_thread_pool_queue_capacity = 14;
+  int32 grpc_max_inbound_message_size = 15;
+  int32 grpc_max_concurrent_calls_per_connection = 16;
+
+  // Admin interface
+  bool proxy_admin_enabled = 20;
+  int32 proxy_admin_server_port = 21;
+  int32 proxy_admin_thread_pool_nums = 22;
+  int32 proxy_admin_max_page_size = 23;
+  int32 proxy_admin_describe_client_concurrency_limit = 24;
+  double proxy_admin_sampling_rate_under_load = 25;
+  int32 proxy_admin_heartbeat_history_size = 26;
+  int64 proxy_admin_sampling_threshold = 27;
+
+  // Thread pools - gRPC activities
+  int32 grpc_producer_thread_pool_nums = 30;
+  int32 grpc_producer_thread_queue_capacity = 31;
+  int32 grpc_consumer_thread_pool_nums = 32;
+  int32 grpc_consumer_thread_queue_capacity = 33;
+  int32 grpc_route_thread_pool_nums = 34;
+  int32 grpc_route_thread_queue_capacity = 35;
+  int32 grpc_client_manager_thread_pool_nums = 36;
+  int32 grpc_client_manager_thread_queue_capacity = 37;
+  int32 grpc_transaction_thread_pool_nums = 38;
+  int32 grpc_transaction_thread_queue_capacity = 39;
+
+  // Thread pools - remoting
+  int32 remoting_heartbeat_thread_pool_nums = 40;
+  int32 remoting_send_message_thread_pool_nums = 41;
+  int32 remoting_pull_message_thread_pool_nums = 42;
+
+  // Message limits
+  int32 max_message_size = 50;
+  int32 max_user_property_size = 51;
+  int32 user_property_max_num = 52;
+  int32 max_message_group_size = 53;
+
+  // Timeout and polling
+  int64 default_invisible_time_mills = 60;
+  int64 max_invisible_time_mills = 61;
+  int64 min_invisible_time_mills_for_recv = 62;
+  int64 max_delay_time_mills = 63;
+  int64 grpc_client_consumer_min_long_polling_timeout_millis = 64;
+  int64 grpc_client_consumer_max_long_polling_timeout_millis = 65;
+  int32 grpc_client_consumer_long_polling_batch_size = 66;
+  int32 grpc_client_producer_max_attempts = 67;
+  int64 grpc_client_producer_backoff_initial_millis = 68;
+  int64 grpc_client_producer_backoff_max_millis = 69;
+  int32 grpc_client_producer_backoff_multiplier = 70;
+
+  // Cache
+  int32 topic_route_service_cache_expired_seconds = 80;
+  int32 topic_route_service_cache_refresh_seconds = 81;
+  int32 topic_route_service_cache_max_num = 82;
+
+  // TLS
+  bool tls_test_mode_enable = 90;
+  string tls_key_path = 91;
+  string tls_cert_path = 92;
+
+  // Metrics
+  string metrics_exporter_type = 100;
+  int32 metrics_prom_exporter_port = 101;
+  bool trace_on = 102;
+}
+
+// GetConfig response
+message GetConfigResponse {
+  AdminCode code = 1;
+  string message = 2;
+  ProxyRuntimeConfig config = 3;
+}
+
+// UpdateConfig request - send the desired config state.
+// The server compares each field with the current config and applies only changed fields.
+// Note: Due to proto3 default value semantics:
+//   - Numeric fields set to 0, string fields set to "" will be treated as "not set" and NOT updated.
+//   - Boolean fields can only be toggled ON (false→true), not OFF (true→false).
+// To reset fields to their defaults, modify the config file (rmq-proxy.json) directly.
+message UpdateConfigRequest {
+  ProxyRuntimeConfig config = 1;
+}
+
+// UpdateConfig response
+message UpdateConfigResponse {
+  AdminCode code = 1;
+  string message = 2;
+  ProxyRuntimeConfig config = 3;
+  // List of field names (snake_case) that were actually changed
+  repeated string changed_fields = 4;
+}
+
+// DisconnectClient request - force disconnect a specific client connection
+// Use cases:
+//   - Malicious client detection and isolation
+//   - Stuck consumer triggering rebalance
+//   - Zombie connection cleanup
+message DisconnectClientRequest {
+  // The unique client identifier to disconnect (required)
+  string client_id = 1;
+  // Human-readable reason for the forced disconnection, used for audit logging (required)
+  string reason = 2;
+}
+
+// DisconnectClient response
+message DisconnectClientResponse {
+  AdminCode code = 1;
+  string message = 2;
+  // Whether the client was found and successfully disconnected
+  bool disconnected = 3;
+}
+
+// POP receipt handle diagnostic info for a single unacked message
+message PopReceiptHandleInfo {
+  // Consumer group name
+  string group = 1;
+  // Topic name
+  string topic = 2;
+  // Queue ID
+  int32 queue_id = 3;
+  // Message ID
+  string message_id = 4;
+  // Queue offset
+  int64 queue_offset = 5;
+  // Reconsume times (retry count)
+  int32 reconsume_times = 6;
+  // Number of successful renewals (ChangeInvisibleTime)
+  int32 renew_times = 7;
+  // Number of failed renewal attempts
+  int32 renew_retry_times = 8;
+  // Timestamp when the message was first consumed (epoch millis)
+  int64 consume_timestamp = 9;
+  // Current receipt handle string
+  string receipt_handle = 10;
+  // Next visible time for this message (epoch millis)
+  int64 next_visible_time = 11;
+  // Invisible time duration (millis)
+  int64 invisible_time = 12;
+  // Broker name where the message resides
+  string broker_name = 13;
+  // Whether the invisible time has expired (message is about to be redelivered)
+  bool is_expired = 14;
+}
+
+// POP receipt handle group summary (aggregated per consumer group)
+message PopReceiptHandleGroupSummary {
+  // Consumer group name
+  string group = 1;
+  // Total number of receipt handles (may exceed message count due to dedup)
+  int32 total_handles = 2;
+  // Total number of unique unacked messages
+  int32 total_messages = 3;
+  // Sum of renew times across all handles in this group
+  int64 total_renew_times = 4;
+  // Sum of renew retry times across all handles in this group
+  int64 total_renew_retry_times = 5;
+  // Number of handles whose invisible time has expired
+  int32 expired_handles = 6;
+}
+
+// DescribePopReceiptHandles request - query POP receipt handles for diagnostics
+// Use cases:
+//   - Diagnose messages with expired invisible time causing duplicate delivery
+//   - Investigate frequent ChangeInvisibleTime (renewal) calls
+//   - Debug consumption timeout issues in POP mode
+//   - Monitor unacked message accumulation per consumer group
+message DescribePopReceiptHandlesRequest {
+  // Consumer group name (required)
+  string group = 1;
+  // Optional topic filter - only return handles for this topic
+  string topic = 2;
+  // Pagination: page number starting from 1
+  int32 page_num = 3;
+  // Pagination: page size, max 100
+  int32 page_size = 4;
+}
+
+// DescribePopReceiptHandles response
+message DescribePopReceiptHandlesResponse {
+  AdminCode code = 1;
+  string message = 2;
+  // Group-level summary statistics
+  PopReceiptHandleGroupSummary summary = 3;
+  // Paginated list of receipt handle details
+  repeated PopReceiptHandleInfo handles = 4;
+  // Pagination metadata
+  Pagination pagination = 5;
+}
+
+// Batch consume diagnostic info for a single client (per-channel aggregation)
+// Aggregates unacked message statistics from ReceiptHandleManager for a specific client channel
+message BatchConsumeClientDiagnostics {
+  // Client identifier (from gRPC channel, empty for remoting clients)
+  string client_id = 1;
+  // Channel identifier (Netty channel ID)
+  string channel_id = 2;
+  // Number of unacked messages held by this client
+  int32 unacked_message_count = 3;
+  // Number of unacked receipt handles (may differ from message count due to dedup)
+  int32 unacked_handle_count = 4;
+  // Sum of renew times across all handles for this client
+  int64 total_renew_times = 5;
+  // Sum of renew retry times across all handles for this client
+  int64 total_renew_retry_times = 6;
+  // Number of handles whose invisible time has expired (about to be redelivered)
+  int32 expired_handle_count = 7;
+  // Distribution of unacked messages by topic (topic -> count)
+  map<string, int32> topic_distribution = 8;
+  // Consumer type: PUSH or PULL (from ConsumerManager)
+  string consume_type = 9;
+  // Message model: CLUSTERING, BROADCASTING, or LITE_SELECTIVE (from ConsumerManager)
+  string message_model = 10;
+  // Configured batch receive size (from client Settings, 0 if unavailable)
+  int32 receive_batch_size = 11;
+  // Configured long polling timeout in ms (from client Settings, 0 if unavailable)
+  int64 long_polling_timeout_ms = 12;
+  // Last measured RTT in ms (from gRPC channel, -1 if unavailable)
+  int64 last_rtt_ms = 13;
+  // Client connection time (epoch millis, 0 if unavailable)
+  int64 connect_time = 14;
+}
+
+// Batch consume group-level summary (aggregated across all clients in the group)
+message BatchConsumeGroupSummary {
+  // Consumer group name
+  string group = 1;
+  // Number of clients with unacked messages
+  int32 total_clients = 2;
+  // Total unacked messages across all clients
+  int32 total_unacked_messages = 3;
+  // Total unacked handles across all clients
+  int32 total_unacked_handles = 4;
+  // Total expired handles across all clients
+  int32 total_expired_handles = 5;
+  // Sum of renew times across all clients
+  int64 total_renew_times = 6;
+  // Sum of renew retry times across all clients
+  int64 total_renew_retry_times = 7;
+}
+
+// DescribeBatchConsumeDiagnostics request - query batch consumption diagnostics
+// Use cases:
+//   - Diagnose batch size too large causing timeout
+//   - Investigate partial message failure but entire batch retry
+//   - Monitor unacked message accumulation per client in a consumer group
+//   - Identify clients with excessive renewal or expired handles
+message DescribeBatchConsumeDiagnosticsRequest {
+  // Consumer group name (required)
+  string group = 1;
+  // Optional topic filter - only count messages for this topic
+  string topic = 2;
+  // Optional client ID filter - only return diagnostics for this client
+  string client_id = 3;
+  // Pagination: page number starting from 1
+  int32 page_num = 4;
+  // Pagination: page size, max 100
+  int32 page_size = 5;
+}
+
+// DescribeBatchConsumeDiagnostics response
+message DescribeBatchConsumeDiagnosticsResponse {
+  AdminCode code = 1;
+  string message = 2;
+  // Group-level summary statistics
+  BatchConsumeGroupSummary summary = 3;
+  // Per-client diagnostic details (paginated)
+  repeated BatchConsumeClientDiagnostics diagnostics = 4;
+  // Pagination metadata
+  Pagination pagination = 5;
+}
+
+// SubscribeRouteEvents request
+message SubscribeRouteEventsRequest {
+  // Optional: subscribe to specific topics only (empty = all topics)
+  repeated string topics = 1;
+  // Optional: subscribe to specific event types only (empty = all event types)
+  repeated RouteChangeEventType event_types = 2;
+}
+
+// SubscribeRouteEvents response (streamed)
+message SubscribeRouteEventsResponse {
+  AdminCode code = 1;
+  string message = 2;
+  RouteChangeEvent event = 3;
+}
+
+// Route change event types
+enum RouteChangeEventType {
+  ROUTE_CHANGE_EVENT_TYPE_UNSPECIFIED = 0;
+  // A broker has come online (registered with NameServer)
+  BROKER_ONLINE = 1;
+  // A broker has gone offline (unregistered from NameServer)
+  BROKER_OFFLINE = 2;
+  // Queue count changed (read or write queue nums scaled up/down)
+  QUEUE_SCALE = 3;
+  // A new topic has been created
+  TOPIC_CREATE = 4;
+  // A topic has been deleted
+  TOPIC_DELETE = 5;
+  // Full route snapshot sent on initial subscription
+  ROUTE_SNAPSHOT = 6;
+}
+
+// Route change event - represents a single route change detected by the proxy
+message RouteChangeEvent {
+  // Event type
+  RouteChangeEventType event_type = 1;
+  // Timestamp when the event was detected (epoch millis)
+  int64 timestamp = 2;
+  // Topic name (set for TOPIC_CREATE, TOPIC_DELETE, QUEUE_SCALE events)
+  string topic = 3;
+  // Broker cluster name (set for BROKER_ONLINE, BROKER_OFFLINE events)
+  string cluster = 4;
+  // Broker name (set for BROKER_ONLINE, BROKER_OFFLINE, QUEUE_SCALE events)
+  string broker_name = 5;
+  // Broker ID (set for BROKER_ONLINE, BROKER_OFFLINE events)
+  int64 broker_id = 6;
+  // Broker address (set for BROKER_ONLINE, BROKER_OFFLINE events)
+  string broker_address = 7;
+  // Previous read queue count (set for QUEUE_SCALE events)
+  int32 previous_read_queue_nums = 8;
+  // Current read queue count (set for QUEUE_SCALE events)
+  int32 current_read_queue_nums = 9;
+  // Previous write queue count (set for QUEUE_SCALE events)
+  int32 previous_write_queue_nums = 10;
+  // Current write queue count (set for QUEUE_SCALE events)
+  int32 current_write_queue_nums = 11;
+  // Full route snapshot (set only for ROUTE_SNAPSHOT events)
+  // Contains the complete current route data for the topic
+  TopicRouteSnapshot route_snapshot = 12;
+}
+
+// Topic route snapshot - complete route data for a topic at a point in time
+message TopicRouteSnapshot {
+  string topic = 1;
+  repeated BrokerInfo brokers = 2;
+  repeated QueueInfo queues = 3;
+}
+
+// Broker info in route snapshot
+message BrokerInfo {
+  string cluster = 1;
+  string broker_name = 2;
+  // Map of broker_id -> broker_address
+  map<int64, string> broker_addrs = 3;
+}
+
+// Queue info in route snapshot
+message QueueInfo {
+  string broker_name = 1;
+  int32 read_queue_nums = 2;
+  int32 write_queue_nums = 3;
+  int32 perm = 4;
+}
+
+// ProxyClientAdminService - Admin service for online client queries
+service ProxyClientAdminService {
+  // List online gRPC clients with filtering and pagination
+  rpc ListClients(ListClientsRequest) returns (ListClientsResponse) {}
+  // Describe a single client's detailed information
+  rpc DescribeClient(DescribeClientRequest) returns (DescribeClientResponse) {}
+  // List online clients by consumer group
+  rpc ListClientsByGroup(ListClientsByGroupRequest) returns (ListClientsByGroupResponse) {}
+  // List online clients by topic
+  rpc ListClientsByTopic(ListClientsByTopicRequest) returns (ListClientsByTopicResponse) {}
+  // Get current runtime configuration of the proxy
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
+  // Hot-update runtime configuration without restarting proxy
+  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse) {}
+  // Force disconnect a specific client connection
+  rpc DisconnectClient(DisconnectClientRequest) returns (DisconnectClientResponse) {}
+  // Query POP receipt handles for diagnostics (RIP-2 M3)
+  // Diagnose invisible time expiration, renewal issues, and consumption timeouts
+  rpc DescribePopReceiptHandles(DescribePopReceiptHandlesRequest) returns (DescribePopReceiptHandlesResponse) {}
+  // Query batch consumption diagnostics (RIP-2 M4)
+  // Diagnose batch size issues, partial failures, and unacked message accumulation per client
+  rpc DescribeBatchConsumeDiagnostics(DescribeBatchConsumeDiagnosticsRequest) returns (DescribeBatchConsumeDiagnosticsResponse) {}
+  // Subscribe to route change events (server-streaming RPC)
+  // Dashboard subscribes once and receives real-time route change notifications
+  // including broker online/offline, queue scaling, topic create/delete
+  rpc SubscribeRouteEvents(SubscribeRouteEventsRequest) returns (stream SubscribeRouteEventsResponse) {}
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnosticsTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnosticsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BatchConsumeClientDiagnosticsTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        Map<String, Integer> topicDistribution = new HashMap<>();
+        topicDistribution.put("topicA", 3);
+        topicDistribution.put("topicB", 7);
+
+        BatchConsumeClientDiagnostics diagnostics = new BatchConsumeClientDiagnostics(
+            "client-1", "channel-1",
+            10, 5,
+            20L, 2L, 1,
+            topicDistribution,
+            "POP", "CLUSTERING",
+            32, 30000L,
+            15L, 1000L);
+
+        assertEquals("client-1", diagnostics.getClientId());
+        assertEquals("channel-1", diagnostics.getChannelId());
+        assertEquals(10, diagnostics.getUnackedMessageCount());
+        assertEquals(5, diagnostics.getUnackedHandleCount());
+        assertEquals(20L, diagnostics.getTotalRenewTimes());
+        assertEquals(2L, diagnostics.getTotalRenewRetryTimes());
+        assertEquals(1, diagnostics.getExpiredHandleCount());
+        assertEquals(topicDistribution, diagnostics.getTopicDistribution());
+        assertEquals("POP", diagnostics.getConsumeType());
+        assertEquals("CLUSTERING", diagnostics.getMessageModel());
+        assertEquals(32, diagnostics.getReceiveBatchSize());
+        assertEquals(30000L, diagnostics.getLongPollingTimeoutMs());
+        assertEquals(15L, diagnostics.getLastRttMs());
+        assertEquals(1000L, diagnostics.getConnectTime());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummaryTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummaryTest.java
@@ -17,18 +17,23 @@
 
 package org.apache.rocketmq.proxy.common;
 
-public class ContextVariable {
-    public static final String REMOTE_ADDRESS = "remote-address";
-    public static final String LOCAL_ADDRESS = "local-address";
-    public static final String CLIENT_ID = "client-id";
-    public static final String CHANNEL = "channel";
-    public static final String LANGUAGE = "language";
-    public static final String CLIENT_VERSION = "client-version";
-    public static final String REMAINING_MS = "remaining-ms";
-    public static final String ACTION = "action";
-    public static final String PROTOCOL_TYPE = "protocol-type";
-    public static final String NAMESPACE = "namespace";
-    public static final String CLIENT_TYPE = "client-type";
-    public static final String SSL_ENABLED = "ssl-enabled";
-    public static final String AUTH_USERNAME = "auth-username";
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BatchConsumeGroupSummaryTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        BatchConsumeGroupSummary summary = new BatchConsumeGroupSummary(
+            "groupA", 3, 100, 50, 5, 200L, 10L);
+
+        assertEquals("groupA", summary.getGroup());
+        assertEquals(3, summary.getTotalClients());
+        assertEquals(100, summary.getTotalUnackedMessages());
+        assertEquals(50, summary.getTotalUnackedHandles());
+        assertEquals(5, summary.getTotalExpiredHandles());
+        assertEquals(200L, summary.getTotalRenewTimes());
+        assertEquals(10L, summary.getTotalRenewRetryTimes());
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummaryTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummaryTest.java
@@ -17,18 +17,22 @@
 
 package org.apache.rocketmq.proxy.common;
 
-public class ContextVariable {
-    public static final String REMOTE_ADDRESS = "remote-address";
-    public static final String LOCAL_ADDRESS = "local-address";
-    public static final String CLIENT_ID = "client-id";
-    public static final String CHANNEL = "channel";
-    public static final String LANGUAGE = "language";
-    public static final String CLIENT_VERSION = "client-version";
-    public static final String REMAINING_MS = "remaining-ms";
-    public static final String ACTION = "action";
-    public static final String PROTOCOL_TYPE = "protocol-type";
-    public static final String NAMESPACE = "namespace";
-    public static final String CLIENT_TYPE = "client-type";
-    public static final String SSL_ENABLED = "ssl-enabled";
-    public static final String AUTH_USERNAME = "auth-username";
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PopReceiptHandleGroupSummaryTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        PopReceiptHandleGroupSummary summary = new PopReceiptHandleGroupSummary(
+            "groupA", 50, 40, 100L, 5L, 3);
+
+        assertEquals("groupA", summary.getGroup());
+        assertEquals(50, summary.getTotalHandles());
+        assertEquals(40, summary.getTotalMessages());
+        assertEquals(100L, summary.getTotalRenewTimes());
+        assertEquals(5L, summary.getTotalRenewRetryTimes());
+        assertEquals(3, summary.getExpiredHandles());
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfoTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfoTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PopReceiptHandleInfoTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        PopReceiptHandleInfo info = new PopReceiptHandleInfo(
+            "groupA", "topicA", 2, "msg-1",
+            100L, 1, 3, 1,
+            1000L, "handle-1", 2000L,
+            60000L, "broker-a", false);
+
+        assertEquals("groupA", info.getGroup());
+        assertEquals("topicA", info.getTopic());
+        assertEquals(2, info.getQueueId());
+        assertEquals("msg-1", info.getMessageId());
+        assertEquals(100L, info.getQueueOffset());
+        assertEquals(1, info.getReconsumeTimes());
+        assertEquals(3, info.getRenewTimes());
+        assertEquals(1, info.getRenewRetryTimes());
+        assertEquals(1000L, info.getConsumeTimestamp());
+        assertEquals("handle-1", info.getReceiptHandle());
+        assertEquals(2000L, info.getNextVisibleTime());
+        assertEquals(60000L, info.getInvisibleTime());
+        assertEquals("broker-a", info.getBrokerName());
+        assertFalse(info.isExpired());
+    }
+
+    @Test
+    public void testExpiredHandle() {
+        PopReceiptHandleInfo info = new PopReceiptHandleInfo(
+            "groupA", "topicA", 0, "msg-2",
+            0L, 0, 0, 0,
+            0L, "handle-2", 0L,
+            0L, "broker-a", true);
+
+        assertTrue(info.isExpired());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/ProxyContextTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/ProxyContextTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class ProxyContextTest {
+
+    @Test
+    public void testSslEnabled() {
+        ProxyContext context = ProxyContext.create();
+        assertNull(context.isSslEnabled());
+
+        ProxyContext returned = context.setSslEnabled(true);
+        assertSame(context, returned);
+        assertTrue(context.isSslEnabled());
+
+        context.setSslEnabled(false);
+        assertFalse(context.isSslEnabled());
+    }
+
+    @Test
+    public void testAuthUsername() {
+        ProxyContext context = ProxyContext.create();
+        assertNull(context.getAuthUsername());
+
+        ProxyContext returned = context.setAuthUsername("rocketmq");
+        assertSame(context, returned);
+        assertEquals("rocketmq", context.getAuthUsername());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
@@ -21,6 +21,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ProxyConfigTest {
 
@@ -34,5 +37,47 @@ public class ProxyConfigTest {
 
         assertThat(StringUtils.isBlank(proxyConfig.getLocalServeAddr())).isFalse();
         assertThat(proxyConfig.getRemotingAccessAddr()).isEqualTo(proxyConfig.getLocalServeAddr());
+    }
+
+    @Test
+    public void testProxyAdminDefaults() {
+        ProxyConfig config = new ProxyConfig();
+        assertTrue(config.isProxyAdminEnabled());
+        assertEquals(Integer.valueOf(8082), config.getProxyAdminServerPort());
+        assertEquals(4, config.getProxyAdminThreadPoolNums());
+        assertEquals(100, config.getProxyAdminMaxPageSize());
+        assertEquals(8, config.getProxyAdminDescribeClientConcurrencyLimit());
+        assertEquals(0.5, config.getProxyAdminSamplingRateUnderLoad(), 0.0001);
+        assertEquals(10, config.getProxyAdminHeartbeatHistorySize());
+        assertEquals(100000L, config.getProxyAdminSamplingThreshold());
+    }
+
+    @Test
+    public void testProxyAdminSettersAndGetters() {
+        ProxyConfig config = new ProxyConfig();
+
+        config.setProxyAdminEnabled(false);
+        assertFalse(config.isProxyAdminEnabled());
+
+        config.setProxyAdminServerPort(9092);
+        assertEquals(Integer.valueOf(9092), config.getProxyAdminServerPort());
+
+        config.setProxyAdminThreadPoolNums(8);
+        assertEquals(8, config.getProxyAdminThreadPoolNums());
+
+        config.setProxyAdminMaxPageSize(50);
+        assertEquals(50, config.getProxyAdminMaxPageSize());
+
+        config.setProxyAdminDescribeClientConcurrencyLimit(16);
+        assertEquals(16, config.getProxyAdminDescribeClientConcurrencyLimit());
+
+        config.setProxyAdminSamplingRateUnderLoad(0.8);
+        assertEquals(0.8, config.getProxyAdminSamplingRateUnderLoad(), 0.0001);
+
+        config.setProxyAdminHeartbeatHistorySize(20);
+        assertEquals(20, config.getProxyAdminHeartbeatHistorySize());
+
+        config.setProxyAdminSamplingThreshold(200000L);
+        assertEquals(200000L, config.getProxyAdminSamplingThreshold());
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/AdminCodeTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/AdminCodeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class AdminCodeTest {
+
+    @Test
+    public void testCodeValues() {
+        assertEquals(1, AdminCode.OK.getCode());
+        assertEquals(2, AdminCode.INTERNAL_ERROR.getCode());
+        assertEquals(3, AdminCode.BAD_REQUEST.getCode());
+        assertEquals(4, AdminCode.UNAUTHORIZED.getCode());
+        assertEquals(5, AdminCode.FORBIDDEN.getCode());
+        assertEquals(6, AdminCode.NOT_FOUND.getCode());
+        assertEquals(7, AdminCode.TOO_MANY_REQUESTS.getCode());
+        assertEquals(8, AdminCode.CONFLICT.getCode());
+    }
+
+    @Test
+    public void testDescriptions() {
+        assertEquals("OK", AdminCode.OK.getDescription());
+        assertEquals("Internal error", AdminCode.INTERNAL_ERROR.getDescription());
+        assertEquals("Bad request", AdminCode.BAD_REQUEST.getDescription());
+        assertEquals("Unauthorized", AdminCode.UNAUTHORIZED.getDescription());
+        assertEquals("Forbidden", AdminCode.FORBIDDEN.getDescription());
+        assertEquals("Not found", AdminCode.NOT_FOUND.getDescription());
+        assertEquals("Too many requests", AdminCode.TOO_MANY_REQUESTS.getDescription());
+        assertEquals("Conflict", AdminCode.CONFLICT.getDescription());
+    }
+
+    @Test
+    public void testFromCode() {
+        for (AdminCode adminCode : AdminCode.values()) {
+            assertSame(adminCode, AdminCode.fromCode(adminCode.getCode()));
+        }
+    }
+
+    @Test
+    public void testFromCodeUnknown() {
+        assertNull(AdminCode.fromCode(0));
+        assertNull(AdminCode.fromCode(-1));
+        assertNull(AdminCode.fromCode(999));
+    }
+
+    @Test
+    public void testEnumCompleteness() {
+        assertEquals(8, AdminCode.values().length);
+        for (AdminCode adminCode : AdminCode.values()) {
+            assertNotNull(adminCode.getDescription());
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminAuthInterceptorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminAuthInterceptorTest.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import io.grpc.Metadata;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.common.action.Action;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for ProxyAdminAuthInterceptor.
+ * <p>
+ * Focuses on the resolveAction method which implements RIP-2 §7.2:
+ * read = list/describe/get
+ * - DescribeClient → Action.GET (single resource read)
+ * - ListClients / ListClientsByGroup / ListClientsByTopic → Action.LIST (collection read)
+ * <p>
+ * Uses sun.misc.Unsafe to create instance without constructor to avoid
+ * Mockito compatibility issues with Java 21 class files.
+ */
+public class ProxyAdminAuthInterceptorTest {
+
+    private ProxyAdminAuthInterceptor interceptor;
+
+    @Before
+    public void setUp() throws Exception {
+        interceptor = createInstanceWithoutConstructor();
+        assertNotNull("Failed to create ProxyAdminAuthInterceptor instance", interceptor);
+    }
+
+    @After
+    public void tearDown() {
+        interceptor = null;
+    }
+
+    // ==================== resolveAction Tests ====================
+
+    @Test
+    public void testResolveAction_DescribeClient() throws Exception {
+        Action action = invokeResolveAction("DescribeClient");
+        assertEquals(Action.GET, action);
+    }
+
+    @Test
+    public void testResolveAction_ListClients() throws Exception {
+        Action action = invokeResolveAction("ListClients");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_ListClientsByGroup() throws Exception {
+        Action action = invokeResolveAction("ListClientsByGroup");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_ListClientsByTopic() throws Exception {
+        Action action = invokeResolveAction("ListClientsByTopic");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_FullMethodName_DescribeClient() throws Exception {
+        // Test with full gRPC method name format
+        Action action = invokeResolveAction("org.apache.rocketmq.proxy.admin/DescribeClient");
+        assertEquals(Action.GET, action);
+    }
+
+    @Test
+    public void testResolveAction_FullMethodName_ListClients() throws Exception {
+        Action action = invokeResolveAction("org.apache.rocketmq.proxy.admin/ListClients");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_NullMethodName() throws Exception {
+        Action action = invokeResolveAction(null);
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_EmptyMethodName() throws Exception {
+        Action action = invokeResolveAction("");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_UnknownMethod() throws Exception {
+        Action action = invokeResolveAction("UnknownMethod");
+        assertEquals(Action.LIST, action);
+    }
+
+    // ==================== Resource Constants Tests ====================
+
+    @Test
+    public void testResourceConstants() {
+        assertEquals("proxy.admin", ProxyAdminAuthInterceptor.ADMIN_RESOURCE_PREFIX);
+        assertEquals("proxy.admin.client", ProxyAdminAuthInterceptor.CLIENT_ADMIN_RESOURCE);
+    }
+
+    // ==================== extractUsername Tests ====================
+
+    @Test
+    public void testExtractUsername_WithAuthAk() throws Exception {
+        Metadata headers = new Metadata();
+        headers.put(org.apache.rocketmq.common.constant.GrpcConstants.AUTHORIZATION_AK, "testuser");
+        String username = invokeExtractUsername(headers);
+        assertEquals("testuser", username);
+    }
+
+    @Test
+    public void testExtractUsername_BlankAuthAk() throws Exception {
+        Metadata headers = new Metadata();
+        headers.put(org.apache.rocketmq.common.constant.GrpcConstants.AUTHORIZATION_AK, "");
+        String username = invokeExtractUsername(headers);
+        assertEquals("unknown", username);
+    }
+
+    @Test
+    public void testExtractUsername_NullHeaders() throws Exception {
+        String username = invokeExtractUsername(null);
+        assertEquals("unknown", username);
+    }
+
+    @Test
+    public void testExtractUsername_NoAuthAk() throws Exception {
+        Metadata headers = new Metadata();
+        String username = invokeExtractUsername(headers);
+        assertEquals("unknown", username);
+    }
+
+    // ==================== extractSourceIp Tests ====================
+
+    @Test
+    public void testExtractSourceIp_WithXForwardedFor() throws Exception {
+        Metadata headers = new Metadata();
+        headers.put(Metadata.Key.of("x-forwarded-for", Metadata.ASCII_STRING_MARSHALLER), "192.168.1.1");
+        String ip = invokeExtractSourceIp(headers);
+        assertEquals("192.168.1.1", ip);
+    }
+
+    @Test
+    public void testExtractSourceIp_NullHeaders() throws Exception {
+        String ip = invokeExtractSourceIp(null);
+        assertNull(ip);
+    }
+
+    @Test
+    public void testExtractSourceIp_BlankXForwardedFor() throws Exception {
+        Metadata headers = new Metadata();
+        headers.put(Metadata.Key.of("x-forwarded-for", Metadata.ASCII_STRING_MARSHALLER), "");
+        String ip = invokeExtractSourceIp(headers);
+        assertNull(ip);
+    }
+
+    @Test
+    public void testExtractSourceIp_NoHeader() throws Exception {
+        Metadata headers = new Metadata();
+        String ip = invokeExtractSourceIp(headers);
+        assertNull(ip);
+    }
+
+    // ==================== More resolveAction Tests ====================
+
+    @Test
+    public void testResolveAction_DescribeClientInPath() throws Exception {
+        // DescribeClient appears anywhere in the path
+        Action action = invokeResolveAction("apache.rocketmq.proxy.admin.v1.ProxyClientAdminService/DescribeClient");
+        assertEquals(Action.GET, action);
+    }
+
+    @Test
+    public void testResolveAction_ListClientsInPath() throws Exception {
+        Action action = invokeResolveAction("apache.rocketmq.proxy.admin.v1.ProxyClientAdminService/ListClients");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_ListClientsByGroupInPath() throws Exception {
+        Action action = invokeResolveAction("apache.rocketmq.proxy.admin.v1.ProxyClientAdminService/ListClientsByGroup");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_ListClientsByTopicInPath() throws Exception {
+        Action action = invokeResolveAction("apache.rocketmq.proxy.admin.v1.ProxyClientAdminService/ListClientsByTopic");
+        assertEquals(Action.LIST, action);
+    }
+
+    // ==================== resolveAction: UpdateConfig / GetConfig / DisconnectClient ====================
+
+    @Test
+    public void testResolveAction_UpdateConfig() throws Exception {
+        Action action = invokeResolveAction("UpdateConfig");
+        assertEquals(Action.UPDATE, action);
+    }
+
+    @Test
+    public void testResolveAction_UpdateConfig_FullMethodName() throws Exception {
+        Action action = invokeResolveAction("org.apache.rocketmq.proxy.admin/UpdateConfig");
+        assertEquals(Action.UPDATE, action);
+    }
+
+    @Test
+    public void testResolveAction_GetConfig() throws Exception {
+        Action action = invokeResolveAction("GetConfig");
+        assertEquals(Action.GET, action);
+    }
+
+    @Test
+    public void testResolveAction_GetConfig_FullMethodName() throws Exception {
+        Action action = invokeResolveAction("org.apache.rocketmq.proxy.admin/GetConfig");
+        assertEquals(Action.GET, action);
+    }
+
+    @Test
+    public void testResolveAction_DisconnectClient() throws Exception {
+        Action action = invokeResolveAction("DisconnectClient");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_DisconnectClient_FullMethodName() throws Exception {
+        Action action = invokeResolveAction("org.apache.rocketmq.proxy.admin/DisconnectClient");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_SubscribeRouteEvents() throws Exception {
+        Action action = invokeResolveAction("SubscribeRouteEvents");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_DescribePopReceiptHandles() throws Exception {
+        Action action = invokeResolveAction("DescribePopReceiptHandles");
+        assertEquals(Action.LIST, action);
+    }
+
+    @Test
+    public void testResolveAction_DescribeBatchConsumeDiagnostics() throws Exception {
+        Action action = invokeResolveAction("DescribeBatchConsumeDiagnostics");
+        assertEquals(Action.LIST, action);
+    }
+
+    // ==================== authenticate Tests ====================
+    // Note: interceptCall cannot be tested directly because ServerCall, ServerCallHandler,
+    // and MethodDescriptor cannot be mocked on Java 21 with Mockito 3.10 (Byte Buddy
+    // class file major version 65 incompatibility). Instead, we test the core private
+    // methods (authenticate, authorize) via reflection.
+
+    @Test
+    public void testAuthenticate_NullEvaluator_ThrowsNPE() throws Exception {
+        // When authenticationEvaluator is null (Unsafe-created instance),
+        // authenticate should throw NullPointerException when calling evaluator.evaluate()
+        Metadata headers = new Metadata();
+        try {
+            invokeAuthenticate(headers, "org.apache.rocketmq.proxy.admin/ListClients");
+            fail("Expected NullPointerException due to null authenticationEvaluator");
+        } catch (InvocationTargetException e) {
+            // Reflection wraps the NPE in InvocationTargetException
+            assertTrue("Expected NullPointerException cause",
+                e.getCause() instanceof NullPointerException);
+        }
+    }
+
+    @Test
+    public void testAuthenticate_WithAuthorizationHeader_ParsesContext() throws Exception {
+        // Verify authenticate correctly parses Authorization header before calling evaluator.
+        // Since evaluator is null, it will NPE, but the context parsing logic runs first.
+        Metadata headers = new Metadata();
+        headers.put(io.grpc.Metadata.Key.of("Authorization", io.grpc.Metadata.ASCII_STRING_MARSHALLER),
+            "MQv2 Credential=testUser/20260701/cn/rocketmq, Signature=testSignature");
+        headers.put(io.grpc.Metadata.Key.of("DateTime", io.grpc.Metadata.ASCII_STRING_MARSHALLER),
+            "20260701T120000Z");
+
+        try {
+            invokeAuthenticate(headers, "org.apache.rocketmq.proxy.admin/UpdateConfig");
+            fail("Expected NullPointerException due to null authenticationEvaluator");
+        } catch (InvocationTargetException e) {
+            // Expected: authenticationEvaluator is null, but header parsing should have completed
+            assertTrue("Expected NullPointerException cause",
+                e.getCause() instanceof NullPointerException);
+        }
+    }
+
+    // ==================== authorize Tests ====================
+
+    @Test
+    public void testAuthorize_NullEvaluator_ThrowsNPE() throws Exception {
+        // When authorizationEvaluator is null (Unsafe-created instance),
+        // authorize should throw NullPointerException when calling evaluator.evaluate()
+        Metadata headers = new Metadata();
+        try {
+            invokeAuthorize(headers, "org.apache.rocketmq.proxy.admin/ListClients");
+            fail("Expected NullPointerException due to null authorizationEvaluator");
+        } catch (InvocationTargetException e) {
+            // Reflection wraps the NPE in InvocationTargetException
+            assertTrue("Expected NullPointerException cause",
+                e.getCause() instanceof NullPointerException);
+        }
+    }
+
+    @Test
+    public void testAuthorize_WithUsername_InvokesResolveAction() throws Exception {
+        // Verify authorize calls resolveAction internally.
+        // Since evaluator is null, it will NPE after building the context.
+        Metadata headers = new Metadata();
+        headers.put(io.grpc.Metadata.Key.of("username", io.grpc.Metadata.ASCII_STRING_MARSHALLER), "testUser");
+
+        try {
+            invokeAuthorize(headers, "UpdateConfig");
+            fail("Expected NullPointerException due to null authorizationEvaluator");
+        } catch (InvocationTargetException e) {
+            // Expected: authorizationEvaluator is null, but resolveAction should have been called
+            assertTrue("Expected NullPointerException cause",
+                e.getCause() instanceof NullPointerException);
+        }
+    }
+
+    // ==================== AuthConfig Flag Tests ====================
+
+    @Test
+    public void testAuthConfig_BothDisabled_DefaultState() throws Exception {
+        // Verify default AuthConfig has both auth flags disabled
+        AuthConfig config = new AuthConfig();
+        setAuthConfig(config);
+        // Access the authConfig field to verify
+        Field field = ProxyAdminAuthInterceptor.class.getDeclaredField("authConfig");
+        field.setAccessible(true);
+        AuthConfig stored = (AuthConfig) field.get(interceptor);
+        assertNotNull(stored);
+        // Default should have both disabled
+        assertTrue(!stored.isAuthenticationEnabled());
+        assertTrue(!stored.isAuthorizationEnabled());
+    }
+
+    @Test
+    public void testAuthConfig_AuthenticationEnabled() throws Exception {
+        AuthConfig config = new AuthConfig();
+        config.setAuthenticationEnabled(true);
+        setAuthConfig(config);
+        Field field = ProxyAdminAuthInterceptor.class.getDeclaredField("authConfig");
+        field.setAccessible(true);
+        AuthConfig stored = (AuthConfig) field.get(interceptor);
+        assertTrue(stored.isAuthenticationEnabled());
+        assertTrue(!stored.isAuthorizationEnabled());
+    }
+
+    @Test
+    public void testAuthConfig_AuthorizationEnabled() throws Exception {
+        AuthConfig config = new AuthConfig();
+        config.setAuthorizationEnabled(true);
+        setAuthConfig(config);
+        Field field = ProxyAdminAuthInterceptor.class.getDeclaredField("authConfig");
+        field.setAccessible(true);
+        AuthConfig stored = (AuthConfig) field.get(interceptor);
+        assertTrue(!stored.isAuthenticationEnabled());
+        assertTrue(stored.isAuthorizationEnabled());
+    }
+
+    /**
+     * Set the authConfig field on the interceptor via reflection.
+     */
+    private void setAuthConfig(AuthConfig config) throws Exception {
+        Field field = ProxyAdminAuthInterceptor.class.getDeclaredField("authConfig");
+        field.setAccessible(true);
+        field.set(interceptor, config);
+    }
+
+    // ==================== Reflection Helpers ====================
+    private Action invokeResolveAction(String methodName) throws Exception {
+        Method method = ProxyAdminAuthInterceptor.class.getDeclaredMethod("resolveAction", String.class);
+        method.setAccessible(true);
+        return (Action) method.invoke(interceptor, methodName);
+    }
+
+    private String invokeExtractUsername(Metadata headers) throws Exception {
+        Method method = ProxyAdminAuthInterceptor.class.getDeclaredMethod("extractUsername", Metadata.class);
+        method.setAccessible(true);
+        return (String) method.invoke(interceptor, new Object[]{headers});
+    }
+
+    private String invokeExtractSourceIp(Metadata headers) throws Exception {
+        Method method = ProxyAdminAuthInterceptor.class.getDeclaredMethod("extractSourceIp", Metadata.class);
+        method.setAccessible(true);
+        return (String) method.invoke(interceptor, new Object[]{headers});
+    }
+
+    private void invokeAuthenticate(Metadata headers, String methodName) throws Exception {
+        Method method = ProxyAdminAuthInterceptor.class.getDeclaredMethod("authenticate", Metadata.class, String.class);
+        method.setAccessible(true);
+        method.invoke(interceptor, headers, methodName);
+    }
+
+    private void invokeAuthorize(Metadata headers, String methodName) throws Exception {
+        Method method = ProxyAdminAuthInterceptor.class.getDeclaredMethod("authorize", Metadata.class, String.class);
+        method.setAccessible(true);
+        method.invoke(interceptor, headers, methodName);
+    }
+
+    /**
+     * Create a ProxyAdminAuthInterceptor instance without calling the constructor.
+     * This avoids Mockito compatibility issues with Java 21 class files
+     * and the complex AuthConfig/MessagingProcessor dependency chain.
+     * Since resolveAction is a pure function, it doesn't need initialized fields.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> T createInstanceWithoutConstructor() throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+        return (T) allocateInstance.invoke(unsafe, ProxyAdminAuthInterceptor.class);
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshallerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshallerTest.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import io.grpc.MethodDescriptor;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.junit.Test;
+import apache.rocketmq.proxy.admin.v1.DescribeClientRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsResponse;
+import apache.rocketmq.proxy.admin.v1.GetConfigRequest;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigRequest;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientRequest;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesRequest;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsRequest;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for ProxyAdminMarshaller verifying all 20 proto marshallers are registered and perform correct serialization round-trips. */
+public class ProxyAdminMarshallerTest {
+
+    @Test
+    public void testListClientsReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeClientReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeClientRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_CLIENT_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByGroupReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByGroupRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByTopicReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByTopicRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testGetConfigReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testGetConfigRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.GET_CONFIG_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testUpdateConfigReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testUpdateConfigRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.UPDATE_CONFIG_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDisconnectClientReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDisconnectClientRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DISCONNECT_CLIENT_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribePopReceiptHandlesReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribePopReceiptHandlesRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeBatchConsumeDiagnosticsReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeBatchConsumeDiagnosticsRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testSubscribeRouteEventsReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testSubscribeRouteEventsRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testParseListClientsRequest() throws Exception {
+        ListClientsRequest request = ListClientsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.stream(request);
+        ListClientsRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(ListClientsRequest.getDefaultInstance(), parsed);
+    }
+
+    @Test
+    public void testParseListClientsResponse() throws Exception {
+        ListClientsResponse response = ListClientsResponse.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER.stream(response);
+        ListClientsResponse parsed = ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(ListClientsResponse.getDefaultInstance(), parsed);
+    }
+
+    @Test
+    public void testRoundTripListClientsRequest() throws Exception {
+        ListClientsRequest request = ListClientsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.stream(request);
+        ListClientsRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDescribeClientRequest() throws Exception {
+        DescribeClientRequest request = DescribeClientRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER.stream(request);
+        DescribeClientRequest parsed = ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripListClientsByGroupRequest() throws Exception {
+        ListClientsByGroupRequest request = ListClientsByGroupRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER.stream(request);
+        ListClientsByGroupRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripListClientsByTopicRequest() throws Exception {
+        ListClientsByTopicRequest request = ListClientsByTopicRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER.stream(request);
+        ListClientsByTopicRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripGetConfigRequest() throws Exception {
+        GetConfigRequest request = GetConfigRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER.stream(request);
+        GetConfigRequest parsed = ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripUpdateConfigRequest() throws Exception {
+        UpdateConfigRequest request = UpdateConfigRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER.stream(request);
+        UpdateConfigRequest parsed = ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDisconnectClientRequest() throws Exception {
+        DisconnectClientRequest request = DisconnectClientRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER.stream(request);
+        DisconnectClientRequest parsed = ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDescribePopReceiptHandlesRequest() throws Exception {
+        DescribePopReceiptHandlesRequest request = DescribePopReceiptHandlesRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER.stream(request);
+        DescribePopReceiptHandlesRequest parsed = ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDescribeBatchConsumeDiagnosticsRequest() throws Exception {
+        DescribeBatchConsumeDiagnosticsRequest request = DescribeBatchConsumeDiagnosticsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER.stream(request);
+        DescribeBatchConsumeDiagnosticsRequest parsed = ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripSubscribeRouteEventsRequest() throws Exception {
+        SubscribeRouteEventsRequest request = SubscribeRouteEventsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER.stream(request);
+        SubscribeRouteEventsRequest parsed = ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testParseEmptyStreamDoesNotThrow() throws Exception {
+        ByteArrayInputStream emptyStream = new ByteArrayInputStream(new byte[0]);
+        // All 20 marshallers should handle empty input without throwing
+        ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.parse(emptyStream);
+        ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_CLIENT_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.GET_CONFIG_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.UPDATE_CONFIG_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DISCONNECT_CLIENT_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+    }
+
+    @Test
+    public void testMarshallerTypesAreCorrect() {
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.DESCRIBE_CLIENT_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminProtoConverterTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminProtoConverterTest.java
@@ -1,0 +1,1003 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientDetailInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientInstanceInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ListClientsFilter;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEvent;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEventType;
+import org.apache.rocketmq.proxy.grpc.admin.model.TopicRouteSnapshot;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService.ListClientsResult;
+import org.junit.Test;
+
+import apache.rocketmq.proxy.admin.v1.AdminCode;
+import apache.rocketmq.proxy.admin.v1.AuthStatus;
+import apache.rocketmq.proxy.admin.v1.BrokerInfo;
+import apache.rocketmq.proxy.admin.v1.ClientDetail;
+import apache.rocketmq.proxy.admin.v1.ClientInstance;
+import apache.rocketmq.proxy.admin.v1.ClientLanguage;
+import apache.rocketmq.proxy.admin.v1.ClientProtocol;
+import apache.rocketmq.proxy.admin.v1.ClientRole;
+import apache.rocketmq.proxy.admin.v1.ClientSettings;
+import apache.rocketmq.proxy.admin.v1.ConsumeProgress;
+import apache.rocketmq.proxy.admin.v1.DescribeClientResponse;
+import apache.rocketmq.proxy.admin.v1.HeartbeatRecord;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsResponse;
+import apache.rocketmq.proxy.admin.v1.NetworkInfo;
+import apache.rocketmq.proxy.admin.v1.QueueInfo;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsResponse;
+import apache.rocketmq.proxy.admin.v1.TopicConsumeProgress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for ProxyAdminProtoConverter covering proto-to-model conversion, enum mapping, and null/edge-case handling for all admin RPC message types. */
+public class ProxyAdminProtoConverterTest {
+
+    // ==================== toFilter Tests ====================
+
+    @Test
+    public void testToFilter_EmptyRequest() {
+        ListClientsRequest request = ListClientsRequest.newBuilder().build();
+        ListClientsFilter filter = ProxyAdminProtoConverter.toFilter(request);
+        assertNotNull(filter);
+        assertEquals("", filter.getGroup());
+        assertEquals("", filter.getTopic());
+        assertEquals("", filter.getClientIdPrefix());
+        assertNull(filter.getLanguage());
+        assertEquals(0, filter.getConnectTimeStart());
+        assertEquals(0, filter.getConnectTimeEnd());
+        // Proto defaults set empty strings, so group/topic/clientIdPrefix are ""
+        // which are not null, so hasFilter() returns true
+        assertTrue(filter.hasFilter());
+    }
+
+    @Test
+    public void testToFilter_FullRequest() {
+        ListClientsRequest request = ListClientsRequest.newBuilder()
+            .setGroup("testGroup")
+            .setTopic("testTopic")
+            .setClientIdPrefix("testPrefix")
+            .setLanguage(ClientLanguage.CLIENT_LANGUAGE_JAVA)
+            .setConnectTimeStart(1000L)
+            .setConnectTimeEnd(2000L)
+            .build();
+        ListClientsFilter filter = ProxyAdminProtoConverter.toFilter(request);
+        assertEquals("testGroup", filter.getGroup());
+        assertEquals("testTopic", filter.getTopic());
+        assertEquals("testPrefix", filter.getClientIdPrefix());
+        assertEquals("JAVA", filter.getLanguage());
+        assertEquals(1000L, filter.getConnectTimeStart());
+        assertEquals(2000L, filter.getConnectTimeEnd());
+        assertTrue(filter.hasFilter());
+    }
+
+    // ==================== toClientLanguage Tests ====================
+
+    @Test
+    public void testToClientLanguage_JAVA() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_JAVA,
+            ProxyAdminProtoConverter.toClientLanguage("JAVA"));
+    }
+
+    @Test
+    public void testToClientLanguage_GOLANG() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_GOLANG,
+            ProxyAdminProtoConverter.toClientLanguage("GOLANG"));
+    }
+
+    @Test
+    public void testToClientLanguage_GO() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_GOLANG,
+            ProxyAdminProtoConverter.toClientLanguage("GO"));
+    }
+
+    @Test
+    public void testToClientLanguage_CPP() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_CPP,
+            ProxyAdminProtoConverter.toClientLanguage("CPP"));
+    }
+
+    @Test
+    public void testToClientLanguage_RUST() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_RUST,
+            ProxyAdminProtoConverter.toClientLanguage("RUST"));
+    }
+
+    @Test
+    public void testToClientLanguage_PYTHON() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_PYTHON,
+            ProxyAdminProtoConverter.toClientLanguage("PYTHON"));
+    }
+
+    @Test
+    public void testToClientLanguage_NODEJS() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_NODEJS,
+            ProxyAdminProtoConverter.toClientLanguage("NODEJS"));
+    }
+
+    @Test
+    public void testToClientLanguage_NODE_JS() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_NODEJS,
+            ProxyAdminProtoConverter.toClientLanguage("NODE_JS"));
+    }
+
+    @Test
+    public void testToClientLanguage_CSHARP() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_CSHARP,
+            ProxyAdminProtoConverter.toClientLanguage("CSHARP"));
+    }
+
+    @Test
+    public void testToClientLanguage_DOTNET() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_CSHARP,
+            ProxyAdminProtoConverter.toClientLanguage("DOTNET"));
+    }
+
+    @Test
+    public void testToClientLanguage_PHP() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_PHP,
+            ProxyAdminProtoConverter.toClientLanguage("PHP"));
+    }
+
+    @Test
+    public void testToClientLanguage_Null() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED,
+            ProxyAdminProtoConverter.toClientLanguage(null));
+    }
+
+    @Test
+    public void testToClientLanguage_Unknown() {
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED,
+            ProxyAdminProtoConverter.toClientLanguage("RUBY"));
+    }
+
+    // ==================== fromClientLanguage Tests ====================
+
+    @Test
+    public void testFromClientLanguage_JAVA() {
+        assertEquals("JAVA",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_JAVA));
+    }
+
+    @Test
+    public void testFromClientLanguage_GOLANG() {
+        assertEquals("GOLANG",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_GOLANG));
+    }
+
+    @Test
+    public void testFromClientLanguage_CPP() {
+        assertEquals("CPP",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_CPP));
+    }
+
+    @Test
+    public void testFromClientLanguage_RUST() {
+        assertEquals("RUST",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_RUST));
+    }
+
+    @Test
+    public void testFromClientLanguage_PYTHON() {
+        assertEquals("PYTHON",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_PYTHON));
+    }
+
+    @Test
+    public void testFromClientLanguage_NODEJS() {
+        assertEquals("NODE_JS",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_NODEJS));
+    }
+
+    @Test
+    public void testFromClientLanguage_CSHARP() {
+        assertEquals("DOTNET",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_CSHARP));
+    }
+
+    @Test
+    public void testFromClientLanguage_PHP() {
+        assertEquals("PHP",
+            ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_PHP));
+    }
+
+    @Test
+    public void testFromClientLanguage_Null() {
+        assertNull(ProxyAdminProtoConverter.fromClientLanguage(null));
+    }
+
+    @Test
+    public void testFromClientLanguage_Unspecified() {
+        assertNull(ProxyAdminProtoConverter.fromClientLanguage(ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED));
+    }
+
+    // ==================== toClientProtocol Tests ====================
+
+    @Test
+    public void testToClientProtocol_GRPC() {
+        assertEquals(ClientProtocol.CLIENT_PROTOCOL_GRPC,
+            ProxyAdminProtoConverter.toClientProtocol("GRPC"));
+    }
+
+    @Test
+    public void testToClientProtocol_GRPC_V2() {
+        assertEquals(ClientProtocol.CLIENT_PROTOCOL_GRPC,
+            ProxyAdminProtoConverter.toClientProtocol("GRPC_V2"));
+    }
+
+    @Test
+    public void testToClientProtocol_REMOTING() {
+        assertEquals(ClientProtocol.CLIENT_PROTOCOL_REMOTING,
+            ProxyAdminProtoConverter.toClientProtocol("REMOTING"));
+    }
+
+    @Test
+    public void testToClientProtocol_Null() {
+        assertEquals(ClientProtocol.CLIENT_PROTOCOL_UNSPECIFIED,
+            ProxyAdminProtoConverter.toClientProtocol(null));
+    }
+
+    // ==================== toClientRole Tests ====================
+
+    @Test
+    public void testToClientRole_PRODUCER() {
+        assertEquals(ClientRole.CLIENT_ROLE_PRODUCER,
+            ProxyAdminProtoConverter.toClientRole("PRODUCER"));
+    }
+
+    @Test
+    public void testToClientRole_PUSH_CONSUMER() {
+        assertEquals(ClientRole.CLIENT_ROLE_PUSH_CONSUMER,
+            ProxyAdminProtoConverter.toClientRole("PUSH_CONSUMER"));
+    }
+
+    @Test
+    public void testToClientRole_SIMPLE_CONSUMER() {
+        assertEquals(ClientRole.CLIENT_ROLE_SIMPLE_CONSUMER,
+            ProxyAdminProtoConverter.toClientRole("SIMPLE_CONSUMER"));
+    }
+
+    @Test
+    public void testToClientRole_Null() {
+        assertEquals(ClientRole.CLIENT_ROLE_UNSPECIFIED,
+            ProxyAdminProtoConverter.toClientRole(null));
+    }
+
+    // ==================== toProtoAdminCode Tests ====================
+
+    @Test
+    public void testToProtoAdminCode_OK() {
+        assertEquals(AdminCode.ADMIN_CODE_OK,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.OK));
+    }
+
+    @Test
+    public void testToProtoAdminCode_INTERNAL_ERROR() {
+        assertEquals(AdminCode.ADMIN_CODE_INTERNAL_ERROR,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.INTERNAL_ERROR));
+    }
+
+    @Test
+    public void testToProtoAdminCode_BAD_REQUEST() {
+        assertEquals(AdminCode.ADMIN_CODE_BAD_REQUEST,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.BAD_REQUEST));
+    }
+
+    @Test
+    public void testToProtoAdminCode_UNAUTHORIZED() {
+        assertEquals(AdminCode.ADMIN_CODE_UNAUTHORIZED,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.UNAUTHORIZED));
+    }
+
+    @Test
+    public void testToProtoAdminCode_FORBIDDEN() {
+        assertEquals(AdminCode.ADMIN_CODE_FORBIDDEN,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.FORBIDDEN));
+    }
+
+    @Test
+    public void testToProtoAdminCode_NOT_FOUND() {
+        assertEquals(AdminCode.ADMIN_CODE_NOT_FOUND,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.NOT_FOUND));
+    }
+
+    @Test
+    public void testToProtoAdminCode_TOO_MANY_REQUESTS() {
+        assertEquals(AdminCode.ADMIN_CODE_TOO_MANY_REQUESTS,
+            ProxyAdminProtoConverter.toProtoAdminCode(org.apache.rocketmq.proxy.grpc.admin.AdminCode.TOO_MANY_REQUESTS));
+    }
+
+    @Test
+    public void testToProtoAdminCode_Null() {
+        assertEquals(AdminCode.ADMIN_CODE_UNSPECIFIED,
+            ProxyAdminProtoConverter.toProtoAdminCode(null));
+    }
+
+    // ==================== toClientInstance Tests ====================
+
+    @Test
+    public void testToClientInstance_Full() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId("testClientId");
+        info.setLanguage("JAVA");
+        info.setClientVersion("5.0.0");
+        info.setProtocol("GRPC");
+        info.setAccessPoint("127.0.0.1:10911");
+        info.setConnectAt(1000L);
+        info.setLastActiveAt(2000L);
+        info.setRole("PRODUCER");
+        info.setGroup("testGroup");
+        info.setTopics(Arrays.asList("topicA", "topicB"));
+
+        ClientInstance instance = ProxyAdminProtoConverter.toClientInstance(info);
+
+        assertEquals("testClientId", instance.getClientId());
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_JAVA, instance.getLanguage());
+        assertEquals("5.0.0", instance.getClientVersion());
+        assertEquals(ClientProtocol.CLIENT_PROTOCOL_GRPC, instance.getProtocol());
+        assertEquals("127.0.0.1:10911", instance.getAccessPoint());
+        assertEquals(1000L, instance.getConnectAt());
+        assertEquals(2000L, instance.getLastActiveAt());
+        assertEquals(ClientRole.CLIENT_ROLE_PRODUCER, instance.getRole());
+        assertEquals("testGroup", instance.getGroup());
+        assertEquals(2, instance.getTopicsCount());
+        assertTrue(instance.getTopicsList().contains("topicA"));
+        assertTrue(instance.getTopicsList().contains("topicB"));
+    }
+
+    @Test
+    public void testToClientInstance_NullFields() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+
+        ClientInstance instance = ProxyAdminProtoConverter.toClientInstance(info);
+
+        assertEquals("", instance.getClientId());
+        assertEquals("", instance.getClientVersion());
+        assertEquals("", instance.getAccessPoint());
+        assertEquals(0L, instance.getConnectAt());
+        assertEquals(0L, instance.getLastActiveAt());
+    }
+
+    @Test
+    public void testToClientInstance_NullLanguageProtocolRole() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId("testClient");
+        info.setLanguage(null);
+        info.setProtocol(null);
+        info.setRole(null);
+
+        ClientInstance instance = ProxyAdminProtoConverter.toClientInstance(info);
+
+        assertEquals("testClient", instance.getClientId());
+        assertEquals(ClientLanguage.CLIENT_LANGUAGE_UNSPECIFIED, instance.getLanguage());
+        assertEquals(ClientProtocol.CLIENT_PROTOCOL_UNSPECIFIED, instance.getProtocol());
+        assertEquals(ClientRole.CLIENT_ROLE_UNSPECIFIED, instance.getRole());
+    }
+
+    // ==================== Error Response Tests ====================
+
+    @Test
+    public void testToListClientsError() {
+        ListClientsResponse response = ProxyAdminProtoConverter.toListClientsError(
+            AdminCode.ADMIN_CODE_BAD_REQUEST, "Invalid filter");
+
+        assertEquals(AdminCode.ADMIN_CODE_BAD_REQUEST, response.getCode());
+        assertEquals("Invalid filter", response.getMessage());
+    }
+
+    @Test
+    public void testToDescribeClientError() {
+        DescribeClientResponse response = ProxyAdminProtoConverter.toDescribeClientError(
+            AdminCode.ADMIN_CODE_NOT_FOUND, "Client not found");
+
+        assertEquals(AdminCode.ADMIN_CODE_NOT_FOUND, response.getCode());
+        assertEquals("Client not found", response.getMessage());
+    }
+
+    @Test
+    public void testToListClientsByGroupError() {
+        ListClientsByGroupResponse response = ProxyAdminProtoConverter.toListClientsByGroupError(
+            AdminCode.ADMIN_CODE_FORBIDDEN, "Access denied");
+
+        assertEquals(AdminCode.ADMIN_CODE_FORBIDDEN, response.getCode());
+        assertEquals("Access denied", response.getMessage());
+    }
+
+    @Test
+    public void testToListClientsByTopicError() {
+        ListClientsByTopicResponse response = ProxyAdminProtoConverter.toListClientsByTopicError(
+            AdminCode.ADMIN_CODE_TOO_MANY_REQUESTS, "Rate limited");
+
+        assertEquals(AdminCode.ADMIN_CODE_TOO_MANY_REQUESTS, response.getCode());
+        assertEquals("Rate limited", response.getMessage());
+    }
+
+    // ==================== toHeartbeatRecord Tests ====================
+
+    @Test
+    public void testToHeartbeatRecord_NullRemark() {
+        ClientDetailInfo.HeartbeatRecordInfo info = new ClientDetailInfo.HeartbeatRecordInfo();
+        info.setTimestamp(3000L);
+        info.setSuccess(true);
+        info.setRemark(null);
+
+        HeartbeatRecord record = ProxyAdminProtoConverter.toHeartbeatRecord(info);
+
+        assertEquals(3000L, record.getTimestamp());
+        assertTrue(record.getSuccess());
+        assertEquals("", record.getRemark());
+    }
+
+    // ==================== toAuthStatus Tests ====================
+
+    @Test
+    public void testToAuthStatus_NullFields() {
+        ClientDetailInfo.AuthStatusInfo info = new ClientDetailInfo.AuthStatusInfo();
+        info.setAuthenticated(false);
+        info.setUsername(null);
+        info.setLastAuthTime(0L);
+        info.setFailureReason(null);
+
+        AuthStatus status = ProxyAdminProtoConverter.toAuthStatus(info);
+
+        assertFalse(status.getAuthenticated());
+        assertEquals("", status.getUsername());
+        assertEquals(0L, status.getLastAuthTime());
+        assertEquals("", status.getFailureReason());
+    }
+
+    // ==================== toNetworkInfo Tests ====================
+
+    @Test
+    public void testToNetworkInfo_SSLEnabled() {
+        ClientDetailInfo.NetworkInfoInfo info = new ClientDetailInfo.NetworkInfoInfo();
+        info.setLocalAddress("192.168.1.1:8080");
+        info.setRemoteAddress("10.0.0.1:9090");
+        info.setRttMs(50L);
+        info.setSslEnabled(true);
+
+        NetworkInfo networkInfo = ProxyAdminProtoConverter.toNetworkInfo(info);
+
+        assertEquals("192.168.1.1:8080", networkInfo.getLocalAddress());
+        assertEquals("10.0.0.1:9090", networkInfo.getRemoteAddress());
+        assertEquals(50L, networkInfo.getRttMs());
+        assertEquals("true", networkInfo.getSslEnabled());
+    }
+
+    @Test
+    public void testToNetworkInfo_SSLDisabled() {
+        ClientDetailInfo.NetworkInfoInfo info = new ClientDetailInfo.NetworkInfoInfo();
+        info.setLocalAddress("192.168.1.1:8080");
+        info.setRemoteAddress("10.0.0.1:9090");
+        info.setRttMs(50L);
+        info.setSslEnabled(false);
+
+        NetworkInfo networkInfo = ProxyAdminProtoConverter.toNetworkInfo(info);
+
+        assertEquals("false", networkInfo.getSslEnabled());
+    }
+
+    // ==================== toConsumeProgress Tests ====================
+
+    @Test
+    public void testToConsumeProgress_NullTopicProgress() {
+        ClientDetailInfo.ConsumeProgressInfo info = new ClientDetailInfo.ConsumeProgressInfo();
+        info.setLag(100L);
+        info.setLatencyMs(10L);
+        info.setTopicProgress(null);
+
+        ConsumeProgress progress = ProxyAdminProtoConverter.toConsumeProgress(info);
+
+        assertEquals(100L, progress.getLag());
+        assertEquals(10L, progress.getLatencyMs());
+        assertEquals(0, progress.getTopicProgressCount());
+    }
+
+    // ==================== toListClientsResponse / toListClientsByGroupResponse / toListClientsByTopicResponse Tests ====================
+
+    @Test
+    public void testToListClientsResponse() {
+        ClientInstanceInfo info1 = new ClientInstanceInfo();
+        info1.setClientId("client1");
+        ClientInstanceInfo info2 = new ClientInstanceInfo();
+        info2.setClientId("client2");
+
+        List<ClientInstanceInfo> list = Arrays.asList(info1, info2);
+        ListClientsResult result = new ListClientsResult(2L, 1, 10, list);
+
+        ListClientsResponse response = ProxyAdminProtoConverter.toListClientsResponse(result);
+
+        assertEquals(AdminCode.ADMIN_CODE_OK, response.getCode());
+        assertEquals(AdminCode.ADMIN_CODE_OK.name(), response.getMessage());
+        assertEquals(2L, response.getPagination().getTotal());
+        assertEquals(1, response.getPagination().getPageNum());
+        assertEquals(10, response.getPagination().getPageSize());
+        assertEquals(2, response.getListCount());
+        assertEquals("client1", response.getList(0).getClientId());
+        assertEquals("client2", response.getList(1).getClientId());
+    }
+
+    @Test
+    public void testToDescribeClientResponse() {
+        ClientDetailInfo detail = new ClientDetailInfo();
+        ClientInstanceInfo instanceInfo = new ClientInstanceInfo();
+        instanceInfo.setClientId("detailClient");
+        detail.setClientInstance(instanceInfo);
+
+        DescribeClientResponse response = ProxyAdminProtoConverter.toDescribeClientResponse(detail);
+
+        assertEquals(AdminCode.ADMIN_CODE_OK, response.getCode());
+        assertEquals(AdminCode.ADMIN_CODE_OK.name(), response.getMessage());
+        assertNotNull(response.getClientDetail());
+        assertEquals("detailClient", response.getClientDetail().getClientInstance().getClientId());
+    }
+
+    @Test
+    public void testToListClientsByGroupResponse() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId("groupClient");
+        info.setGroup("myGroup");
+        List<ClientInstanceInfo> list = Collections.singletonList(info);
+        ListClientsResult result = new ListClientsResult(1L, 1, 10, list);
+
+        ListClientsByGroupResponse response = ProxyAdminProtoConverter.toListClientsByGroupResponse(result);
+
+        assertEquals(AdminCode.ADMIN_CODE_OK, response.getCode());
+        assertEquals(1, response.getListCount());
+        assertEquals("groupClient", response.getList(0).getClientId());
+    }
+
+    @Test
+    public void testToListClientsByTopicResponse() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId("topicClient");
+        info.setTopics(Arrays.asList("myTopic"));
+        List<ClientInstanceInfo> list = Collections.singletonList(info);
+        ListClientsResult result = new ListClientsResult(1L, 1, 10, list);
+
+        ListClientsByTopicResponse response = ProxyAdminProtoConverter.toListClientsByTopicResponse(result);
+
+        assertEquals(AdminCode.ADMIN_CODE_OK, response.getCode());
+        assertEquals(1, response.getListCount());
+        assertEquals("topicClient", response.getList(0).getClientId());
+    }
+
+    // ==================== toClientDetail Tests ====================
+
+    @Test
+    public void testToClientDetail_Full() {
+        ClientDetailInfo detail = new ClientDetailInfo();
+
+        // ClientInstance
+        ClientInstanceInfo instanceInfo = new ClientInstanceInfo();
+        instanceInfo.setClientId("fullClient");
+        instanceInfo.setLanguage("JAVA");
+        instanceInfo.setClientVersion("5.0.0");
+        instanceInfo.setProtocol("GRPC");
+        instanceInfo.setAccessPoint("127.0.0.1:10911");
+        instanceInfo.setConnectAt(1000L);
+        instanceInfo.setLastActiveAt(2000L);
+        instanceInfo.setRole("PRODUCER");
+        instanceInfo.setGroup("testGroup");
+        instanceInfo.setTopics(Arrays.asList("topic1"));
+        detail.setClientInstance(instanceInfo);
+
+        // Settings
+        ClientDetailInfo.ClientSettingsInfo settings = new ClientDetailInfo.ClientSettingsInfo();
+        settings.setSubscriptionMode("POP");
+        settings.setReceiveBatchSize(32);
+        settings.setLongPollingTimeoutMs(30000L);
+        settings.setFifo(true);
+        settings.setSubscriptionTopics(Arrays.asList("subTopic"));
+        settings.setPublishingTopics(Arrays.asList("pubTopic"));
+        detail.setSettings(settings);
+
+        // HeartbeatHistory
+        ClientDetailInfo.HeartbeatRecordInfo heartbeat = new ClientDetailInfo.HeartbeatRecordInfo();
+        heartbeat.setTimestamp(5000L);
+        heartbeat.setSuccess(true);
+        heartbeat.setRemark("ok");
+        detail.setHeartbeatHistory(Collections.singletonList(heartbeat));
+
+        // AuthStatus
+        ClientDetailInfo.AuthStatusInfo authStatus = new ClientDetailInfo.AuthStatusInfo();
+        authStatus.setAuthenticated(true);
+        authStatus.setUsername("admin");
+        authStatus.setLastAuthTime(4000L);
+        authStatus.setFailureReason(null);
+        detail.setAuthStatus(authStatus);
+
+        // ConsumeProgress
+        ClientDetailInfo.ConsumeProgressInfo consumeProgress = new ClientDetailInfo.ConsumeProgressInfo();
+        consumeProgress.setLag(50L);
+        consumeProgress.setLatencyMs(5L);
+        ClientDetailInfo.TopicConsumeProgressInfo topicProgress = new ClientDetailInfo.TopicConsumeProgressInfo();
+        topicProgress.setTopic("topic1");
+        topicProgress.setLag(25L);
+        topicProgress.setLatencyMs(3L);
+        consumeProgress.setTopicProgress(Collections.singletonList(topicProgress));
+        detail.setConsumeProgress(consumeProgress);
+
+        // NetworkInfo
+        ClientDetailInfo.NetworkInfoInfo networkInfo = new ClientDetailInfo.NetworkInfoInfo();
+        networkInfo.setLocalAddress("192.168.1.1");
+        networkInfo.setRemoteAddress("10.0.0.1");
+        networkInfo.setRttMs(10L);
+        networkInfo.setSslEnabled(true);
+        detail.setNetworkInfo(networkInfo);
+
+        ClientDetail clientDetail = ProxyAdminProtoConverter.toClientDetail(detail);
+
+        // Verify ClientInstance
+        assertNotNull(clientDetail.getClientInstance());
+        assertEquals("fullClient", clientDetail.getClientInstance().getClientId());
+
+        // Verify Settings
+        assertNotNull(clientDetail.getSettings());
+        assertEquals("POP", clientDetail.getSettings().getSubscriptionMode());
+        assertEquals(32, clientDetail.getSettings().getReceiveBatchSize());
+        assertEquals(30000L, clientDetail.getSettings().getLongPollingTimeoutMs());
+        assertTrue(clientDetail.getSettings().getFifo());
+        assertEquals(1, clientDetail.getSettings().getSubscriptionTopicsCount());
+        assertEquals("subTopic", clientDetail.getSettings().getSubscriptionTopics(0));
+        assertEquals(1, clientDetail.getSettings().getPublishingTopicsCount());
+        assertEquals("pubTopic", clientDetail.getSettings().getPublishingTopics(0));
+
+        // Verify HeartbeatHistory
+        assertEquals(1, clientDetail.getHeartbeatHistoryCount());
+        assertEquals(5000L, clientDetail.getHeartbeatHistory(0).getTimestamp());
+        assertTrue(clientDetail.getHeartbeatHistory(0).getSuccess());
+        assertEquals("ok", clientDetail.getHeartbeatHistory(0).getRemark());
+
+        // Verify AuthStatus
+        assertNotNull(clientDetail.getAuthStatus());
+        assertTrue(clientDetail.getAuthStatus().getAuthenticated());
+        assertEquals("admin", clientDetail.getAuthStatus().getUsername());
+
+        // Verify ConsumeProgress
+        assertNotNull(clientDetail.getConsumeProgress());
+        assertEquals(50L, clientDetail.getConsumeProgress().getLag());
+        assertEquals(5L, clientDetail.getConsumeProgress().getLatencyMs());
+        assertEquals(1, clientDetail.getConsumeProgress().getTopicProgressCount());
+        assertEquals("topic1", clientDetail.getConsumeProgress().getTopicProgress(0).getTopic());
+        assertEquals(25L, clientDetail.getConsumeProgress().getTopicProgress(0).getLag());
+
+        // Verify NetworkInfo
+        assertNotNull(clientDetail.getNetworkInfo());
+        assertEquals("192.168.1.1", clientDetail.getNetworkInfo().getLocalAddress());
+        assertEquals("true", clientDetail.getNetworkInfo().getSslEnabled());
+    }
+
+    // ==================== toClientSettings Tests ====================
+
+    @Test
+    public void testToClientSettings_Full() {
+        ClientDetailInfo.ClientSettingsInfo info = new ClientDetailInfo.ClientSettingsInfo();
+        info.setSubscriptionMode("SUBSCRIBE");
+        info.setReceiveBatchSize(64);
+        info.setLongPollingTimeoutMs(15000L);
+        info.setFifo(false);
+        info.setSubscriptionTopics(Arrays.asList("topicX", "topicY"));
+        info.setPublishingTopics(Collections.singletonList("pubX"));
+
+        ClientSettings settings = ProxyAdminProtoConverter.toClientSettings(info);
+
+        assertEquals("SUBSCRIBE", settings.getSubscriptionMode());
+        assertEquals(64, settings.getReceiveBatchSize());
+        assertEquals(15000L, settings.getLongPollingTimeoutMs());
+        assertFalse(settings.getFifo());
+        assertEquals(2, settings.getSubscriptionTopicsCount());
+        assertEquals("topicX", settings.getSubscriptionTopics(0));
+        assertEquals("topicY", settings.getSubscriptionTopics(1));
+        assertEquals(1, settings.getPublishingTopicsCount());
+        assertEquals("pubX", settings.getPublishingTopics(0));
+    }
+
+    // ==================== toTopicConsumeProgress Tests ====================
+
+    @Test
+    public void testToTopicConsumeProgress_NullTopic() {
+        ClientDetailInfo.TopicConsumeProgressInfo info = new ClientDetailInfo.TopicConsumeProgressInfo();
+        info.setTopic(null);
+        info.setLag(100L);
+        info.setLatencyMs(5L);
+
+        TopicConsumeProgress progress = ProxyAdminProtoConverter.toTopicConsumeProgress(info);
+
+        assertEquals("", progress.getTopic());
+        assertEquals(100L, progress.getLag());
+        assertEquals(5L, progress.getLatencyMs());
+    }
+
+    // ==================== toProtoRouteChangeEventType Tests ====================
+
+    @Test
+    public void testToProtoRouteChangeEventType_AllTypes() {
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_ONLINE,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(RouteChangeEventType.BROKER_ONLINE));
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_OFFLINE,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(RouteChangeEventType.BROKER_OFFLINE));
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.QUEUE_SCALE,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(RouteChangeEventType.QUEUE_SCALE));
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_CREATE,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(RouteChangeEventType.TOPIC_CREATE));
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_DELETE,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(RouteChangeEventType.TOPIC_DELETE));
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.ROUTE_SNAPSHOT,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(RouteChangeEventType.ROUTE_SNAPSHOT));
+    }
+
+    @Test
+    public void testToProtoRouteChangeEventType_Null() {
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.ROUTE_CHANGE_EVENT_TYPE_UNSPECIFIED,
+            ProxyAdminProtoConverter.toProtoRouteChangeEventType(null));
+    }
+
+    // ==================== toProtoBrokerInfo Tests ====================
+
+    @Test
+    public void testToProtoBrokerInfo_Full() {
+        TopicRouteSnapshot.BrokerInfo info = new TopicRouteSnapshot.BrokerInfo();
+        info.setCluster("testCluster");
+        info.setBrokerName("broker-a");
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        addrs.put(1L, "127.0.0.1:10912");
+        info.setBrokerAddrs(addrs);
+
+        BrokerInfo protoInfo = ProxyAdminProtoConverter.toProtoBrokerInfo(info);
+
+        assertEquals("testCluster", protoInfo.getCluster());
+        assertEquals("broker-a", protoInfo.getBrokerName());
+        assertEquals(2, protoInfo.getBrokerAddrsCount());
+        assertEquals("127.0.0.1:10911", protoInfo.getBrokerAddrsOrThrow(0L));
+        assertEquals("127.0.0.1:10912", protoInfo.getBrokerAddrsOrThrow(1L));
+    }
+
+    @Test
+    public void testToProtoBrokerInfo_NullFields() {
+        TopicRouteSnapshot.BrokerInfo info = new TopicRouteSnapshot.BrokerInfo();
+
+        BrokerInfo protoInfo = ProxyAdminProtoConverter.toProtoBrokerInfo(info);
+
+        assertEquals("", protoInfo.getCluster());
+        assertEquals("", protoInfo.getBrokerName());
+        assertEquals(0, protoInfo.getBrokerAddrsCount());
+    }
+
+    // ==================== toProtoQueueInfo Tests ====================
+
+    @Test
+    public void testToProtoQueueInfo_Full() {
+        TopicRouteSnapshot.QueueInfo info = new TopicRouteSnapshot.QueueInfo();
+        info.setBrokerName("broker-a");
+        info.setReadQueueNums(8);
+        info.setWriteQueueNums(8);
+        info.setPerm(6);
+
+        QueueInfo protoInfo = ProxyAdminProtoConverter.toProtoQueueInfo(info);
+
+        assertEquals("broker-a", protoInfo.getBrokerName());
+        assertEquals(8, protoInfo.getReadQueueNums());
+        assertEquals(8, protoInfo.getWriteQueueNums());
+        assertEquals(6, protoInfo.getPerm());
+    }
+
+    @Test
+    public void testToProtoQueueInfo_NullBrokerName() {
+        TopicRouteSnapshot.QueueInfo info = new TopicRouteSnapshot.QueueInfo();
+
+        QueueInfo protoInfo = ProxyAdminProtoConverter.toProtoQueueInfo(info);
+
+        assertEquals("", protoInfo.getBrokerName());
+        assertEquals(0, protoInfo.getReadQueueNums());
+        assertEquals(0, protoInfo.getWriteQueueNums());
+        assertEquals(0, protoInfo.getPerm());
+    }
+
+    // ==================== toProtoTopicRouteSnapshot Tests ====================
+
+    @Test
+    public void testToProtoTopicRouteSnapshot_Full() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("testTopic");
+
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        brokerInfo.setCluster("cluster1");
+        brokerInfo.setBrokerName("broker-a");
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        brokerInfo.setBrokerAddrs(addrs);
+        snapshot.setBrokers(Collections.singletonList(brokerInfo));
+
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        queueInfo.setBrokerName("broker-a");
+        queueInfo.setReadQueueNums(4);
+        queueInfo.setWriteQueueNums(4);
+        queueInfo.setPerm(6);
+        snapshot.setQueues(Collections.singletonList(queueInfo));
+
+        apache.rocketmq.proxy.admin.v1.TopicRouteSnapshot protoSnapshot = ProxyAdminProtoConverter.toProtoTopicRouteSnapshot(snapshot);
+
+        assertEquals("testTopic", protoSnapshot.getTopic());
+        assertEquals(1, protoSnapshot.getBrokersCount());
+        assertEquals("cluster1", protoSnapshot.getBrokers(0).getCluster());
+        assertEquals("broker-a", protoSnapshot.getBrokers(0).getBrokerName());
+        assertEquals(1, protoSnapshot.getQueuesCount());
+        assertEquals("broker-a", protoSnapshot.getQueues(0).getBrokerName());
+        assertEquals(4, protoSnapshot.getQueues(0).getReadQueueNums());
+    }
+
+    @Test
+    public void testToProtoTopicRouteSnapshot_NullTopic() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+
+        apache.rocketmq.proxy.admin.v1.TopicRouteSnapshot protoSnapshot = ProxyAdminProtoConverter.toProtoTopicRouteSnapshot(snapshot);
+
+        assertEquals("", protoSnapshot.getTopic());
+        assertEquals(0, protoSnapshot.getBrokersCount());
+        assertEquals(0, protoSnapshot.getQueuesCount());
+    }
+
+    @Test
+    public void testToProtoTopicRouteSnapshot_NullBrokersAndQueues() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("testTopic");
+        snapshot.setBrokers(null);
+        snapshot.setQueues(null);
+
+        apache.rocketmq.proxy.admin.v1.TopicRouteSnapshot protoSnapshot = ProxyAdminProtoConverter.toProtoTopicRouteSnapshot(snapshot);
+
+        assertEquals("testTopic", protoSnapshot.getTopic());
+        assertEquals(0, protoSnapshot.getBrokersCount());
+        assertEquals(0, protoSnapshot.getQueuesCount());
+    }
+
+    // ==================== toSubscribeRouteEventsResponse Tests ====================
+
+    @Test
+    public void testToSubscribeRouteEventsResponse_TopicCreate() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.TOPIC_CREATE);
+        event.setTimestamp(1234567890L);
+        event.setTopic("newTopic");
+        event.setCluster("testCluster");
+        event.setBrokerName("broker-a");
+        event.setBrokerId(0L);
+        event.setBrokerAddress("127.0.0.1:10911");
+
+        SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+
+        assertEquals(AdminCode.ADMIN_CODE_OK, response.getCode());
+        assertEquals(AdminCode.ADMIN_CODE_OK.name(), response.getMessage());
+        assertNotNull(response.getEvent());
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_CREATE, response.getEvent().getEventType());
+        assertEquals(1234567890L, response.getEvent().getTimestamp());
+        assertEquals("newTopic", response.getEvent().getTopic());
+        assertEquals("testCluster", response.getEvent().getCluster());
+        assertEquals("broker-a", response.getEvent().getBrokerName());
+        assertEquals(0L, response.getEvent().getBrokerId());
+        assertEquals("127.0.0.1:10911", response.getEvent().getBrokerAddress());
+    }
+
+    @Test
+    public void testToSubscribeRouteEventsResponse_QueueScale() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.QUEUE_SCALE);
+        event.setTimestamp(9999L);
+        event.setTopic("scaleTopic");
+        event.setBrokerName("broker-b");
+        event.setPreviousReadQueueNums(4);
+        event.setCurrentReadQueueNums(8);
+        event.setPreviousWriteQueueNums(4);
+        event.setCurrentWriteQueueNums(8);
+
+        SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.QUEUE_SCALE, response.getEvent().getEventType());
+        assertEquals(4, response.getEvent().getPreviousReadQueueNums());
+        assertEquals(8, response.getEvent().getCurrentReadQueueNums());
+        assertEquals(4, response.getEvent().getPreviousWriteQueueNums());
+        assertEquals(8, response.getEvent().getCurrentWriteQueueNums());
+    }
+
+    @Test
+    public void testToSubscribeRouteEventsResponse_WithRouteSnapshot() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.ROUTE_SNAPSHOT);
+        event.setTimestamp(1000L);
+        event.setTopic("snapshotTopic");
+
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("snapshotTopic");
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        brokerInfo.setCluster("cluster1");
+        brokerInfo.setBrokerName("broker-a");
+        snapshot.setBrokers(Collections.singletonList(brokerInfo));
+        event.setRouteSnapshot(snapshot);
+
+        SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.ROUTE_SNAPSHOT, response.getEvent().getEventType());
+        assertNotNull(response.getEvent().getRouteSnapshot());
+        assertEquals("snapshotTopic", response.getEvent().getRouteSnapshot().getTopic());
+        assertEquals(1, response.getEvent().getRouteSnapshot().getBrokersCount());
+        assertEquals("broker-a", response.getEvent().getRouteSnapshot().getBrokers(0).getBrokerName());
+    }
+
+    @Test
+    public void testToSubscribeRouteEventsResponse_NullFields() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.BROKER_ONLINE);
+        event.setTimestamp(0L);
+        event.setTopic(null);
+        event.setCluster(null);
+        event.setBrokerName(null);
+        event.setBrokerAddress(null);
+
+        SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_ONLINE, response.getEvent().getEventType());
+        assertEquals("", response.getEvent().getTopic());
+        // In proto3, string fields always have default values (empty string), no hasX() methods
+    }
+
+    @Test
+    public void testToSubscribeRouteEventsResponse_BrokerOffline() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.BROKER_OFFLINE);
+        event.setTimestamp(5555L);
+        event.setTopic("offlineTopic");
+        event.setBrokerName("broker-c");
+        event.setBrokerId(1L);
+        event.setBrokerAddress("10.0.0.1:10911");
+
+        SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_OFFLINE, response.getEvent().getEventType());
+        assertEquals("offlineTopic", response.getEvent().getTopic());
+        assertEquals("broker-c", response.getEvent().getBrokerName());
+        assertEquals(1L, response.getEvent().getBrokerId());
+        assertEquals("10.0.0.1:10911", response.getEvent().getBrokerAddress());
+    }
+
+    @Test
+    public void testToSubscribeRouteEventsResponse_TopicDelete() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.TOPIC_DELETE);
+        event.setTimestamp(7777L);
+        event.setTopic("deletedTopic");
+
+        SubscribeRouteEventsResponse response = ProxyAdminProtoConverter.toSubscribeRouteEventsResponse(event);
+
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_DELETE, response.getEvent().getEventType());
+        assertEquals("deletedTopic", response.getEvent().getTopic());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeEventDetectorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeEventDetectorTest.java
@@ -1,0 +1,610 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * The License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEvent;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEventType;
+import org.apache.rocketmq.proxy.grpc.admin.model.TopicRouteSnapshot;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for RouteChangeEventDetector.
+ * Covers: topic create/delete, broker online/offline, queue scaling,
+ * address changes, null/empty route handling, and snapshot building.
+ */
+public class RouteChangeEventDetectorTest {
+
+    private RouteChangeEventDetector detector;
+
+    @Before
+    public void setUp() {
+        detector = new RouteChangeEventDetector();
+    }
+
+    // ==================== Topic Create Tests ====================
+
+    @Test
+    public void testDetectChanges_TopicCreate() {
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", null, newRoute);
+
+        assertEquals(2, events.size());
+        assertEquals(RouteChangeEventType.TOPIC_CREATE, events.get(0).getEventType());
+        assertEquals("test-topic", events.get(0).getTopic());
+        assertEquals(RouteChangeEventType.BROKER_ONLINE, events.get(1).getEventType());
+        assertEquals("broker-0", events.get(1).getBrokerName());
+        assertEquals(0L, events.get(1).getBrokerId());
+        assertEquals("127.0.0.1:10911", events.get(1).getBrokerAddress());
+    }
+
+    @Test
+    public void testDetectChanges_TopicCreateFromEmptyRoute() {
+        TopicRouteData emptyRoute = new TopicRouteData();
+        emptyRoute.setBrokerDatas(new ArrayList<>());
+        emptyRoute.setQueueDatas(new ArrayList<>());
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", emptyRoute, newRoute);
+
+        assertTrue(events.size() >= 1);
+        assertEquals(RouteChangeEventType.TOPIC_CREATE, events.get(0).getEventType());
+    }
+
+    // ==================== Topic Delete Tests ====================
+
+    @Test
+    public void testDetectChanges_TopicDelete() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, null);
+
+        assertEquals(2, events.size());
+        assertEquals(RouteChangeEventType.TOPIC_DELETE, events.get(0).getEventType());
+        assertEquals("test-topic", events.get(0).getTopic());
+        assertEquals(RouteChangeEventType.BROKER_OFFLINE, events.get(1).getEventType());
+        assertEquals("broker-0", events.get(1).getBrokerName());
+    }
+
+    @Test
+    public void testDetectChanges_TopicDeleteToEmptyRoute() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData emptyRoute = new TopicRouteData();
+        emptyRoute.setBrokerDatas(new ArrayList<>());
+        emptyRoute.setQueueDatas(new ArrayList<>());
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, emptyRoute);
+
+        assertTrue(events.size() >= 1);
+        assertEquals(RouteChangeEventType.TOPIC_DELETE, events.get(0).getEventType());
+    }
+
+    // ==================== No Change Tests ====================
+
+    @Test
+    public void testDetectChanges_BothNull() {
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", null, null);
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    public void testDetectChanges_BothEmpty() {
+        TopicRouteData empty1 = new TopicRouteData();
+        empty1.setBrokerDatas(new ArrayList<>());
+        empty1.setQueueDatas(new ArrayList<>());
+
+        TopicRouteData empty2 = new TopicRouteData();
+        empty2.setBrokerDatas(new ArrayList<>());
+        empty2.setQueueDatas(new ArrayList<>());
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", empty1, empty2);
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    public void testDetectChanges_SameRoute() {
+        TopicRouteData route = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", route, route);
+        assertTrue(events.isEmpty());
+    }
+
+    // ==================== Broker Online Tests ====================
+
+    @Test
+    public void testDetectChanges_BrokerOnline_NewBrokerName() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{
+                createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+                createBrokerData("cluster-a", "broker-1", 0L, "127.0.0.2:10911")
+            },
+            new QueueData[]{
+                createQueueData("broker-0", 4, 4, 6),
+                createQueueData("broker-1", 4, 4, 6)
+            }
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasBrokerOnline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_ONLINE
+                && "broker-1".equals(e.getBrokerName()));
+        assertTrue("Should detect broker-1 online", hasBrokerOnline);
+    }
+
+    @Test
+    public void testDetectChanges_BrokerOnline_NewBrokerInstance() {
+        // Old route: broker-0 with master (id=0)
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        // New route: broker-0 with master (id=0) and slave (id=1)
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        addrs.put(1L, "127.0.0.1:10921");
+        BrokerData newBrokerData = new BrokerData();
+        newBrokerData.setCluster("cluster-a");
+        newBrokerData.setBrokerName("broker-0");
+        newBrokerData.setBrokerAddrs(addrs);
+
+        TopicRouteData newRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{newBrokerData},
+            new QueueData[]{createQueueData("broker-0", 4, 4, 6)}
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasBrokerOnline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_ONLINE
+                && e.getBrokerId() == 1L);
+        assertTrue("Should detect new slave broker instance online", hasBrokerOnline);
+    }
+
+    // ==================== Broker Offline Tests ====================
+
+    @Test
+    public void testDetectChanges_BrokerOffline_RemovedBrokerName() {
+        TopicRouteData oldRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{
+                createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+                createBrokerData("cluster-a", "broker-1", 0L, "127.0.0.2:10911")
+            },
+            new QueueData[]{
+                createQueueData("broker-0", 4, 4, 6),
+                createQueueData("broker-1", 4, 4, 6)
+            }
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasBrokerOffline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_OFFLINE
+                && "broker-1".equals(e.getBrokerName()));
+        assertTrue("Should detect broker-1 offline", hasBrokerOffline);
+    }
+
+    @Test
+    public void testDetectChanges_BrokerOffline_RemovedBrokerInstance() {
+        HashMap<Long, String> oldAddrs = new HashMap<>();
+        oldAddrs.put(0L, "127.0.0.1:10911");
+        oldAddrs.put(1L, "127.0.0.1:10921");
+        BrokerData oldBrokerData = new BrokerData();
+        oldBrokerData.setCluster("cluster-a");
+        oldBrokerData.setBrokerName("broker-0");
+        oldBrokerData.setBrokerAddrs(oldAddrs);
+
+        TopicRouteData oldRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{oldBrokerData},
+            new QueueData[]{createQueueData("broker-0", 4, 4, 6)}
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasBrokerOffline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_OFFLINE
+                && e.getBrokerId() == 1L);
+        assertTrue("Should detect slave broker instance offline", hasBrokerOffline);
+    }
+
+    // ==================== Broker Address Change Tests ====================
+
+    @Test
+    public void testDetectChanges_BrokerAddressChange() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10912"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasOffline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_OFFLINE
+                && "127.0.0.1:10911".equals(e.getBrokerAddress()));
+        boolean hasOnline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_ONLINE
+                && "127.0.0.1:10912".equals(e.getBrokerAddress()));
+        assertTrue("Should detect broker offline for old address", hasOffline);
+        assertTrue("Should detect broker online for new address", hasOnline);
+    }
+
+    // ==================== Queue Scale Tests ====================
+
+    @Test
+    public void testDetectChanges_QueueScale_ReadQueueChange() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 8, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasQueueScale = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.QUEUE_SCALE
+                && e.getPreviousReadQueueNums() == 4
+                && e.getCurrentReadQueueNums() == 8);
+        assertTrue("Should detect read queue scale change", hasQueueScale);
+    }
+
+    @Test
+    public void testDetectChanges_QueueScale_WriteQueueChange() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 8, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        boolean hasQueueScale = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.QUEUE_SCALE
+                && e.getPreviousWriteQueueNums() == 4
+                && e.getCurrentWriteQueueNums() == 8);
+        assertTrue("Should detect write queue scale change", hasQueueScale);
+    }
+
+    @Test
+    public void testDetectChanges_NoQueueScaleWhenSame() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+        assertTrue("No events when route is the same", events.isEmpty());
+    }
+
+    // ==================== Complex Scenario Tests ====================
+
+    @Test
+    public void testDetectChanges_MultipleBrokerAndQueueChanges() {
+        TopicRouteData oldRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{
+                createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+                createBrokerData("cluster-a", "broker-1", 0L, "127.0.0.2:10911")
+            },
+            new QueueData[]{
+                createQueueData("broker-0", 4, 4, 6),
+                createQueueData("broker-1", 4, 4, 6)
+            }
+        );
+
+        TopicRouteData newRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{
+                createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+                createBrokerData("cluster-a", "broker-2", 0L, "127.0.0.3:10911")
+            },
+            new QueueData[]{
+                createQueueData("broker-0", 8, 4, 6),
+                createQueueData("broker-2", 4, 4, 6)
+            }
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        // broker-1 offline, broker-2 online, broker-0 queue scale
+        boolean hasBroker1Offline = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_OFFLINE
+                && "broker-1".equals(e.getBrokerName()));
+        boolean hasBroker2Online = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.BROKER_ONLINE
+                && "broker-2".equals(e.getBrokerName()));
+        boolean hasQueueScale = events.stream()
+            .anyMatch(e -> e.getEventType() == RouteChangeEventType.QUEUE_SCALE
+                && "broker-0".equals(e.getBrokerName()));
+
+        assertTrue("Should detect broker-1 offline", hasBroker1Offline);
+        assertTrue("Should detect broker-2 online", hasBroker2Online);
+        assertTrue("Should detect broker-0 queue scale", hasQueueScale);
+    }
+
+    @Test
+    public void testDetectChanges_TopicCreateWithMultipleBrokers() {
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        addrs.put(1L, "127.0.0.1:10921");
+        BrokerData brokerData = new BrokerData();
+        brokerData.setCluster("cluster-a");
+        brokerData.setBrokerName("broker-0");
+        brokerData.setBrokerAddrs(addrs);
+
+        TopicRouteData newRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{brokerData},
+            new QueueData[]{createQueueData("broker-0", 8, 8, 6)}
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("multi-broker-topic", null, newRoute);
+
+        // 1 TOPIC_CREATE + 2 BROKER_ONLINE (master + slave)
+        assertEquals(3, events.size());
+        assertEquals(RouteChangeEventType.TOPIC_CREATE, events.get(0).getEventType());
+        long brokerOnlineCount = events.stream()
+            .filter(e -> e.getEventType() == RouteChangeEventType.BROKER_ONLINE)
+            .count();
+        assertEquals(2, brokerOnlineCount);
+    }
+
+    // ==================== Event Field Tests ====================
+
+    @Test
+    public void testDetectChanges_EventFieldsPopulated() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 8, 8, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("field-test", oldRoute, newRoute);
+
+        RouteChangeEvent queueEvent = events.stream()
+            .filter(e -> e.getEventType() == RouteChangeEventType.QUEUE_SCALE)
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(queueEvent);
+        assertEquals("field-test", queueEvent.getTopic());
+        assertEquals("broker-0", queueEvent.getBrokerName());
+        assertEquals(4, queueEvent.getPreviousReadQueueNums());
+        assertEquals(8, queueEvent.getCurrentReadQueueNums());
+        assertEquals(4, queueEvent.getPreviousWriteQueueNums());
+        assertEquals(8, queueEvent.getCurrentWriteQueueNums());
+        assertTrue(queueEvent.getTimestamp() > 0);
+    }
+
+    @Test
+    public void testDetectChanges_BrokerEventFieldsPopulated() {
+        TopicRouteData oldRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteData newRoute = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{
+                createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+                createBrokerData("cluster-b", "broker-1", 0L, "127.0.0.2:10911")
+            },
+            new QueueData[]{
+                createQueueData("broker-0", 4, 4, 6),
+                createQueueData("broker-1", 4, 4, 6)
+            }
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("test-topic", oldRoute, newRoute);
+
+        RouteChangeEvent brokerEvent = events.stream()
+            .filter(e -> e.getEventType() == RouteChangeEventType.BROKER_ONLINE
+                && "broker-1".equals(e.getBrokerName()))
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(brokerEvent);
+        assertEquals("cluster-b", brokerEvent.getCluster());
+        assertEquals(0L, brokerEvent.getBrokerId());
+        assertEquals("127.0.0.2:10911", brokerEvent.getBrokerAddress());
+    }
+
+    // ==================== Snapshot Building Tests ====================
+
+    @Test
+    public void testBuildSnapshot_NormalRoute() {
+        TopicRouteData route = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        TopicRouteSnapshot snapshot = detector.buildSnapshot("test-topic", route);
+
+        assertEquals("test-topic", snapshot.getTopic());
+        assertEquals(1, snapshot.getBrokers().size());
+        assertEquals("cluster-a", snapshot.getBrokers().get(0).getCluster());
+        assertEquals("broker-0", snapshot.getBrokers().get(0).getBrokerName());
+        assertEquals(1, snapshot.getBrokers().get(0).getBrokerAddrs().size());
+        assertEquals("127.0.0.1:10911", snapshot.getBrokers().get(0).getBrokerAddrs().get(0L));
+        assertEquals(1, snapshot.getQueues().size());
+        assertEquals("broker-0", snapshot.getQueues().get(0).getBrokerName());
+        assertEquals(4, snapshot.getQueues().get(0).getReadQueueNums());
+        assertEquals(4, snapshot.getQueues().get(0).getWriteQueueNums());
+        assertEquals(6, snapshot.getQueues().get(0).getPerm());
+    }
+
+    @Test
+    public void testBuildSnapshot_NullRoute() {
+        TopicRouteSnapshot snapshot = detector.buildSnapshot("test-topic", null);
+
+        assertEquals("test-topic", snapshot.getTopic());
+        assertNotNull(snapshot.getBrokers());
+        assertTrue(snapshot.getBrokers().isEmpty());
+        assertNotNull(snapshot.getQueues());
+        assertTrue(snapshot.getQueues().isEmpty());
+    }
+
+    @Test
+    public void testBuildSnapshot_MultipleBrokers() {
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        addrs.put(1L, "127.0.0.1:10921");
+        BrokerData brokerData = new BrokerData();
+        brokerData.setCluster("cluster-a");
+        brokerData.setBrokerName("broker-0");
+        brokerData.setBrokerAddrs(addrs);
+
+        TopicRouteData route = createRouteDataWithMultipleBrokers(
+            new BrokerData[]{brokerData},
+            new QueueData[]{createQueueData("broker-0", 8, 8, 6)}
+        );
+
+        TopicRouteSnapshot snapshot = detector.buildSnapshot("multi-addr-topic", route);
+
+        assertEquals("multi-addr-topic", snapshot.getTopic());
+        assertEquals(1, snapshot.getBrokers().size());
+        assertEquals(2, snapshot.getBrokers().get(0).getBrokerAddrs().size());
+        assertEquals("127.0.0.1:10911", snapshot.getBrokers().get(0).getBrokerAddrs().get(0L));
+        assertEquals("127.0.0.1:10921", snapshot.getBrokers().get(0).getBrokerAddrs().get(1L));
+    }
+
+    // ==================== Topic Create with Snapshot ====================
+
+    @Test
+    public void testDetectChanges_TopicCreateHasSnapshot() {
+        TopicRouteData newRoute = createRouteData(
+            createBrokerData("cluster-a", "broker-0", 0L, "127.0.0.1:10911"),
+            createQueueData("broker-0", 4, 4, 6)
+        );
+
+        List<RouteChangeEvent> events = detector.detectChanges("snapshot-topic", null, newRoute);
+
+        RouteChangeEvent createEvent = events.get(0);
+        assertEquals(RouteChangeEventType.TOPIC_CREATE, createEvent.getEventType());
+        assertNotNull(createEvent.getRouteSnapshot());
+        assertEquals("snapshot-topic", createEvent.getRouteSnapshot().getTopic());
+    }
+
+    // ==================== Helper Methods ====================
+
+    private TopicRouteData createRouteData(BrokerData brokerData, QueueData queueData) {
+        TopicRouteData routeData = new TopicRouteData();
+        List<BrokerData> brokerDatas = new ArrayList<>();
+        brokerDatas.add(brokerData);
+        List<QueueData> queueDatas = new ArrayList<>();
+        queueDatas.add(queueData);
+        routeData.setBrokerDatas(brokerDatas);
+        routeData.setQueueDatas(queueDatas);
+        return routeData;
+    }
+
+    private TopicRouteData createRouteDataWithMultipleBrokers(BrokerData[] brokerDatas, QueueData[] queueDatas) {
+        TopicRouteData routeData = new TopicRouteData();
+        List<BrokerData> brokerList = new ArrayList<>();
+        for (BrokerData bd : brokerDatas) {
+            brokerList.add(bd);
+        }
+        List<QueueData> queueList = new ArrayList<>();
+        for (QueueData qd : queueDatas) {
+            queueList.add(qd);
+        }
+        routeData.setBrokerDatas(brokerList);
+        routeData.setQueueDatas(queueList);
+        return routeData;
+    }
+
+    private BrokerData createBrokerData(String cluster, String brokerName, long brokerId, String brokerAddr) {
+        BrokerData brokerData = new BrokerData();
+        brokerData.setCluster(cluster);
+        brokerData.setBrokerName(brokerName);
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(brokerId, brokerAddr);
+        brokerData.setBrokerAddrs(addrs);
+        return brokerData;
+    }
+
+    private QueueData createQueueData(String brokerName, int readQueueNums, int writeQueueNums, int perm) {
+        QueueData queueData = new QueueData();
+        queueData.setBrokerName(brokerName);
+        queueData.setReadQueueNums(readQueueNums);
+        queueData.setWriteQueueNums(writeQueueNums);
+        queueData.setPerm(perm);
+        return queueData;
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeNotifierTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/RouteChangeNotifierTest.java
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsResponse;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.proxy.common.Address;
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.grpc.admin.model.RouteChangeEventType;
+import org.apache.rocketmq.proxy.service.route.AddressableMessageQueue;
+import org.apache.rocketmq.proxy.service.route.MessageQueueView;
+import org.apache.rocketmq.proxy.service.route.ProxyTopicRouteData;
+import org.apache.rocketmq.proxy.service.route.TopicRouteService;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for RouteChangeNotifier.
+ * <p>
+ * Uses sun.misc.Unsafe.allocateInstance() to create TopicRouteService instances
+ * without calling the constructor, avoiding Mockito 3.10 / Java 21 Byte Buddy
+ * incompatibility and bypassing the complex TopicRouteService constructor that
+ * requires MQClientAPIFactory and ConfigurationManager initialization.
+ */
+public class RouteChangeNotifierTest {
+
+    private TestTopicRouteService topicRouteService;
+    private TestServerCallStreamObserver streamObserver;
+    private RouteChangeNotifier notifier;
+
+    @Before
+    public void setUp() throws Exception {
+        topicRouteService = TestTopicRouteService.create();
+        topicRouteService.setAllTopicNames(Collections.emptySet());
+        streamObserver = new TestServerCallStreamObserver();
+        notifier = new RouteChangeNotifier(topicRouteService);
+    }
+
+    // ========== Subscribe Tests ==========
+
+    @Test
+    public void testSubscribe_RegistersSubscription() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        assertEquals(1, notifier.getSubscriberCount());
+    }
+
+    @Test
+    public void testSubscribe_SetsOnCancelHandler() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        assertNotNull(streamObserver.cancelHandler);
+    }
+
+    @Test
+    public void testSubscribe_OnCancelRemovesSubscription() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        assertNotNull(streamObserver.cancelHandler);
+        streamObserver.cancelHandler.run();
+        assertEquals(0, notifier.getSubscriberCount());
+    }
+
+    @Test
+    public void testSubscribe_WithNonServerCallStreamObserver() {
+        TestStreamObserver plainObserver = new TestStreamObserver();
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), plainObserver);
+        assertEquals(1, notifier.getSubscriberCount());
+        // No setOnCancelHandler called for plain StreamObserver - this is expected
+    }
+
+    @Test
+    public void testSubscribe_MultipleSubscribers() {
+        TestServerCallStreamObserver observer2 = new TestServerCallStreamObserver();
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), observer2);
+        assertEquals(2, notifier.getSubscriberCount());
+    }
+
+    @Test
+    public void testSubscribe_SendsInitialSnapshot() {
+        Set<String> cachedTopics = new HashSet<>();
+        cachedTopics.add("topic-a");
+        cachedTopics.add("topic-b");
+        topicRouteService.setAllTopicNames(cachedTopics);
+
+        TopicRouteData routeData = createTopicRouteData("topic-a");
+        MessageQueueView view = new MessageQueueView("topic-a", routeData, null);
+        topicRouteService.setCachedTopicRouteData("topic-a", view);
+        // topic-b returns null view (not set in cache)
+
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+
+        // Should send snapshot for topic-a only (topic-b returns null view)
+        assertEquals(1, streamObserver.responses.size());
+        assertEquals("topic-a", streamObserver.responses.get(0).getEvent().getTopic());
+    }
+
+    @Test
+    public void testSubscribe_WithTopicFilter() {
+        Set<String> cachedTopics = new HashSet<>();
+        cachedTopics.add("topic-a");
+        cachedTopics.add("topic-b");
+        topicRouteService.setAllTopicNames(cachedTopics);
+
+        TopicRouteData routeDataA = createTopicRouteData("topic-a");
+        TopicRouteData routeDataB = createTopicRouteData("topic-b");
+        topicRouteService.setCachedTopicRouteData("topic-a", new MessageQueueView("topic-a", routeDataA, null));
+        topicRouteService.setCachedTopicRouteData("topic-b", new MessageQueueView("topic-b", routeDataB, null));
+
+        notifier.subscribe(Arrays.asList("topic-a"), Collections.emptyList(), streamObserver);
+
+        // Should only send snapshot for topic-a (topic-b filtered out)
+        assertEquals(1, streamObserver.responses.size());
+        assertEquals("topic-a", streamObserver.responses.get(0).getEvent().getTopic());
+    }
+
+    @Test
+    public void testSubscribe_WithEventTypeFilter() {
+        Set<String> cachedTopics = new HashSet<>();
+        cachedTopics.add("topic-a");
+        topicRouteService.setAllTopicNames(cachedTopics);
+
+        TopicRouteData routeData = createTopicRouteData("topic-a");
+        topicRouteService.setCachedTopicRouteData("topic-a", new MessageQueueView("topic-a", routeData, null));
+
+        // Subscribe with only BROKER_ONLINE filter - ROUTE_SNAPSHOT should be filtered out
+        notifier.subscribe(Collections.emptyList(), Arrays.asList(RouteChangeEventType.BROKER_ONLINE), streamObserver);
+
+        // Should NOT send ROUTE_SNAPSHOT since event type filter doesn't include it
+        assertTrue(streamObserver.responses.isEmpty());
+    }
+
+    @Test
+    public void testSubscribe_NullTopicRouteService() {
+        RouteChangeNotifier notifierNoService = new RouteChangeNotifier(null);
+        notifierNoService.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        assertEquals(1, notifierNoService.getSubscriberCount());
+        // No snapshot sent, no exception thrown
+        assertTrue(streamObserver.responses.isEmpty());
+    }
+
+    // ========== onRouteRefreshed Tests ==========
+
+    @Test
+    public void testOnRouteRefreshed_NoSubscribers() {
+        TopicRouteData oldRoute = createTopicRouteData("topic-a");
+        TopicRouteData newRoute = createTopicRouteData("topic-a");
+        MessageQueueView oldView = new MessageQueueView("topic-a", oldRoute, null);
+        MessageQueueView newView = new MessageQueueView("topic-a", newRoute, null);
+
+        // Should not throw when no subscribers
+        notifier.onRouteRefreshed("topic-a", oldView, newView);
+    }
+
+    @Test
+    public void testOnRouteRefreshed_TopicCreate() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+
+        TopicRouteData newRoute = createTopicRouteData("topic-a");
+        MessageQueueView newView = new MessageQueueView("topic-a", newRoute, null);
+
+        notifier.onRouteRefreshed("topic-a", null, newView);
+
+        // null -> route with 1 broker produces TOPIC_CREATE + BROKER_ONLINE events
+        assertEquals(2, streamObserver.responses.size());
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_CREATE,
+            streamObserver.responses.get(0).getEvent().getEventType());
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_ONLINE,
+            streamObserver.responses.get(1).getEvent().getEventType());
+    }
+
+    @Test
+    public void testOnRouteRefreshed_TopicDelete() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+
+        TopicRouteData oldRoute = createTopicRouteData("topic-a");
+        MessageQueueView oldView = new MessageQueueView("topic-a", oldRoute, null);
+
+        notifier.onRouteRefreshed("topic-a", oldView, null);
+
+        // route with 1 broker -> null produces BROKER_OFFLINE + TOPIC_DELETE events
+        assertEquals(2, streamObserver.responses.size());
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.TOPIC_DELETE,
+            streamObserver.responses.get(0).getEvent().getEventType());
+        assertEquals(apache.rocketmq.proxy.admin.v1.RouteChangeEventType.BROKER_OFFLINE,
+            streamObserver.responses.get(1).getEvent().getEventType());
+    }
+
+    @Test
+    public void testOnRouteRefreshed_NoChange() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+
+        TopicRouteData route = createTopicRouteData("topic-a");
+        MessageQueueView oldView = new MessageQueueView("topic-a", route, null);
+        MessageQueueView newView = new MessageQueueView("topic-a", route, null);
+
+        notifier.onRouteRefreshed("topic-a", oldView, newView);
+
+        // No events should be pushed (same route data, no initial snapshot since no cached topics)
+        assertTrue(streamObserver.responses.isEmpty());
+    }
+
+    @Test
+    public void testOnRouteRefreshed_WithTopicFilter() {
+        notifier.subscribe(Arrays.asList("topic-b"), Collections.emptyList(), streamObserver);
+
+        TopicRouteData newRoute = createTopicRouteData("topic-a");
+        MessageQueueView newView = new MessageQueueView("topic-a", newRoute, null);
+
+        notifier.onRouteRefreshed("topic-a", null, newView);
+
+        // Event for topic-a should be filtered out (subscriber only wants topic-b)
+        assertTrue(streamObserver.responses.isEmpty());
+    }
+
+    @Test
+    public void testOnRouteRefreshed_WithEventTypeFilter() {
+        notifier.subscribe(Collections.emptyList(), Arrays.asList(RouteChangeEventType.BROKER_ONLINE), streamObserver);
+
+        TopicRouteData oldRoute = createTopicRouteData("topic-a");
+        MessageQueueView oldView = new MessageQueueView("topic-a", oldRoute, null);
+
+        notifier.onRouteRefreshed("topic-a", oldView, null);
+
+        // TOPIC_DELETE should be filtered out (subscriber only wants BROKER_ONLINE)
+        assertTrue(streamObserver.responses.isEmpty());
+    }
+
+    @Test
+    public void testOnRouteRefreshed_BroadcastsToMultipleSubscribers() {
+        TestServerCallStreamObserver observer2 = new TestServerCallStreamObserver();
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), observer2);
+
+        TopicRouteData newRoute = createTopicRouteData("topic-a");
+        MessageQueueView newView = new MessageQueueView("topic-a", newRoute, null);
+
+        notifier.onRouteRefreshed("topic-a", null, newView);
+
+        assertFalse(streamObserver.responses.isEmpty());
+        assertFalse(observer2.responses.isEmpty());
+    }
+
+    // ========== Shutdown Tests ==========
+
+    @Test
+    public void testShutdown_CompletesAllStreams() {
+        TestServerCallStreamObserver observer2 = new TestServerCallStreamObserver();
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), observer2);
+
+        notifier.shutdown();
+
+        assertTrue(streamObserver.completed);
+        assertTrue(observer2.completed);
+        assertEquals(0, notifier.getSubscriberCount());
+    }
+
+    @Test
+    public void testShutdown_NoSubscribers() {
+        notifier.shutdown();
+        assertEquals(0, notifier.getSubscriberCount());
+    }
+
+    // ========== getSubscriberCount Tests ==========
+
+    @Test
+    public void testGetSubscriberCount_Initial() {
+        assertEquals(0, notifier.getSubscriberCount());
+    }
+
+    @Test
+    public void testGetSubscriberCount_AfterSubscribeAndCancel() {
+        notifier.subscribe(Collections.emptyList(), Collections.emptyList(), streamObserver);
+        assertEquals(1, notifier.getSubscriberCount());
+
+        assertNotNull(streamObserver.cancelHandler);
+        streamObserver.cancelHandler.run();
+
+        assertEquals(0, notifier.getSubscriberCount());
+    }
+
+    // ========== Helper Methods ==========
+
+    private TopicRouteData createTopicRouteData(String topic) {
+        TopicRouteData routeData = new TopicRouteData();
+        HashMap<Long, String> brokerAddrs = new HashMap<>();
+        brokerAddrs.put(0L, "127.0.0.1:10911");
+
+        BrokerData brokerData = new BrokerData();
+        brokerData.setCluster("default-cluster");
+        brokerData.setBrokerName("broker-a");
+        brokerData.setBrokerAddrs(brokerAddrs);
+
+        QueueData queueData = new QueueData();
+        queueData.setBrokerName("broker-a");
+        queueData.setReadQueueNums(4);
+        queueData.setWriteQueueNums(4);
+        queueData.setPerm(6);
+
+        List<BrokerData> brokerDatas = new ArrayList<>();
+        brokerDatas.add(brokerData);
+        List<QueueData> queueDatas = new ArrayList<>();
+        queueDatas.add(queueData);
+
+        routeData.setBrokerDatas(brokerDatas);
+        routeData.setQueueDatas(queueDatas);
+        return routeData;
+    }
+
+    /**
+     * Create an instance without calling the constructor using sun.misc.Unsafe.
+     * This bypasses constructor logic and avoids Mockito 3.10 / Java 21 Byte Buddy
+     * incompatibility with classes extending AbstractStartAndShutdown.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> T createInstanceWithoutConstructor(Class<T> clazz) throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+        return (T) allocateInstance.invoke(unsafe, clazz);
+    }
+
+    // ========== Test Helper Classes ==========
+
+    /**
+     * Test implementation of TopicRouteService that uses field-backed overrides
+     * for getAllTopicNames() and getCachedTopicRouteData() instead of Mockito mocking.
+     * <p>
+     * Created via Unsafe.allocateInstance() to bypass the TopicRouteService constructor
+     * which requires MQClientAPIFactory and ConfigurationManager initialization.
+     * Abstract methods throw UnsupportedOperationException as they are not needed
+     * by RouteChangeNotifier tests.
+     */
+    private static class TestTopicRouteService extends TopicRouteService {
+        private Set<String> allTopicNames;
+        private Map<String, MessageQueueView> cachedViews;
+
+        /**
+         * Constructor exists only to satisfy the Java compiler.
+         * Never called at runtime - Unsafe.allocateInstance() bypasses all constructors,
+         * avoiding the TopicRouteService constructor that requires MQClientAPIFactory
+         * and ConfigurationManager initialization.
+         */
+        @SuppressWarnings("unused")
+        TestTopicRouteService() {
+            super(null);
+        }
+
+        static TestTopicRouteService create() throws Exception {
+            return createInstanceWithoutConstructor(TestTopicRouteService.class);
+        }
+
+        void setAllTopicNames(Set<String> topics) {
+            this.allTopicNames = topics;
+        }
+
+        void setCachedTopicRouteData(String topic, MessageQueueView view) {
+            if (this.cachedViews == null) {
+                this.cachedViews = new HashMap<>();
+            }
+            this.cachedViews.put(topic, view);
+        }
+
+        @Override
+        public Set<String> getAllTopicNames() {
+            if (allTopicNames == null) {
+                allTopicNames = Collections.emptySet();
+            }
+            return allTopicNames;
+        }
+
+        @Override
+        public MessageQueueView getCachedTopicRouteData(String topic) {
+            if (cachedViews == null) {
+                return null;
+            }
+            return cachedViews.get(topic);
+        }
+
+        @Override
+        public MessageQueueView getCurrentMessageQueueView(ProxyContext ctx, String topicName) {
+            throw new UnsupportedOperationException("Not needed for RouteChangeNotifier tests");
+        }
+
+        @Override
+        public ProxyTopicRouteData getTopicRouteForProxy(ProxyContext ctx,
+            List<Address> requestHostAndPortList, String topicName) {
+            throw new UnsupportedOperationException("Not needed for RouteChangeNotifier tests");
+        }
+
+        @Override
+        public String getBrokerAddr(ProxyContext ctx, String brokerName) {
+            throw new UnsupportedOperationException("Not needed for RouteChangeNotifier tests");
+        }
+
+        @Override
+        public AddressableMessageQueue buildAddressableMessageQueue(ProxyContext ctx,
+            MessageQueue messageQueue) {
+            throw new UnsupportedOperationException("Not needed for RouteChangeNotifier tests");
+        }
+    }
+
+    /**
+     * Test implementation of ServerCallStreamObserver that records method calls
+     * for verification without requiring Mockito mocking (which is incompatible
+     * with Java 21 Byte Buddy).
+     */
+    private static class TestServerCallStreamObserver extends ServerCallStreamObserver<SubscribeRouteEventsResponse> {
+        final List<SubscribeRouteEventsResponse> responses = new ArrayList<>();
+        volatile boolean completed = false;
+        volatile Throwable error;
+        Runnable cancelHandler;
+        Runnable readyHandler;
+        boolean cancelled = false;
+
+        @Override
+        public void setOnCancelHandler(Runnable onCancelHandler) {
+            this.cancelHandler = onCancelHandler;
+        }
+
+        @Override
+        public void setOnReadyHandler(Runnable onReadyHandler) {
+            this.readyHandler = onReadyHandler;
+        }
+
+        @Override
+        public void disableAutoInboundFlowControl() {
+
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setCompression(String compression) {
+            // no-op for test
+        }
+
+        @Override
+        public void request(int numMessages) {
+            // no-op for test
+        }
+
+        @Override
+        public void setMessageCompression(boolean b) {
+
+        }
+
+        @Override
+        public void onNext(SubscribeRouteEventsResponse value) {
+            responses.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            this.completed = true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+    }
+
+    /**
+     * Test implementation of plain StreamObserver for testing non-ServerCallStreamObserver paths.
+     */
+    private static class TestStreamObserver implements StreamObserver<SubscribeRouteEventsResponse> {
+        final List<SubscribeRouteEventsResponse> responses = new ArrayList<>();
+        volatile boolean completed = false;
+        volatile Throwable error;
+
+        @Override
+        public void onNext(SubscribeRouteEventsResponse value) {
+            responses.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            this.completed = true;
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfoTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfoTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class ClientDetailInfoTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ClientDetailInfo detail = new ClientDetailInfo();
+        assertNull(detail.getClientInstance());
+        assertNull(detail.getSettings());
+        assertNull(detail.getHeartbeatHistory());
+        assertNull(detail.getAuthStatus());
+        assertNull(detail.getConsumeProgress());
+        assertNull(detail.getNetworkInfo());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        ClientDetailInfo detail = new ClientDetailInfo();
+
+        ClientInstanceInfo instance = new ClientInstanceInfo();
+        instance.setClientId("client-1");
+        detail.setClientInstance(instance);
+        assertSame(instance, detail.getClientInstance());
+
+        ClientDetailInfo.ClientSettingsInfo settings = new ClientDetailInfo.ClientSettingsInfo();
+        detail.setSettings(settings);
+        assertSame(settings, detail.getSettings());
+
+        ClientDetailInfo.HeartbeatRecordInfo record = new ClientDetailInfo.HeartbeatRecordInfo();
+        detail.setHeartbeatHistory(Collections.singletonList(record));
+        assertEquals(1, detail.getHeartbeatHistory().size());
+        assertSame(record, detail.getHeartbeatHistory().get(0));
+
+        ClientDetailInfo.AuthStatusInfo authStatus = new ClientDetailInfo.AuthStatusInfo();
+        detail.setAuthStatus(authStatus);
+        assertSame(authStatus, detail.getAuthStatus());
+
+        ClientDetailInfo.ConsumeProgressInfo progress = new ClientDetailInfo.ConsumeProgressInfo();
+        detail.setConsumeProgress(progress);
+        assertSame(progress, detail.getConsumeProgress());
+
+        ClientDetailInfo.NetworkInfoInfo networkInfo = new ClientDetailInfo.NetworkInfoInfo();
+        detail.setNetworkInfo(networkInfo);
+        assertSame(networkInfo, detail.getNetworkInfo());
+    }
+
+    @Test
+    public void testClientSettingsInfo() {
+        ClientDetailInfo.ClientSettingsInfo settings = new ClientDetailInfo.ClientSettingsInfo();
+        settings.setSubscriptionMode("PUSH");
+        settings.setReceiveBatchSize(32);
+        settings.setLongPollingTimeoutMs(30000L);
+        settings.setFifo(true);
+        settings.setSubscriptionTopics(Arrays.asList("topicA", "topicB"));
+        settings.setPublishingTopics(Collections.singletonList("topicC"));
+
+        assertEquals("PUSH", settings.getSubscriptionMode());
+        assertEquals(32, settings.getReceiveBatchSize());
+        assertEquals(30000L, settings.getLongPollingTimeoutMs());
+        assertTrue(settings.isFifo());
+        assertEquals(Arrays.asList("topicA", "topicB"), settings.getSubscriptionTopics());
+        assertEquals(Collections.singletonList("topicC"), settings.getPublishingTopics());
+    }
+
+    @Test
+    public void testHeartbeatRecordInfo() {
+        ClientDetailInfo.HeartbeatRecordInfo record = new ClientDetailInfo.HeartbeatRecordInfo();
+        record.setTimestamp(1234567890L);
+        record.setSuccess(true);
+        record.setRemark("ok");
+
+        assertEquals(1234567890L, record.getTimestamp());
+        assertTrue(record.isSuccess());
+        assertEquals("ok", record.getRemark());
+    }
+
+    @Test
+    public void testAuthStatusInfo() {
+        ClientDetailInfo.AuthStatusInfo authStatus = new ClientDetailInfo.AuthStatusInfo();
+        authStatus.setAuthenticated(true);
+        authStatus.setUsername("rocketmq");
+        authStatus.setLastAuthTime(1234567890L);
+        authStatus.setFailureReason("none");
+
+        assertTrue(authStatus.isAuthenticated());
+        assertEquals("rocketmq", authStatus.getUsername());
+        assertEquals(1234567890L, authStatus.getLastAuthTime());
+        assertEquals("none", authStatus.getFailureReason());
+    }
+
+    @Test
+    public void testConsumeProgressInfo() {
+        ClientDetailInfo.TopicConsumeProgressInfo topicProgress = new ClientDetailInfo.TopicConsumeProgressInfo();
+        topicProgress.setTopic("topicA");
+        topicProgress.setLag(100L);
+        topicProgress.setLatencyMs(50L);
+
+        assertEquals("topicA", topicProgress.getTopic());
+        assertEquals(100L, topicProgress.getLag());
+        assertEquals(50L, topicProgress.getLatencyMs());
+
+        ClientDetailInfo.ConsumeProgressInfo progress = new ClientDetailInfo.ConsumeProgressInfo();
+        progress.setLag(200L);
+        progress.setLatencyMs(80L);
+        progress.setTopicProgress(Collections.singletonList(topicProgress));
+
+        assertEquals(200L, progress.getLag());
+        assertEquals(80L, progress.getLatencyMs());
+        assertEquals(1, progress.getTopicProgress().size());
+        assertSame(topicProgress, progress.getTopicProgress().get(0));
+    }
+
+    @Test
+    public void testNetworkInfoInfo() {
+        ClientDetailInfo.NetworkInfoInfo networkInfo = new ClientDetailInfo.NetworkInfoInfo();
+        networkInfo.setLocalAddress("127.0.0.1:8081");
+        networkInfo.setRemoteAddress("127.0.0.1:12345");
+        networkInfo.setRttMs(5L);
+        networkInfo.setSslEnabled(false);
+
+        assertEquals("127.0.0.1:8081", networkInfo.getLocalAddress());
+        assertEquals("127.0.0.1:12345", networkInfo.getRemoteAddress());
+        assertEquals(5L, networkInfo.getRttMs());
+        assertFalse(networkInfo.isSslEnabled());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfoTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfoTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ClientInstanceInfoTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        assertNull(info.getClientId());
+        assertNull(info.getLanguage());
+        assertNull(info.getClientVersion());
+        assertNull(info.getProtocol());
+        assertNull(info.getAccessPoint());
+        assertEquals(0, info.getConnectAt());
+        assertEquals(0, info.getLastActiveAt());
+        assertNull(info.getRole());
+        assertNull(info.getGroup());
+        assertNull(info.getTopics());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        List<String> topics = Arrays.asList("topicA", "topicB");
+
+        info.setClientId("client-1");
+        info.setLanguage("JAVA");
+        info.setClientVersion("5.0.0");
+        info.setProtocol("grpc");
+        info.setAccessPoint("127.0.0.1:8081");
+        info.setConnectAt(1000L);
+        info.setLastActiveAt(2000L);
+        info.setRole("CONSUMER");
+        info.setGroup("groupA");
+        info.setTopics(topics);
+
+        assertEquals("client-1", info.getClientId());
+        assertEquals("JAVA", info.getLanguage());
+        assertEquals("5.0.0", info.getClientVersion());
+        assertEquals("grpc", info.getProtocol());
+        assertEquals("127.0.0.1:8081", info.getAccessPoint());
+        assertEquals(1000L, info.getConnectAt());
+        assertEquals(2000L, info.getLastActiveAt());
+        assertEquals("CONSUMER", info.getRole());
+        assertEquals("groupA", info.getGroup());
+        assertEquals(topics, info.getTopics());
+    }
+
+    @Test
+    public void testToString() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId("client-1");
+        info.setLanguage("JAVA");
+        info.setGroup("groupA");
+
+        String str = info.toString();
+        assertTrue(str.contains("client-1"));
+        assertTrue(str.contains("JAVA"));
+        assertTrue(str.contains("groupA"));
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilterTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ListClientsFilterTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ListClientsFilter filter = new ListClientsFilter();
+        assertNull(filter.getGroup());
+        assertNull(filter.getTopic());
+        assertNull(filter.getClientIdPrefix());
+        assertNull(filter.getLanguage());
+        assertEquals(0, filter.getConnectTimeStart());
+        assertEquals(0, filter.getConnectTimeEnd());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup("groupA");
+        filter.setTopic("topicA");
+        filter.setClientIdPrefix("client-");
+        filter.setLanguage("JAVA");
+        filter.setConnectTimeStart(1000L);
+        filter.setConnectTimeEnd(2000L);
+
+        assertEquals("groupA", filter.getGroup());
+        assertEquals("topicA", filter.getTopic());
+        assertEquals("client-", filter.getClientIdPrefix());
+        assertEquals("JAVA", filter.getLanguage());
+        assertEquals(1000L, filter.getConnectTimeStart());
+        assertEquals(2000L, filter.getConnectTimeEnd());
+    }
+
+    @Test
+    public void testHasFilterEmpty() {
+        ListClientsFilter filter = new ListClientsFilter();
+        assertFalse(filter.hasFilter());
+    }
+
+    @Test
+    public void testHasFilterEachField() {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup("groupA");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setTopic("topicA");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setClientIdPrefix("client-");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setLanguage("JAVA");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setConnectTimeStart(1000L);
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setConnectTimeEnd(2000L);
+        assertTrue(filter.hasFilter());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RouteChangeEventTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        assertNull(event.getEventType());
+        assertEquals(0, event.getTimestamp());
+        assertNull(event.getTopic());
+        assertNull(event.getCluster());
+        assertNull(event.getBrokerName());
+        assertEquals(0, event.getBrokerId());
+        assertNull(event.getBrokerAddress());
+        assertEquals(0, event.getPreviousReadQueueNums());
+        assertEquals(0, event.getCurrentReadQueueNums());
+        assertEquals(0, event.getPreviousWriteQueueNums());
+        assertEquals(0, event.getCurrentWriteQueueNums());
+        assertNull(event.getRouteSnapshot());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("test-topic");
+
+        event.setEventType(RouteChangeEventType.BROKER_ONLINE);
+        event.setTimestamp(1234567890L);
+        event.setTopic("test-topic");
+        event.setCluster("test-cluster");
+        event.setBrokerName("broker-a");
+        event.setBrokerId(0L);
+        event.setBrokerAddress("127.0.0.1:10911");
+        event.setPreviousReadQueueNums(4);
+        event.setCurrentReadQueueNums(8);
+        event.setPreviousWriteQueueNums(4);
+        event.setCurrentWriteQueueNums(8);
+        event.setRouteSnapshot(snapshot);
+
+        assertEquals(RouteChangeEventType.BROKER_ONLINE, event.getEventType());
+        assertEquals(1234567890L, event.getTimestamp());
+        assertEquals("test-topic", event.getTopic());
+        assertEquals("test-cluster", event.getCluster());
+        assertEquals("broker-a", event.getBrokerName());
+        assertEquals(0L, event.getBrokerId());
+        assertEquals("127.0.0.1:10911", event.getBrokerAddress());
+        assertEquals(4, event.getPreviousReadQueueNums());
+        assertEquals(8, event.getCurrentReadQueueNums());
+        assertEquals(4, event.getPreviousWriteQueueNums());
+        assertEquals(8, event.getCurrentWriteQueueNums());
+        assertEquals(snapshot, event.getRouteSnapshot());
+    }
+
+    @Test
+    public void testAllEventTypes() {
+        RouteChangeEvent event = new RouteChangeEvent();
+
+        for (RouteChangeEventType type : RouteChangeEventType.values()) {
+            event.setEventType(type);
+            assertEquals(type, event.getEventType());
+        }
+    }
+
+    @Test
+    public void testQueueScaleEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.QUEUE_SCALE);
+        event.setTopic("scale-topic");
+        event.setBrokerName("broker-b");
+        event.setPreviousReadQueueNums(4);
+        event.setCurrentReadQueueNums(8);
+        event.setPreviousWriteQueueNums(4);
+        event.setCurrentWriteQueueNums(8);
+
+        assertEquals(RouteChangeEventType.QUEUE_SCALE, event.getEventType());
+        assertEquals(4, event.getPreviousReadQueueNums());
+        assertEquals(8, event.getCurrentReadQueueNums());
+        assertEquals(4, event.getPreviousWriteQueueNums());
+        assertEquals(8, event.getCurrentWriteQueueNums());
+    }
+
+    @Test
+    public void testTopicCreateEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.TOPIC_CREATE);
+        event.setTopic("new-topic");
+
+        assertEquals(RouteChangeEventType.TOPIC_CREATE, event.getEventType());
+        assertEquals("new-topic", event.getTopic());
+    }
+
+    @Test
+    public void testTopicDeleteEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.TOPIC_DELETE);
+        event.setTopic("deleted-topic");
+
+        assertEquals(RouteChangeEventType.TOPIC_DELETE, event.getEventType());
+        assertEquals("deleted-topic", event.getTopic());
+    }
+
+    @Test
+    public void testRouteSnapshotEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.ROUTE_SNAPSHOT);
+        event.setTopic("snapshot-topic");
+
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("snapshot-topic");
+        event.setRouteSnapshot(snapshot);
+
+        assertEquals(RouteChangeEventType.ROUTE_SNAPSHOT, event.getEventType());
+        assertEquals("snapshot-topic", event.getRouteSnapshot().getTopic());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshotTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshotTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TopicRouteSnapshotTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        assertNull(snapshot.getTopic());
+        assertNull(snapshot.getBrokers());
+        assertNull(snapshot.getQueues());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("test-topic");
+
+        List<TopicRouteSnapshot.BrokerInfo> brokers = new ArrayList<>();
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        brokerInfo.setCluster("cluster-a");
+        brokerInfo.setBrokerName("broker-0");
+        Map<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        brokerInfo.setBrokerAddrs(addrs);
+        brokers.add(brokerInfo);
+        snapshot.setBrokers(brokers);
+
+        List<TopicRouteSnapshot.QueueInfo> queues = new ArrayList<>();
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        queueInfo.setBrokerName("broker-0");
+        queueInfo.setReadQueueNums(8);
+        queueInfo.setWriteQueueNums(8);
+        queueInfo.setPerm(6);
+        queues.add(queueInfo);
+        snapshot.setQueues(queues);
+
+        assertEquals("test-topic", snapshot.getTopic());
+        assertEquals(1, snapshot.getBrokers().size());
+        assertEquals("cluster-a", snapshot.getBrokers().get(0).getCluster());
+        assertEquals("broker-0", snapshot.getBrokers().get(0).getBrokerName());
+        assertEquals(1, snapshot.getBrokers().get(0).getBrokerAddrs().size());
+        assertEquals("127.0.0.1:10911", snapshot.getBrokers().get(0).getBrokerAddrs().get(0L));
+        assertEquals(1, snapshot.getQueues().size());
+        assertEquals("broker-0", snapshot.getQueues().get(0).getBrokerName());
+        assertEquals(8, snapshot.getQueues().get(0).getReadQueueNums());
+        assertEquals(8, snapshot.getQueues().get(0).getWriteQueueNums());
+        assertEquals(6, snapshot.getQueues().get(0).getPerm());
+    }
+
+    @Test
+    public void testBrokerInfoDefaultConstructor() {
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        assertNull(brokerInfo.getCluster());
+        assertNull(brokerInfo.getBrokerName());
+        assertNull(brokerInfo.getBrokerAddrs());
+    }
+
+    @Test
+    public void testBrokerInfoWithMultipleAddresses() {
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        Map<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        addrs.put(1L, "127.0.0.1:10921");
+        brokerInfo.setBrokerAddrs(addrs);
+
+        assertEquals(2, brokerInfo.getBrokerAddrs().size());
+        assertEquals("127.0.0.1:10911", brokerInfo.getBrokerAddrs().get(0L));
+        assertEquals("127.0.0.1:10921", brokerInfo.getBrokerAddrs().get(1L));
+    }
+
+    @Test
+    public void testQueueInfoDefaultConstructor() {
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        assertNull(queueInfo.getBrokerName());
+        assertEquals(0, queueInfo.getReadQueueNums());
+        assertEquals(0, queueInfo.getWriteQueueNums());
+        assertEquals(0, queueInfo.getPerm());
+    }
+
+    @Test
+    public void testQueueInfoSetters() {
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        queueInfo.setBrokerName("broker-x");
+        queueInfo.setReadQueueNums(16);
+        queueInfo.setWriteQueueNums(16);
+        queueInfo.setPerm(4);
+
+        assertEquals("broker-x", queueInfo.getBrokerName());
+        assertEquals(16, queueInfo.getReadQueueNums());
+        assertEquals(16, queueInfo.getWriteQueueNums());
+        assertEquals(4, queueInfo.getPerm());
+    }
+
+    @Test
+    public void testSnapshotWithMultipleBrokersAndQueues() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("multi-broker-topic");
+
+        List<TopicRouteSnapshot.BrokerInfo> brokers = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+            brokerInfo.setCluster("cluster-a");
+            brokerInfo.setBrokerName("broker-" + i);
+            Map<Long, String> addrs = new HashMap<>();
+            addrs.put(0L, "127.0.0.1:1091" + i);
+            brokerInfo.setBrokerAddrs(addrs);
+            brokers.add(brokerInfo);
+        }
+        snapshot.setBrokers(brokers);
+
+        List<TopicRouteSnapshot.QueueInfo> queues = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+            queueInfo.setBrokerName("broker-" + i);
+            queueInfo.setReadQueueNums(8);
+            queueInfo.setWriteQueueNums(8);
+            queueInfo.setPerm(6);
+            queues.add(queueInfo);
+        }
+        snapshot.setQueues(queues);
+
+        assertEquals(3, snapshot.getBrokers().size());
+        assertEquals(3, snapshot.getQueues().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals("broker-" + i, snapshot.getBrokers().get(i).getBrokerName());
+            assertEquals("broker-" + i, snapshot.getQueues().get(i).getBrokerName());
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
@@ -79,6 +79,11 @@ public class AbstractRemotingActivityTest extends InitConfigTest {
                 ProxyContext context) throws Exception {
                 return null;
             }
+
+            @Override
+            public boolean rejectRequest() {
+                return false;
+            }
         };
         Channel channel = ctx.channel();
         RemotingHelper.setPropertyToAttr(channel, AttributeKeys.CLIENT_ID_KEY, CLIENT_ID);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultProxyAdminClientServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultProxyAdminClientServiceTest.java
@@ -1,0 +1,934 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.admin;
+
+import apache.rocketmq.v2.ClientType;
+import apache.rocketmq.v2.Language;
+import apache.rocketmq.v2.Publishing;
+import apache.rocketmq.v2.Resource;
+import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.Subscription;
+import apache.rocketmq.v2.UA;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientDetailInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientInstanceInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ListClientsFilter;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService.ListClientsResult;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService.BatchConsumeDiagnosticResult;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
+import org.apache.rocketmq.proxy.service.channel.SimpleChannel;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager.PopReceiptHandleDiagnosticResult;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for DefaultProxyAdminClientService.
+ * <p>
+ * Uses sun.misc.Unsafe.allocateInstance() to create GrpcChannelManager,
+ * GrpcClientSettingsManager, and GrpcClientChannel instances without calling
+ * their constructors, because Mockito 3.10 cannot mock classes implementing
+ * StartAndShutdown or extending Netty AbstractChannel on Java 21
+ * (class file major version 65 incompatibility with Byte Buddy).
+ */
+public class DefaultProxyAdminClientServiceTest {
+
+    private GrpcChannelManager grpcChannelManager;
+    private GrpcClientSettingsManager grpcClientSettingsManager;
+    private DefaultProxyAdminClientService adminService;
+    private ConcurrentMap<String, GrpcClientChannel> channelMap;
+
+    @Before
+    public void before() throws Exception {
+        // Create GrpcChannelManager without constructor (avoids scheduled executor startup)
+        grpcChannelManager = createInstanceWithoutConstructor(GrpcChannelManager.class);
+        channelMap = new ConcurrentHashMap<>();
+        setFieldUnsafe(grpcChannelManager, GrpcChannelManager.class, "clientIdChannelMap", channelMap);
+
+        // Create GrpcClientSettingsManager without constructor
+        grpcClientSettingsManager = createInstanceWithoutConstructor(GrpcClientSettingsManager.class);
+
+        adminService = new DefaultProxyAdminClientService(grpcChannelManager, grpcClientSettingsManager);
+    }
+
+    @After
+    public void after() throws Exception {
+        clearClientSettingsMap();
+        if (channelMap != null) {
+            channelMap.clear();
+        }
+    }
+
+    // ==================== convertLanguage Tests ====================
+
+    @Test
+    public void testConvertLanguageFromUserAgent_JAVA() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.JAVA);
+        assertEquals("JAVA", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_GOLANG() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.GOLANG);
+        assertEquals("GOLANG", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_CPP() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.CPP);
+        assertEquals("CPP", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_RUST() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.RUST);
+        assertEquals("RUST", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_PYTHON() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.PYTHON);
+        assertEquals("PYTHON", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_DOT_NET() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.DOT_NET);
+        assertEquals("DOTNET", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_PHP() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.PHP);
+        assertEquals("PHP", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_NODE_JS() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.NODE_JS);
+        assertEquals("NODE_JS", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_RUBY() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.RUBY);
+        assertEquals("RUBY", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_KOTLIN() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.KOTLIN);
+        assertEquals("KOTLIN", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguageFromUserAgent_UNSPECIFIED() {
+        ClientInstanceInfo info = buildClientWithLanguage(Language.LANGUAGE_UNSPECIFIED);
+        assertEquals("UNSPECIFIED", info.getLanguage());
+    }
+
+    @Test
+    public void testConvertLanguage_NoUserAgent() {
+        String clientId = "test-client-no-ua";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 10);
+        assertEquals(1, result.getList().size());
+        assertEquals("UNSPECIFIED", result.getList().get(0).getLanguage());
+    }
+
+    // ==================== clientVersion Tests ====================
+
+    @Test
+    public void testClientVersionFromUserAgent() {
+        String clientId = "test-client-version";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        UA userAgent = UA.newBuilder()
+            .setLanguage(Language.JAVA)
+            .setVersion("5.0.0")
+            .build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(userAgent)
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 10);
+        assertEquals(1, result.getList().size());
+        assertEquals("5.0.0", result.getList().get(0).getClientVersion());
+    }
+
+    // ==================== listClients Tests ====================
+
+    @Test
+    public void testListClients_Pagination() {
+        for (int i = 0; i < 5; i++) {
+            String clientId = "client-" + i;
+            GrpcClientChannel channel = createTestChannel((long) i * 1000, (long) i * 1000 + 500, "10.0.0." + i + ":1234");
+
+            UA userAgent = UA.newBuilder()
+                .setLanguage(Language.JAVA)
+                .setVersion("5.0.0")
+                .build();
+            Settings settings = Settings.newBuilder()
+                .setClientType(ClientType.PRODUCER)
+                .setUserAgent(userAgent)
+                .setPublishing(Publishing.newBuilder()
+                    .addTopics(Resource.newBuilder().setName("topic-" + i).build())
+                    .build())
+                .build();
+
+            channelMap.put(clientId, channel);
+            putClientSettings(clientId, settings);
+        }
+
+        // Page 1 with size 2
+        ListClientsResult page1 = adminService.listClients(new ListClientsFilter(), 1, 2);
+        assertEquals(5, page1.getTotal());
+        assertEquals(2, page1.getList().size());
+        assertEquals(1, page1.getPageNum());
+        assertEquals(2, page1.getPageSize());
+
+        // Page 2 with size 2
+        ListClientsResult page2 = adminService.listClients(new ListClientsFilter(), 2, 2);
+        assertEquals(5, page2.getTotal());
+        assertEquals(2, page2.getList().size());
+
+        // Page 3 with size 2 (only 1 remaining)
+        ListClientsResult page3 = adminService.listClients(new ListClientsFilter(), 3, 2);
+        assertEquals(5, page3.getTotal());
+        assertEquals(1, page3.getList().size());
+    }
+
+    @Test
+    public void testListClients_PageSizeUpperBound() {
+        // Request pageSize=200, should be capped at 100
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 200);
+        assertEquals(100, result.getPageSize());
+    }
+
+    @Test
+    public void testListClients_FilterByGroup() {
+        // Producer client (no group)
+        GrpcClientChannel producerChannel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings producerSettings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+        channelMap.put("producer-1", producerChannel);
+        putClientSettings("producer-1", producerSettings);
+
+        // Consumer client with group
+        GrpcClientChannel consumerChannel = createTestChannel(3000L, 4000L, "10.0.0.2:1234");
+        Settings consumerSettings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("test-group").build())
+                .build())
+            .build();
+        channelMap.put("consumer-1", consumerChannel);
+        putClientSettings("consumer-1", consumerSettings);
+
+        // Filter by group
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup("test-group");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("test-group", result.getList().get(0).getGroup());
+    }
+
+    @Test
+    public void testListClients_EmptyResult() {
+        // channelMap is already empty (no channels added)
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 10);
+        assertEquals(0, result.getTotal());
+        assertTrue(result.getList().isEmpty());
+    }
+
+    // ==================== describeClient Tests ====================
+
+    @Test
+    public void testDescribeClient_Success() {
+        String clientId = "test-describe-client";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        UA userAgent = UA.newBuilder()
+            .setLanguage(Language.GOLANG)
+            .setVersion("1.2.3")
+            .build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setUserAgent(userAgent)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("my-group").build())
+                .build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getClientInstance());
+        assertEquals("GOLANG", detail.getClientInstance().getLanguage());
+        assertEquals("1.2.3", detail.getClientInstance().getClientVersion());
+        assertEquals("PUSH_CONSUMER", detail.getClientInstance().getRole());
+    }
+
+    @Test
+    public void testDescribeClient_NotFound() {
+        // channelMap doesn't contain "nonexistent", so getChannel returns null
+        ClientDetailInfo detail = adminService.describeClient("nonexistent");
+        assertNull(detail);
+    }
+
+    @Test
+    public void testDescribeClient_BlankClientId() {
+        ClientDetailInfo detail = adminService.describeClient("");
+        assertNull(detail);
+    }
+
+    // ==================== Filter Pushdown Tests (RIP-2 §8.1) ====================
+
+    @Test
+    public void testListClients_FilterByClientIdPrefix() {
+        GrpcClientChannel channel1 = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        GrpcClientChannel channel2 = createTestChannel(3000L, 4000L, "10.0.0.2:1234");
+
+        UA userAgent = UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(userAgent)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put("producer-app1-001", channel1);
+        putClientSettings("producer-app1-001", settings);
+        channelMap.put("consumer-app2-001", channel2);
+        putClientSettings("consumer-app2-001", settings);
+
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setClientIdPrefix("producer");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("producer-app1-001", result.getList().get(0).getClientId());
+    }
+
+    @Test
+    public void testListClients_FilterByLanguage() {
+        GrpcClientChannel javaChannel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        GrpcClientChannel goChannel = createTestChannel(3000L, 4000L, "10.0.0.2:1234");
+
+        UA javaUA = UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build();
+        Settings javaSettings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(javaUA)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        UA goUA = UA.newBuilder().setLanguage(Language.GOLANG).setVersion("1.2.3").build();
+        Settings goSettings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(goUA)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put("java-client", javaChannel);
+        putClientSettings("java-client", javaSettings);
+        channelMap.put("go-client", goChannel);
+        putClientSettings("go-client", goSettings);
+
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setLanguage("JAVA");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("java-client", result.getList().get(0).getClientId());
+    }
+
+    @Test
+    public void testListClients_FilterByConnectTimeRange() {
+        GrpcClientChannel oldChannel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        GrpcClientChannel newChannel = createTestChannel(5000L, 6000L, "10.0.0.2:1234");
+
+        UA userAgent = UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(userAgent)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put("old-client", oldChannel);
+        putClientSettings("old-client", settings);
+        channelMap.put("new-client", newChannel);
+        putClientSettings("new-client", settings);
+
+        // Filter: connect time after 3000
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setConnectTimeStart(3000L);
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("new-client", result.getList().get(0).getClientId());
+    }
+
+    @Test
+    public void testListClients_FilterByTopic() {
+        GrpcClientChannel channel1 = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        GrpcClientChannel channel2 = createTestChannel(3000L, 4000L, "10.0.0.2:1234");
+
+        Settings settings1 = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("topic-A").build())
+                .build())
+            .build();
+
+        Settings settings2 = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("topic-B").build())
+                .build())
+            .build();
+
+        channelMap.put("producer-A", channel1);
+        putClientSettings("producer-A", settings1);
+        channelMap.put("producer-B", channel2);
+        putClientSettings("producer-B", settings2);
+
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setTopic("topic-A");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("producer-A", result.getList().get(0).getClientId());
+    }
+
+    @Test
+    public void testListClients_CombinedFilter() {
+        GrpcClientChannel channel1 = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        GrpcClientChannel channel2 = createTestChannel(5000L, 6000L, "10.0.0.2:1234");
+
+        // Java producer with topic-A
+        Settings settings1 = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("topic-A").build())
+                .build())
+            .build();
+
+        // Go producer with topic-A
+        Settings settings2 = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.GOLANG).setVersion("1.2.3").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("topic-A").build())
+                .build())
+            .build();
+
+        channelMap.put("java-producer-A", channel1);
+        putClientSettings("java-producer-A", settings1);
+        channelMap.put("go-producer-A", channel2);
+        putClientSettings("go-producer-A", settings2);
+
+        // Combined filter: JAVA language + topic-A
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setLanguage("JAVA");
+        filter.setTopic("topic-A");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("java-producer-A", result.getList().get(0).getClientId());
+    }
+
+    // ==================== DescribeClient Field Completion Tests ====================
+
+    @Test
+    public void testDescribeClient_AuthStatusWithUsername() {
+        String clientId = "test-auth-client";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        UA userAgent = UA.newBuilder()
+            .setLanguage(Language.JAVA)
+            .setVersion("5.0.0")
+            .setPlatform("test-user")
+            .build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(userAgent)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getAuthStatus());
+        assertTrue(detail.getAuthStatus().isAuthenticated());
+        assertEquals("test-user", detail.getAuthStatus().getUsername());
+        assertEquals(1000L, detail.getAuthStatus().getLastAuthTime());
+    }
+
+    @Test
+    public void testDescribeClient_NetworkInfoWithLocalAddress() throws Exception {
+        String clientId = "test-network-client";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        // Also set localAddress
+        setFieldUnsafe(channel, SimpleChannel.class, "localAddress", "192.168.1.1:8080");
+
+        UA userAgent = UA.newBuilder()
+            .setLanguage(Language.JAVA)
+            .setVersion("5.0.0")
+            .build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(userAgent)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getNetworkInfo());
+        assertEquals("10.0.0.1:1234", detail.getNetworkInfo().getRemoteAddress());
+        assertEquals("192.168.1.1:8080", detail.getNetworkInfo().getLocalAddress());
+    }
+
+    @Test
+    public void testDescribeClient_HeartbeatHistoryFallback() {
+        String clientId = "test-heartbeat-client";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getHeartbeatHistory());
+        // Without tracked heartbeat records, should have synthetic fallback
+        assertTrue(detail.getHeartbeatHistory().size() >= 1);
+        assertEquals(true, detail.getHeartbeatHistory().get(0).isSuccess());
+    }
+
+    @Test
+    public void testDescribeClient_ConsumerWithConsumeProgress() {
+        String clientId = "test-consumer-progress";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("test-group").build())
+                .addSubscriptions(apache.rocketmq.v2.SubscriptionEntry.newBuilder()
+                    .setTopic(Resource.newBuilder().setName("topic-1").build())
+                    .build())
+                .build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getConsumeProgress());
+        assertNotNull(detail.getConsumeProgress().getTopicProgress());
+        assertEquals(1, detail.getConsumeProgress().getTopicProgress().size());
+        assertEquals("topic-1", detail.getConsumeProgress().getTopicProgress().get(0).getTopic());
+        // Lag and latency are -1 in M1 (requires broker-side data, M2 scope)
+        assertEquals(-1, detail.getConsumeProgress().getTopicProgress().get(0).getLag());
+    }
+
+    @Test
+    public void testDescribeClient_ProducerNoConsumeProgress() {
+        String clientId = "test-producer-no-progress";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        // Producer should not have consume progress
+        assertNull(detail.getConsumeProgress());
+    }
+
+    @Test
+    public void testDescribeClient_ClientSettingsInfo() {
+        String clientId = "test-settings-client";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("test-group").build())
+                .setFifo(true)
+                .setReceiveBatchSize(32)
+                .setLongPollingTimeout(com.google.protobuf.Duration.newBuilder()
+                    .setSeconds(30)
+                    .setNanos(0)
+                    .build())
+                .addSubscriptions(apache.rocketmq.v2.SubscriptionEntry.newBuilder()
+                    .setTopic(Resource.newBuilder().setName("topic-1").build())
+                    .build())
+                .build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getSettings());
+        assertEquals("FIFO", detail.getSettings().getSubscriptionMode());
+        assertEquals(32, detail.getSettings().getReceiveBatchSize());
+        assertEquals(30000L, detail.getSettings().getLongPollingTimeoutMs());
+        assertTrue(detail.getSettings().isFifo());
+    }
+
+    // ==================== Sampling and Degradation Tests ====================
+
+    @Test
+    public void testShouldSample_BelowThreshold() {
+        // With empty channelMap, client count is 0, which is below SAMPLING_THRESHOLD
+        // shouldSample() should return false
+        assertFalse(adminService.shouldSample());
+    }
+
+    @Test
+    public void testRecordHeartbeat() {
+        String clientId = "heartbeat-test-client";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        // Record heartbeat
+        adminService.recordHeartbeat(clientId);
+
+        // Verify heartbeat history is populated
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNotNull(detail);
+        assertNotNull(detail.getHeartbeatHistory());
+        // Should have tracked heartbeat records (not just synthetic fallback)
+        assertTrue(detail.getHeartbeatHistory().size() >= 1);
+        assertTrue(detail.getHeartbeatHistory().get(0).isSuccess());
+        assertEquals("Heartbeat OK", detail.getHeartbeatHistory().get(0).getRemark());
+    }
+
+    // ==================== listClientsByGroup / listClientsByTopic Tests ====================
+
+    @Test
+    public void testListClientsByGroup() {
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("target-group").build())
+                .build())
+            .build();
+
+        channelMap.put("consumer-1", channel);
+        putClientSettings("consumer-1", settings);
+
+        ListClientsResult result = adminService.listClientsByGroup("target-group", 1, 10);
+        assertEquals(1, result.getTotal());
+    }
+
+    @Test
+    public void testListClientsByTopic() {
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("target-topic").build())
+                .build())
+            .build();
+
+        channelMap.put("producer-1", channel);
+        putClientSettings("producer-1", settings);
+
+        ListClientsResult result = adminService.listClientsByTopic("target-topic", 1, 10);
+        assertEquals(1, result.getTotal());
+    }
+
+    // ==================== Helper Methods ====================
+
+    private ClientInstanceInfo buildClientWithLanguage(Language language) {
+        String clientId = "client-lang-" + language.name();
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        UA userAgent = UA.newBuilder()
+            .setLanguage(language)
+            .setVersion("1.0.0")
+            .build();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(userAgent)
+            .build();
+
+        channelMap.put(clientId, channel);
+        putClientSettings(clientId, settings);
+
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 10);
+        assertEquals(1, result.getList().size());
+        return result.getList().get(0);
+    }
+
+    // ==================== forceDisconnectClient Tests ====================
+
+    @Test
+    public void testForceDisconnectClient_BlankClientId() {
+        boolean result = adminService.forceDisconnectClient("", "test reason");
+        assertFalse("Should return false for blank clientId", result);
+    }
+
+    @Test
+    public void testForceDisconnectClient_NullClientId() {
+        boolean result = adminService.forceDisconnectClient(null, "test reason");
+        assertFalse("Should return false for null clientId", result);
+    }
+
+    @Test
+    public void testForceDisconnectClient_ClientNotFound() {
+        boolean result = adminService.forceDisconnectClient("nonexistent-client", "test reason");
+        assertFalse("Should return false when client not found in channel manager", result);
+    }
+
+    @Test
+    public void testForceDisconnectClient_Success() {
+        String clientId = "disconnect-client-1";
+        GrpcClientChannel channel = createTestChannel(1000L, 2000L, "10.0.0.1:1234");
+        channelMap.put(clientId, channel);
+
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .build();
+        putClientSettings(clientId, settings);
+
+        boolean result = adminService.forceDisconnectClient(clientId, "admin disconnect");
+
+        // forceClose returns false (no active stream observer), but forceDisconnectClient
+        // still returns true because channel exists and cleanup is performed.
+        assertTrue("Should return true on successful disconnect", result);
+        // Verify channel was removed from channelMap regardless of forceClose result
+        assertNull("Channel should be removed from channel map", channelMap.get(clientId));
+        // Verify settings were removed
+        assertNull("Settings should be removed", grpcClientSettingsManager.getRawClientSettings(clientId));
+    }
+
+    // ==================== describePopReceiptHandles Tests ====================
+
+    @Test
+    public void testDescribePopReceiptHandles_ReceiptHandleManagerNotInitialized() {
+        // Default adminService has no ReceiptHandleManager (null)
+        PopReceiptHandleDiagnosticResult result = adminService.describePopReceiptHandles("test-group", "test-topic", 1, 10);
+
+        assertNotNull("Should return non-null result", result);
+        assertEquals(0, result.getTotal());
+        assertEquals(1, result.getPageNum());
+        assertEquals(1, result.getPageSize());
+        assertTrue("Handles should be empty", result.getHandles().isEmpty());
+    }
+
+    // ==================== describeBatchConsumeDiagnostics Tests ====================
+
+    @Test
+    public void testDescribeBatchConsumeDiagnostics_ReceiptHandleManagerNotInitialized() {
+        // Default adminService has no ReceiptHandleManager (null)
+        BatchConsumeDiagnosticResult result = adminService.describeBatchConsumeDiagnostics(
+            "test-group", "test-topic", "client-1", 1, 10);
+
+        assertNotNull("Should return non-null result", result);
+        assertEquals(0, result.getTotal());
+        assertEquals(1, result.getPageNum());
+        assertEquals(1, result.getPageSize());
+        assertTrue("Diagnostics should be empty", result.getDiagnostics().isEmpty());
+    }
+
+    @Test
+    public void testDescribeBatchConsumeDiagnostics_BlankGroup() {
+        BatchConsumeDiagnosticResult result = adminService.describeBatchConsumeDiagnostics(
+            "", "test-topic", "client-1", 1, 10);
+
+        assertNotNull("Should return non-null result for blank group", result);
+        assertEquals(0, result.getTotal());
+        assertTrue("Diagnostics should be empty for blank group", result.getDiagnostics().isEmpty());
+    }
+
+    /**
+     * Create a GrpcClientChannel instance without calling the constructor.
+     * Uses Unsafe.allocateInstance() and sets createTime, lastAccessTime, remoteAddress fields
+     * via Unsafe to bypass final field restrictions.
+     * <p>
+     * Field locations in the class hierarchy:
+     * - createTime: declared in GrpcClientChannel (private final long)
+     * - lastAccessTime: declared in SimpleChannel (protected long)
+     * - remoteAddress: declared in SimpleChannel (protected final String)
+     */
+    private static GrpcClientChannel createTestChannel(long createTime, long lastAccessTime,
+        String remoteAddress) {
+        try {
+            GrpcClientChannel channel = createInstanceWithoutConstructor(GrpcClientChannel.class);
+            // createTime is declared in GrpcClientChannel
+            setLongFieldUnsafe(channel, GrpcClientChannel.class, "createTime", createTime);
+            // lastAccessTime is declared in SimpleChannel (grandparent class)
+            setLongFieldUnsafe(channel, SimpleChannel.class, "lastAccessTime", lastAccessTime);
+            // remoteAddress is declared in SimpleChannel
+            setFieldUnsafe(channel, SimpleChannel.class, "remoteAddress", remoteAddress);
+            // telemetryCommandRef is needed for forceClose() to work without NPE.
+            // With AtomicReference(null), forceClose() returns false (no active stream observer).
+            setFieldUnsafe(channel, GrpcClientChannel.class, "telemetryCommandRef",
+                new java.util.concurrent.atomic.AtomicReference<>());
+            return channel;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create test GrpcClientChannel", e);
+        }
+    }
+
+    /**
+     * Put client settings into the static CLIENT_SETTINGS_MAP via reflection.
+     * GrpcClientSettingsManager.getRawClientSettings() reads from this static map.
+     */
+    @SuppressWarnings("unchecked")
+    private void putClientSettings(String clientId, Settings settings) {
+        try {
+            Field field = GrpcClientSettingsManager.class.getDeclaredField("CLIENT_SETTINGS_MAP");
+            field.setAccessible(true);
+            Map<String, Settings> map = (Map<String, Settings>) field.get(null);
+            map.put(clientId, settings);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to put client settings", e);
+        }
+    }
+
+    /**
+     * Clear the static CLIENT_SETTINGS_MAP after each test to avoid interference.
+     */
+    @SuppressWarnings("unchecked")
+    private void clearClientSettingsMap() {
+        try {
+            Field field = GrpcClientSettingsManager.class.getDeclaredField("CLIENT_SETTINGS_MAP");
+            field.setAccessible(true);
+            Map<String, Settings> map = (Map<String, Settings>) field.get(null);
+            map.clear();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clear client settings map", e);
+        }
+    }
+
+    /**
+     * Create an instance without calling the constructor using sun.misc.Unsafe.
+     * This bypasses constructor logic (e.g., scheduled executor startup in GrpcChannelManager)
+     * and avoids Mockito 3.10 / Java 21 incompatibility with classes implementing StartAndShutdown
+     * or extending Netty AbstractChannel.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> T createInstanceWithoutConstructor(Class<T> clazz) throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+        return (T) allocateInstance.invoke(unsafe, clazz);
+    }
+
+    /**
+     * Set an Object field value using sun.misc.Unsafe, bypassing final field restrictions.
+     * Accepts the declaring class to support fields in parent classes.
+     */
+    private static void setFieldUnsafe(Object obj, Class<?> declaringClass, String fieldName,
+        Object value) throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+
+        Field field = declaringClass.getDeclaredField(fieldName);
+        Method objectFieldOffsetMethod = unsafeClass.getMethod("objectFieldOffset", Field.class);
+        long offset = (Long) objectFieldOffsetMethod.invoke(unsafe, field);
+
+        Method putObjectMethod = unsafeClass.getMethod("putObject", Object.class, long.class, Object.class);
+        putObjectMethod.invoke(unsafe, obj, offset, value);
+    }
+
+    /**
+     * Set a long field value using sun.misc.Unsafe, bypassing final field restrictions.
+     * Accepts the declaring class to support fields in parent classes.
+     */
+    private static void setLongFieldUnsafe(Object obj, Class<?> declaringClass, String fieldName,
+        long value) throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+
+        Field field = declaringClass.getDeclaredField(fieldName);
+        Method objectFieldOffsetMethod = unsafeClass.getMethod("objectFieldOffset", Field.class);
+        long offset = (Long) objectFieldOffsetMethod.invoke(unsafe, field);
+
+        Method putLongMethod = unsafeClass.getMethod("putLong", Object.class, long.class, long.class);
+        putLongMethod.invoke(unsafe, obj, offset, value);
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultProxyAdminClientServiceUnitTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultProxyAdminClientServiceUnitTest.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.service.admin;
+
+import apache.rocketmq.v2.ClientType;
+import apache.rocketmq.v2.Language;
+import apache.rocketmq.v2.Publishing;
+import apache.rocketmq.v2.Resource;
+import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.Subscription;
+import apache.rocketmq.v2.UA;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.rocketmq.proxy.grpc.admin.model.ClientDetailInfo;
+import org.apache.rocketmq.proxy.grpc.admin.model.ListClientsFilter;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
+import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
+import org.apache.rocketmq.proxy.service.admin.ProxyAdminClientService.ListClientsResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for DefaultProxyAdminClientService using Mockito mocks.
+ * <p>
+ * Uses Mockito to mock GrpcChannelManager, GrpcClientSettingsManager, and GrpcClientChannel.
+ * Real Settings proto objects are built via {@code Settings.newBuilder()}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultProxyAdminClientServiceUnitTest {
+
+    @Mock
+    private GrpcChannelManager grpcChannelManager;
+
+    @Mock
+    private GrpcClientSettingsManager grpcClientSettingsManager;
+
+    private DefaultProxyAdminClientService adminService;
+    private Map<String, GrpcClientChannel> channelMap;
+
+    @Before
+    public void before() {
+        channelMap = new HashMap<>();
+        when(grpcChannelManager.getClientIdChannelMap()).thenReturn(channelMap);
+        adminService = new DefaultProxyAdminClientService(grpcChannelManager, grpcClientSettingsManager);
+    }
+
+    // ==================== Helper Methods ====================
+
+    /**
+     * Create a mock GrpcClientChannel with specified attributes.
+     * All unmocked methods will return Mockito defaults (null / 0 / false).
+     */
+    private GrpcClientChannel mockChannel(long createTime, long lastAccessTime, String remoteAddress) {
+        GrpcClientChannel channel = mock(GrpcClientChannel.class);
+        when(channel.getCreateTime()).thenReturn(createTime);
+        when(channel.getLastAccessTime()).thenReturn(lastAccessTime);
+        when(channel.getRemoteAddress()).thenReturn(remoteAddress);
+        return channel;
+    }
+
+    /**
+     * Add a client to the channel map and stub the settings lookup.
+     * Also stubs {@code grpcChannelManager.getChannel(clientId)} for describeClient tests.
+     */
+    private void addClient(String clientId, GrpcClientChannel channel, Settings settings) {
+        channelMap.put(clientId, channel);
+        when(grpcClientSettingsManager.getRawClientSettings(clientId)).thenReturn(settings);
+        lenient().when(grpcChannelManager.getChannel(clientId)).thenReturn(channel);
+    }
+
+    // ==================== Test 1: listClients empty channels ====================
+
+    @Test
+    public void testListClients_EmptyChannels_ReturnsEmptyResultWithTotalZero() {
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 10);
+
+        assertEquals(0, result.getTotal());
+        assertTrue(result.getList().isEmpty());
+    }
+
+    // ==================== Test 2: listClients pageNum=0 normalized to 1 ====================
+
+    @Test
+    public void testListClients_PageNumZero_NormalizedToOne() {
+        // Add 3 clients
+        for (int i = 0; i < 3; i++) {
+            String clientId = "client-" + i;
+            GrpcClientChannel channel = mockChannel(i * 1000L, i * 1000L + 500, "10.0.0." + i + ":1234");
+            Settings settings = createProducerSettings(Language.JAVA, "5.0.0", "topic-" + i);
+            addClient(clientId, channel, settings);
+        }
+
+        // pageNum=0 should be normalized to 1
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 0, 10);
+        assertEquals(1, result.getPageNum());
+    }
+
+    // ==================== Test 3: listClients pageSize=0 normalized to 1 ====================
+
+    @Test
+    public void testListClients_PageSizeZero_NormalizedToOne() {
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings settings = createProducerSettings(Language.JAVA, "5.0.0", "topic-A");
+        addClient("client-1", channel, settings);
+
+        // pageSize=0 should be normalized to 1
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 0);
+        assertEquals(1, result.getPageSize());
+    }
+
+    // ==================== Test 4: listClients pageSize > 100 capped at 100 ====================
+
+    @Test
+    public void testListClients_PageSizeExceedsMax_CappedAt100() {
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 1, 200);
+        assertEquals(100, result.getPageSize());
+    }
+
+    // ==================== Test 5: listClients null filter no NPE ====================
+
+    @Test
+    public void testListClients_NullFilter_NoNpe() {
+        // Add one client so the filter path is exercised
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings settings = createProducerSettings(Language.JAVA, "5.0.0", "topic-A");
+        addClient("client-1", channel, settings);
+
+        // Passing null filter should not cause NullPointerException
+        // The FilterContext constructor handles null by using a default empty filter
+        ListClientsResult result = adminService.listClients(null, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("client-1", result.getList().get(0).getClientId());
+    }
+
+    // ==================== Test 6: listClients pagination first page ====================
+
+    @Test
+    public void testListClients_Pagination_FirstPageReturnsCorrectSubset() {
+        // Add 5 clients
+        for (int i = 0; i < 5; i++) {
+            String clientId = "client-" + i;
+            GrpcClientChannel channel = mockChannel(i * 1000L, i * 1000L + 500, "10.0.0." + i + ":1234");
+            Settings settings = createProducerSettings(Language.JAVA, "5.0.0", "topic-" + i);
+            addClient(clientId, channel, settings);
+        }
+
+        // Page 1 with size 2
+        ListClientsResult page1 = adminService.listClients(new ListClientsFilter(), 1, 2);
+        assertEquals(5, page1.getTotal());
+        assertEquals(2, page1.getList().size());
+        assertEquals(1, page1.getPageNum());
+        assertEquals(2, page1.getPageSize());
+
+        // Page 2 with size 2
+        ListClientsResult page2 = adminService.listClients(new ListClientsFilter(), 2, 2);
+        assertEquals(5, page2.getTotal());
+        assertEquals(2, page2.getList().size());
+
+        // Page 3 with size 2 (only 1 remaining)
+        ListClientsResult page3 = adminService.listClients(new ListClientsFilter(), 3, 2);
+        assertEquals(5, page3.getTotal());
+        assertEquals(1, page3.getList().size());
+    }
+
+    // ==================== Test 7: listClients pageNum beyond range ====================
+
+    @Test
+    public void testListClients_PageNumBeyondRange_ReturnsEmptyList() {
+        // Add 2 clients
+        for (int i = 0; i < 2; i++) {
+            String clientId = "client-" + i;
+            GrpcClientChannel channel = mockChannel(i * 1000L, i * 1000L + 500, "10.0.0." + i + ":1234");
+            Settings settings = createProducerSettings(Language.JAVA, "5.0.0", "topic-" + i);
+            addClient(clientId, channel, settings);
+        }
+
+        // Request page 5 when only 2 clients exist (page 5 starts at index 8, beyond size 2)
+        ListClientsResult result = adminService.listClients(new ListClientsFilter(), 5, 2);
+        assertEquals(2, result.getTotal());
+        assertTrue(result.getList().isEmpty());
+    }
+
+    // ==================== Test 8: listClients filtering by group ====================
+
+    @Test
+    public void testListClients_FilterByGroup_ReturnsOnlyMatchingClients() {
+        // Producer client (no group)
+        GrpcClientChannel producerChannel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings producerSettings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setPublishing(Publishing.newBuilder().build())
+            .build();
+        addClient("producer-1", producerChannel, producerSettings);
+
+        // Consumer client with group "test-group"
+        GrpcClientChannel consumerChannel = mockChannel(3000L, 4000L, "10.0.0.2:1234");
+        Settings consumerSettings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("test-group").build())
+                .build())
+            .build();
+        addClient("consumer-1", consumerChannel, consumerSettings);
+
+        // Filter by group
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup("test-group");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("test-group", result.getList().get(0).getGroup());
+    }
+
+    // ==================== Test 9: listClients filtering by clientIdPrefix ====================
+
+    @Test
+    public void testListClients_FilterByClientIdPrefix_ReturnsOnlyMatchingClients() {
+        GrpcClientChannel channel1 = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        GrpcClientChannel channel2 = mockChannel(3000L, 4000L, "10.0.0.2:1234");
+
+        Settings settings1 = createProducerSettings(Language.JAVA, "5.0.0", "topic-A");
+        Settings settings2 = createProducerSettings(Language.GOLANG, "1.2.3", "topic-B");
+
+        addClient("producer-app1-001", channel1, settings1);
+        addClient("consumer-app1-001", channel2, settings2);
+
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setClientIdPrefix("producer");
+        ListClientsResult result = adminService.listClients(filter, 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("producer-app1-001", result.getList().get(0).getClientId());
+    }
+
+    // ==================== Test 10: describeClient null/blank clientId ====================
+
+    @Test
+    public void testDescribeClient_NullClientId_ReturnsNull() {
+        ClientDetailInfo detail = adminService.describeClient(null);
+        assertNull(detail);
+    }
+
+    @Test
+    public void testDescribeClient_BlankClientId_ReturnsNull() {
+        ClientDetailInfo detail = adminService.describeClient("");
+        assertNull(detail);
+
+        detail = adminService.describeClient("   ");
+        assertNull(detail);
+    }
+
+    // ==================== Test 11: describeClient nonexistent clientId ====================
+
+    @Test
+    public void testDescribeClient_NonexistentClientId_ReturnsNull() {
+        // channelMap does not contain "nonexistent", so getChannel returns null
+        ClientDetailInfo detail = adminService.describeClient("nonexistent");
+        assertNull(detail);
+    }
+
+    // ==================== Test 12: describeClient client found but no settings ====================
+
+    @Test
+    public void testDescribeClient_ClientFoundButNoSettings_ReturnsNull() {
+        String clientId = "client-no-settings";
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+
+        // Add channel to map but do NOT stub settings (returns null by default)
+        channelMap.put(clientId, channel);
+        when(grpcChannelManager.getChannel(clientId)).thenReturn(channel);
+        // grpcClientSettingsManager.getRawClientSettings(clientId) returns null (mock default)
+
+        ClientDetailInfo detail = adminService.describeClient(clientId);
+        assertNull(detail);
+    }
+
+    // ==================== Test 13: listClientsByGroup delegates correctly ====================
+
+    @Test
+    public void testListClientsByGroup_DelegatesWithGroupFilter() {
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("target-group").build())
+                .build())
+            .build();
+        addClient("consumer-1", channel, settings);
+
+        // Also add a producer that should be filtered out
+        GrpcClientChannel producerChannel = mockChannel(5000L, 6000L, "10.0.0.2:1234");
+        Settings producerSettings = createProducerSettings(Language.JAVA, "5.0.0", "topic-A");
+        addClient("producer-1", producerChannel, producerSettings);
+
+        ListClientsResult result = adminService.listClientsByGroup("target-group", 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("target-group", result.getList().get(0).getGroup());
+        assertEquals("consumer-1", result.getList().get(0).getClientId());
+    }
+
+    @Test
+    public void testListClientsByGroup_NoMatchingGroup_ReturnsEmpty() {
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("other-group").build())
+                .build())
+            .build();
+        addClient("consumer-1", channel, settings);
+
+        ListClientsResult result = adminService.listClientsByGroup("nonexistent-group", 1, 10);
+        assertEquals(0, result.getTotal());
+        assertTrue(result.getList().isEmpty());
+    }
+
+    // ==================== Test 14: listClientsByTopic delegates correctly ====================
+
+    @Test
+    public void testListClientsByTopic_DelegatesWithTopicFilter() {
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("target-topic").build())
+                .build())
+            .build();
+        addClient("producer-1", channel, settings);
+
+        // Also add a producer on a different topic that should be filtered out
+        GrpcClientChannel otherChannel = mockChannel(5000L, 6000L, "10.0.0.2:1234");
+        Settings otherSettings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("other-topic").build())
+                .build())
+            .build();
+        addClient("producer-2", otherChannel, otherSettings);
+
+        ListClientsResult result = adminService.listClientsByTopic("target-topic", 1, 10);
+        assertEquals(1, result.getTotal());
+        assertEquals("producer-1", result.getList().get(0).getClientId());
+    }
+
+    @Test
+    public void testListClientsByTopic_NoMatchingTopic_ReturnsEmpty() {
+        GrpcClientChannel channel = mockChannel(1000L, 2000L, "10.0.0.1:1234");
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder().setLanguage(Language.JAVA).setVersion("5.0.0").build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName("some-topic").build())
+                .build())
+            .build();
+        addClient("producer-1", channel, settings);
+
+        ListClientsResult result = adminService.listClientsByTopic("nonexistent-topic", 1, 10);
+        assertEquals(0, result.getTotal());
+        assertTrue(result.getList().isEmpty());
+    }
+
+    // ==================== Private Helpers ====================
+
+    /**
+     * Create a simple producer Settings object with a user agent and publishing topic.
+     */
+    private static Settings createProducerSettings(Language language, String version, String topicName) {
+        return Settings.newBuilder()
+            .setClientType(ClientType.PRODUCER)
+            .setUserAgent(UA.newBuilder()
+                .setLanguage(language)
+                .setVersion(version)
+                .build())
+            .setPublishing(Publishing.newBuilder()
+                .addTopics(Resource.newBuilder().setName(topicName).build())
+                .build())
+            .build();
+    }
+}

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.remoting;
 
 import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.remoting.common.TlsMode;
+import org.apache.rocketmq.remoting.exception.RemotingConnectException;
 import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
@@ -220,7 +221,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 5);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 
@@ -238,7 +241,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 5);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 
@@ -257,7 +262,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 3);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 
@@ -270,7 +277,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 3);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 

--- a/style/rmq_checkstyle.xml
+++ b/style/rmq_checkstyle.xml
@@ -24,6 +24,11 @@
 
     <property name="localeLanguage" value="en"/>
 
+    <!-- Exclude generated source files (protobuf, gRPC, etc.) from all checks -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*[\\/]generated\-sources[\\/].*"/>
+    </module>
+
     <!--To configure the check to report on the first instance in each file-->
     <module name="FileTabCharacter"/>
 

--- a/style/rmq_checkstyle_suppressions.xml
+++ b/style/rmq_checkstyle_suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!-- Exclude all generated sources (protobuf, gRPC, etc.) from checkstyle checks -->
+    <suppress files=".*[\\/]generated-sources[\\/].*" checks=".*"/>
+</suppressions>


### PR DESCRIPTION
## [Studio] feat: Proxy Admin Authentication and Security Interceptor

**Issue:** #10634
**Branch:** `feature/rip-2-pr3-security-interceptor`

---

### Overview

This PR adds the authentication and authorization layer for the RIP-2 Proxy Admin Interface, implementing a gRPC `ServerInterceptor` that enforces ACL 2.0 security policies on all admin endpoints. It also extends the proxy's context propagation to carry SSL and authentication metadata.

### Key Changes

**ProxyAdminAuthInterceptor** -- Core gRPC `ServerInterceptor` (239 lines) implementing ACL 2.0 authentication and authorization for admin endpoints.

- **`interceptCall()`**: Entry point. If both auth and authz are disabled, passes through. Otherwise calls `authenticate()` then `authorize()`. Catches `AuthenticationException` (returns `Status.UNAUTHENTICATED`), `AuthorizationException` (returns `Status.PERMISSION_DENIED`), and generic exceptions (returns `Status.INTERNAL`).
- **`authenticate(Metadata, String)`**: Builds a `DefaultAuthenticationContext` from gRPC headers. Parses the `Authorization` header to extract `Credential=<username>/...` and `Signature=...` fields. Uses `DateTime` header as the signed content. Delegates to `AuthenticationEvaluator.evaluate()`.
- **`authorize(Metadata, String)`**: Extracts username from `AUTHORIZATION_AK` header. Builds a `Resource` of type `ResourceType.ANY` with name `"proxy.admin.client"` and pattern `LITERAL`. Calls `resolveAction()` to determine the required `Action`. Builds `DefaultAuthorizationContext` with subject, resource, action, and source IP (from `x-forwarded-for`). Delegates to `AuthorizationEvaluator.evaluate()`.
- **`resolveAction(String)`**: Maps RPC method names to ACL actions per RIP-2 section 7.2: `UpdateConfig` -> `Action.UPDATE` (write); `DescribeClient`/`GetConfig` -> `Action.GET` (single resource read); all others -> `Action.LIST` (collection read).

**Context Propagation Extensions**

- `ContextVariable`: Added `SSL_ENABLED` and `AUTH_USERNAME` constants; removed unused `CLIENT_TYPE`.
- `ProxyContext`: Added `setSslEnabled()`/`isSslEnabled()`, `setAuthUsername()`/`getAuthUsername()` for carrying security metadata through the request pipeline.
- `HeaderInterceptor`: Added `isSslEnabled(Attributes)` method that checks `Grpc.TRANSPORT_ATTR_SSL_SESSION` from the gRPC call's transport attributes and writes the result as `SSL_ENABLED` header.
- `AuthenticationPipeline`: After successful authentication, stores the resolved username into `ProxyContext.setAuthUsername()`.
- `ContextInitPipeline`: Extracts `SSL_ENABLED` and `AUTHORIZATION_AK` from gRPC metadata into `ProxyContext`.

### Test Coverage

| Test File | Lines | Coverage |
|-----------|-------|----------|
| `ProxyAdminAuthInterceptorTest.java` | 443 | `resolveAction` for all 10 RPCs, full gRPC method name paths, null/empty inputs, `extractUsername`/`extractSourceIp`, `authenticate`/`authorize` via reflection, `AuthConfig` flag combinations |
| `ProxyAdminSecurityTest.java` | 681 | Four security categories per RIP-2 section 11.4: auth bypass (both disabled passes through; auth enabled with no credentials rejected with UNAUTHENTICATED), unauthorized access (resource constants, action resolution), parameter injection (SQL injection, XSS, path traversal, null bytes, JNDI injection in clientId/group/topic/clientIdPrefix), oversized query (pageSize truncation to max 100, default to 20) |
| `HeaderInterceptorTest.java` | 149 | SSL detection, remote/local address extraction, next handler invocation |
| `ContextInitPipelineTest.java` | 140 | SSL enabled true/false/missing, auth username extraction/missing, namespace/action extraction |

### Files Changed

| File | Description |
|------|-------------|
| `proxy/src/main/java/.../grpc/admin/ProxyAdminAuthInterceptor.java` | ACL 2.0 auth interceptor (new, 239 lines) |
| `proxy/src/main/java/.../common/ContextVariable.java` | Added SSL_ENABLED, AUTH_USERNAME |
| `proxy/src/main/java/.../common/ProxyContext.java` | Added SSL and auth username fields |
| `proxy/src/main/java/.../grpc/interceptor/HeaderInterceptor.java` | SSL detection from transport attributes |
| `proxy/src/main/java/.../grpc/pipeline/AuthenticationPipeline.java` | Store username after auth |
| `proxy/src/main/java/.../grpc/pipeline/ContextInitPipeline.java` | Extract SSL and auth metadata |
| `proxy/src/test/java/.../grpc/admin/ProxyAdminAuthInterceptorTest.java` | Auth interceptor tests (new, 443 lines) |
| `proxy/src/test/java/.../grpc/admin/ProxyAdminSecurityTest.java` | Security-focused tests (new, 681 lines) |
| `proxy/src/test/java/.../grpc/interceptor/HeaderInterceptorTest.java` | Header interceptor tests (new, 149 lines) |
| `proxy/src/test/java/.../grpc/pipeline/ContextInitPipelineTest.java` | Context init tests (new, 140 lines) |

### Security Design

- **Defense in depth**: Authentication and authorization are independently configurable; either can be enabled without the other.
- **Input sanitization**: All user-supplied parameters (clientId, group, topic, clientIdPrefix) are validated against injection attacks (SQL, XSS, path traversal, null bytes, JNDI).
- **Query size enforcement**: Page size is capped at 100 (default 20) to prevent resource exhaustion from oversized queries.
- **Source IP tracking**: The `x-forwarded-for` header is captured for audit logging and authorization decisions, supporting deployment behind load balancers.
