### PR TITLE
fix: guard NPE in NetworkUtil and concurrent read in IndexService

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java
@@ -193,6 +193,9 @@ public class NetworkUtil {
 
     public static SocketAddress string2SocketAddress(final String addr) {
         int split = addr.lastIndexOf(":");
+        if (split < 0) {
+            throw new IllegalArgumentException("Invalid socket address, missing ':': " + addr);
+        }
         String host = addr.substring(0, split);
         String port = addr.substring(split + 1);
         return new InetSocketAddress(host, Integer.parseInt(port));
@@ -201,7 +204,9 @@ public class NetworkUtil {
     public static String socketAddress2String(final SocketAddress addr) {
         StringBuilder sb = new StringBuilder();
         InetSocketAddress inetSocketAddress = (InetSocketAddress) addr;
-        sb.append(inetSocketAddress.getAddress().getHostAddress());
+        // getAddress() returns null when the hostname could not be resolved; fall back to the host string.
+        InetAddress address = inetSocketAddress.getAddress();
+        sb.append(address != null ? address.getHostAddress() : inetSocketAddress.getHostString());
         sb.append(":");
         sb.append(inetSocketAddress.getPort());
         return sb.toString();

--- a/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
@@ -92,11 +92,16 @@ public class IndexService implements CommitLogDispatchStore {
     }
 
     public long getTotalSize() {
-        if (indexFileList.isEmpty()) {
-            return 0;
-        }
+        this.readWriteLock.readLock().lock();
+        try {
+            if (indexFileList.isEmpty()) {
+                return 0;
+            }
 
-        return (long) indexFileList.get(0).getFileSize() * indexFileList.size();
+            return (long) indexFileList.get(0).getFileSize() * indexFileList.size();
+        } finally {
+            this.readWriteLock.readLock().unlock();
+        }
     }
 
     public void deleteExpiredFile(long offset) {


### PR DESCRIPTION
### Motivation

Three edge-case bugs found by code review (verified against the current develop branch):

1. **`NetworkUtil.socketAddress2String` NPE** (`common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java`)
   `InetSocketAddress.getAddress()` returns `null` when the hostname could not be resolved, so `getAddress().getHostAddress()` threw `NullPointerException`. This util is used across broker/namesrv/tools. Fall back to `getHostString()` when the address is null.

2. **`NetworkUtil.string2SocketAddress` StringIndexOutOfBoundsException**
   An address without `:` makes `lastIndexOf(":")` return `-1`, and `substring(0, -1)` throws `StringIndexOutOfBoundsException`. Throw a clear `IllegalArgumentException` instead.

3. **`IndexService.getTotalSize` concurrent read** (`store/src/main/java/org/apache/rocketmq/store/index/IndexService.java`)
   `indexFileList` is a plain `ArrayList` guarded by `readWriteLock` in every other accessor, but `getTotalSize` read it without the lock. A concurrent `destroy()`/`deleteExpiredFile()` could clear the list between the `isEmpty()` check and `get(0)`, causing `IndexOutOfBoundsException`. Acquire the read lock.

### Verification

`mvn -pl broker -am compile` passes on the build server.

### Diff

2 files changed, +15 / -5.