### PR TITLE
[ISSUE #10709] Return failed futures for unsupported Proxy ACL metadata operations

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/auth/ProxyAuthenticationMetadataProvider.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/auth/ProxyAuthenticationMetadataProvider.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import org.apache.rocketmq.auth.authentication.provider.AuthenticationMetadataProvider;
 import org.apache.rocketmq.auth.authentication.model.User;
 import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.common.utils.FutureUtils;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
 
 public class ProxyAuthenticationMetadataProvider implements AuthenticationMetadataProvider {
@@ -44,17 +45,17 @@ public class ProxyAuthenticationMetadataProvider implements AuthenticationMetada
 
     @Override
     public CompletableFuture<Void> createUser(User user) {
-        return null;
+        return unsupported("createUser");
     }
 
     @Override
     public CompletableFuture<Void> deleteUser(String username) {
-        return null;
+        return unsupported("deleteUser");
     }
 
     @Override
     public CompletableFuture<Void> updateUser(User user) {
-        return null;
+        return unsupported("updateUser");
     }
 
     @Override
@@ -64,6 +65,11 @@ public class ProxyAuthenticationMetadataProvider implements AuthenticationMetada
 
     @Override
     public CompletableFuture<List<User>> listUser(String filter) {
-        return null;
+        return unsupported("listUser");
+    }
+
+    private static <T> CompletableFuture<T> unsupported(String operation) {
+        return FutureUtils.completeExceptionally(new UnsupportedOperationException(
+            "Proxy authentication metadata provider does not support " + operation));
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/auth/ProxyAuthorizationMetadataProvider.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/auth/ProxyAuthorizationMetadataProvider.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.auth.authentication.model.Subject;
 import org.apache.rocketmq.auth.authorization.provider.AuthorizationMetadataProvider;
 import org.apache.rocketmq.auth.authorization.model.Acl;
 import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.common.utils.FutureUtils;
 import org.apache.rocketmq.proxy.service.metadata.MetadataService;
 
 public class ProxyAuthorizationMetadataProvider implements AuthorizationMetadataProvider {
@@ -46,17 +47,17 @@ public class ProxyAuthorizationMetadataProvider implements AuthorizationMetadata
 
     @Override
     public CompletableFuture<Void> createAcl(Acl acl) {
-        return null;
+        return unsupported("createAcl");
     }
 
     @Override
     public CompletableFuture<Void> deleteAcl(Subject subject) {
-        return null;
+        return unsupported("deleteAcl");
     }
 
     @Override
     public CompletableFuture<Void> updateAcl(Acl acl) {
-        return null;
+        return unsupported("updateAcl");
     }
 
     @Override
@@ -66,6 +67,11 @@ public class ProxyAuthorizationMetadataProvider implements AuthorizationMetadata
 
     @Override
     public CompletableFuture<List<Acl>> listAcl(String subjectFilter, String resourceFilter) {
-        return null;
+        return unsupported("listAcl");
+    }
+
+    private static <T> CompletableFuture<T> unsupported(String operation) {
+        return FutureUtils.completeExceptionally(new UnsupportedOperationException(
+            "Proxy authorization metadata provider does not support " + operation));
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/auth/ProxyMetadataProviderTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/auth/ProxyMetadataProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.auth;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ProxyMetadataProviderTest {
+
+    @Test
+    public void testUnsupportedAuthenticationMetadataOperationsReturnFailedFuture() throws Exception {
+        ProxyAuthenticationMetadataProvider provider = new ProxyAuthenticationMetadataProvider();
+
+        assertUnsupported(provider.createUser(null), "createUser");
+        assertUnsupported(provider.deleteUser("user"), "deleteUser");
+        assertUnsupported(provider.updateUser(null), "updateUser");
+        assertUnsupported(provider.listUser(null), "listUser");
+    }
+
+    @Test
+    public void testUnsupportedAuthorizationMetadataOperationsReturnFailedFuture() throws Exception {
+        ProxyAuthorizationMetadataProvider provider = new ProxyAuthorizationMetadataProvider();
+
+        assertUnsupported(provider.createAcl(null), "createAcl");
+        assertUnsupported(provider.deleteAcl(null), "deleteAcl");
+        assertUnsupported(provider.updateAcl(null), "updateAcl");
+        assertUnsupported(provider.listAcl(null, null), "listAcl");
+    }
+
+    private static void assertUnsupported(CompletableFuture<?> future, String operation) throws Exception {
+        assertNotNull(future);
+        try {
+            future.get();
+            fail("Expected unsupported operation future for " + operation);
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+            assertTrue(e.getCause().getMessage().contains(operation));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- return failed CompletableFuture instances for unsupported Proxy authentication metadata mutations
- return failed CompletableFuture instances for unsupported Proxy authorization metadata mutations
- add tests to ensure unsupported operations never return null futures

Fixes https://github.com/apache/rocketmq/issues/10709
Closes #10709

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -Dtest=ProxyMetadataProviderTest -DfailIfNoTests=false test