### PR TITLE
[ISSUE #10710] Sanitize lite offline Settings failure logs

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
@@ -25,6 +25,7 @@ import apache.rocketmq.v2.Endpoints;
 import apache.rocketmq.v2.ExponentialBackoff;
 import apache.rocketmq.v2.Metric;
 import apache.rocketmq.v2.Settings;
+import apache.rocketmq.v2.Subscription;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import java.util.Arrays;
@@ -253,8 +254,30 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
                     }
                 });
         } catch (Exception e) {
-            log.error("offlineClientLiteSubscription error, clientId:{}, settings:{}", clientId, settings, e);
+            log.error("offlineClientLiteSubscription error, clientId:{}, settings:{}",
+                clientId, summarizeLiteSettings(settings), e);
         }
+    }
+
+    protected static String summarizeLiteSettings(Settings settings) {
+        if (settings == null) {
+            return "null";
+        }
+        String group = "";
+        String topic = "";
+        int subscriptionCount = 0;
+        if (settings.hasSubscription()) {
+            Subscription subscription = settings.getSubscription();
+            group = subscription.getGroup().getName();
+            subscriptionCount = subscription.getSubscriptionsCount();
+            if (subscriptionCount > 0) {
+                topic = subscription.getSubscriptions(0).getTopic().getName();
+            }
+        }
+        return "clientType:" + settings.getClientType()
+            + ", group:" + group
+            + ", topic:" + topic
+            + ", subscriptionCount:" + subscriptionCount;
     }
 
     @Override

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.proxy.grpc.v2.common;
 import apache.rocketmq.v2.ClientType;
 import apache.rocketmq.v2.CustomizedBackoff;
 import apache.rocketmq.v2.ExponentialBackoff;
+import apache.rocketmq.v2.FilterExpression;
 import apache.rocketmq.v2.Publishing;
 import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.RetryPolicy;
@@ -40,8 +41,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -200,5 +203,31 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
         grpcClientSettingsManager.offlineClientLiteSubscription(ctx, clientId, settings);
 
         verify(messagingProcessor, times(1)).syncLiteSubscription(any(), any(LiteSubscriptionDTO.class), anyLong());
+    }
+
+    @Test
+    public void testSummarizeLiteSettingsDoesNotLeakSubscriptionDetails() {
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.LITE_PUSH_CONSUMER)
+            .setSubscription(Subscription.newBuilder()
+                .setGroup(Resource.newBuilder().setName("testGroup").build())
+                .addSubscriptions(SubscriptionEntry.newBuilder()
+                    .setTopic(Resource.newBuilder().setName("testTopic").build())
+                    .setExpression(FilterExpression.newBuilder().setExpression("sensitive-filter").build())
+                    .build())
+                .addSubscriptions(SubscriptionEntry.newBuilder()
+                    .setTopic(Resource.newBuilder().setName("otherTopic").build())
+                    .build())
+                .build())
+            .build();
+
+        String summary = GrpcClientSettingsManager.summarizeLiteSettings(settings);
+
+        assertTrue(summary.contains("clientType:LITE_PUSH_CONSUMER"));
+        assertTrue(summary.contains("group:testGroup"));
+        assertTrue(summary.contains("topic:testTopic"));
+        assertTrue(summary.contains("subscriptionCount:2"));
+        assertFalse(summary.contains("sensitive-filter"));
+        assertFalse(summary.contains("otherTopic"));
     }
 }


### PR DESCRIPTION
## Summary
- replace full protobuf Settings logging in lite offline cleanup failures with a compact diagnostic summary
- keep client type, group, first topic, and subscription count for troubleshooting
- add a regression test that ensures subscription filter details are not leaked

Fixes https://github.com/apache/rocketmq/issues/10710

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -Dtest=GrpcClientSettingsManagerTest -DfailIfNoTests=false test