### PR TITLE
fix: guard NPE/IOOBE edge cases in admin, transaction, store and http client

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -2560,8 +2560,12 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         if (compareOffset != null && !compareOffset.isEmpty()) {
             for (Map.Entry<Integer, Long> entry : compareOffset.entrySet()) {
                 Integer queueId = entry.getKey();
-                correctionOffset.put(queueId,
-                    correctionOffset.get(queueId) > entry.getValue() ? Long.MAX_VALUE : correctionOffset.get(queueId));
+                Long minOffset = correctionOffset.get(queueId);
+                // correctionOffset only contains queueIds present in the topic's offset table;
+                // skip queueIds the compare group has but no other group consumed.
+                if (minOffset != null) {
+                    correctionOffset.put(queueId, minOffset > entry.getValue() ? Long.MAX_VALUE : minOffset);
+                }
             }
         }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -293,7 +293,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                         }
                         List<MessageExt> opMsg = pullResult == null ? null : pullResult.getMsgFoundList();
                         boolean isNeedCheck = opMsg == null && valueOfCurrentMinusBorn > checkImmunityTime
-                            || opMsg != null && opMsg.get(opMsg.size() - 1).getBornTimestamp() - startTime > transactionTimeout
+                            || opMsg != null && !opMsg.isEmpty() && opMsg.get(opMsg.size() - 1).getBornTimestamp() - startTime > transactionTimeout
                             || valueOfCurrentMinusBorn <= -1;
 
                         if (isNeedCheck) {

--- a/common/src/main/java/org/apache/rocketmq/common/utils/HttpTinyClient.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/HttpTinyClient.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.common.utils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -49,7 +50,8 @@ public class HttpTinyClient {
             if (HttpURLConnection.HTTP_OK == respCode) {
                 resp = IOTinyUtils.toString(conn.getInputStream(), encoding);
             } else {
-                resp = IOTinyUtils.toString(conn.getErrorStream(), encoding);
+                InputStream errorStream = conn.getErrorStream();
+                resp = errorStream == null ? null : IOTinyUtils.toString(errorStream, encoding);
             }
             return new HttpResult(respCode, resp);
         } finally {
@@ -114,7 +116,8 @@ public class HttpTinyClient {
             if (HttpURLConnection.HTTP_OK == respCode) {
                 resp = IOTinyUtils.toString(conn.getInputStream(), encoding);
             } else {
-                resp = IOTinyUtils.toString(conn.getErrorStream(), encoding);
+                InputStream errorStream = conn.getErrorStream();
+                resp = errorStream == null ? null : IOTinyUtils.toString(errorStream, encoding);
             }
             return new HttpResult(respCode, resp);
         } finally {

--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -1219,7 +1219,9 @@ public class ConsumeQueue implements ConsumeQueueInterface {
                         ConsumeQueueExt.CqExtUnit ext = null;
                         if (isExtWriteEnable()) {
                             ext = consumeQueueExt.get(tagCode);
-                            tagCode = ext.getTagsCode();
+                            if (ext != null) {
+                                tagCode = ext.getTagsCode();
+                            }
                         }
                         if (filter.isMatchedByConsumeQueue(tagCode, ext)) {
                             match++;


### PR DESCRIPTION
### Motivation

Four edge-case crashes found by code review (verified against the current develop branch):

1. **`AdminBrokerProcessor.queryCorrectionOffset` NPE** (`broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java`)
   `correctionOffset` only contains queueIds present in the topic's offset table. When the compare group has an offset for a queue no other group consumed, `correctionOffset.get(queueId)` is `null` and the ternary auto-unboxes it → NPE, failing the `QUERY_CORRECTION_OFFSET` admin RPC. Guarded with a null check.

2. **`ConsumeQueue.estimateMessageCount` NPE** (`store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java`)
   `consumeQueueExt.get(tagCode)` returns `null` for CQ entries written before ext was enabled (or when a previous ext put fell back to a plain tagsCode), so `ext.getTagsCode()` threw NPE and broke consumer-lag metrics. Skip when `ext` is `null` (the filter already handles a `null` CqExtUnit).

3. **`TransactionalMessageServiceImpl` IndexOutOfBoundsException** (`broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java`)
   `opMsg` can be a non-null **empty** list, so `opMsg.get(opMsg.size() - 1)` threw `IndexOutOfBoundsException` and aborted the entire transaction-check pass for all queues. Guarded with `!opMsg.isEmpty()`.

4. **`HttpTinyClient` NPE on error responses without a body** (`common/src/main/java/org/apache/rocketmq/common/utils/HttpTinyClient.java`)
   `HttpURLConnection.getErrorStream()` returns `null` when the error response has no body; `IOTinyUtils.toString(null, ...)` threw NPE and broke namesrv discovery via `DefaultTopAddressing`. Guarded both `httpGet` and `httpPost`.

### Verification

`mvn -pl broker -am compile` passes on the build server.

### Diff

4 files changed, +15 / -6.