### PR TITLE
[ISSUE #10748] Fix unsupported ProxyChannel command completion

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/relay/ProxyChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/relay/ProxyChannel.java
@@ -111,6 +111,8 @@ public abstract class ProxyChannel extends SimpleChannel {
                         break;
                     }
                     default:
+                        processFuture.completeExceptionally(new UnsupportedOperationException(
+                            "Unsupported remoting command code: " + command.getCode()));
                         break;
                 }
             } else {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/relay/ProxyChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/relay/ProxyChannelTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.proxy.service.relay;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +26,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.rocketmq.common.message.MessageClientIDSetter;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.utils.ExceptionUtils;
 import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.proxy.service.transaction.TransactionData;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
@@ -43,9 +45,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -159,5 +164,57 @@ public class ProxyChannelTest {
         assertTrue(channel.writeAndFlush(checkTransactionRequest).isSuccess());
         assertTrue(channel.writeAndFlush(consumerRunningInfoRequest).isSuccess());
         assertTrue(channel.writeAndFlush(consumeMessageDirectlyResult).isSuccess());
+    }
+
+    @Test
+    public void testWriteAndFlushUnsupportedRemotingCommandCompletesWithFailure() {
+        MockProxyChannel channel = new MockProxyChannel(this.proxyRelayService, null,
+            "127.0.0.2:8888", "127.0.0.1:10911") {
+            @Override
+            protected CompletableFuture<Void> processOtherMessage(Object msg) {
+                throw new AssertionError("unexpected other message");
+            }
+
+            @Override
+            protected CompletableFuture<Void> processCheckTransaction(CheckTransactionStateRequestHeader header,
+                MessageExt messageExt, TransactionData transactionData,
+                CompletableFuture<ProxyRelayResult<Void>> responseFuture) {
+                throw new AssertionError("unexpected transaction check");
+            }
+
+            @Override
+            protected CompletableFuture<Void> processNotifyUnsubscribeLite(
+                NotifyUnsubscribeLiteRequestHeader header) {
+                throw new AssertionError("unexpected unsubscribe notification");
+            }
+
+            @Override
+            protected CompletableFuture<Void> processGetConsumerRunningInfo(RemotingCommand command,
+                GetConsumerRunningInfoRequestHeader header,
+                CompletableFuture<ProxyRelayResult<ConsumerRunningInfo>> responseFuture) {
+                throw new AssertionError("unexpected consumer running info request");
+            }
+
+            @Override
+            protected CompletableFuture<Void> processConsumeMessageDirectly(RemotingCommand command,
+                ConsumeMessageDirectlyResultRequestHeader header, MessageExt messageExt,
+                CompletableFuture<ProxyRelayResult<ConsumeMessageDirectlyResult>> responseFuture) {
+                throw new AssertionError("unexpected direct consumption request");
+            }
+        };
+
+        int unsupportedCode = Integer.MAX_VALUE;
+        RemotingCommand unsupportedCommand = RemotingCommand.createRequestCommand(unsupportedCode, null);
+        ChannelFuture future = channel.writeAndFlush(unsupportedCommand);
+
+        assertTrue("unsupported command future should be completed", future.isDone());
+        assertFalse("unsupported command future should fail", future.isSuccess());
+        assertNotNull("unsupported command failure should have a cause", future.cause());
+        Throwable failure = ExceptionUtils.getRealException(future.cause());
+        assertTrue("unsupported command should fail with UnsupportedOperationException",
+            failure instanceof UnsupportedOperationException);
+        assertTrue("failure should identify the unsupported command code",
+            failure.getMessage().contains(String.valueOf(unsupportedCode)));
+        verifyNoInteractions(proxyRelayService);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10748

### Brief Description

`ProxyChannel.writeAndFlush()` created an incomplete `processFuture` before dispatching a `RemotingCommand`, but the `default` switch branch only broke out of the switch. No producer remained that could complete the future, so the returned channel future stayed pending forever.

This change:

- completes the existing processing future exceptionally for unsupported remoting command codes;
- includes the unsupported request code in the failure for diagnosis;
- keeps relay services untouched for commands that have no supported dispatch path;
- reports that the command was not delivered instead of returning success or waiting for a response that cannot arrive.

### How Did You Test This Change?

- Unmodified `develop`: the deterministic strengthened regression failed in 5/5 isolated JDK 8 Maven processes.
- Fixed regression: 20 isolated Maven/JVM processes at 1/1 each (20/20 total).
- Complete `proxy -am` reactor: all 11 modules passed with 0 failures and 0 errors.
- Project Checkstyle: 0 violations.
- SpotBugs: 0 bug instances and 0 errors.
- Maven validate: passed.
- `git diff --check`: passed.

### Compatibility and Failure Semantics

Supported `RemotingCommand` branches and non-`RemotingCommand` messages are unchanged. Only the unsupported request-code branch changes: instead of leaving the returned `ChannelFuture` pending forever, it now completes exceptionally and does not invoke a relay service, allowing callers to observe that the command was not delivered.
