### PR TITLE
[ISSUE #10671] Improve unsupported client type diagnostics

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -124,8 +124,10 @@ public class ClientActivity extends AbstractMessagingActivity {
                     break;
                 }
                 default: {
+                    log.warn("heartbeat rejected unsupported client type. clientId:{}, clientType:{}",
+                        ctx.getClientID(), clientSettings.getClientType());
                     future.complete(HeartbeatResponse.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.UNRECOGNIZED_CLIENT_TYPE, clientSettings.getClientType().name()))
+                        .setStatus(buildUnsupportedClientTypeStatus(clientSettings.getClientType()))
                         .build());
                     return future;
                 }
@@ -181,8 +183,10 @@ public class ClientActivity extends AbstractMessagingActivity {
                     }
                     break;
                 default:
+                    log.warn("client termination rejected unsupported client type. clientId:{}, clientType:{}",
+                        clientId, clientSettings.getClientType());
                     future.complete(NotifyClientTerminationResponse.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.UNRECOGNIZED_CLIENT_TYPE, clientSettings.getClientType().name()))
+                        .setStatus(buildUnsupportedClientTypeStatus(clientSettings.getClientType()))
                         .build());
                     return future;
             }
@@ -193,6 +197,12 @@ public class ClientActivity extends AbstractMessagingActivity {
             future.completeExceptionally(t);
         }
         return future;
+    }
+
+    private Status buildUnsupportedClientTypeStatus(ClientType clientType) {
+        String message = String.format("unsupported client type: %s. Proxy supports PRODUCER, PUSH_CONSUMER, "
+            + "SIMPLE_CONSUMER, LITE_PUSH_CONSUMER and LITE_SIMPLE_CONSUMER", clientType.name());
+        return ResponseBuilder.getInstance().buildStatus(Code.UNRECOGNIZED_CLIENT_TYPE, message);
     }
 
     public CompletableFuture<SyncLiteSubscriptionResponse> syncLiteSubscription(ProxyContext ctx,

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
@@ -212,6 +212,40 @@ public class ClientActivityTest extends BaseActivityTest {
         assertEquals("tag", data.getSubString());
     }
 
+    @Test
+    public void testHeartbeatWithUnsupportedClientType() throws Throwable {
+        ProxyContext context = createContext();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.CLIENT_TYPE_UNSPECIFIED)
+            .build();
+        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(settings);
+
+        HeartbeatResponse response = this.clientActivity.heartbeat(context, HeartbeatRequest.newBuilder()
+            .setClientType(ClientType.CLIENT_TYPE_UNSPECIFIED)
+            .build()).get();
+
+        assertEquals(Code.UNRECOGNIZED_CLIENT_TYPE, response.getStatus().getCode());
+        assertThat(response.getStatus().getMessage()).contains("unsupported client type: CLIENT_TYPE_UNSPECIFIED");
+        assertThat(response.getStatus().getMessage()).contains("Proxy supports");
+    }
+
+    @Test
+    public void testNotifyClientTerminationWithUnsupportedClientType() throws Throwable {
+        ProxyContext context = createContext();
+        Settings settings = Settings.newBuilder()
+            .setClientType(ClientType.CLIENT_TYPE_UNSPECIFIED)
+            .build();
+        when(this.grpcClientSettingsManager.removeAndGetClientSettings(any())).thenReturn(settings);
+
+        NotifyClientTerminationResponse response = this.clientActivity.notifyClientTermination(
+            context,
+            NotifyClientTerminationRequest.newBuilder().build()).get();
+
+        assertEquals(Code.UNRECOGNIZED_CLIENT_TYPE, response.getStatus().getCode());
+        assertThat(response.getStatus().getMessage()).contains("unsupported client type: CLIENT_TYPE_UNSPECIFIED");
+        assertThat(response.getStatus().getMessage()).contains("Proxy supports");
+    }
+
     protected void assertClientChannelInfo(ClientChannelInfo clientChannelInfo, String group) {
         assertEquals(LanguageCode.JAVA, clientChannelInfo.getLanguage());
         assertEquals(CLIENT_ID, clientChannelInfo.getClientId());


### PR DESCRIPTION
### Summary

- Return a clearer `UNRECOGNIZED_CLIENT_TYPE` status message when Proxy gRPC heartbeat rejects an unsupported client type.
- Return the same diagnostic from client termination when cached settings contain an unsupported client type.
- Add focused `ClientActivityTest` coverage for both paths.

### Motivation

Fixes #10671.

The previous response only echoed the enum name, for example `CLIENT_TYPE_UNSPECIFIED`, which does not explain why the Proxy rejected the client or which client types are accepted. This keeps the behavior compatible while making the rejection reason visible to clients and adding a Proxy-side warning log.

### Tests

- `git diff --check`
- `mvn -Dmaven.repo.local=$env:USERPROFILE\.m2\repository -pl proxy -am -Dtest=ClientActivityTest -DfailIfNoTests=false test`

Result: `ClientActivityTest` passed with 17 tests. The local JDK17 run emitted existing JaCoCo 0.8.5 instrumentation warnings for class file version 61, but Maven exited successfully and surefire reports 0 failures / 0 errors.