### PR TITLE
fix: infinite loop in getBulkData, CME in PopReviveService, and NPEs in broker client code

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/net/Broker2Client.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/net/Broker2Client.java
@@ -253,8 +253,8 @@ public class Broker2Client {
                 requestHeader);
 
         Map<String, Map<MessageQueue, Long>> consumerStatusTable = new HashMap<>();
-        ConcurrentMap<Channel, ClientChannelInfo> channelInfoTable =
-            this.brokerController.getConsumerManager().getConsumerGroupInfo(group).getChannelInfoTable();
+        ConsumerGroupInfo consumerGroupInfo = this.brokerController.getConsumerManager().getConsumerGroupInfo(group);
+        ConcurrentMap<Channel, ClientChannelInfo> channelInfoTable = consumerGroupInfo == null ? null : consumerGroupInfo.getChannelInfoTable();
         if (null == channelInfoTable || channelInfoTable.isEmpty()) {
             result.setCode(ResponseCode.SYSTEM_ERROR);
             result.setRemark(String.format("No Any Consumer online in the consumer group: [%s]", group));

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -54,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -592,12 +593,16 @@ public class PopReviveService extends ServiceThread {
                 if (inflightReviveRequestMap.containsKey(popCheckPoint)) {
                     inflightReviveRequestMap.get(popCheckPoint).setObject2(true);
                 }
-                for (Map.Entry<PopCheckPoint, Pair<Long, Boolean>> entry : inflightReviveRequestMap.entrySet()) {
+                // Use the iterator to remove entries: directly calling map.remove() while
+                // iterating over the fail-fast TreeMap iterator throws ConcurrentModificationException.
+                Iterator<Map.Entry<PopCheckPoint, Pair<Long, Boolean>>> iterator = inflightReviveRequestMap.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<PopCheckPoint, Pair<Long, Boolean>> entry = iterator.next();
                     PopCheckPoint oldCK = entry.getKey();
                     Pair<Long, Boolean> pair = entry.getValue();
                     if (pair.getObject2()) {
                         brokerController.getConsumerOffsetManager().commitOffset(PopAckConstants.LOCAL_HOST, PopAckConstants.REVIVE_GROUP, reviveTopic, queueId, oldCK.getReviveOffset());
-                        inflightReviveRequestMap.remove(oldCK);
+                        iterator.remove();
                     } else {
                         break;
                     }

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -311,6 +311,9 @@ public class CommitLog implements Swappable {
                 bufferResultList.add(bufferResult);
                 remainSize -= readSize;
                 startOffset += readSize;
+            } else {
+                log.warn("getBulkData: can not find mapped file by offset, break to avoid infinite loop. offset: {}, size: {}", startOffset, remainSize);
+                break;
             }
         }
 


### PR DESCRIPTION
### Motivation

Three bugs found by code review (verified against the current develop branch):

1. **`CommitLog.getBulkData` can loop forever** (`store/src/main/java/org/apache/rocketmq/store/CommitLog.java`)
   When `findMappedFileByOffset` returns `null` (offset below the first mapped file or in a deleted-file gap), the loop body does nothing — neither `remainSize` nor `startOffset` advances and there is no `else break`. The calling thread (e.g. replication checksum) spins forever. Added a warning log and `break`.

2. **`PopReviveService` throws `ConcurrentModificationException` while committing offsets** (`broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java`)
   The loop removed entries via `inflightReviveRequestMap.remove(oldCK)` while iterating the fail-fast `TreeMap` iterator, so two consecutive finished checkpoints threw CME and aborted the offset-commit loop, risking duplicate redelivery. Switched to `iterator.remove()`.

3. **`Broker2Client.getConsumeStatus` NPE for offline groups** (`broker/src/main/java/org/apache/rocketmq/broker/client/net/Broker2Client.java`)
   `getConsumerGroupInfo(group)` returns `null` when the group has no connected consumers; dereferencing it threw NPE on the `GET_CONSUMER_STATUS` admin RPC. Guarded the null case.

### Verification

`mvn -pl broker -am compile` passes on the build server.

### Diff

3 files changed, +12 / -4.