### PR TITLE
[ISSUE #10750] Fix POP lock cleanup race

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerLockService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerLockService.java
@@ -16,16 +16,13 @@
  */
 package org.apache.rocketmq.broker.pop;
 
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.rocketmq.common.KeyBuilder;
 import org.apache.rocketmq.common.PopAckConstants;
 import org.apache.rocketmq.common.constant.LoggerName;
-import org.apache.rocketmq.common.utils.ConcurrentHashMapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +39,13 @@ public class PopConsumerLockService {
     }
 
     public boolean tryLock(String key) {
-        return Objects.requireNonNull(ConcurrentHashMapUtils.computeIfAbsent(lockTable,
-            key, s -> new TimedLock())).tryLock();
+        AtomicBoolean locked = new AtomicBoolean(false);
+        lockTable.compute(key, (k, currentLock) -> {
+            TimedLock lock = currentLock == null ? new TimedLock() : currentLock;
+            locked.set(lock.tryLock());
+            return lock;
+        });
+        return locked.get();
     }
 
     public boolean tryLock(String groupId, String topicId) {
@@ -69,13 +71,22 @@ public class PopConsumerLockService {
     }
 
     public void removeTimeout() {
-        Iterator<Map.Entry<String, TimedLock>> iterator = lockTable.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, TimedLock> entry = iterator.next();
-            if (System.currentTimeMillis() - entry.getValue().getLockTime() > timeout) {
+        for (Map.Entry<String, TimedLock> entry : lockTable.entrySet()) {
+            if (System.currentTimeMillis() - entry.getValue().getLockTime() <= timeout) {
+                continue;
+            }
+
+            TimedLock[] removedLock = new TimedLock[1];
+            lockTable.computeIfPresent(entry.getKey(), (key, currentLock) -> {
+                if (System.currentTimeMillis() - currentLock.getLockTime() > timeout) {
+                    removedLock[0] = currentLock;
+                    return null;
+                }
+                return currentLock;
+            });
+            if (removedLock[0] != null) {
                 log.info("PopConsumerLockService remove timeout lock, " +
-                    "key={}, locked={}", entry.getKey(), entry.getValue().lock.get());
-                iterator.remove();
+                    "key={}, locked={}", entry.getKey(), removedLock[0].lock.get());
             }
         }
     }

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerLockServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerLockServiceTest.java
@@ -18,6 +18,10 @@ package org.apache.rocketmq.broker.pop;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.common.PopAckConstants;
 import org.junit.Assert;
@@ -56,5 +60,60 @@ public class PopConsumerLockServiceTest {
         lockService.removeTimeout();
 
         Assert.assertEquals(0, table.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void removeTimeoutShouldNotRemoveReacquiredLock() throws Exception {
+        String key = "groupId" + PopAckConstants.SPLIT + "topicId";
+        PopConsumerLockService lockService =
+            new PopConsumerLockService(TimeUnit.MINUTES.toMillis(2));
+
+        Field tableField = PopConsumerLockService.class.getDeclaredField("lockTable");
+        tableField.setAccessible(true);
+        Map<String, PopConsumerLockService.TimedLock> table =
+            (Map<String, PopConsumerLockService.TimedLock>) tableField.get(lockService);
+
+        CountDownLatch timeoutObserved = new CountDownLatch(1);
+        CountDownLatch continueCleanup = new CountDownLatch(1);
+        PopConsumerLockService.TimedLock expiredLock = new PopConsumerLockService.TimedLock() {
+            @Override
+            public long getLockTime() {
+                long observedLockTime = super.getLockTime();
+                timeoutObserved.countDown();
+                try {
+                    if (!continueCleanup.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting to continue lock cleanup");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+                return observedLockTime;
+            }
+        };
+
+        Field lockTimeField = PopConsumerLockService.TimedLock.class.getDeclaredField("lockTime");
+        lockTimeField.setAccessible(true);
+        lockTimeField.setLong(expiredLock, 0L);
+        table.put(key, expiredLock);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> cleanup = executor.submit(lockService::removeTimeout);
+            Assert.assertTrue("Cleanup did not inspect the expired lock",
+                timeoutObserved.await(5, TimeUnit.SECONDS));
+
+            Assert.assertTrue("The expired lock should be reacquired before cleanup continues",
+                lockService.tryLock(key));
+            continueCleanup.countDown();
+            cleanup.get(5, TimeUnit.SECONDS);
+
+            Assert.assertFalse("Cleanup removed the reacquired lock and allowed a second holder",
+                lockService.tryLock(key));
+        } finally {
+            continueCleanup.countDown();
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10750

### Brief Description

`PopConsumerLockService.removeTimeout()` previously made its expiration decision before removing the map entry. A concurrent `tryLock()` could reacquire the same `TimedLock` and refresh its timestamp after that decision, but cleanup would still remove the refreshed entry and allow a second holder to be created.

This change makes acquisition/refresh and the authoritative cleanup recheck atomic for each key:

- `tryLock()` uses `ConcurrentHashMap.compute()` to select/create and acquire the mapped lock within the per-key remapping boundary.
- `removeTimeout()` uses `computeIfPresent()` to recheck the current lock timestamp before removing it.
- Existing behavior for leases that remain expired at the authoritative recheck is preserved.

### How Did You Test This Change?

- Unmodified `develop`: the deterministic latch regression failed in 5/5 isolated JDK 8 Maven processes; an independent rerun also failed 5/5.
- Fixed targeted test class: 20 isolated JDK 8 Maven processes, 2/2 each (40/40 total).
- Full `broker -am test`: all 10 reactor modules passed; broker ran 753 tests with 0 failures, 0 errors, and 4 skips.
- Checkstyle: 0 violations.
- SpotBugs: 0 bugs/errors.
- `git diff --check`: passed.

### Applicability and performance boundary

The lock service is used by the POP KV consumer service and the Lite POP path. `popConsumerKVServiceEnable` defaults to `false`; this is not a claim that every POP deployment uses the affected lock. The race requires an expired-entry cleanup decision to overlap with successful reacquisition of that key. Expiration semantics for a lease that remains expired are intentionally unchanged.

The patch introduces map remapping on acquisition and a per-attempt result holder. The regression establishes the mutual-exclusion repair, not a throughput improvement or zero overhead. Same-key contention, allocation rate and unaffected traffic should be considered in a representative load test before making performance claims.
