### PR TITLE
[ISSUE #7703] Upgrade fastjson2 to 2.0.63 for security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <netty.version>4.1.130.Final</netty.version>
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
-        <fastjson.version>1.2.84</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <fastjson2.version>2.0.63</fastjson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <jna.version>4.2.2</jna.version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@
         <netty.version>4.1.130.Final</netty.version>
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
-        <fastjson.version>1.2.83</fastjson.version>
-        <fastjson2.version>2.0.59</fastjson2.version>
+        <fastjson.version>1.2.84</fastjson.version>
+        <fastjson2.version>2.0.63</fastjson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <jna.version>4.2.2</jna.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>


### PR DESCRIPTION
## What is the purpose of the change

Upgrade fastjson2 from 2.0.59 to 2.0.63 to address security vulnerabilities fixed in this release. fastjson 1.x stays at 1.2.83.

## Security fixes addressed

- **fastjson2 2.0.63** (2026-07-29):
  - Hardened AutoType class name validation and whitelist verification (URL special character rejection, secondary text check after hash collision, accept prefix no longer covers `ClassLoader`/`DataSource`/`RowSet` gadget base classes) #7703
  - Limited numeric literal digit count, fixed `BigInteger` O(n²) DoS #7668
  - Fixed JSONB `BC_BIGINT` / `BC_BINARY` declared length OOM #7669

## Verification

- Full `mvn clean install -DskipTests` compilation passes
- 17 serialization-related unit tests pass (GenericMapSuperclassDeserializerTest, RemotingSerializableCompatTest, DataVersionTest, BatchAckTest, TopicQueueMappingTest)
- Performance benchmark (2B scenario, medium cluster, 6000 TPS target):
  - gRPC: TPS ratio 0.989, PASS
  - Remoting: TPS ratio 0.982, PASS
- E2E regression: 461/462 tests pass (1 skipped), 0 failures across metadata/grpc/remoting tags

## Brief changelog

- \`pom.xml\`: fastjson2 2.0.59 → 2.0.63