### PR TITLE
[ISSUE #10726] Avoid raw heartbeat sync body logs

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncer.java
@@ -188,8 +188,9 @@ public class HeartbeatSyncer extends AbstractSystemMessageSyncer {
         }
 
         for (MessageExt msg : msgs) {
+            HeartbeatSyncerData data = null;
             try {
-                HeartbeatSyncerData data = JSON.parseObject(new String(msg.getBody(), StandardCharsets.UTF_8), HeartbeatSyncerData.class);
+                data = JSON.parseObject(new String(msg.getBody(), StandardCharsets.UTF_8), HeartbeatSyncerData.class);
                 if (data.getLocalProxyId().equals(localProxyId)) {
                     continue;
                 }
@@ -222,11 +223,29 @@ public class HeartbeatSyncer extends AbstractSystemMessageSyncer {
                     );
                 }
             } catch (Throwable t) {
-                log.error("heartbeat consume message failed. msg:{}, data:{}", msg, new String(msg.getBody(), StandardCharsets.UTF_8), t);
+                log.error("heartbeat consume message failed. summary:{}", summarizeHeartbeatMessage(msg, data), t);
             }
         }
 
         return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+    }
+
+    static String summarizeHeartbeatMessage(MessageExt msg, HeartbeatSyncerData data) {
+        if (msg == null) {
+            return "msg=null";
+        }
+        StringBuilder summary = new StringBuilder()
+            .append("topic=").append(msg.getTopic())
+            .append(", msgId=").append(msg.getMsgId())
+            .append(", bodySize=").append(msg.getBody() == null ? 0 : msg.getBody().length);
+        if (data != null) {
+            summary.append(", heartbeatType=").append(data.getHeartbeatType())
+                .append(", group=").append(data.getGroup())
+                .append(", clientId=").append(data.getClientId())
+                .append(", subscriptionCount=")
+                .append(data.getSubscriptionDataSet() == null ? 0 : data.getSubscriptionDataSet().size());
+        }
+        return summary.toString();
     }
 
     private String buildLocalProxyId() {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncerTest.java
@@ -23,9 +23,11 @@ import apache.rocketmq.v2.Resource;
 import apache.rocketmq.v2.Settings;
 import apache.rocketmq.v2.Subscription;
 import apache.rocketmq.v2.SubscriptionEntry;
+import com.alibaba.fastjson2.JSON;
 import com.google.common.collect.Sets;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelId;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -77,6 +79,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -386,6 +389,53 @@ public class HeartbeatSyncerTest extends InitConfigTest {
 
         heartbeatSyncer.processConsumerGroupEvent(ConsumerGroupEvent.CLIENT_UNREGISTER, consumerGroup, channelInfoArgumentCaptor.getValue());
         assertTrue(heartbeatSyncer.remoteChannelMap.isEmpty());
+    }
+
+    @Test
+    public void testSummarizeHeartbeatMessageDoesNotExposeSubscriptionOrChannelData() throws Exception {
+        SubscriptionData subscriptionData = FilterAPI.buildSubscriptionData("topic", "secret-tag");
+        HeartbeatSyncerData data = new HeartbeatSyncerData(
+            HeartbeatType.REGISTER,
+            "client-secret",
+            LanguageCode.JAVA,
+            5,
+            "consumerGroup",
+            ConsumeType.CONSUME_PASSIVELY,
+            MessageModel.CLUSTERING,
+            ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET,
+            "proxyId",
+            "secret-channel-data"
+        );
+        data.setSubscriptionDataSet(Sets.newHashSet(subscriptionData));
+        MessageExt msg = new MessageExt();
+        msg.setTopic("heartbeatTopic");
+        msg.setMsgId("msgId");
+        msg.setBody(JSON.toJSONString(data).getBytes(StandardCharsets.UTF_8));
+
+        String summary = HeartbeatSyncer.summarizeHeartbeatMessage(msg, data);
+
+        assertTrue(summary.contains("topic=heartbeatTopic"));
+        assertTrue(summary.contains("msgId=msgId"));
+        assertTrue(summary.contains("heartbeatType=REGISTER"));
+        assertTrue(summary.contains("group=consumerGroup"));
+        assertTrue(summary.contains("subscriptionCount=1"));
+        assertFalse(summary.contains("secret-tag"));
+        assertFalse(summary.contains("secret-channel-data"));
+    }
+
+    @Test
+    public void testSummarizeHeartbeatMessageDoesNotExposeUnparsedBody() {
+        MessageExt msg = new MessageExt();
+        msg.setTopic("heartbeatTopic");
+        msg.setMsgId("msgId");
+        msg.setBody("raw-secret-body".getBytes(StandardCharsets.UTF_8));
+
+        String summary = HeartbeatSyncer.summarizeHeartbeatMessage(msg, null);
+
+        assertTrue(summary.contains("topic=heartbeatTopic"));
+        assertTrue(summary.contains("msgId=msgId"));
+        assertTrue(summary.contains("bodySize=15"));
+        assertFalse(summary.contains("raw-secret-body"));
     }
 
     private MessageExt convertFromMessage(Message message) {


### PR DESCRIPTION
## Summary
- replace raw heartbeat sync message/body logging with a compact failure summary
- include topic, message id, body size, and parsed heartbeat metadata counts when available
- add tests to ensure subscription expressions, channel data, and unparsed raw bodies are not emitted in the summary

Fixes https://github.com/apache/rocketmq/issues/10726

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -Dtest=HeartbeatSyncerTest clean test