### PR TITLE
[Studio] feat: Feature/rip 2 pr6 messaging integration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,6 +158,22 @@ load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_jav
 rules_java_dependencies()
 rules_java_toolchains()
 
+# rules_proto 5.3.0-21.7 — last 5.x release, WORKSPACE-compatible (avoids
+# bazel_features Bzlmod requirement introduced in 6.0.0).
+# Uses git archive URL because the GitHub Release asset was removed (returns 404).
+http_archive(
+    name = "rules_proto",
+    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+    strip_prefix = "rules_proto-5.3.0-21.7",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
 load("@rules_java//toolchains:local_java_repository.bzl", "local_java_repository")
 local_java_repository(
   name = "jdk8",

--- a/common/src/test/java/org/apache/rocketmq/common/ServiceThreadTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/ServiceThreadTest.java
@@ -161,8 +161,11 @@ public class ServiceThreadTest {
     public void serviceThreadShouldNotLoseWakeupUnderStress() throws Exception {
         final int stressIterations = 10000;
         final int wakerThreads = 4;
-        final long waitTimeoutMs = 20;
-        final long lostWakeupThresholdMs = 18;
+        // A delivered wakeup returns in microseconds while a lost one blocks for the whole
+        // interval. Keep the interval and the threshold far above CI scheduler/GC jitter
+        // (which can easily exceed tens of milliseconds) so the two cases stay distinguishable.
+        final long waitTimeoutMs = 2000;
+        final long lostWakeupThresholdMs = 1000;
 
         StressServiceThread service = new StressServiceThread();
         AtomicInteger activeIteration = new AtomicInteger(-1);

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -15,12 +15,26 @@
 # limitations under the License.
 #
 load("//bazel:GenTestRules.bzl", "GenTestRules")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "proxy_admin_proto",
+    srcs = ["src/main/proto/proxy_admin.proto"],
+)
+
+# java_proto_library: native rule in Bazel 6.x; rules_java 7.x does not export it.
+java_proto_library(
+    name = "proxy_admin_java_proto",
+    deps = [":proxy_admin_proto"],
+    visibility = ["//visibility:public"],
+)
 
 java_library(
     name = "proxy",
     srcs = glob(["src/main/java/**/*.java"]),
     visibility = ["//visibility:public"],
     deps = [
+        ":proxy_admin_java_proto",
         "//auth",
         "//broker",
         "//client",
@@ -80,6 +94,7 @@ java_library(
     deps = [
 	    "//auth",
         ":proxy",
+        ":proxy_admin_java_proto",
         "//:test_deps",
         "//broker",
         "//client",

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -32,7 +32,46 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.root>${basedir}/..</project.root>
+        <protobuf.version>3.20.1</protobuf.version>
+        <grpc.version>1.53.0</grpc.version>
     </properties>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
+                    <outputDirectory>${basedir}/target/generated-sources/protobuf/java</outputDirectory>
+                    <clearOutputDirectory>false</clearOutputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>**/generated-sources/**/*.java</excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnostics.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnostics.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import java.util.Map;
+
+/**
+ * Diagnostic information for batch consumption, aggregated per client channel.
+ * <p>
+ * Combines data from ReceiptHandleManager (unacked message statistics)
+ * with enrichment from ConsumerManager and GrpcClientSettingsManager.
+ * <p>
+ * Key diagnostic use cases:
+ * - Identify clients with excessive unacked messages (batch too large)
+ * - Detect clients with high expired handle counts (timeout issues)
+ * - Monitor renewal patterns per client (ChangeInvisibleTime frequency)
+ * - Correlate unacked count with configured receiveBatchSize
+ */
+public class BatchConsumeClientDiagnostics {
+    private final String clientId;
+    private final String channelId;
+    private final int unackedMessageCount;
+    private final int unackedHandleCount;
+    private final long totalRenewTimes;
+    private final long totalRenewRetryTimes;
+    private final int expiredHandleCount;
+    private final Map<String, Integer> topicDistribution;
+    private final String consumeType;
+    private final String messageModel;
+    private final int receiveBatchSize;
+    private final long longPollingTimeoutMs;
+    private final long lastRttMs;
+    private final long connectTime;
+
+    public BatchConsumeClientDiagnostics(String clientId, String channelId,
+        int unackedMessageCount, int unackedHandleCount,
+        long totalRenewTimes, long totalRenewRetryTimes, int expiredHandleCount,
+        Map<String, Integer> topicDistribution,
+        String consumeType, String messageModel,
+        int receiveBatchSize, long longPollingTimeoutMs,
+        long lastRttMs, long connectTime) {
+        this.clientId = clientId;
+        this.channelId = channelId;
+        this.unackedMessageCount = unackedMessageCount;
+        this.unackedHandleCount = unackedHandleCount;
+        this.totalRenewTimes = totalRenewTimes;
+        this.totalRenewRetryTimes = totalRenewRetryTimes;
+        this.expiredHandleCount = expiredHandleCount;
+        this.topicDistribution = topicDistribution;
+        this.consumeType = consumeType;
+        this.messageModel = messageModel;
+        this.receiveBatchSize = receiveBatchSize;
+        this.longPollingTimeoutMs = longPollingTimeoutMs;
+        this.lastRttMs = lastRttMs;
+        this.connectTime = connectTime;
+    }
+
+    public String getClientId() { return clientId; }
+    public String getChannelId() { return channelId; }
+    public int getUnackedMessageCount() { return unackedMessageCount; }
+    public int getUnackedHandleCount() { return unackedHandleCount; }
+    public long getTotalRenewTimes() { return totalRenewTimes; }
+    public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+    public int getExpiredHandleCount() { return expiredHandleCount; }
+    public Map<String, Integer> getTopicDistribution() { return topicDistribution; }
+    public String getConsumeType() { return consumeType; }
+    public String getMessageModel() { return messageModel; }
+    public int getReceiveBatchSize() { return receiveBatchSize; }
+    public long getLongPollingTimeoutMs() { return longPollingTimeoutMs; }
+    public long getLastRttMs() { return lastRttMs; }
+    public long getConnectTime() { return connectTime; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummary.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+/**
+ * Aggregated summary statistics for batch consumption diagnostics across a consumer group.
+ * <p>
+ * Provides a high-level view of the batch consumption state for a group,
+ * useful for quickly identifying groups with excessive unacked messages,
+ * high renewal rates, or expired handles across all clients.
+ */
+public class BatchConsumeGroupSummary {
+    private final String group;
+    private final int totalClients;
+    private final int totalUnackedMessages;
+    private final int totalUnackedHandles;
+    private final int totalExpiredHandles;
+    private final long totalRenewTimes;
+    private final long totalRenewRetryTimes;
+
+    public BatchConsumeGroupSummary(String group, int totalClients,
+        int totalUnackedMessages, int totalUnackedHandles, int totalExpiredHandles,
+        long totalRenewTimes, long totalRenewRetryTimes) {
+        this.group = group;
+        this.totalClients = totalClients;
+        this.totalUnackedMessages = totalUnackedMessages;
+        this.totalUnackedHandles = totalUnackedHandles;
+        this.totalExpiredHandles = totalExpiredHandles;
+        this.totalRenewTimes = totalRenewTimes;
+        this.totalRenewRetryTimes = totalRenewRetryTimes;
+    }
+
+    public String getGroup() { return group; }
+    public int getTotalClients() { return totalClients; }
+    public int getTotalUnackedMessages() { return totalUnackedMessages; }
+    public int getTotalUnackedHandles() { return totalUnackedHandles; }
+    public int getTotalExpiredHandles() { return totalExpiredHandles; }
+    public long getTotalRenewTimes() { return totalRenewTimes; }
+    public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummary.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummary.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+/**
+ * Aggregated summary statistics for POP receipt handles in a consumer group.
+ * <p>
+ * Provides a high-level view of the POP consumption state for a group,
+ * useful for quickly identifying groups with excessive unacked messages,
+ * high renewal rates, or expired handles.
+ */
+public class PopReceiptHandleGroupSummary {
+    private final String group;
+    private final int totalHandles;
+    private final int totalMessages;
+    private final long totalRenewTimes;
+    private final long totalRenewRetryTimes;
+    private final int expiredHandles;
+
+    public PopReceiptHandleGroupSummary(String group, int totalHandles, int totalMessages,
+        long totalRenewTimes, long totalRenewRetryTimes, int expiredHandles) {
+        this.group = group;
+        this.totalHandles = totalHandles;
+        this.totalMessages = totalMessages;
+        this.totalRenewTimes = totalRenewTimes;
+        this.totalRenewRetryTimes = totalRenewRetryTimes;
+        this.expiredHandles = expiredHandles;
+    }
+
+    public String getGroup() { return group; }
+    public int getTotalHandles() { return totalHandles; }
+    public int getTotalMessages() { return totalMessages; }
+    public long getTotalRenewTimes() { return totalRenewTimes; }
+    public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+    public int getExpiredHandles() { return expiredHandles; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfo.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+/**
+ * Diagnostic information for a single POP receipt handle.
+ * <p>
+ * Contains all relevant fields for diagnosing POP consumption issues:
+ * - Message identification (group, topic, queueId, messageId, queueOffset)
+ * - Consumption state (reconsumeTimes, renewTimes, renewRetryTimes, consumeTimestamp)
+ * - Invisible time management (receiptHandle, nextVisibleTime, invisibleTime, isExpired)
+ * - Broker location (brokerName)
+ */
+public class PopReceiptHandleInfo {
+    private final String group;
+    private final String topic;
+    private final int queueId;
+    private final String messageId;
+    private final long queueOffset;
+    private final int reconsumeTimes;
+    private final int renewTimes;
+    private final int renewRetryTimes;
+    private final long consumeTimestamp;
+    private final String receiptHandle;
+    private final long nextVisibleTime;
+    private final long invisibleTime;
+    private final String brokerName;
+    private final boolean expired;
+
+    public PopReceiptHandleInfo(String group, String topic, int queueId, String messageId,
+        long queueOffset, int reconsumeTimes, int renewTimes, int renewRetryTimes,
+        long consumeTimestamp, String receiptHandle, long nextVisibleTime,
+        long invisibleTime, String brokerName, boolean expired) {
+        this.group = group;
+        this.topic = topic;
+        this.queueId = queueId;
+        this.messageId = messageId;
+        this.queueOffset = queueOffset;
+        this.reconsumeTimes = reconsumeTimes;
+        this.renewTimes = renewTimes;
+        this.renewRetryTimes = renewRetryTimes;
+        this.consumeTimestamp = consumeTimestamp;
+        this.receiptHandle = receiptHandle;
+        this.nextVisibleTime = nextVisibleTime;
+        this.invisibleTime = invisibleTime;
+        this.brokerName = brokerName;
+        this.expired = expired;
+    }
+
+    public String getGroup() { return group; }
+    public String getTopic() { return topic; }
+    public int getQueueId() { return queueId; }
+    public String getMessageId() { return messageId; }
+    public long getQueueOffset() { return queueOffset; }
+    public int getReconsumeTimes() { return reconsumeTimes; }
+    public int getRenewTimes() { return renewTimes; }
+    public int getRenewRetryTimes() { return renewRetryTimes; }
+    public long getConsumeTimestamp() { return consumeTimestamp; }
+    public String getReceiptHandle() { return receiptHandle; }
+    public long getNextVisibleTime() { return nextVisibleTime; }
+    public long getInvisibleTime() { return invisibleTime; }
+    public String getBrokerName() { return brokerName; }
+    public boolean isExpired() { return expired; }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/common/ProxyContext.java
@@ -156,4 +156,22 @@ public class ProxyContext {
             || ClientType.LITE_SIMPLE_CONSUMER.name().equals(clientType);
     }
 
+    public ProxyContext setSslEnabled(Boolean sslEnabled) {
+        this.withVal(ContextVariable.SSL_ENABLED, sslEnabled);
+        return this;
+    }
+
+    public Boolean isSslEnabled() {
+        return this.getVal(ContextVariable.SSL_ENABLED);
+    }
+
+    public ProxyContext setAuthUsername(String username) {
+        this.withVal(ContextVariable.AUTH_USERNAME, username);
+        return this;
+    }
+
+    public String getAuthUsername() {
+        return this.getVal(ContextVariable.AUTH_USERNAME);
+    }
+
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -112,6 +112,40 @@ public class ProxyConfig implements ConfigFile {
      * 130M = 4M * 32 messages + 2M attributes
      */
     private int grpcMaxInboundMessageSize = 130 * 1024 * 1024;
+
+    /**
+     * Proxy Admin gRPC configuration (RIP-2)
+     * Admin interface runs on a separate port from the data plane.
+     */
+    private boolean proxyAdminEnabled = true;
+    private Integer proxyAdminServerPort = 8082;
+    private int proxyAdminThreadPoolNums = 4;
+    private int proxyAdminMaxPageSize = 100;
+    /**
+     * Sampling concurrency limit for DescribeClient diagnostic queries (RIP-2 §8.5).
+     * When concurrent DescribeClient requests exceed this value, new requests are rejected.
+     * Default: 8
+     */
+    private int proxyAdminDescribeClientConcurrencyLimit = 8;
+    /**
+     * Sampling rate under medium load (RIP-2 §8.5).
+     * When concurrency is between half the limit and the full limit, this fraction of
+     * DescribeClient requests are accepted. Value between 0.0 and 1.0.
+     * Default: 0.5
+     */
+    private double proxyAdminSamplingRateUnderLoad = 0.5;
+    /**
+     * Maximum heartbeat history records per client (RIP-2 §5.2.2).
+     * Controls memory usage for heartbeat tracking.
+     * Default: 10
+     */
+    private int proxyAdminHeartbeatHistorySize = 10;
+    /**
+     * Sampling threshold for client count (RIP-2 §8.5).
+     * When total client count exceeds this value, diagnostic interfaces may apply sampling.
+     * Default: 100000
+     */
+    private long proxyAdminSamplingThreshold = 100000L;
     /**
      * max message body size, 0 or negative number means no limit for proxy
      */
@@ -481,6 +515,70 @@ public class ProxyConfig implements ConfigFile {
 
     public void setGrpcServerPort(Integer grpcServerPort) {
         this.grpcServerPort = grpcServerPort;
+    }
+
+    public boolean isProxyAdminEnabled() {
+        return proxyAdminEnabled;
+    }
+
+    public void setProxyAdminEnabled(boolean proxyAdminEnabled) {
+        this.proxyAdminEnabled = proxyAdminEnabled;
+    }
+
+    public Integer getProxyAdminServerPort() {
+        return proxyAdminServerPort;
+    }
+
+    public void setProxyAdminServerPort(Integer proxyAdminServerPort) {
+        this.proxyAdminServerPort = proxyAdminServerPort;
+    }
+
+    public int getProxyAdminThreadPoolNums() {
+        return proxyAdminThreadPoolNums;
+    }
+
+    public void setProxyAdminThreadPoolNums(int proxyAdminThreadPoolNums) {
+        this.proxyAdminThreadPoolNums = proxyAdminThreadPoolNums;
+    }
+
+    public int getProxyAdminMaxPageSize() {
+        return proxyAdminMaxPageSize;
+    }
+
+    public void setProxyAdminMaxPageSize(int proxyAdminMaxPageSize) {
+        this.proxyAdminMaxPageSize = proxyAdminMaxPageSize;
+    }
+
+    public int getProxyAdminDescribeClientConcurrencyLimit() {
+        return proxyAdminDescribeClientConcurrencyLimit;
+    }
+
+    public void setProxyAdminDescribeClientConcurrencyLimit(int proxyAdminDescribeClientConcurrencyLimit) {
+        this.proxyAdminDescribeClientConcurrencyLimit = proxyAdminDescribeClientConcurrencyLimit;
+    }
+
+    public double getProxyAdminSamplingRateUnderLoad() {
+        return proxyAdminSamplingRateUnderLoad;
+    }
+
+    public void setProxyAdminSamplingRateUnderLoad(double proxyAdminSamplingRateUnderLoad) {
+        this.proxyAdminSamplingRateUnderLoad = proxyAdminSamplingRateUnderLoad;
+    }
+
+    public int getProxyAdminHeartbeatHistorySize() {
+        return proxyAdminHeartbeatHistorySize;
+    }
+
+    public void setProxyAdminHeartbeatHistorySize(int proxyAdminHeartbeatHistorySize) {
+        this.proxyAdminHeartbeatHistorySize = proxyAdminHeartbeatHistorySize;
+    }
+
+    public long getProxyAdminSamplingThreshold() {
+        return proxyAdminSamplingThreshold;
+    }
+
+    public void setProxyAdminSamplingThreshold(long proxyAdminSamplingThreshold) {
+        this.proxyAdminSamplingThreshold = proxyAdminSamplingThreshold;
     }
 
     public long getGrpcShutdownTimeSeconds() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/AdminCode.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/AdminCode.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+/**
+ * Admin API response codes (RIP-2 §5.2.3).
+ * Mirrors the AdminCode enum defined in proxy_admin.proto.
+ * <p>
+ * These codes provide structured error information in the response body,
+ * complementing gRPC status codes with application-level semantics.
+ */
+public enum AdminCode {
+    /**
+     * Success.
+     */
+    OK(1, "OK"),
+
+    /**
+     * Internal server error.
+     */
+    INTERNAL_ERROR(2, "Internal error"),
+
+    /**
+     * Bad request - invalid parameters.
+     */
+    BAD_REQUEST(3, "Bad request"),
+
+    /**
+     * Unauthorized - authentication required.
+     */
+    UNAUTHORIZED(4, "Unauthorized"),
+
+    /**
+     * Forbidden - insufficient permissions.
+     */
+    FORBIDDEN(5, "Forbidden"),
+
+    /**
+     * Resource not found.
+     */
+    NOT_FOUND(6, "Not found"),
+
+    /**
+     * Too many requests - rate limited.
+     */
+    TOO_MANY_REQUESTS(7, "Too many requests"),
+
+    /**
+     * Conflict - client already disconnected or in transition.
+     */
+    CONFLICT(8, "Conflict");
+
+    private final int code;
+    private final String description;
+
+    AdminCode(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Convert a numeric code to the corresponding AdminCode.
+     *
+     * @param code the numeric code
+     * @return the AdminCode, or null if not found
+     */
+    public static AdminCode fromCode(int code) {
+        for (AdminCode ac : values()) {
+            if (ac.code == code) {
+                return ac;
+            }
+        }
+        return null;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshaller.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshaller.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * The License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
+import apache.rocketmq.proxy.admin.v1.ListClientsRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsResponse;
+import apache.rocketmq.proxy.admin.v1.DescribeClientRequest;
+import apache.rocketmq.proxy.admin.v1.DescribeClientResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupResponse;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicResponse;
+import apache.rocketmq.proxy.admin.v1.GetConfigRequest;
+import apache.rocketmq.proxy.admin.v1.GetConfigResponse;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigRequest;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigResponse;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientRequest;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientResponse;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesRequest;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesResponse;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsRequest;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsResponse;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsRequest;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsResponse;
+
+/**
+ * Protobuf-based Marshallers for Proxy Admin gRPC requests and responses.
+ * <p>
+ * Uses protobuf binary serialization as the wire format for admin RPCs,
+ * replacing the previous JSON-based marshalling. This is the standard
+ * approach for gRPC services defined via .proto files.
+ * <p>
+ * The proto definitions are compiled by protobuf-maven-plugin from
+ * src/main/proto/proxy_admin.proto into Java classes in the
+ * apache.rocketmq.proxy.admin.v1 package.
+ */
+public class ProxyAdminMarshaller {
+
+    private ProxyAdminMarshaller() {
+        // Utility class
+    }
+
+    // Request marshallers
+    public static final MethodDescriptor.Marshaller<ListClientsRequest>
+        LIST_CLIENTS_REQ_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeClientRequest>
+        DESCRIBE_CLIENT_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DescribeClientRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByGroupRequest>
+        LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByGroupRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByTopicRequest>
+        LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByTopicRequest.getDefaultInstance());
+
+    // Response marshallers
+    public static final MethodDescriptor.Marshaller<ListClientsResponse>
+        LIST_CLIENTS_RESP_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeClientResponse>
+        DESCRIBE_CLIENT_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DescribeClientResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByGroupResponse>
+        LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByGroupResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<ListClientsByTopicResponse>
+        LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER = ProtoLiteUtils.marshaller(ListClientsByTopicResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<GetConfigRequest>
+        GET_CONFIG_REQ_MARSHALLER = ProtoLiteUtils.marshaller(GetConfigRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<GetConfigResponse>
+        GET_CONFIG_RESP_MARSHALLER = ProtoLiteUtils.marshaller(GetConfigResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<UpdateConfigRequest>
+        UPDATE_CONFIG_REQ_MARSHALLER = ProtoLiteUtils.marshaller(UpdateConfigRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<UpdateConfigResponse>
+        UPDATE_CONFIG_RESP_MARSHALLER = ProtoLiteUtils.marshaller(UpdateConfigResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DisconnectClientRequest>
+        DISCONNECT_CLIENT_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DisconnectClientRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DisconnectClientResponse>
+        DISCONNECT_CLIENT_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DisconnectClientResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribePopReceiptHandlesRequest>
+        DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DescribePopReceiptHandlesRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribePopReceiptHandlesResponse>
+        DESCRIBE_POP_RECEIPT_HANDLES_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DescribePopReceiptHandlesResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeBatchConsumeDiagnosticsRequest>
+        DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER = ProtoLiteUtils.marshaller(DescribeBatchConsumeDiagnosticsRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<DescribeBatchConsumeDiagnosticsResponse>
+        DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_RESP_MARSHALLER = ProtoLiteUtils.marshaller(DescribeBatchConsumeDiagnosticsResponse.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<SubscribeRouteEventsRequest>
+        SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER = ProtoLiteUtils.marshaller(SubscribeRouteEventsRequest.getDefaultInstance());
+
+    public static final MethodDescriptor.Marshaller<SubscribeRouteEventsResponse>
+        SUBSCRIBE_ROUTE_EVENTS_RESP_MARSHALLER = ProtoLiteUtils.marshaller(SubscribeRouteEventsResponse.getDefaultInstance());
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfo.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfo.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.List;
+
+/**
+ * Client detail information model.
+ * Extends ClientInstanceInfo with additional diagnostic data.
+ * Maps to the ClientDetail proto message.
+ */
+public class ClientDetailInfo {
+    private ClientInstanceInfo clientInstance;
+    private ClientSettingsInfo settings;
+    private List<HeartbeatRecordInfo> heartbeatHistory;
+    private AuthStatusInfo authStatus;
+    private ConsumeProgressInfo consumeProgress;
+    private NetworkInfoInfo networkInfo;
+
+    public ClientDetailInfo() {
+    }
+
+    public ClientInstanceInfo getClientInstance() {
+        return clientInstance;
+    }
+
+    public void setClientInstance(ClientInstanceInfo clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public ClientSettingsInfo getSettings() {
+        return settings;
+    }
+
+    public void setSettings(ClientSettingsInfo settings) {
+        this.settings = settings;
+    }
+
+    public List<HeartbeatRecordInfo> getHeartbeatHistory() {
+        return heartbeatHistory;
+    }
+
+    public void setHeartbeatHistory(List<HeartbeatRecordInfo> heartbeatHistory) {
+        this.heartbeatHistory = heartbeatHistory;
+    }
+
+    public AuthStatusInfo getAuthStatus() {
+        return authStatus;
+    }
+
+    public void setAuthStatus(AuthStatusInfo authStatus) {
+        this.authStatus = authStatus;
+    }
+
+    public ConsumeProgressInfo getConsumeProgress() {
+        return consumeProgress;
+    }
+
+    public void setConsumeProgress(ConsumeProgressInfo consumeProgress) {
+        this.consumeProgress = consumeProgress;
+    }
+
+    public NetworkInfoInfo getNetworkInfo() {
+        return networkInfo;
+    }
+
+    public void setNetworkInfo(NetworkInfoInfo networkInfo) {
+        this.networkInfo = networkInfo;
+    }
+
+    /**
+     * Client settings information.
+     */
+    public static class ClientSettingsInfo {
+        private String subscriptionMode;
+        private int receiveBatchSize;
+        private long longPollingTimeoutMs;
+        private boolean fifo;
+        private List<String> subscriptionTopics;
+        private List<String> publishingTopics;
+
+        public String getSubscriptionMode() { return subscriptionMode; }
+        public void setSubscriptionMode(String subscriptionMode) { this.subscriptionMode = subscriptionMode; }
+        public int getReceiveBatchSize() { return receiveBatchSize; }
+        public void setReceiveBatchSize(int receiveBatchSize) { this.receiveBatchSize = receiveBatchSize; }
+        public long getLongPollingTimeoutMs() { return longPollingTimeoutMs; }
+        public void setLongPollingTimeoutMs(long longPollingTimeoutMs) { this.longPollingTimeoutMs = longPollingTimeoutMs; }
+        public boolean isFifo() { return fifo; }
+        public void setFifo(boolean fifo) { this.fifo = fifo; }
+        public List<String> getSubscriptionTopics() { return subscriptionTopics; }
+        public void setSubscriptionTopics(List<String> subscriptionTopics) { this.subscriptionTopics = subscriptionTopics; }
+        public List<String> getPublishingTopics() { return publishingTopics; }
+        public void setPublishingTopics(List<String> publishingTopics) { this.publishingTopics = publishingTopics; }
+    }
+
+    /**
+     * Heartbeat record information.
+     */
+    public static class HeartbeatRecordInfo {
+        private long timestamp;
+        private boolean success;
+        private String remark;
+
+        public long getTimestamp() { return timestamp; }
+        public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
+        public boolean isSuccess() { return success; }
+        public void setSuccess(boolean success) { this.success = success; }
+        public String getRemark() { return remark; }
+        public void setRemark(String remark) { this.remark = remark; }
+    }
+
+    /**
+     * Auth status information.
+     */
+    public static class AuthStatusInfo {
+        private boolean authenticated;
+        private String username;
+        private long lastAuthTime;
+        private String failureReason;
+
+        public boolean isAuthenticated() { return authenticated; }
+        public void setAuthenticated(boolean authenticated) { this.authenticated = authenticated; }
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public long getLastAuthTime() { return lastAuthTime; }
+        public void setLastAuthTime(long lastAuthTime) { this.lastAuthTime = lastAuthTime; }
+        public String getFailureReason() { return failureReason; }
+        public void setFailureReason(String failureReason) { this.failureReason = failureReason; }
+    }
+
+    /**
+     * Consume progress information.
+     */
+    public static class ConsumeProgressInfo {
+        private long lag;
+        private long latencyMs;
+        private List<TopicConsumeProgressInfo> topicProgress;
+
+        public long getLag() { return lag; }
+        public void setLag(long lag) { this.lag = lag; }
+        public long getLatencyMs() { return latencyMs; }
+        public void setLatencyMs(long latencyMs) { this.latencyMs = latencyMs; }
+        public List<TopicConsumeProgressInfo> getTopicProgress() { return topicProgress; }
+        public void setTopicProgress(List<TopicConsumeProgressInfo> topicProgress) { this.topicProgress = topicProgress; }
+    }
+
+    /**
+     * Topic consume progress information.
+     */
+    public static class TopicConsumeProgressInfo {
+        private String topic;
+        private long lag;
+        private long latencyMs;
+
+        public String getTopic() { return topic; }
+        public void setTopic(String topic) { this.topic = topic; }
+        public long getLag() { return lag; }
+        public void setLag(long lag) { this.lag = lag; }
+        public long getLatencyMs() { return latencyMs; }
+        public void setLatencyMs(long latencyMs) { this.latencyMs = latencyMs; }
+    }
+
+    /**
+     * Network information.
+     */
+    public static class NetworkInfoInfo {
+        private String localAddress;
+        private String remoteAddress;
+        private long rttMs;
+        private boolean sslEnabled;
+
+        public String getLocalAddress() { return localAddress; }
+        public void setLocalAddress(String localAddress) { this.localAddress = localAddress; }
+        public String getRemoteAddress() { return remoteAddress; }
+        public void setRemoteAddress(String remoteAddress) { this.remoteAddress = remoteAddress; }
+        public long getRttMs() { return rttMs; }
+        public void setRttMs(long rttMs) { this.rttMs = rttMs; }
+        public boolean isSslEnabled() { return sslEnabled; }
+        public void setSslEnabled(boolean sslEnabled) { this.sslEnabled = sslEnabled; }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfo.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfo.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.List;
+
+/**
+ * Client instance basic information model.
+ * Maps to the ClientInstance proto message.
+ */
+public class ClientInstanceInfo {
+    private String clientId;
+    private String language;
+    private String clientVersion;
+    private String protocol;
+    private String accessPoint;
+    private long connectAt;
+    private long lastActiveAt;
+    private String role;
+    private String group;
+    private List<String> topics;
+
+    public ClientInstanceInfo() {
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getClientVersion() {
+        return clientVersion;
+    }
+
+    public void setClientVersion(String clientVersion) {
+        this.clientVersion = clientVersion;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getAccessPoint() {
+        return accessPoint;
+    }
+
+    public void setAccessPoint(String accessPoint) {
+        this.accessPoint = accessPoint;
+    }
+
+    public long getConnectAt() {
+        return connectAt;
+    }
+
+    public void setConnectAt(long connectAt) {
+        this.connectAt = connectAt;
+    }
+
+    public long getLastActiveAt() {
+        return lastActiveAt;
+    }
+
+    public void setLastActiveAt(long lastActiveAt) {
+        this.lastActiveAt = lastActiveAt;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public List<String> getTopics() {
+        return topics;
+    }
+
+    public void setTopics(List<String> topics) {
+        this.topics = topics;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientInstanceInfo{" +
+            "clientId='" + clientId + '\'' +
+            ", language='" + language + '\'' +
+            ", clientVersion='" + clientVersion + '\'' +
+            ", protocol='" + protocol + '\'' +
+            ", accessPoint='" + accessPoint + '\'' +
+            ", connectAt=" + connectAt +
+            ", lastActiveAt=" + lastActiveAt +
+            ", role='" + role + '\'' +
+            ", group='" + group + '\'' +
+            ", topics=" + topics +
+            '}';
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilter.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilter.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+/**
+ * Filter criteria for ListClients query.
+ * Supports filter pushdown to avoid full memory traversal.
+ */
+public class ListClientsFilter {
+    private String group;
+    private String topic;
+    private String clientIdPrefix;
+    private String language;
+    private long connectTimeStart;
+    private long connectTimeEnd;
+
+    public ListClientsFilter() {
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getClientIdPrefix() {
+        return clientIdPrefix;
+    }
+
+    public void setClientIdPrefix(String clientIdPrefix) {
+        this.clientIdPrefix = clientIdPrefix;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public long getConnectTimeStart() {
+        return connectTimeStart;
+    }
+
+    public void setConnectTimeStart(long connectTimeStart) {
+        this.connectTimeStart = connectTimeStart;
+    }
+
+    public long getConnectTimeEnd() {
+        return connectTimeEnd;
+    }
+
+    public void setConnectTimeEnd(long connectTimeEnd) {
+        this.connectTimeEnd = connectTimeEnd;
+    }
+
+    /**
+     * Check if any filter criteria is set.
+     *
+     * @return true if at least one filter criterion is set
+     */
+    public boolean hasFilter() {
+        return group != null || topic != null || clientIdPrefix != null
+            || language != null || connectTimeStart > 0 || connectTimeEnd > 0;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEvent.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEvent.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+/**
+ * Route change event model.
+ * Represents a single route change detected by the proxy.
+ */
+public class RouteChangeEvent {
+    private RouteChangeEventType eventType;
+    private long timestamp;
+    private String topic;
+    private String cluster;
+    private String brokerName;
+    private long brokerId;
+    private String brokerAddress;
+    private int previousReadQueueNums;
+    private int currentReadQueueNums;
+    private int previousWriteQueueNums;
+    private int currentWriteQueueNums;
+    private TopicRouteSnapshot routeSnapshot;
+
+    public RouteChangeEvent() {
+    }
+
+    public RouteChangeEventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(RouteChangeEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
+    }
+
+    public String getBrokerName() {
+        return brokerName;
+    }
+
+    public void setBrokerName(String brokerName) {
+        this.brokerName = brokerName;
+    }
+
+    public long getBrokerId() {
+        return brokerId;
+    }
+
+    public void setBrokerId(long brokerId) {
+        this.brokerId = brokerId;
+    }
+
+    public String getBrokerAddress() {
+        return brokerAddress;
+    }
+
+    public void setBrokerAddress(String brokerAddress) {
+        this.brokerAddress = brokerAddress;
+    }
+
+    public int getPreviousReadQueueNums() {
+        return previousReadQueueNums;
+    }
+
+    public void setPreviousReadQueueNums(int previousReadQueueNums) {
+        this.previousReadQueueNums = previousReadQueueNums;
+    }
+
+    public int getCurrentReadQueueNums() {
+        return currentReadQueueNums;
+    }
+
+    public void setCurrentReadQueueNums(int currentReadQueueNums) {
+        this.currentReadQueueNums = currentReadQueueNums;
+    }
+
+    public int getPreviousWriteQueueNums() {
+        return previousWriteQueueNums;
+    }
+
+    public void setPreviousWriteQueueNums(int previousWriteQueueNums) {
+        this.previousWriteQueueNums = previousWriteQueueNums;
+    }
+
+    public int getCurrentWriteQueueNums() {
+        return currentWriteQueueNums;
+    }
+
+    public void setCurrentWriteQueueNums(int currentWriteQueueNums) {
+        this.currentWriteQueueNums = currentWriteQueueNums;
+    }
+
+    public TopicRouteSnapshot getRouteSnapshot() {
+        return routeSnapshot;
+    }
+
+    public void setRouteSnapshot(TopicRouteSnapshot routeSnapshot) {
+        this.routeSnapshot = routeSnapshot;
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventType.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+/**
+ * Route change event type enum.
+ * Maps to the RouteChangeEventType proto enum.
+ */
+public enum RouteChangeEventType {
+    BROKER_ONLINE,
+    BROKER_OFFLINE,
+    QUEUE_SCALE,
+    TOPIC_CREATE,
+    TOPIC_DELETE,
+    ROUTE_SNAPSHOT
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshot.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshot.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.List;
+
+/**
+ * Topic route snapshot model.
+ * Contains the complete route data for a topic at a point in time.
+ */
+public class TopicRouteSnapshot {
+    private String topic;
+    private List<BrokerInfo> brokers;
+    private List<QueueInfo> queues;
+
+    public TopicRouteSnapshot() {
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public List<BrokerInfo> getBrokers() {
+        return brokers;
+    }
+
+    public void setBrokers(List<BrokerInfo> brokers) {
+        this.brokers = brokers;
+    }
+
+    public List<QueueInfo> getQueues() {
+        return queues;
+    }
+
+    public void setQueues(List<QueueInfo> queues) {
+        this.queues = queues;
+    }
+
+    /**
+     * Broker info in route snapshot.
+     */
+    public static class BrokerInfo {
+        private String cluster;
+        private String brokerName;
+        private java.util.Map<Long, String> brokerAddrs;
+
+        public BrokerInfo() {
+        }
+
+        public String getCluster() {
+            return cluster;
+        }
+
+        public void setCluster(String cluster) {
+            this.cluster = cluster;
+        }
+
+        public String getBrokerName() {
+            return brokerName;
+        }
+
+        public void setBrokerName(String brokerName) {
+            this.brokerName = brokerName;
+        }
+
+        public java.util.Map<Long, String> getBrokerAddrs() {
+            return brokerAddrs;
+        }
+
+        public void setBrokerAddrs(java.util.Map<Long, String> brokerAddrs) {
+            this.brokerAddrs = brokerAddrs;
+        }
+    }
+
+    /**
+     * Queue info in route snapshot.
+     */
+    public static class QueueInfo {
+        private String brokerName;
+        private int readQueueNums;
+        private int writeQueueNums;
+        private int perm;
+
+        public QueueInfo() {
+        }
+
+        public String getBrokerName() {
+            return brokerName;
+        }
+
+        public void setBrokerName(String brokerName) {
+            this.brokerName = brokerName;
+        }
+
+        public int getReadQueueNums() {
+            return readQueueNums;
+        }
+
+        public void setReadQueueNums(int readQueueNums) {
+            this.readQueueNums = readQueueNums;
+        }
+
+        public int getWriteQueueNums() {
+            return writeQueueNums;
+        }
+
+        public void setWriteQueueNums(int writeQueueNums) {
+            this.writeQueueNums = writeQueueNums;
+        }
+
+        public int getPerm() {
+            return perm;
+        }
+
+        public void setPerm(int perm) {
+            this.perm = perm;
+        }
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/channel/GrpcChannelManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.proxy.grpc.v2.channel;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -71,6 +72,16 @@ public class GrpcChannelManager implements StartAndShutdown {
 
     public GrpcClientChannel removeChannel(String clientId) {
         return this.clientIdChannelMap.remove(clientId);
+    }
+
+    /**
+     * Get all client channel mappings for admin queries.
+     * Returns an unmodifiable view of the clientId-channel map.
+     *
+     * @return unmodifiable map of clientId to GrpcClientChannel
+     */
+    public Map<String, GrpcClientChannel> getClientIdChannelMap() {
+        return java.util.Collections.unmodifiableMap(this.clientIdChannelMap);
     }
 
     public <T> String addResponseFuture(CompletableFuture<ProxyRelayResult<T>> responseFuture) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
@@ -55,8 +55,10 @@ import org.apache.rocketmq.proxy.service.ServiceManager;
 import org.apache.rocketmq.proxy.service.ServiceManagerFactory;
 import org.apache.rocketmq.proxy.service.message.ReceiptHandleMessage;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
 import org.apache.rocketmq.proxy.service.relay.ProxyRelayService;
 import org.apache.rocketmq.proxy.service.route.ProxyTopicRouteData;
+import org.apache.rocketmq.proxy.service.route.TopicRouteService;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumeType;
@@ -399,5 +401,15 @@ public class DefaultMessagingProcessor extends AbstractStartAndShutdown implemen
 
     @Override public int getUnackedMessageCount(ProxyContext ctx, Channel channel, String group) {
         return receiptHandleProcessor.getUnackedMessageCount(ctx, channel, group);
+    }
+
+    @Override
+    public ReceiptHandleManager getReceiptHandleManager() {
+        return receiptHandleProcessor.getReceiptHandleManager();
+    }
+
+    @Override
+    public TopicRouteService getTopicRouteService() {
+        return this.serviceManager.getTopicRouteService();
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/MessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/MessagingProcessor.java
@@ -40,8 +40,10 @@ import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.service.message.ReceiptHandleMessage;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
 import org.apache.rocketmq.proxy.service.relay.ProxyRelayService;
 import org.apache.rocketmq.proxy.service.route.ProxyTopicRouteData;
+import org.apache.rocketmq.proxy.service.route.TopicRouteService;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumeType;
 import org.apache.rocketmq.remoting.protocol.heartbeat.MessageModel;
@@ -420,4 +422,18 @@ public interface MessagingProcessor extends StartAndShutdown {
         String receiptHandle);
 
     int getUnackedMessageCount(ProxyContext ctx, Channel channel, String group);
+
+    /**
+     * Get the ReceiptHandleManager for POP diagnostics.
+     *
+     * @return the receipt handle manager instance
+     */
+    ReceiptHandleManager getReceiptHandleManager();
+
+    /**
+     * Get the TopicRouteService for route change event subscriptions.
+     *
+     * @return the topic route service instance
+     */
+    TopicRouteService getTopicRouteService();
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ReceiptHandleProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ReceiptHandleProcessor.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.common.RenewEvent;
 import org.apache.rocketmq.proxy.service.ServiceManager;
 import org.apache.rocketmq.proxy.service.receipt.DefaultReceiptHandleManager;
+import org.apache.rocketmq.proxy.service.receipt.ReceiptHandleManager;
 
 public class ReceiptHandleProcessor extends AbstractProcessor {
     protected final static Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
@@ -70,6 +71,15 @@ public class ReceiptHandleProcessor extends AbstractProcessor {
 
     public int getUnackedMessageCount(ProxyContext ctx, Channel channel, String group) {
         return receiptHandleManager.getUnackedMessageCount(ctx, channel, group);
+    }
+
+    /**
+     * Get the ReceiptHandleManager for POP diagnostics.
+     *
+     * @return the receipt handle manager instance
+     */
+    public ReceiptHandleManager getReceiptHandleManager() {
+        return receiptHandleManager;
     }
 
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/SimpleChannel.java
@@ -204,6 +204,10 @@ public class SimpleChannel extends AbstractChannel {
         return localAddress;
     }
 
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
     public ChannelHandlerContext getChannelHandlerContext() {
         return channelHandlerContext;
     }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -19,6 +19,9 @@ package org.apache.rocketmq.proxy.service.receipt;
 
 import com.google.common.base.Stopwatch;
 import io.netty.channel.Channel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +48,10 @@ import org.apache.rocketmq.common.utils.StartAndShutdown;
 import org.apache.rocketmq.common.utils.ThreadUtils;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary;
 import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleGroupSummary;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleInfo;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.common.ProxyException;
 import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
@@ -302,5 +308,215 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
 
     protected ProxyContext createContext(String actionName) {
         return ProxyContext.createForInner(this.getClass().getSimpleName() + actionName);
+    }
+
+    /**
+     * Query POP receipt handles for diagnostics.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group name,
+     * collects diagnostic information for each unacked message handle,
+     * and returns a summary with paginated handle details.
+     * <p>
+     * This method is thread-safe: it iterates over the ConcurrentHashMap without
+     * locking, providing a weakly consistent snapshot of the current state.
+     */
+    @Override
+    public PopReceiptHandleDiagnosticResult describePopReceiptHandles(String group, String topic, int pageNum, int pageSize) {
+        List<PopReceiptHandleInfo> allHandles = new ArrayList<>();
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+        int expiredHandles = 0;
+        int totalHandleCount = 0;
+        int totalMessageCount = 0;
+
+        long currentTime = System.currentTimeMillis();
+
+        // Scan all receipt handle groups matching the group name
+        for (Map.Entry<ReceiptHandleGroupKey, ReceiptHandleGroup> entry : receiptHandleGroupMap.entrySet()) {
+            ReceiptHandleGroupKey key = entry.getKey();
+            if (!key.getGroup().equals(group)) {
+                continue;
+            }
+
+            ReceiptHandleGroup handleGroup = entry.getValue();
+            totalHandleCount += (int) handleGroup.getHandleNum();
+            totalMessageCount += handleGroup.getMsgCount();
+
+            // Scan handles in this group
+            handleGroup.scan((msgID, handleStr, messageReceiptHandle) -> {
+                // Apply topic filter if specified
+                if (topic != null && !topic.isEmpty() && !topic.equals(messageReceiptHandle.getTopic())) {
+                    return;
+                }
+
+                // Decode receipt handle to get invisible time info
+                ReceiptHandle receiptHandle = ReceiptHandle.decode(messageReceiptHandle.getReceiptHandleStr());
+                boolean isExpired = receiptHandle.getNextVisibleTime() <= currentTime;
+
+                PopReceiptHandleInfo info = new PopReceiptHandleInfo(
+                    messageReceiptHandle.getGroup(),
+                    messageReceiptHandle.getTopic(),
+                    messageReceiptHandle.getQueueId(),
+                    messageReceiptHandle.getMessageId(),
+                    messageReceiptHandle.getQueueOffset(),
+                    messageReceiptHandle.getReconsumeTimes(),
+                    messageReceiptHandle.getRenewTimes(),
+                    messageReceiptHandle.getRenewRetryTimes(),
+                    messageReceiptHandle.getConsumeTimestamp(),
+                    messageReceiptHandle.getReceiptHandleStr(),
+                    receiptHandle.getNextVisibleTime(),
+                    receiptHandle.getInvisibleTime(),
+                    receiptHandle.getBrokerName(),
+                    isExpired
+                );
+                allHandles.add(info);
+            });
+        }
+
+        // Aggregate summary statistics
+        for (PopReceiptHandleInfo info : allHandles) {
+            totalRenewTimes += info.getRenewTimes();
+            totalRenewRetryTimes += info.getRenewRetryTimes();
+            if (info.isExpired()) {
+                expiredHandles++;
+            }
+        }
+
+        PopReceiptHandleGroupSummary summary = new PopReceiptHandleGroupSummary(
+            group, totalHandleCount, totalMessageCount,
+            totalRenewTimes, totalRenewRetryTimes, expiredHandles
+        );
+
+        // Apply pagination
+        long total = allHandles.size();
+        int fromIndex = (pageNum - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, allHandles.size());
+        List<PopReceiptHandleInfo> pagedHandles;
+        if (fromIndex >= allHandles.size()) {
+            pagedHandles = new ArrayList<>();
+        } else {
+            pagedHandles = allHandles.subList(fromIndex, toIndex);
+        }
+
+        return new PopReceiptHandleDiagnosticResult(summary, pagedHandles, total, pageNum, pageSize);
+    }
+
+    /**
+     * Query batch consumption diagnostics, aggregated per client channel.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group,
+     * aggregates unacked message statistics per Channel, and returns
+     * a summary with paginated per-channel diagnostic data.
+     * <p>
+     * This method is thread-safe: it iterates over the ConcurrentHashMap without
+     * locking, providing a weakly consistent snapshot of the current state.
+     */
+    @Override
+    public BatchConsumeDiagnosticResult describeBatchConsumeDiagnostics(String group, String topic, int pageNum, int pageSize) {
+        long currentTime = System.currentTimeMillis();
+
+        // Aggregate per-channel data: Channel -> aggregated stats
+        Map<Channel, ChannelAggregator> channelAggregators = new HashMap<>();
+
+        // Scan all receipt handle groups matching the group name
+        for (Map.Entry<ReceiptHandleGroupKey, ReceiptHandleGroup> entry : receiptHandleGroupMap.entrySet()) {
+            ReceiptHandleGroupKey key = entry.getKey();
+            if (!key.getGroup().equals(group)) {
+                continue;
+            }
+
+            Channel channel = key.getChannel();
+            ReceiptHandleGroup handleGroup = entry.getValue();
+            ChannelAggregator aggregator = channelAggregators.computeIfAbsent(channel, ChannelAggregator::new);
+
+            // Scan handles in this group
+            handleGroup.scan((msgID, handleStr, messageReceiptHandle) -> {
+                // Apply topic filter if specified
+                if (topic != null && !topic.isEmpty() && !topic.equals(messageReceiptHandle.getTopic())) {
+                    return;
+                }
+
+                // Decode receipt handle to check expiration
+                ReceiptHandle receiptHandle = ReceiptHandle.decode(messageReceiptHandle.getReceiptHandleStr());
+                boolean isExpired = receiptHandle.getNextVisibleTime() <= currentTime;
+
+                aggregator.unackedMessageCount++;
+                aggregator.totalRenewTimes += messageReceiptHandle.getRenewTimes();
+                aggregator.totalRenewRetryTimes += messageReceiptHandle.getRenewRetryTimes();
+                if (isExpired) {
+                    aggregator.expiredHandleCount++;
+                }
+                aggregator.topicDistribution.merge(messageReceiptHandle.getTopic(), 1, Integer::sum);
+            });
+
+            // Handle count is per-group (one ReceiptHandleGroup per Channel+group key)
+            aggregator.unackedHandleCount += (int) handleGroup.getHandleNum();
+        }
+
+        // Build per-channel data list
+        List<ChannelBatchConsumeData> allChannelData = new ArrayList<>();
+        int totalUnackedMessages = 0;
+        int totalUnackedHandles = 0;
+        int totalExpiredHandles = 0;
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+
+        for (ChannelAggregator aggregator : channelAggregators.values()) {
+            // Skip channels with no unacked messages (after topic filter)
+            if (aggregator.unackedMessageCount == 0) {
+                continue;
+            }
+
+            allChannelData.add(new ChannelBatchConsumeData(
+                aggregator.channel,
+                aggregator.unackedMessageCount,
+                aggregator.unackedHandleCount,
+                aggregator.totalRenewTimes,
+                aggregator.totalRenewRetryTimes,
+                aggregator.expiredHandleCount,
+                new HashMap<>(aggregator.topicDistribution)
+            ));
+
+            totalUnackedMessages += aggregator.unackedMessageCount;
+            totalUnackedHandles += aggregator.unackedHandleCount;
+            totalExpiredHandles += aggregator.expiredHandleCount;
+            totalRenewTimes += aggregator.totalRenewTimes;
+            totalRenewRetryTimes += aggregator.totalRenewRetryTimes;
+        }
+
+        BatchConsumeGroupSummary summary = new BatchConsumeGroupSummary(
+            group, allChannelData.size(), totalUnackedMessages,
+            totalUnackedHandles, totalExpiredHandles, totalRenewTimes, totalRenewRetryTimes
+        );
+
+        // Apply pagination
+        long total = allChannelData.size();
+        int fromIndex = (pageNum - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, allChannelData.size());
+        List<ChannelBatchConsumeData> pagedData;
+        if (fromIndex >= allChannelData.size()) {
+            pagedData = new ArrayList<>();
+        } else {
+            pagedData = allChannelData.subList(fromIndex, toIndex);
+        }
+
+        return new BatchConsumeDiagnosticResult(summary, pagedData, total, pageNum, pageSize);
+    }
+
+    /**
+     * Internal aggregator for per-channel statistics during batch diagnostics scan.
+     */
+    private static class ChannelAggregator {
+        final Channel channel;
+        int unackedMessageCount = 0;
+        int unackedHandleCount = 0;
+        long totalRenewTimes = 0;
+        long totalRenewRetryTimes = 0;
+        int expiredHandleCount = 0;
+        final Map<String, Integer> topicDistribution = new HashMap<>();
+
+        ChannelAggregator(Channel channel) {
+            this.channel = channel;
+        }
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/ReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/ReceiptHandleManager.java
@@ -18,7 +18,12 @@
 package org.apache.rocketmq.proxy.service.receipt;
 
 import io.netty.channel.Channel;
+import java.util.List;
+import java.util.Map;
+import org.apache.rocketmq.proxy.common.BatchConsumeGroupSummary;
 import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleInfo;
+import org.apache.rocketmq.proxy.common.PopReceiptHandleGroupSummary;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 
 public interface ReceiptHandleManager {
@@ -27,4 +32,139 @@ public interface ReceiptHandleManager {
     MessageReceiptHandle removeReceiptHandle(ProxyContext context, Channel channel, String group, String msgID, String receiptHandle);
 
     int getUnackedMessageCount(ProxyContext context, Channel channel, String group);
+
+    /**
+     * Query POP receipt handles for diagnostics.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group,
+     * collects diagnostic information for each unacked message handle,
+     * and returns a summary with paginated handle details.
+     *
+     * @param group    consumer group name (required)
+     * @param topic    optional topic filter, null or empty means no filter
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return diagnostic result containing summary and paginated handle details
+     */
+    PopReceiptHandleDiagnosticResult describePopReceiptHandles(String group, String topic, int pageNum, int pageSize);
+
+    /**
+     * Result of POP receipt handle diagnostic query.
+     */
+    class PopReceiptHandleDiagnosticResult {
+        private final PopReceiptHandleGroupSummary summary;
+        private final List<PopReceiptHandleInfo> handles;
+        private final long total;
+        private final int pageNum;
+        private final int pageSize;
+
+        public PopReceiptHandleDiagnosticResult(PopReceiptHandleGroupSummary summary, List<PopReceiptHandleInfo> handles,
+            long total, int pageNum, int pageSize) {
+            this.summary = summary;
+            this.handles = handles;
+            this.total = total;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+        }
+
+        public PopReceiptHandleGroupSummary getSummary() {
+            return summary;
+        }
+
+        public List<PopReceiptHandleInfo> getHandles() {
+            return handles;
+        }
+
+        public long getTotal() {
+            return total;
+        }
+
+        public int getPageNum() {
+            return pageNum;
+        }
+
+        public int getPageSize() {
+            return pageSize;
+        }
+    }
+
+    /**
+     * Query batch consumption diagnostics, aggregated per client channel.
+     * <p>
+     * Scans all receipt handle groups matching the given consumer group,
+     * aggregates unacked message statistics per Channel, and returns
+     * a summary with paginated per-client diagnostic details.
+     * <p>
+     * This method only returns raw data from ReceiptHandleManager.
+     * The caller (DefaultProxyAdminClientService) is responsible for
+     * enriching with GrpcChannelManager/GrpcClientSettingsManager data.
+     *
+     * @param group    consumer group name (required)
+     * @param topic    optional topic filter, null or empty means no filter
+     * @param pageNum  page number starting from 1
+     * @param pageSize page size, max 100
+     * @return diagnostic result containing summary and paginated per-channel diagnostics
+     */
+    BatchConsumeDiagnosticResult describeBatchConsumeDiagnostics(String group, String topic, int pageNum, int pageSize);
+
+    /**
+     * Per-channel raw data for batch consumption diagnostics.
+     * Used internally to transfer data from ReceiptHandleManager to DefaultProxyAdminClientService
+     * for enrichment with gRPC channel/settings data.
+     */
+    class ChannelBatchConsumeData {
+        private final Channel channel;
+        private final int unackedMessageCount;
+        private final int unackedHandleCount;
+        private final long totalRenewTimes;
+        private final long totalRenewRetryTimes;
+        private final int expiredHandleCount;
+        private final Map<String, Integer> topicDistribution;
+
+        public ChannelBatchConsumeData(Channel channel, int unackedMessageCount, int unackedHandleCount,
+            long totalRenewTimes, long totalRenewRetryTimes, int expiredHandleCount,
+            Map<String, Integer> topicDistribution) {
+            this.channel = channel;
+            this.unackedMessageCount = unackedMessageCount;
+            this.unackedHandleCount = unackedHandleCount;
+            this.totalRenewTimes = totalRenewTimes;
+            this.totalRenewRetryTimes = totalRenewRetryTimes;
+            this.expiredHandleCount = expiredHandleCount;
+            this.topicDistribution = topicDistribution;
+        }
+
+        public Channel getChannel() { return channel; }
+        public int getUnackedMessageCount() { return unackedMessageCount; }
+        public int getUnackedHandleCount() { return unackedHandleCount; }
+        public long getTotalRenewTimes() { return totalRenewTimes; }
+        public long getTotalRenewRetryTimes() { return totalRenewRetryTimes; }
+        public int getExpiredHandleCount() { return expiredHandleCount; }
+        public Map<String, Integer> getTopicDistribution() { return topicDistribution; }
+    }
+
+    /**
+     * Result of batch consumption diagnostic query.
+     */
+    class BatchConsumeDiagnosticResult {
+        private final BatchConsumeGroupSummary summary;
+        private final List<ChannelBatchConsumeData> channelData;
+        private final long total;
+        private final int pageNum;
+        private final int pageSize;
+
+        public BatchConsumeDiagnosticResult(BatchConsumeGroupSummary summary,
+            List<ChannelBatchConsumeData> channelData, long total, int pageNum, int pageSize) {
+            this.summary = summary;
+            this.channelData = channelData;
+            this.total = total;
+            this.pageNum = pageNum;
+            this.pageSize = pageSize;
+        }
+
+        public BatchConsumeGroupSummary getSummary() { return summary; }
+        public List<ChannelBatchConsumeData> getChannelData() { return channelData; }
+        public long getTotal() { return total; }
+        public int getPageNum() { return pageNum; }
+        public int getPageSize() { return pageSize; }
+    }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/TopicRouteService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/TopicRouteService.java
@@ -23,9 +23,12 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
@@ -51,11 +54,28 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public abstract class TopicRouteService extends AbstractStartAndShutdown {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.PROXY_LOGGER_NAME);
 
+    /**
+     * Listener interface for route refresh events.
+     * Implementations are notified when the Caffeine cache reloads route data for a topic,
+     * enabling detection and propagation of route changes (broker online/offline, queue scaling, etc.).
+     */
+    public interface RouteRefreshListener {
+        /**
+         * Called when a topic's route data has been refreshed in the cache.
+         *
+         * @param topic the topic whose route was refreshed
+         * @param oldView the previous MessageQueueView (may be null if not previously cached)
+         * @param newView the new MessageQueueView (may be WRAPPED_EMPTY_QUEUE if topic was deleted)
+         */
+        void onRouteRefreshed(String topic, MessageQueueView oldView, MessageQueueView newView);
+    }
+
     private final MQFaultStrategy mqFaultStrategy;
     protected final LoadingCache<String /* topicName */, MessageQueueView> topicCache;
     protected final ThreadPoolExecutor cacheRefreshExecutor;
     protected final List<MessageQueuePenalizer<AddressableMessageQueue>> penalizers = new ArrayList<>();
     protected MessageQueuePriorityProvider<AddressableMessageQueue> priorityProvider = new DefaultMessageQueuePriorityProvider();
+    protected final CopyOnWriteArrayList<RouteRefreshListener> routeRefreshListeners = new CopyOnWriteArrayList<>();
 
     public TopicRouteService(MQClientAPIFactory mqClientAPIFactory) {
         ProxyConfig config = ConfigurationManager.getProxyConfig();
@@ -91,7 +111,18 @@ public abstract class TopicRouteService extends AbstractStartAndShutdown {
                 public @Nullable MessageQueueView reload(@NonNull String key,
                     @NonNull MessageQueueView oldValue) throws Exception {
                     try {
-                        return load(key);
+                        MessageQueueView newValue = load(key);
+                        // Notify route refresh listeners if the new value differs from old
+                        if (!routeRefreshListeners.isEmpty()) {
+                            for (RouteRefreshListener listener : routeRefreshListeners) {
+                                try {
+                                    listener.onRouteRefreshed(key, oldValue, newValue);
+                                } catch (Exception e) {
+                                    log.warn("Route refresh listener error for topic {}: {}", key, e.getMessage());
+                                }
+                            }
+                        }
+                        return newValue;
                     } catch (Exception e) {
                         log.warn(String.format("reload topic route from namesrv. topic: %s", key), e);
                         return oldValue;
@@ -213,6 +244,47 @@ public abstract class TopicRouteService extends AbstractStartAndShutdown {
 
     public void addPenalizer(MessageQueuePenalizer<AddressableMessageQueue> penalizer) {
         this.penalizers.add(penalizer);
+    }
+
+    /**
+     * Add a route refresh listener that will be notified when route data is refreshed in the cache.
+     *
+     * @param listener the listener to add
+     */
+    public void addRouteRefreshListener(RouteRefreshListener listener) {
+        this.routeRefreshListeners.add(listener);
+    }
+
+    /**
+     * Get all topic names currently in the route cache.
+     * Topics with empty route data (WRAPPED_EMPTY_QUEUE) are excluded.
+     *
+     * @return set of topic names with valid route data
+     */
+    public Set<String> getAllTopicNames() {
+        Set<String> result = new java.util.HashSet<>();
+        for (Map.Entry<String, MessageQueueView> entry : topicCache.asMap().entrySet()) {
+            MessageQueueView view = entry.getValue();
+            if (view != null && !view.isEmptyCachedQueue()) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get cached MessageQueueView for a topic without triggering a cache load.
+     * Returns null if the topic is not in the cache.
+     *
+     * @param topic the topic name
+     * @return the cached MessageQueueView, or null if not cached
+     */
+    public MessageQueueView getCachedTopicRouteData(String topic) {
+        MessageQueueView view = topicCache.getIfPresent(topic);
+        if (view != null && !view.isEmptyCachedQueue()) {
+            return view;
+        }
+        return null;
     }
 
     @VisibleForTesting

--- a/proxy/src/main/proto/proxy_admin.proto
+++ b/proxy/src/main/proto/proxy_admin.proto
@@ -1,0 +1,606 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package apache.rocketmq.proxy.admin.v1;
+
+option java_multiple_files = true;
+option java_package = "apache.rocketmq.proxy.admin.v1";
+option java_outer_classname = "ProxyAdminProto";
+
+// Client language enum
+enum ClientLanguage {
+  CLIENT_LANGUAGE_UNSPECIFIED = 0;
+  CLIENT_LANGUAGE_JAVA = 1;
+  CLIENT_LANGUAGE_GOLANG = 2;
+  CLIENT_LANGUAGE_CPP = 3;
+  CLIENT_LANGUAGE_RUST = 4;
+  CLIENT_LANGUAGE_PYTHON = 5;
+  CLIENT_LANGUAGE_NODEJS = 6;
+  CLIENT_LANGUAGE_CSHARP = 7;
+  CLIENT_LANGUAGE_PHP = 8;
+}
+
+// Client protocol enum
+enum ClientProtocol {
+  CLIENT_PROTOCOL_UNSPECIFIED = 0;
+  CLIENT_PROTOCOL_GRPC = 1;
+  CLIENT_PROTOCOL_REMOTING = 2;
+}
+
+// Client role enum
+enum ClientRole {
+  CLIENT_ROLE_UNSPECIFIED = 0;
+  CLIENT_ROLE_PRODUCER = 1;
+  CLIENT_ROLE_PUSH_CONSUMER = 2;
+  CLIENT_ROLE_SIMPLE_CONSUMER = 3;
+}
+
+// Status code for admin responses
+enum AdminCode {
+  ADMIN_CODE_UNSPECIFIED = 0;
+  ADMIN_CODE_OK = 1;
+  ADMIN_CODE_INTERNAL_ERROR = 2;
+  ADMIN_CODE_BAD_REQUEST = 3;
+  ADMIN_CODE_UNAUTHORIZED = 4;
+  ADMIN_CODE_FORBIDDEN = 5;
+  ADMIN_CODE_NOT_FOUND = 6;
+  ADMIN_CODE_TOO_MANY_REQUESTS = 7;
+}
+
+// Client instance basic information
+message ClientInstance {
+  string client_id = 1;
+  ClientLanguage language = 2;
+  string client_version = 3;
+  ClientProtocol protocol = 4;
+  string access_point = 5;
+  int64 connect_at = 6;
+  int64 last_active_at = 7;
+  ClientRole role = 8;
+  string group = 9;
+  repeated string topics = 10;
+}
+
+// Client detail information (extends ClientInstance)
+message ClientDetail {
+  ClientInstance client_instance = 1;
+  ClientSettings settings = 2;
+  repeated HeartbeatRecord heartbeat_history = 3;
+  AuthStatus auth_status = 4;
+  ConsumeProgress consume_progress = 5;
+  NetworkInfo network_info = 6;
+}
+
+// Client settings
+message ClientSettings {
+  string subscription_mode = 1;
+  int32 receive_batch_size = 2;
+  int64 long_polling_timeout_ms = 3;
+  bool fifo = 4;
+  repeated string subscription_topics = 5;
+  repeated string publishing_topics = 6;
+}
+
+// Heartbeat record
+message HeartbeatRecord {
+  int64 timestamp = 1;
+  bool success = 2;
+  string remark = 3;
+}
+
+// Auth status
+message AuthStatus {
+  bool authenticated = 1;
+  string username = 2;
+  int64 last_auth_time = 3;
+  string failure_reason = 4;
+}
+
+// Consume progress
+message ConsumeProgress {
+  int64 lag = 1;
+  int64 latency_ms = 2;
+  repeated TopicConsumeProgress topic_progress = 3;
+}
+
+// Topic consume progress
+message TopicConsumeProgress {
+  string topic = 1;
+  int64 lag = 2;
+  int64 latency_ms = 3;
+}
+
+// Network info
+message NetworkInfo {
+  string local_address = 1;
+  string remote_address = 2;
+  int64 rtt_ms = 3;
+  string ssl_enabled = 4;
+}
+
+// Pagination metadata
+message Pagination {
+  int64 total = 1;
+  int32 page_num = 2;
+  int32 page_size = 3;
+}
+
+// ListClients request
+message ListClientsRequest {
+  string group = 1;
+  string topic = 2;
+  string client_id_prefix = 3;
+  ClientLanguage language = 4;
+  int64 connect_time_start = 5;
+  int64 connect_time_end = 6;
+  int32 page_num = 7;
+  int32 page_size = 8;
+}
+
+// ListClients response
+message ListClientsResponse {
+  AdminCode code = 1;
+  string message = 2;
+  Pagination pagination = 3;
+  repeated ClientInstance list = 4;
+}
+
+// DescribeClient request
+message DescribeClientRequest {
+  string client_id = 1;
+}
+
+// DescribeClient response
+message DescribeClientResponse {
+  AdminCode code = 1;
+  string message = 2;
+  ClientDetail client_detail = 3;
+}
+
+// ListClientsByGroup request
+message ListClientsByGroupRequest {
+  string group = 1;
+  int32 page_num = 2;
+  int32 page_size = 3;
+}
+
+// ListClientsByGroup response
+message ListClientsByGroupResponse {
+  AdminCode code = 1;
+  string message = 2;
+  Pagination pagination = 3;
+  repeated ClientInstance list = 4;
+}
+
+// ListClientsByTopic request
+message ListClientsByTopicRequest {
+  string topic = 1;
+  int32 page_num = 2;
+  int32 page_size = 3;
+}
+
+// ListClientsByTopic response
+message ListClientsByTopicResponse {
+  AdminCode code = 1;
+  string message = 2;
+  Pagination pagination = 3;
+  repeated ClientInstance list = 4;
+}
+
+// GetConfig request - no parameters needed, returns current runtime config
+message GetConfigRequest {
+}
+
+// Proxy runtime configuration snapshot
+message ProxyRuntimeConfig {
+  // Basic info
+  string proxy_mode = 1;
+  string rocketmq_cluster_name = 2;
+  string proxy_cluster_name = 3;
+  string proxy_name = 4;
+  string local_serve_addr = 5;
+  string namesrv_addr = 6;
+
+  // gRPC data plane
+  int32 grpc_server_port = 10;
+  int32 grpc_boss_loop_num = 11;
+  int32 grpc_worker_loop_num = 12;
+  int32 grpc_thread_pool_nums = 13;
+  int32 grpc_thread_pool_queue_capacity = 14;
+  int32 grpc_max_inbound_message_size = 15;
+  int32 grpc_max_concurrent_calls_per_connection = 16;
+
+  // Admin interface
+  bool proxy_admin_enabled = 20;
+  int32 proxy_admin_server_port = 21;
+  int32 proxy_admin_thread_pool_nums = 22;
+  int32 proxy_admin_max_page_size = 23;
+  int32 proxy_admin_describe_client_concurrency_limit = 24;
+  double proxy_admin_sampling_rate_under_load = 25;
+  int32 proxy_admin_heartbeat_history_size = 26;
+  int64 proxy_admin_sampling_threshold = 27;
+
+  // Thread pools - gRPC activities
+  int32 grpc_producer_thread_pool_nums = 30;
+  int32 grpc_producer_thread_queue_capacity = 31;
+  int32 grpc_consumer_thread_pool_nums = 32;
+  int32 grpc_consumer_thread_queue_capacity = 33;
+  int32 grpc_route_thread_pool_nums = 34;
+  int32 grpc_route_thread_queue_capacity = 35;
+  int32 grpc_client_manager_thread_pool_nums = 36;
+  int32 grpc_client_manager_thread_queue_capacity = 37;
+  int32 grpc_transaction_thread_pool_nums = 38;
+  int32 grpc_transaction_thread_queue_capacity = 39;
+
+  // Thread pools - remoting
+  int32 remoting_heartbeat_thread_pool_nums = 40;
+  int32 remoting_send_message_thread_pool_nums = 41;
+  int32 remoting_pull_message_thread_pool_nums = 42;
+
+  // Message limits
+  int32 max_message_size = 50;
+  int32 max_user_property_size = 51;
+  int32 user_property_max_num = 52;
+  int32 max_message_group_size = 53;
+
+  // Timeout and polling
+  int64 default_invisible_time_mills = 60;
+  int64 max_invisible_time_mills = 61;
+  int64 min_invisible_time_mills_for_recv = 62;
+  int64 max_delay_time_mills = 63;
+  int64 grpc_client_consumer_min_long_polling_timeout_millis = 64;
+  int64 grpc_client_consumer_max_long_polling_timeout_millis = 65;
+  int32 grpc_client_consumer_long_polling_batch_size = 66;
+  int32 grpc_client_producer_max_attempts = 67;
+  int64 grpc_client_producer_backoff_initial_millis = 68;
+  int64 grpc_client_producer_backoff_max_millis = 69;
+  int32 grpc_client_producer_backoff_multiplier = 70;
+
+  // Cache
+  int32 topic_route_service_cache_expired_seconds = 80;
+  int32 topic_route_service_cache_refresh_seconds = 81;
+  int32 topic_route_service_cache_max_num = 82;
+
+  // TLS
+  bool tls_test_mode_enable = 90;
+  string tls_key_path = 91;
+  string tls_cert_path = 92;
+
+  // Metrics
+  string metrics_exporter_type = 100;
+  int32 metrics_prom_exporter_port = 101;
+  bool trace_on = 102;
+}
+
+// GetConfig response
+message GetConfigResponse {
+  AdminCode code = 1;
+  string message = 2;
+  ProxyRuntimeConfig config = 3;
+}
+
+// UpdateConfig request - send the desired config state.
+// The server compares each field with the current config and applies only changed fields.
+// Note: Due to proto3 default value semantics:
+//   - Numeric fields set to 0, string fields set to "" will be treated as "not set" and NOT updated.
+//   - Boolean fields can only be toggled ON (false→true), not OFF (true→false).
+// To reset fields to their defaults, modify the config file (rmq-proxy.json) directly.
+message UpdateConfigRequest {
+  ProxyRuntimeConfig config = 1;
+}
+
+// UpdateConfig response
+message UpdateConfigResponse {
+  AdminCode code = 1;
+  string message = 2;
+  ProxyRuntimeConfig config = 3;
+  // List of field names (snake_case) that were actually changed
+  repeated string changed_fields = 4;
+}
+
+// DisconnectClient request - force disconnect a specific client connection
+// Use cases:
+//   - Malicious client detection and isolation
+//   - Stuck consumer triggering rebalance
+//   - Zombie connection cleanup
+message DisconnectClientRequest {
+  // The unique client identifier to disconnect (required)
+  string client_id = 1;
+  // Human-readable reason for the forced disconnection, used for audit logging (required)
+  string reason = 2;
+}
+
+// DisconnectClient response
+message DisconnectClientResponse {
+  AdminCode code = 1;
+  string message = 2;
+  // Whether the client was found and successfully disconnected
+  bool disconnected = 3;
+}
+
+// POP receipt handle diagnostic info for a single unacked message
+message PopReceiptHandleInfo {
+  // Consumer group name
+  string group = 1;
+  // Topic name
+  string topic = 2;
+  // Queue ID
+  int32 queue_id = 3;
+  // Message ID
+  string message_id = 4;
+  // Queue offset
+  int64 queue_offset = 5;
+  // Reconsume times (retry count)
+  int32 reconsume_times = 6;
+  // Number of successful renewals (ChangeInvisibleTime)
+  int32 renew_times = 7;
+  // Number of failed renewal attempts
+  int32 renew_retry_times = 8;
+  // Timestamp when the message was first consumed (epoch millis)
+  int64 consume_timestamp = 9;
+  // Current receipt handle string
+  string receipt_handle = 10;
+  // Next visible time for this message (epoch millis)
+  int64 next_visible_time = 11;
+  // Invisible time duration (millis)
+  int64 invisible_time = 12;
+  // Broker name where the message resides
+  string broker_name = 13;
+  // Whether the invisible time has expired (message is about to be redelivered)
+  bool is_expired = 14;
+}
+
+// POP receipt handle group summary (aggregated per consumer group)
+message PopReceiptHandleGroupSummary {
+  // Consumer group name
+  string group = 1;
+  // Total number of receipt handles (may exceed message count due to dedup)
+  int32 total_handles = 2;
+  // Total number of unique unacked messages
+  int32 total_messages = 3;
+  // Sum of renew times across all handles in this group
+  int64 total_renew_times = 4;
+  // Sum of renew retry times across all handles in this group
+  int64 total_renew_retry_times = 5;
+  // Number of handles whose invisible time has expired
+  int32 expired_handles = 6;
+}
+
+// DescribePopReceiptHandles request - query POP receipt handles for diagnostics
+// Use cases:
+//   - Diagnose messages with expired invisible time causing duplicate delivery
+//   - Investigate frequent ChangeInvisibleTime (renewal) calls
+//   - Debug consumption timeout issues in POP mode
+//   - Monitor unacked message accumulation per consumer group
+message DescribePopReceiptHandlesRequest {
+  // Consumer group name (required)
+  string group = 1;
+  // Optional topic filter - only return handles for this topic
+  string topic = 2;
+  // Pagination: page number starting from 1
+  int32 page_num = 3;
+  // Pagination: page size, max 100
+  int32 page_size = 4;
+}
+
+// DescribePopReceiptHandles response
+message DescribePopReceiptHandlesResponse {
+  AdminCode code = 1;
+  string message = 2;
+  // Group-level summary statistics
+  PopReceiptHandleGroupSummary summary = 3;
+  // Paginated list of receipt handle details
+  repeated PopReceiptHandleInfo handles = 4;
+  // Pagination metadata
+  Pagination pagination = 5;
+}
+
+// Batch consume diagnostic info for a single client (per-channel aggregation)
+// Aggregates unacked message statistics from ReceiptHandleManager for a specific client channel
+message BatchConsumeClientDiagnostics {
+  // Client identifier (from gRPC channel, empty for remoting clients)
+  string client_id = 1;
+  // Channel identifier (Netty channel ID)
+  string channel_id = 2;
+  // Number of unacked messages held by this client
+  int32 unacked_message_count = 3;
+  // Number of unacked receipt handles (may differ from message count due to dedup)
+  int32 unacked_handle_count = 4;
+  // Sum of renew times across all handles for this client
+  int64 total_renew_times = 5;
+  // Sum of renew retry times across all handles for this client
+  int64 total_renew_retry_times = 6;
+  // Number of handles whose invisible time has expired (about to be redelivered)
+  int32 expired_handle_count = 7;
+  // Distribution of unacked messages by topic (topic -> count)
+  map<string, int32> topic_distribution = 8;
+  // Consumer type: PUSH or PULL (from ConsumerManager)
+  string consume_type = 9;
+  // Message model: CLUSTERING, BROADCASTING, or LITE_SELECTIVE (from ConsumerManager)
+  string message_model = 10;
+  // Configured batch receive size (from client Settings, 0 if unavailable)
+  int32 receive_batch_size = 11;
+  // Configured long polling timeout in ms (from client Settings, 0 if unavailable)
+  int64 long_polling_timeout_ms = 12;
+  // Last measured RTT in ms (from gRPC channel, -1 if unavailable)
+  int64 last_rtt_ms = 13;
+  // Client connection time (epoch millis, 0 if unavailable)
+  int64 connect_time = 14;
+}
+
+// Batch consume group-level summary (aggregated across all clients in the group)
+message BatchConsumeGroupSummary {
+  // Consumer group name
+  string group = 1;
+  // Number of clients with unacked messages
+  int32 total_clients = 2;
+  // Total unacked messages across all clients
+  int32 total_unacked_messages = 3;
+  // Total unacked handles across all clients
+  int32 total_unacked_handles = 4;
+  // Total expired handles across all clients
+  int32 total_expired_handles = 5;
+  // Sum of renew times across all clients
+  int64 total_renew_times = 6;
+  // Sum of renew retry times across all clients
+  int64 total_renew_retry_times = 7;
+}
+
+// DescribeBatchConsumeDiagnostics request - query batch consumption diagnostics
+// Use cases:
+//   - Diagnose batch size too large causing timeout
+//   - Investigate partial message failure but entire batch retry
+//   - Monitor unacked message accumulation per client in a consumer group
+//   - Identify clients with excessive renewal or expired handles
+message DescribeBatchConsumeDiagnosticsRequest {
+  // Consumer group name (required)
+  string group = 1;
+  // Optional topic filter - only count messages for this topic
+  string topic = 2;
+  // Optional client ID filter - only return diagnostics for this client
+  string client_id = 3;
+  // Pagination: page number starting from 1
+  int32 page_num = 4;
+  // Pagination: page size, max 100
+  int32 page_size = 5;
+}
+
+// DescribeBatchConsumeDiagnostics response
+message DescribeBatchConsumeDiagnosticsResponse {
+  AdminCode code = 1;
+  string message = 2;
+  // Group-level summary statistics
+  BatchConsumeGroupSummary summary = 3;
+  // Per-client diagnostic details (paginated)
+  repeated BatchConsumeClientDiagnostics diagnostics = 4;
+  // Pagination metadata
+  Pagination pagination = 5;
+}
+
+// SubscribeRouteEvents request
+message SubscribeRouteEventsRequest {
+  // Optional: subscribe to specific topics only (empty = all topics)
+  repeated string topics = 1;
+  // Optional: subscribe to specific event types only (empty = all event types)
+  repeated RouteChangeEventType event_types = 2;
+}
+
+// SubscribeRouteEvents response (streamed)
+message SubscribeRouteEventsResponse {
+  AdminCode code = 1;
+  string message = 2;
+  RouteChangeEvent event = 3;
+}
+
+// Route change event types
+enum RouteChangeEventType {
+  ROUTE_CHANGE_EVENT_TYPE_UNSPECIFIED = 0;
+  // A broker has come online (registered with NameServer)
+  BROKER_ONLINE = 1;
+  // A broker has gone offline (unregistered from NameServer)
+  BROKER_OFFLINE = 2;
+  // Queue count changed (read or write queue nums scaled up/down)
+  QUEUE_SCALE = 3;
+  // A new topic has been created
+  TOPIC_CREATE = 4;
+  // A topic has been deleted
+  TOPIC_DELETE = 5;
+  // Full route snapshot sent on initial subscription
+  ROUTE_SNAPSHOT = 6;
+}
+
+// Route change event - represents a single route change detected by the proxy
+message RouteChangeEvent {
+  // Event type
+  RouteChangeEventType event_type = 1;
+  // Timestamp when the event was detected (epoch millis)
+  int64 timestamp = 2;
+  // Topic name (set for TOPIC_CREATE, TOPIC_DELETE, QUEUE_SCALE events)
+  string topic = 3;
+  // Broker cluster name (set for BROKER_ONLINE, BROKER_OFFLINE events)
+  string cluster = 4;
+  // Broker name (set for BROKER_ONLINE, BROKER_OFFLINE, QUEUE_SCALE events)
+  string broker_name = 5;
+  // Broker ID (set for BROKER_ONLINE, BROKER_OFFLINE events)
+  int64 broker_id = 6;
+  // Broker address (set for BROKER_ONLINE, BROKER_OFFLINE events)
+  string broker_address = 7;
+  // Previous read queue count (set for QUEUE_SCALE events)
+  int32 previous_read_queue_nums = 8;
+  // Current read queue count (set for QUEUE_SCALE events)
+  int32 current_read_queue_nums = 9;
+  // Previous write queue count (set for QUEUE_SCALE events)
+  int32 previous_write_queue_nums = 10;
+  // Current write queue count (set for QUEUE_SCALE events)
+  int32 current_write_queue_nums = 11;
+  // Full route snapshot (set only for ROUTE_SNAPSHOT events)
+  // Contains the complete current route data for the topic
+  TopicRouteSnapshot route_snapshot = 12;
+}
+
+// Topic route snapshot - complete route data for a topic at a point in time
+message TopicRouteSnapshot {
+  string topic = 1;
+  repeated BrokerInfo brokers = 2;
+  repeated QueueInfo queues = 3;
+}
+
+// Broker info in route snapshot
+message BrokerInfo {
+  string cluster = 1;
+  string broker_name = 2;
+  // Map of broker_id -> broker_address
+  map<int64, string> broker_addrs = 3;
+}
+
+// Queue info in route snapshot
+message QueueInfo {
+  string broker_name = 1;
+  int32 read_queue_nums = 2;
+  int32 write_queue_nums = 3;
+  int32 perm = 4;
+}
+
+// ProxyClientAdminService - Admin service for online client queries
+service ProxyClientAdminService {
+  // List online gRPC clients with filtering and pagination
+  rpc ListClients(ListClientsRequest) returns (ListClientsResponse) {}
+  // Describe a single client's detailed information
+  rpc DescribeClient(DescribeClientRequest) returns (DescribeClientResponse) {}
+  // List online clients by consumer group
+  rpc ListClientsByGroup(ListClientsByGroupRequest) returns (ListClientsByGroupResponse) {}
+  // List online clients by topic
+  rpc ListClientsByTopic(ListClientsByTopicRequest) returns (ListClientsByTopicResponse) {}
+  // Get current runtime configuration of the proxy
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
+  // Hot-update runtime configuration without restarting proxy
+  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse) {}
+  // Force disconnect a specific client connection
+  rpc DisconnectClient(DisconnectClientRequest) returns (DisconnectClientResponse) {}
+  // Query POP receipt handles for diagnostics (RIP-2 M3)
+  // Diagnose invisible time expiration, renewal issues, and consumption timeouts
+  rpc DescribePopReceiptHandles(DescribePopReceiptHandlesRequest) returns (DescribePopReceiptHandlesResponse) {}
+  // Query batch consumption diagnostics (RIP-2 M4)
+  // Diagnose batch size issues, partial failures, and unacked message accumulation per client
+  rpc DescribeBatchConsumeDiagnostics(DescribeBatchConsumeDiagnosticsRequest) returns (DescribeBatchConsumeDiagnosticsResponse) {}
+  // Subscribe to route change events (server-streaming RPC)
+  // Dashboard subscribes once and receives real-time route change notifications
+  // including broker online/offline, queue scaling, topic create/delete
+  rpc SubscribeRouteEvents(SubscribeRouteEventsRequest) returns (stream SubscribeRouteEventsResponse) {}
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnosticsTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeClientDiagnosticsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BatchConsumeClientDiagnosticsTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        Map<String, Integer> topicDistribution = new HashMap<>();
+        topicDistribution.put("topicA", 3);
+        topicDistribution.put("topicB", 7);
+
+        BatchConsumeClientDiagnostics diagnostics = new BatchConsumeClientDiagnostics(
+            "client-1", "channel-1",
+            10, 5,
+            20L, 2L, 1,
+            topicDistribution,
+            "POP", "CLUSTERING",
+            32, 30000L,
+            15L, 1000L);
+
+        assertEquals("client-1", diagnostics.getClientId());
+        assertEquals("channel-1", diagnostics.getChannelId());
+        assertEquals(10, diagnostics.getUnackedMessageCount());
+        assertEquals(5, diagnostics.getUnackedHandleCount());
+        assertEquals(20L, diagnostics.getTotalRenewTimes());
+        assertEquals(2L, diagnostics.getTotalRenewRetryTimes());
+        assertEquals(1, diagnostics.getExpiredHandleCount());
+        assertEquals(topicDistribution, diagnostics.getTopicDistribution());
+        assertEquals("POP", diagnostics.getConsumeType());
+        assertEquals("CLUSTERING", diagnostics.getMessageModel());
+        assertEquals(32, diagnostics.getReceiveBatchSize());
+        assertEquals(30000L, diagnostics.getLongPollingTimeoutMs());
+        assertEquals(15L, diagnostics.getLastRttMs());
+        assertEquals(1000L, diagnostics.getConnectTime());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummaryTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/BatchConsumeGroupSummaryTest.java
@@ -17,18 +17,23 @@
 
 package org.apache.rocketmq.proxy.common;
 
-public class ContextVariable {
-    public static final String REMOTE_ADDRESS = "remote-address";
-    public static final String LOCAL_ADDRESS = "local-address";
-    public static final String CLIENT_ID = "client-id";
-    public static final String CHANNEL = "channel";
-    public static final String LANGUAGE = "language";
-    public static final String CLIENT_VERSION = "client-version";
-    public static final String REMAINING_MS = "remaining-ms";
-    public static final String ACTION = "action";
-    public static final String PROTOCOL_TYPE = "protocol-type";
-    public static final String NAMESPACE = "namespace";
-    public static final String CLIENT_TYPE = "client-type";
-    public static final String SSL_ENABLED = "ssl-enabled";
-    public static final String AUTH_USERNAME = "auth-username";
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BatchConsumeGroupSummaryTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        BatchConsumeGroupSummary summary = new BatchConsumeGroupSummary(
+            "groupA", 3, 100, 50, 5, 200L, 10L);
+
+        assertEquals("groupA", summary.getGroup());
+        assertEquals(3, summary.getTotalClients());
+        assertEquals(100, summary.getTotalUnackedMessages());
+        assertEquals(50, summary.getTotalUnackedHandles());
+        assertEquals(5, summary.getTotalExpiredHandles());
+        assertEquals(200L, summary.getTotalRenewTimes());
+        assertEquals(10L, summary.getTotalRenewRetryTimes());
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummaryTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleGroupSummaryTest.java
@@ -17,18 +17,22 @@
 
 package org.apache.rocketmq.proxy.common;
 
-public class ContextVariable {
-    public static final String REMOTE_ADDRESS = "remote-address";
-    public static final String LOCAL_ADDRESS = "local-address";
-    public static final String CLIENT_ID = "client-id";
-    public static final String CHANNEL = "channel";
-    public static final String LANGUAGE = "language";
-    public static final String CLIENT_VERSION = "client-version";
-    public static final String REMAINING_MS = "remaining-ms";
-    public static final String ACTION = "action";
-    public static final String PROTOCOL_TYPE = "protocol-type";
-    public static final String NAMESPACE = "namespace";
-    public static final String CLIENT_TYPE = "client-type";
-    public static final String SSL_ENABLED = "ssl-enabled";
-    public static final String AUTH_USERNAME = "auth-username";
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PopReceiptHandleGroupSummaryTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        PopReceiptHandleGroupSummary summary = new PopReceiptHandleGroupSummary(
+            "groupA", 50, 40, 100L, 5L, 3);
+
+        assertEquals("groupA", summary.getGroup());
+        assertEquals(50, summary.getTotalHandles());
+        assertEquals(40, summary.getTotalMessages());
+        assertEquals(100L, summary.getTotalRenewTimes());
+        assertEquals(5L, summary.getTotalRenewRetryTimes());
+        assertEquals(3, summary.getExpiredHandles());
+    }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfoTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/PopReceiptHandleInfoTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PopReceiptHandleInfoTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        PopReceiptHandleInfo info = new PopReceiptHandleInfo(
+            "groupA", "topicA", 2, "msg-1",
+            100L, 1, 3, 1,
+            1000L, "handle-1", 2000L,
+            60000L, "broker-a", false);
+
+        assertEquals("groupA", info.getGroup());
+        assertEquals("topicA", info.getTopic());
+        assertEquals(2, info.getQueueId());
+        assertEquals("msg-1", info.getMessageId());
+        assertEquals(100L, info.getQueueOffset());
+        assertEquals(1, info.getReconsumeTimes());
+        assertEquals(3, info.getRenewTimes());
+        assertEquals(1, info.getRenewRetryTimes());
+        assertEquals(1000L, info.getConsumeTimestamp());
+        assertEquals("handle-1", info.getReceiptHandle());
+        assertEquals(2000L, info.getNextVisibleTime());
+        assertEquals(60000L, info.getInvisibleTime());
+        assertEquals("broker-a", info.getBrokerName());
+        assertFalse(info.isExpired());
+    }
+
+    @Test
+    public void testExpiredHandle() {
+        PopReceiptHandleInfo info = new PopReceiptHandleInfo(
+            "groupA", "topicA", 0, "msg-2",
+            0L, 0, 0, 0,
+            0L, "handle-2", 0L,
+            0L, "broker-a", true);
+
+        assertTrue(info.isExpired());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/ProxyContextTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/ProxyContextTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class ProxyContextTest {
+
+    @Test
+    public void testSslEnabled() {
+        ProxyContext context = ProxyContext.create();
+        assertNull(context.isSslEnabled());
+
+        ProxyContext returned = context.setSslEnabled(true);
+        assertSame(context, returned);
+        assertTrue(context.isSslEnabled());
+
+        context.setSslEnabled(false);
+        assertFalse(context.isSslEnabled());
+    }
+
+    @Test
+    public void testAuthUsername() {
+        ProxyContext context = ProxyContext.create();
+        assertNull(context.getAuthUsername());
+
+        ProxyContext returned = context.setAuthUsername("rocketmq");
+        assertSame(context, returned);
+        assertEquals("rocketmq", context.getAuthUsername());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
@@ -21,6 +21,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ProxyConfigTest {
 
@@ -34,5 +37,47 @@ public class ProxyConfigTest {
 
         assertThat(StringUtils.isBlank(proxyConfig.getLocalServeAddr())).isFalse();
         assertThat(proxyConfig.getRemotingAccessAddr()).isEqualTo(proxyConfig.getLocalServeAddr());
+    }
+
+    @Test
+    public void testProxyAdminDefaults() {
+        ProxyConfig config = new ProxyConfig();
+        assertTrue(config.isProxyAdminEnabled());
+        assertEquals(Integer.valueOf(8082), config.getProxyAdminServerPort());
+        assertEquals(4, config.getProxyAdminThreadPoolNums());
+        assertEquals(100, config.getProxyAdminMaxPageSize());
+        assertEquals(8, config.getProxyAdminDescribeClientConcurrencyLimit());
+        assertEquals(0.5, config.getProxyAdminSamplingRateUnderLoad(), 0.0001);
+        assertEquals(10, config.getProxyAdminHeartbeatHistorySize());
+        assertEquals(100000L, config.getProxyAdminSamplingThreshold());
+    }
+
+    @Test
+    public void testProxyAdminSettersAndGetters() {
+        ProxyConfig config = new ProxyConfig();
+
+        config.setProxyAdminEnabled(false);
+        assertFalse(config.isProxyAdminEnabled());
+
+        config.setProxyAdminServerPort(9092);
+        assertEquals(Integer.valueOf(9092), config.getProxyAdminServerPort());
+
+        config.setProxyAdminThreadPoolNums(8);
+        assertEquals(8, config.getProxyAdminThreadPoolNums());
+
+        config.setProxyAdminMaxPageSize(50);
+        assertEquals(50, config.getProxyAdminMaxPageSize());
+
+        config.setProxyAdminDescribeClientConcurrencyLimit(16);
+        assertEquals(16, config.getProxyAdminDescribeClientConcurrencyLimit());
+
+        config.setProxyAdminSamplingRateUnderLoad(0.8);
+        assertEquals(0.8, config.getProxyAdminSamplingRateUnderLoad(), 0.0001);
+
+        config.setProxyAdminHeartbeatHistorySize(20);
+        assertEquals(20, config.getProxyAdminHeartbeatHistorySize());
+
+        config.setProxyAdminSamplingThreshold(200000L);
+        assertEquals(200000L, config.getProxyAdminSamplingThreshold());
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/AdminCodeTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/AdminCodeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class AdminCodeTest {
+
+    @Test
+    public void testCodeValues() {
+        assertEquals(1, AdminCode.OK.getCode());
+        assertEquals(2, AdminCode.INTERNAL_ERROR.getCode());
+        assertEquals(3, AdminCode.BAD_REQUEST.getCode());
+        assertEquals(4, AdminCode.UNAUTHORIZED.getCode());
+        assertEquals(5, AdminCode.FORBIDDEN.getCode());
+        assertEquals(6, AdminCode.NOT_FOUND.getCode());
+        assertEquals(7, AdminCode.TOO_MANY_REQUESTS.getCode());
+        assertEquals(8, AdminCode.CONFLICT.getCode());
+    }
+
+    @Test
+    public void testDescriptions() {
+        assertEquals("OK", AdminCode.OK.getDescription());
+        assertEquals("Internal error", AdminCode.INTERNAL_ERROR.getDescription());
+        assertEquals("Bad request", AdminCode.BAD_REQUEST.getDescription());
+        assertEquals("Unauthorized", AdminCode.UNAUTHORIZED.getDescription());
+        assertEquals("Forbidden", AdminCode.FORBIDDEN.getDescription());
+        assertEquals("Not found", AdminCode.NOT_FOUND.getDescription());
+        assertEquals("Too many requests", AdminCode.TOO_MANY_REQUESTS.getDescription());
+        assertEquals("Conflict", AdminCode.CONFLICT.getDescription());
+    }
+
+    @Test
+    public void testFromCode() {
+        for (AdminCode adminCode : AdminCode.values()) {
+            assertSame(adminCode, AdminCode.fromCode(adminCode.getCode()));
+        }
+    }
+
+    @Test
+    public void testFromCodeUnknown() {
+        assertNull(AdminCode.fromCode(0));
+        assertNull(AdminCode.fromCode(-1));
+        assertNull(AdminCode.fromCode(999));
+    }
+
+    @Test
+    public void testEnumCompleteness() {
+        assertEquals(8, AdminCode.values().length);
+        for (AdminCode adminCode : AdminCode.values()) {
+            assertNotNull(adminCode.getDescription());
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshallerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/ProxyAdminMarshallerTest.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin;
+
+import io.grpc.MethodDescriptor;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.junit.Test;
+import apache.rocketmq.proxy.admin.v1.DescribeClientRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByGroupRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsByTopicRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsRequest;
+import apache.rocketmq.proxy.admin.v1.ListClientsResponse;
+import apache.rocketmq.proxy.admin.v1.GetConfigRequest;
+import apache.rocketmq.proxy.admin.v1.UpdateConfigRequest;
+import apache.rocketmq.proxy.admin.v1.DisconnectClientRequest;
+import apache.rocketmq.proxy.admin.v1.DescribePopReceiptHandlesRequest;
+import apache.rocketmq.proxy.admin.v1.DescribeBatchConsumeDiagnosticsRequest;
+import apache.rocketmq.proxy.admin.v1.SubscribeRouteEventsRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for ProxyAdminMarshaller verifying all 20 proto marshallers are registered and perform correct serialization round-trips. */
+public class ProxyAdminMarshallerTest {
+
+    @Test
+    public void testListClientsReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeClientReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeClientRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_CLIENT_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByGroupReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByGroupRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByTopicReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testListClientsByTopicRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testGetConfigReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testGetConfigRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.GET_CONFIG_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testUpdateConfigReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testUpdateConfigRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.UPDATE_CONFIG_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDisconnectClientReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDisconnectClientRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DISCONNECT_CLIENT_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribePopReceiptHandlesReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribePopReceiptHandlesRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeBatchConsumeDiagnosticsReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testDescribeBatchConsumeDiagnosticsRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testSubscribeRouteEventsReqMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER);
+    }
+
+    @Test
+    public void testSubscribeRouteEventsRespMarshallerNotNull() {
+        assertNotNull(ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_RESP_MARSHALLER);
+    }
+
+    @Test
+    public void testParseListClientsRequest() throws Exception {
+        ListClientsRequest request = ListClientsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.stream(request);
+        ListClientsRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(ListClientsRequest.getDefaultInstance(), parsed);
+    }
+
+    @Test
+    public void testParseListClientsResponse() throws Exception {
+        ListClientsResponse response = ListClientsResponse.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER.stream(response);
+        ListClientsResponse parsed = ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(ListClientsResponse.getDefaultInstance(), parsed);
+    }
+
+    @Test
+    public void testRoundTripListClientsRequest() throws Exception {
+        ListClientsRequest request = ListClientsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.stream(request);
+        ListClientsRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDescribeClientRequest() throws Exception {
+        DescribeClientRequest request = DescribeClientRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER.stream(request);
+        DescribeClientRequest parsed = ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripListClientsByGroupRequest() throws Exception {
+        ListClientsByGroupRequest request = ListClientsByGroupRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER.stream(request);
+        ListClientsByGroupRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripListClientsByTopicRequest() throws Exception {
+        ListClientsByTopicRequest request = ListClientsByTopicRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER.stream(request);
+        ListClientsByTopicRequest parsed = ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripGetConfigRequest() throws Exception {
+        GetConfigRequest request = GetConfigRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER.stream(request);
+        GetConfigRequest parsed = ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripUpdateConfigRequest() throws Exception {
+        UpdateConfigRequest request = UpdateConfigRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER.stream(request);
+        UpdateConfigRequest parsed = ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDisconnectClientRequest() throws Exception {
+        DisconnectClientRequest request = DisconnectClientRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER.stream(request);
+        DisconnectClientRequest parsed = ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDescribePopReceiptHandlesRequest() throws Exception {
+        DescribePopReceiptHandlesRequest request = DescribePopReceiptHandlesRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER.stream(request);
+        DescribePopReceiptHandlesRequest parsed = ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripDescribeBatchConsumeDiagnosticsRequest() throws Exception {
+        DescribeBatchConsumeDiagnosticsRequest request = DescribeBatchConsumeDiagnosticsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER.stream(request);
+        DescribeBatchConsumeDiagnosticsRequest parsed = ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testRoundTripSubscribeRouteEventsRequest() throws Exception {
+        SubscribeRouteEventsRequest request = SubscribeRouteEventsRequest.newBuilder().build();
+        InputStream stream = ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER.stream(request);
+        SubscribeRouteEventsRequest parsed = ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER.parse(stream);
+        assertNotNull(parsed);
+        assertEquals(request.toString(), parsed.toString());
+    }
+
+    @Test
+    public void testParseEmptyStreamDoesNotThrow() throws Exception {
+        ByteArrayInputStream emptyStream = new ByteArrayInputStream(new byte[0]);
+        // All 20 marshallers should handle empty input without throwing
+        ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER.parse(emptyStream);
+        ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_CLIENT_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.GET_CONFIG_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.GET_CONFIG_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.UPDATE_CONFIG_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.UPDATE_CONFIG_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DISCONNECT_CLIENT_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DISCONNECT_CLIENT_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_POP_RECEIPT_HANDLES_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.DESCRIBE_BATCH_CONSUME_DIAGNOSTICS_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_REQ_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+        ProxyAdminMarshaller.SUBSCRIBE_ROUTE_EVENTS_RESP_MARSHALLER.parse(new ByteArrayInputStream(new byte[0]));
+    }
+
+    @Test
+    public void testMarshallerTypesAreCorrect() {
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.DESCRIBE_CLIENT_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.DESCRIBE_CLIENT_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_GROUP_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_REQ_MARSHALLER instanceof MethodDescriptor.Marshaller);
+        assertTrue(ProxyAdminMarshaller.LIST_CLIENTS_BY_TOPIC_RESP_MARSHALLER instanceof MethodDescriptor.Marshaller);
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfoTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientDetailInfoTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class ClientDetailInfoTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ClientDetailInfo detail = new ClientDetailInfo();
+        assertNull(detail.getClientInstance());
+        assertNull(detail.getSettings());
+        assertNull(detail.getHeartbeatHistory());
+        assertNull(detail.getAuthStatus());
+        assertNull(detail.getConsumeProgress());
+        assertNull(detail.getNetworkInfo());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        ClientDetailInfo detail = new ClientDetailInfo();
+
+        ClientInstanceInfo instance = new ClientInstanceInfo();
+        instance.setClientId("client-1");
+        detail.setClientInstance(instance);
+        assertSame(instance, detail.getClientInstance());
+
+        ClientDetailInfo.ClientSettingsInfo settings = new ClientDetailInfo.ClientSettingsInfo();
+        detail.setSettings(settings);
+        assertSame(settings, detail.getSettings());
+
+        ClientDetailInfo.HeartbeatRecordInfo record = new ClientDetailInfo.HeartbeatRecordInfo();
+        detail.setHeartbeatHistory(Collections.singletonList(record));
+        assertEquals(1, detail.getHeartbeatHistory().size());
+        assertSame(record, detail.getHeartbeatHistory().get(0));
+
+        ClientDetailInfo.AuthStatusInfo authStatus = new ClientDetailInfo.AuthStatusInfo();
+        detail.setAuthStatus(authStatus);
+        assertSame(authStatus, detail.getAuthStatus());
+
+        ClientDetailInfo.ConsumeProgressInfo progress = new ClientDetailInfo.ConsumeProgressInfo();
+        detail.setConsumeProgress(progress);
+        assertSame(progress, detail.getConsumeProgress());
+
+        ClientDetailInfo.NetworkInfoInfo networkInfo = new ClientDetailInfo.NetworkInfoInfo();
+        detail.setNetworkInfo(networkInfo);
+        assertSame(networkInfo, detail.getNetworkInfo());
+    }
+
+    @Test
+    public void testClientSettingsInfo() {
+        ClientDetailInfo.ClientSettingsInfo settings = new ClientDetailInfo.ClientSettingsInfo();
+        settings.setSubscriptionMode("PUSH");
+        settings.setReceiveBatchSize(32);
+        settings.setLongPollingTimeoutMs(30000L);
+        settings.setFifo(true);
+        settings.setSubscriptionTopics(Arrays.asList("topicA", "topicB"));
+        settings.setPublishingTopics(Collections.singletonList("topicC"));
+
+        assertEquals("PUSH", settings.getSubscriptionMode());
+        assertEquals(32, settings.getReceiveBatchSize());
+        assertEquals(30000L, settings.getLongPollingTimeoutMs());
+        assertTrue(settings.isFifo());
+        assertEquals(Arrays.asList("topicA", "topicB"), settings.getSubscriptionTopics());
+        assertEquals(Collections.singletonList("topicC"), settings.getPublishingTopics());
+    }
+
+    @Test
+    public void testHeartbeatRecordInfo() {
+        ClientDetailInfo.HeartbeatRecordInfo record = new ClientDetailInfo.HeartbeatRecordInfo();
+        record.setTimestamp(1234567890L);
+        record.setSuccess(true);
+        record.setRemark("ok");
+
+        assertEquals(1234567890L, record.getTimestamp());
+        assertTrue(record.isSuccess());
+        assertEquals("ok", record.getRemark());
+    }
+
+    @Test
+    public void testAuthStatusInfo() {
+        ClientDetailInfo.AuthStatusInfo authStatus = new ClientDetailInfo.AuthStatusInfo();
+        authStatus.setAuthenticated(true);
+        authStatus.setUsername("rocketmq");
+        authStatus.setLastAuthTime(1234567890L);
+        authStatus.setFailureReason("none");
+
+        assertTrue(authStatus.isAuthenticated());
+        assertEquals("rocketmq", authStatus.getUsername());
+        assertEquals(1234567890L, authStatus.getLastAuthTime());
+        assertEquals("none", authStatus.getFailureReason());
+    }
+
+    @Test
+    public void testConsumeProgressInfo() {
+        ClientDetailInfo.TopicConsumeProgressInfo topicProgress = new ClientDetailInfo.TopicConsumeProgressInfo();
+        topicProgress.setTopic("topicA");
+        topicProgress.setLag(100L);
+        topicProgress.setLatencyMs(50L);
+
+        assertEquals("topicA", topicProgress.getTopic());
+        assertEquals(100L, topicProgress.getLag());
+        assertEquals(50L, topicProgress.getLatencyMs());
+
+        ClientDetailInfo.ConsumeProgressInfo progress = new ClientDetailInfo.ConsumeProgressInfo();
+        progress.setLag(200L);
+        progress.setLatencyMs(80L);
+        progress.setTopicProgress(Collections.singletonList(topicProgress));
+
+        assertEquals(200L, progress.getLag());
+        assertEquals(80L, progress.getLatencyMs());
+        assertEquals(1, progress.getTopicProgress().size());
+        assertSame(topicProgress, progress.getTopicProgress().get(0));
+    }
+
+    @Test
+    public void testNetworkInfoInfo() {
+        ClientDetailInfo.NetworkInfoInfo networkInfo = new ClientDetailInfo.NetworkInfoInfo();
+        networkInfo.setLocalAddress("127.0.0.1:8081");
+        networkInfo.setRemoteAddress("127.0.0.1:12345");
+        networkInfo.setRttMs(5L);
+        networkInfo.setSslEnabled(false);
+
+        assertEquals("127.0.0.1:8081", networkInfo.getLocalAddress());
+        assertEquals("127.0.0.1:12345", networkInfo.getRemoteAddress());
+        assertEquals(5L, networkInfo.getRttMs());
+        assertFalse(networkInfo.isSslEnabled());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfoTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ClientInstanceInfoTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ClientInstanceInfoTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        assertNull(info.getClientId());
+        assertNull(info.getLanguage());
+        assertNull(info.getClientVersion());
+        assertNull(info.getProtocol());
+        assertNull(info.getAccessPoint());
+        assertEquals(0, info.getConnectAt());
+        assertEquals(0, info.getLastActiveAt());
+        assertNull(info.getRole());
+        assertNull(info.getGroup());
+        assertNull(info.getTopics());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        List<String> topics = Arrays.asList("topicA", "topicB");
+
+        info.setClientId("client-1");
+        info.setLanguage("JAVA");
+        info.setClientVersion("5.0.0");
+        info.setProtocol("grpc");
+        info.setAccessPoint("127.0.0.1:8081");
+        info.setConnectAt(1000L);
+        info.setLastActiveAt(2000L);
+        info.setRole("CONSUMER");
+        info.setGroup("groupA");
+        info.setTopics(topics);
+
+        assertEquals("client-1", info.getClientId());
+        assertEquals("JAVA", info.getLanguage());
+        assertEquals("5.0.0", info.getClientVersion());
+        assertEquals("grpc", info.getProtocol());
+        assertEquals("127.0.0.1:8081", info.getAccessPoint());
+        assertEquals(1000L, info.getConnectAt());
+        assertEquals(2000L, info.getLastActiveAt());
+        assertEquals("CONSUMER", info.getRole());
+        assertEquals("groupA", info.getGroup());
+        assertEquals(topics, info.getTopics());
+    }
+
+    @Test
+    public void testToString() {
+        ClientInstanceInfo info = new ClientInstanceInfo();
+        info.setClientId("client-1");
+        info.setLanguage("JAVA");
+        info.setGroup("groupA");
+
+        String str = info.toString();
+        assertTrue(str.contains("client-1"));
+        assertTrue(str.contains("JAVA"));
+        assertTrue(str.contains("groupA"));
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilterTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/ListClientsFilterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ListClientsFilterTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ListClientsFilter filter = new ListClientsFilter();
+        assertNull(filter.getGroup());
+        assertNull(filter.getTopic());
+        assertNull(filter.getClientIdPrefix());
+        assertNull(filter.getLanguage());
+        assertEquals(0, filter.getConnectTimeStart());
+        assertEquals(0, filter.getConnectTimeEnd());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup("groupA");
+        filter.setTopic("topicA");
+        filter.setClientIdPrefix("client-");
+        filter.setLanguage("JAVA");
+        filter.setConnectTimeStart(1000L);
+        filter.setConnectTimeEnd(2000L);
+
+        assertEquals("groupA", filter.getGroup());
+        assertEquals("topicA", filter.getTopic());
+        assertEquals("client-", filter.getClientIdPrefix());
+        assertEquals("JAVA", filter.getLanguage());
+        assertEquals(1000L, filter.getConnectTimeStart());
+        assertEquals(2000L, filter.getConnectTimeEnd());
+    }
+
+    @Test
+    public void testHasFilterEmpty() {
+        ListClientsFilter filter = new ListClientsFilter();
+        assertFalse(filter.hasFilter());
+    }
+
+    @Test
+    public void testHasFilterEachField() {
+        ListClientsFilter filter = new ListClientsFilter();
+        filter.setGroup("groupA");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setTopic("topicA");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setClientIdPrefix("client-");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setLanguage("JAVA");
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setConnectTimeStart(1000L);
+        assertTrue(filter.hasFilter());
+
+        filter = new ListClientsFilter();
+        filter.setConnectTimeEnd(2000L);
+        assertTrue(filter.hasFilter());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/RouteChangeEventTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RouteChangeEventTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        assertNull(event.getEventType());
+        assertEquals(0, event.getTimestamp());
+        assertNull(event.getTopic());
+        assertNull(event.getCluster());
+        assertNull(event.getBrokerName());
+        assertEquals(0, event.getBrokerId());
+        assertNull(event.getBrokerAddress());
+        assertEquals(0, event.getPreviousReadQueueNums());
+        assertEquals(0, event.getCurrentReadQueueNums());
+        assertEquals(0, event.getPreviousWriteQueueNums());
+        assertEquals(0, event.getCurrentWriteQueueNums());
+        assertNull(event.getRouteSnapshot());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("test-topic");
+
+        event.setEventType(RouteChangeEventType.BROKER_ONLINE);
+        event.setTimestamp(1234567890L);
+        event.setTopic("test-topic");
+        event.setCluster("test-cluster");
+        event.setBrokerName("broker-a");
+        event.setBrokerId(0L);
+        event.setBrokerAddress("127.0.0.1:10911");
+        event.setPreviousReadQueueNums(4);
+        event.setCurrentReadQueueNums(8);
+        event.setPreviousWriteQueueNums(4);
+        event.setCurrentWriteQueueNums(8);
+        event.setRouteSnapshot(snapshot);
+
+        assertEquals(RouteChangeEventType.BROKER_ONLINE, event.getEventType());
+        assertEquals(1234567890L, event.getTimestamp());
+        assertEquals("test-topic", event.getTopic());
+        assertEquals("test-cluster", event.getCluster());
+        assertEquals("broker-a", event.getBrokerName());
+        assertEquals(0L, event.getBrokerId());
+        assertEquals("127.0.0.1:10911", event.getBrokerAddress());
+        assertEquals(4, event.getPreviousReadQueueNums());
+        assertEquals(8, event.getCurrentReadQueueNums());
+        assertEquals(4, event.getPreviousWriteQueueNums());
+        assertEquals(8, event.getCurrentWriteQueueNums());
+        assertEquals(snapshot, event.getRouteSnapshot());
+    }
+
+    @Test
+    public void testAllEventTypes() {
+        RouteChangeEvent event = new RouteChangeEvent();
+
+        for (RouteChangeEventType type : RouteChangeEventType.values()) {
+            event.setEventType(type);
+            assertEquals(type, event.getEventType());
+        }
+    }
+
+    @Test
+    public void testQueueScaleEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.QUEUE_SCALE);
+        event.setTopic("scale-topic");
+        event.setBrokerName("broker-b");
+        event.setPreviousReadQueueNums(4);
+        event.setCurrentReadQueueNums(8);
+        event.setPreviousWriteQueueNums(4);
+        event.setCurrentWriteQueueNums(8);
+
+        assertEquals(RouteChangeEventType.QUEUE_SCALE, event.getEventType());
+        assertEquals(4, event.getPreviousReadQueueNums());
+        assertEquals(8, event.getCurrentReadQueueNums());
+        assertEquals(4, event.getPreviousWriteQueueNums());
+        assertEquals(8, event.getCurrentWriteQueueNums());
+    }
+
+    @Test
+    public void testTopicCreateEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.TOPIC_CREATE);
+        event.setTopic("new-topic");
+
+        assertEquals(RouteChangeEventType.TOPIC_CREATE, event.getEventType());
+        assertEquals("new-topic", event.getTopic());
+    }
+
+    @Test
+    public void testTopicDeleteEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.TOPIC_DELETE);
+        event.setTopic("deleted-topic");
+
+        assertEquals(RouteChangeEventType.TOPIC_DELETE, event.getEventType());
+        assertEquals("deleted-topic", event.getTopic());
+    }
+
+    @Test
+    public void testRouteSnapshotEvent() {
+        RouteChangeEvent event = new RouteChangeEvent();
+        event.setEventType(RouteChangeEventType.ROUTE_SNAPSHOT);
+        event.setTopic("snapshot-topic");
+
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("snapshot-topic");
+        event.setRouteSnapshot(snapshot);
+
+        assertEquals(RouteChangeEventType.ROUTE_SNAPSHOT, event.getEventType());
+        assertEquals("snapshot-topic", event.getRouteSnapshot().getTopic());
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshotTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/admin/model/TopicRouteSnapshotTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.admin.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TopicRouteSnapshotTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        assertNull(snapshot.getTopic());
+        assertNull(snapshot.getBrokers());
+        assertNull(snapshot.getQueues());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("test-topic");
+
+        List<TopicRouteSnapshot.BrokerInfo> brokers = new ArrayList<>();
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        brokerInfo.setCluster("cluster-a");
+        brokerInfo.setBrokerName("broker-0");
+        Map<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        brokerInfo.setBrokerAddrs(addrs);
+        brokers.add(brokerInfo);
+        snapshot.setBrokers(brokers);
+
+        List<TopicRouteSnapshot.QueueInfo> queues = new ArrayList<>();
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        queueInfo.setBrokerName("broker-0");
+        queueInfo.setReadQueueNums(8);
+        queueInfo.setWriteQueueNums(8);
+        queueInfo.setPerm(6);
+        queues.add(queueInfo);
+        snapshot.setQueues(queues);
+
+        assertEquals("test-topic", snapshot.getTopic());
+        assertEquals(1, snapshot.getBrokers().size());
+        assertEquals("cluster-a", snapshot.getBrokers().get(0).getCluster());
+        assertEquals("broker-0", snapshot.getBrokers().get(0).getBrokerName());
+        assertEquals(1, snapshot.getBrokers().get(0).getBrokerAddrs().size());
+        assertEquals("127.0.0.1:10911", snapshot.getBrokers().get(0).getBrokerAddrs().get(0L));
+        assertEquals(1, snapshot.getQueues().size());
+        assertEquals("broker-0", snapshot.getQueues().get(0).getBrokerName());
+        assertEquals(8, snapshot.getQueues().get(0).getReadQueueNums());
+        assertEquals(8, snapshot.getQueues().get(0).getWriteQueueNums());
+        assertEquals(6, snapshot.getQueues().get(0).getPerm());
+    }
+
+    @Test
+    public void testBrokerInfoDefaultConstructor() {
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        assertNull(brokerInfo.getCluster());
+        assertNull(brokerInfo.getBrokerName());
+        assertNull(brokerInfo.getBrokerAddrs());
+    }
+
+    @Test
+    public void testBrokerInfoWithMultipleAddresses() {
+        TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+        Map<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "127.0.0.1:10911");
+        addrs.put(1L, "127.0.0.1:10921");
+        brokerInfo.setBrokerAddrs(addrs);
+
+        assertEquals(2, brokerInfo.getBrokerAddrs().size());
+        assertEquals("127.0.0.1:10911", brokerInfo.getBrokerAddrs().get(0L));
+        assertEquals("127.0.0.1:10921", brokerInfo.getBrokerAddrs().get(1L));
+    }
+
+    @Test
+    public void testQueueInfoDefaultConstructor() {
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        assertNull(queueInfo.getBrokerName());
+        assertEquals(0, queueInfo.getReadQueueNums());
+        assertEquals(0, queueInfo.getWriteQueueNums());
+        assertEquals(0, queueInfo.getPerm());
+    }
+
+    @Test
+    public void testQueueInfoSetters() {
+        TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+        queueInfo.setBrokerName("broker-x");
+        queueInfo.setReadQueueNums(16);
+        queueInfo.setWriteQueueNums(16);
+        queueInfo.setPerm(4);
+
+        assertEquals("broker-x", queueInfo.getBrokerName());
+        assertEquals(16, queueInfo.getReadQueueNums());
+        assertEquals(16, queueInfo.getWriteQueueNums());
+        assertEquals(4, queueInfo.getPerm());
+    }
+
+    @Test
+    public void testSnapshotWithMultipleBrokersAndQueues() {
+        TopicRouteSnapshot snapshot = new TopicRouteSnapshot();
+        snapshot.setTopic("multi-broker-topic");
+
+        List<TopicRouteSnapshot.BrokerInfo> brokers = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            TopicRouteSnapshot.BrokerInfo brokerInfo = new TopicRouteSnapshot.BrokerInfo();
+            brokerInfo.setCluster("cluster-a");
+            brokerInfo.setBrokerName("broker-" + i);
+            Map<Long, String> addrs = new HashMap<>();
+            addrs.put(0L, "127.0.0.1:1091" + i);
+            brokerInfo.setBrokerAddrs(addrs);
+            brokers.add(brokerInfo);
+        }
+        snapshot.setBrokers(brokers);
+
+        List<TopicRouteSnapshot.QueueInfo> queues = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            TopicRouteSnapshot.QueueInfo queueInfo = new TopicRouteSnapshot.QueueInfo();
+            queueInfo.setBrokerName("broker-" + i);
+            queueInfo.setReadQueueNums(8);
+            queueInfo.setWriteQueueNums(8);
+            queueInfo.setPerm(6);
+            queues.add(queueInfo);
+        }
+        snapshot.setQueues(queues);
+
+        assertEquals(3, snapshot.getBrokers().size());
+        assertEquals(3, snapshot.getQueues().size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals("broker-" + i, snapshot.getBrokers().get(i).getBrokerName());
+            assertEquals("broker-" + i, snapshot.getQueues().get(i).getBrokerName());
+        }
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
@@ -79,6 +79,11 @@ public class AbstractRemotingActivityTest extends InitConfigTest {
                 ProxyContext context) throws Exception {
                 return null;
             }
+
+            @Override
+            public boolean rejectRequest() {
+                return false;
+            }
         };
         Channel channel = ctx.channel();
         RemotingHelper.setPropertyToAttr(channel, AttributeKeys.CLIENT_ID_KEY, CLIENT_ID);

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.remoting;
 
 import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.remoting.common.TlsMode;
+import org.apache.rocketmq.remoting.exception.RemotingConnectException;
 import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
@@ -220,7 +221,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 5);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 
@@ -238,7 +241,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 5);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 
@@ -257,7 +262,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 3);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 
@@ -270,7 +277,9 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 3);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingSendRequestException | RemotingConnectException ignore) {
+            // The handshake failure may surface as a send failure, or as a connect failure
+            // when the channel is closed before the request is flushed.
         }
     }
 

--- a/style/rmq_checkstyle.xml
+++ b/style/rmq_checkstyle.xml
@@ -24,6 +24,11 @@
 
     <property name="localeLanguage" value="en"/>
 
+    <!-- Exclude generated source files (protobuf, gRPC, etc.) from all checks -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*[\\/]generated\-sources[\\/].*"/>
+    </module>
+
     <!--To configure the check to report on the first instance in each file-->
     <module name="FileTabCharacter"/>
 

--- a/style/rmq_checkstyle_suppressions.xml
+++ b/style/rmq_checkstyle_suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!-- Exclude all generated sources (protobuf, gRPC, etc.) from checkstyle checks -->
+    <suppress files=".*[\\/]generated-sources[\\/].*" checks=".*"/>
+</suppressions>


### PR DESCRIPTION
## [Studio] feat: Admin Service Integration with Messaging Pipeline and E2E Tests

**Issue:** #10637
**Branch:** `feature/rip-2-pr6-messaging-integration`

---

### Overview

This PR completes the RIP-2 Proxy Admin Interface by integrating the admin service with the messaging pipeline and providing end-to-end integration tests. It wires the admin client service into the gRPC data plane for heartbeat recording, enriches client channels with connection diagnostics metadata, extends the receipt handle manager with diagnostic query capabilities, and validates the entire system through comprehensive E2E tests.

### Key Changes

**Messaging Pipeline Integration**

- **GrpcMessagingActivity** (interface): Added `getGrpcChannelManager()` and `getGrpcClientSettingsManager()` to expose internal managers for admin queries.
- **DefaultGrpcMessagingActivity**: Implements the new getters; added `setProxyAdminClientService()` to wire the admin service for heartbeat recording (RIP-2 section 5.2.2).
- **GrpcMessagingApplication**: Delegates the new getters and setter to the activity layer.
- **GrpcChannelManager**: Added `getClientIdChannelMap()` returning an unmodifiable view of the client-to-channel mapping for admin queries.

**Client Connection Diagnostics** (RIP-2 section 5.2)

- **GrpcClientChannel** (+121 lines): Enriched with per-connection metadata:
  - `createTime` -- connection establishment timestamp.
  - `lastRttMs` (volatile) -- estimated round-trip time from telemetry command round-trip.
  - `sslEnabled` (volatile) -- TLS state captured at connection time.
  - `authUsername` (volatile) -- authenticated username from ACL.
  - `updateRttMeasurement()` -- computes RTT from `System.currentTimeMillis() - lastTelemetrySendTimeMs`.
  - `forceClose(String reason)` -- sends `Status.UNAVAILABLE` error to client via telemetry stream for server-side disconnection.

**ClientActivity Integration**

- Added `proxyAdminClientService` field (volatile, set post-construction to break circular dependency).
- In `heartbeat()`: calls `recordHeartbeat(ctx.getClientID())` after processing.
- In telemetry `onNext()`: calls `updateRttMeasurement(ctx)` and `recordHeartbeat(ctx.getClientID())` on SETTINGS commands.
- Null-safe delegation with error handling to prevent data plane disruption.

**MessagingProcessor Extensions**

- Added `popLiteMessage()` method signature (same params as `popMessage`).
- Added `getReceiptHandleManager()` -- returns `ReceiptHandleManager` for POP diagnostics.
- Added `getTopicRouteService()` -- returns `TopicRouteService` for route change event subscriptions.
- `DefaultMessagingProcessor` implements all three, delegating to `receiptHandleProcessor` and `serviceManager`.

**Receipt Handle Diagnostic Queries**

- **ReceiptHandleManager** (interface, +140 lines): Added `describePopReceiptHandles()` and `describeBatchConsumeDiagnostics()` with pagination. New inner classes: `PopReceiptHandleDiagnosticResult`, `ChannelBatchConsumeData`, `BatchConsumeDiagnosticResult`.
- **DefaultReceiptHandleManager** (+216 lines): Implements both diagnostic methods by scanning the concurrent receipt handle group map. Uses inner `ChannelAggregator` class for per-channel stat aggregation during batch diagnostics.

### End-to-End Integration Test

**ProxyAdminGrpcIT** (602 lines) -- Full gRPC client-to-admin-server integration test (RIP-2 M1 milestone).

Test environment: Namesrv + 3 Brokers, data plane gRPC server (`MessagingServiceGrpc`), admin plane gRPC server (`ProxyAdminBindableService`), both with TLS (SelfSignedCertificate).

| Test Method | Scenario |
|-------------|----------|
| `test01_ListClients_NoClients_ReturnsOkWithEmptyList` | Empty state returns OK with 0 total |
| `test02_DescribeClient_NonExistentClient_ReturnsNotFound` | Returns NOT_FOUND for unknown client |
| `test03_ListClientsByGroup_NonExistentGroup_ReturnsOkWithEmptyList` | Empty result for unknown group |
| `test04_ListClientsByTopic_NonExistentTopic_ReturnsOkWithEmptyList` | Empty result for unknown topic |
| `test05_ListClients_Pagination` | Verifies pageSize/pageNum in response |
| `test06_ListClients_WithConnectedProducer` | Connects a real producer via telemetry, verifies it appears in admin list |
| `test07_DescribeClient_WithConnectedProducer` | Describes a connected producer, verifies clientId in response |
| `test08_ListClientsByGroup_WithConnectedConsumer` | Connects a push consumer, queries by group |
| `test09_ListClientsByTopic_WithConnectedProducer` | Connects a producer, queries by topic |
| `test10_ListClients_WithLanguageFilter` | Verifies JAVA filter includes, GOLANG filter excludes the same Java client |

### Files Changed

| File | Description |
|------|-------------|
| `proxy/src/main/java/.../grpc/v2/GrpcMessagingActivity.java` | Added channel/settings manager getters |
| `proxy/src/main/java/.../grpc/v2/DefaultGrpcMessagingActivity.java` | Implemented getters + admin service setter |
| `proxy/src/main/java/.../grpc/v2/GrpcMessagingApplication.java` | Delegated new methods to activity |
| `proxy/src/main/java/.../grpc/v2/channel/GrpcChannelManager.java` | Exposed clientId-channel map |
| `proxy/src/main/java/.../grpc/v2/channel/GrpcClientChannel.java` | Connection metadata + forceClose (+121 lines) |
| `proxy/src/main/java/.../grpc/v2/client/ClientActivity.java` | Heartbeat recording + RTT measurement (+68 lines) |
| `proxy/src/main/java/.../processor/MessagingProcessor.java` | Added popLiteMessage + getter methods |
| `proxy/src/main/java/.../processor/DefaultMessagingProcessor.java` | Implemented new interface methods |
| `proxy/src/main/java/.../processor/ReceiptHandleProcessor.java` | Exposed ReceiptHandleManager |
| `proxy/src/main/java/.../service/receipt/ReceiptHandleManager.java` | Diagnostic query interface (+140 lines) |
| `proxy/src/main/java/.../service/receipt/DefaultReceiptHandleManager.java` | Diagnostic implementation (+216 lines) |
| `proxy/src/main/java/.../service/channel/SimpleChannel.java` | Added getLastAccessTime() |
| `WORKSPACE` | Added rules_proto dependency for E2E test |
| `test/src/test/java/.../grpc/admin/ProxyAdminGrpcIT.java` | E2E integration test (new, 602 lines) |
| `proxy/src/test/java/.../receipt/ReceiptHandleDiagnosticResultTest.java` | Diagnostic result tests (new, 172 lines) |

### Integration Architecture

```
Data Plane (port 8081)                    Admin Plane (port 8082)
  GrpcMessagingApplication                  ProxyAdminGrpcService
    -> DefaultGrpcMessagingActivity           -> ProxyAdminBindableService
      -> ClientActivity                         -> ProxyAdminClientService
        -> heartbeat recording                    -> GrpcChannelManager (read)
        -> RTT measurement                        -> GrpcClientSettingsManager (read)
      -> GrpcChannelManager                       -> ReceiptHandleManager (read)
      -> GrpcClientSettingsManager                -> RouteChangeNotifier (subscribe)
```
