### PR TITLE
[ISSUE #10745] Close both HTTP/2 proxy channels on failure

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyBackendHandler.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyBackendHandler.java
@@ -51,6 +51,7 @@ public class Http2ProxyBackendHandler extends ChannelInboundHandlerAdapter {
                     ctx.channel().read();
                 } else {
                     future.channel().close();
+                    ctx.channel().close();
                 }
             }
         });
@@ -65,5 +66,6 @@ public class Http2ProxyBackendHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         log.error("Http2ProxyBackendHandler#exceptionCaught", cause);
         Http2ProxyFrontendHandler.closeOnFlush(ctx.channel());
+        Http2ProxyFrontendHandler.closeOnFlush(inboundChannel);
     }
 }


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/42681543.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Closed both sides of an HTTP/2 proxy connection when a backend write or handler fails.

Issue: https://github.com/apache/rocketmq/issues/10745

