### PR TITLE
[ISSUE #10739] Complete proxy futures when processor executors reject tasks

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/FutureUtils.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/FutureUtils.java
@@ -24,13 +24,18 @@ public class FutureUtils {
 
     public static <T> CompletableFuture<T> appendNextFuture(CompletableFuture<T> future,
         CompletableFuture<T> nextFuture, ExecutorService executor) {
-        future.whenCompleteAsync((t, throwable) -> {
+        CompletableFuture<T> completionFuture = future.whenCompleteAsync((t, throwable) -> {
             if (throwable != null) {
                 nextFuture.completeExceptionally(throwable);
             } else {
                 nextFuture.complete(t);
             }
         }, executor);
+        completionFuture.whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                nextFuture.completeExceptionally(throwable);
+            }
+        });
         return nextFuture;
     }
 

--- a/common/src/test/java/org/apache/rocketmq/common/utils/FutureUtilsTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/FutureUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.utils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class FutureUtilsTest {
+
+    @Test
+    public void testAddExecutorCompletesExceptionallyWhenExecutorRejectsTask() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.shutdown();
+
+        CompletableFuture<String> result = FutureUtils.addExecutor(
+            CompletableFuture.completedFuture("value"), executor);
+
+        assertTrue("the returned future must not remain pending", result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        CompletionException exception = assertThrows(CompletionException.class, () -> result.join());
+        assertTrue(exception.getCause() instanceof RejectedExecutionException);
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessor.java
@@ -86,7 +86,8 @@ public class DefaultMessagingProcessor extends AbstractStartAndShutdown implemen
             1,
             TimeUnit.MINUTES,
             "ProducerProcessorExecutor",
-            proxyConfig.getProducerProcessorThreadPoolQueueCapacity()
+            proxyConfig.getProducerProcessorThreadPoolQueueCapacity(),
+            new ThreadPoolExecutor.AbortPolicy()
         );
         this.consumerProcessorExecutor = ThreadPoolMonitor.createAndMonitor(
             proxyConfig.getConsumerProcessorThreadPoolNums(),
@@ -94,7 +95,8 @@ public class DefaultMessagingProcessor extends AbstractStartAndShutdown implemen
             1,
             TimeUnit.MINUTES,
             "ConsumerProcessorExecutor",
-            proxyConfig.getConsumerProcessorThreadPoolQueueCapacity()
+            proxyConfig.getConsumerProcessorThreadPoolQueueCapacity(),
+            new ThreadPoolExecutor.AbortPolicy()
         );
 
         this.serviceManager = serviceManager;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/DefaultMessagingProcessorTest.java
@@ -19,7 +19,14 @@ package org.apache.rocketmq.proxy.processor;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.rocketmq.common.utils.FutureUtils;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.ProxyConfig;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.junit.Assert;
@@ -38,6 +45,11 @@ public class DefaultMessagingProcessorTest extends BaseProcessorTest {
     @Before
     public void before() throws Throwable {
         super.before();
+        ProxyConfig proxyConfig = ConfigurationManager.getProxyConfig();
+        proxyConfig.setProducerProcessorThreadPoolNums(1);
+        proxyConfig.setProducerProcessorThreadPoolQueueCapacity(1);
+        proxyConfig.setConsumerProcessorThreadPoolNums(1);
+        proxyConfig.setConsumerProcessorThreadPoolQueueCapacity(1);
         this.defaultMessagingProcessor = new DefaultMessagingProcessor(this.serviceManager);
     }
 
@@ -106,5 +118,55 @@ public class DefaultMessagingProcessorTest extends BaseProcessorTest {
             () -> this.defaultMessagingProcessor.requestOneway(createContext(), "broker-a", request, 3000));
 
         Assert.assertEquals(originalOpaque, request.getOpaque());
+    }
+
+    @Test
+    public void testProcessorFutureCompletesWhenExecutorIsShutDown() {
+        defaultMessagingProcessor.producerProcessorExecutor.shutdown();
+        defaultMessagingProcessor.consumerProcessorExecutor.shutdown();
+
+        assertRejectedExecutor(FutureUtils.addExecutor(
+            CompletableFuture.completedFuture("value"),
+            defaultMessagingProcessor.producerProcessorExecutor));
+        assertRejectedExecutor(FutureUtils.addExecutor(
+            CompletableFuture.completedFuture("value"),
+            defaultMessagingProcessor.consumerProcessorExecutor));
+    }
+
+    @Test
+    public void testProcessorFutureCompletesWhenExecutorIsSaturated() throws Exception {
+        assertSaturatedExecutorRejectsCompletion(defaultMessagingProcessor.producerProcessorExecutor);
+        assertSaturatedExecutorRejectsCompletion(defaultMessagingProcessor.consumerProcessorExecutor);
+    }
+
+    private void assertSaturatedExecutorRejectsCompletion(ThreadPoolExecutor executor) throws Exception {
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        executor.execute(() -> {
+            workerStarted.countDown();
+            try {
+                releaseWorker.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        Assert.assertTrue(workerStarted.await(5, TimeUnit.SECONDS));
+        executor.execute(() -> {
+        });
+        Assert.assertEquals(0, executor.getQueue().remainingCapacity());
+
+        try {
+            assertRejectedExecutor(FutureUtils.addExecutor(CompletableFuture.completedFuture("value"), executor));
+        } finally {
+            releaseWorker.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private void assertRejectedExecutor(CompletableFuture<String> result) {
+        Assert.assertTrue("the returned future must not remain pending", result.isDone());
+        Assert.assertTrue(result.isCompletedExceptionally());
+        CompletionException exception = Assert.assertThrows(CompletionException.class, () -> result.join());
+        Assert.assertTrue(exception.getCause() instanceof RejectedExecutionException);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10739

### Brief Description

`FutureUtils.appendNextFuture` now retains the stage returned by `whenCompleteAsync` and propagates completion-task scheduling failures to the future returned to the caller.

The Proxy producer and consumer processor executors now use an explicit `AbortPolicy`. This is required because the shared default `DiscardOldestPolicy` can silently discard completion tasks during shutdown or saturation, leaving no rejection for `FutureUtils` to propagate. Other RocketMQ thread pools keep their existing rejection behavior.

Together, these changes ensure that Proxy request futures reach an exceptional terminal state instead of remaining pending when processor completion work is rejected.

### How Did You Test This Change?

- On the unmodified JDK 8 baseline, the helper-level and real producer-pool shutdown regressions each failed at the expected pending-future assertion in 5/5 runs.
- Added a deterministic real-pool saturation regression using one worker and one queue slot. Latches occupy the worker and fill the queue without sleeps or randomized scheduling.
- Temporarily restoring the old `DiscardOldestPolicy` made the saturation regression fail 1/1 at `the returned future must not remain pending`; restoring `AbortPolicy` made it pass.
- On the refreshed head, `FutureUtilsTest` passed 1/1 and `DefaultMessagingProcessorTest` passed 6/6. All 11 modules in the targeted `proxy -am` reactor succeeded with Checkstyle and SpotBugs enabled.
- The earlier full JDK 8 `proxy -am` test reactor also passed: Broker 752 tests (0 failures, 0 errors, 4 skipped) and Proxy 304 tests (0 failures, 0 errors, 3 skipped).
- `git diff --check` passed.
