### PR TITLE
fix: guard NPE in TopicRouteWrapper when brokerName is absent from the route

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/TopicRouteWrapper.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/TopicRouteWrapper.java
@@ -43,11 +43,19 @@ public class TopicRouteWrapper {
     }
 
     public String getMasterAddr(String brokerName) {
-        return this.brokerNameRouteData.get(brokerName).getBrokerAddrs().get(MixAll.MASTER_ID);
+        BrokerData brokerData = this.brokerNameRouteData.get(brokerName);
+        if (brokerData == null) {
+            return null;
+        }
+        return brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
     }
 
     public String getMasterAddrPrefer(String brokerName) {
-        HashMap<Long, String> brokerAddr = brokerNameRouteData.get(brokerName).getBrokerAddrs();
+        BrokerData brokerData = brokerNameRouteData.get(brokerName);
+        if (brokerData == null) {
+            return null;
+        }
+        HashMap<Long, String> brokerAddr = brokerData.getBrokerAddrs();
         String addr = brokerAddr.get(MixAll.MASTER_ID);
         if (addr == null) {
             Optional<Long> optional = brokerAddr.keySet().stream().findFirst();


### PR DESCRIPTION
### Motivation

`TopicRouteWrapper.getMasterAddr` and `getMasterAddrPrefer` called `brokerNameRouteData.get(brokerName).getBrokerAddrs()` without a null check. When `brokerName` is not present in the current route snapshot (e.g. during broker failover, or a stale `MessageQueue` referencing a broker no longer in the route), `get(brokerName)` returns `null` and the chained `getBrokerAddrs()` throws `NullPointerException`.

This contradicts the contract the callers rely on. In `MessageQueueSelector.buildRead`/`buildWrite` and `ClusterTopicRouteService`, every call site checks the return value for `null` and skips the broker:

```java
String brokerAddr = topicRoute.getMasterAddr(qd.getBrokerName());
if (brokerAddr == null) {
    continue;
}
```

So these methods are *supposed* to return `null` for a missing broker, but instead they throw. The fix guards the lookup and returns `null`, making the existing caller handling work as intended.

### Verification

`mvn -pl proxy -am compile` passes on the build server.

### Diff

1 file changed, +10 / -2.