### PR TITLE
[ISSUE #10756] Fix duplicate dispatch ConsumeQueueExt leak

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -727,7 +727,7 @@ public class ConsumeQueue implements ConsumeQueueInterface {
         boolean canWrite = this.messageStore.getRunningFlags().isCQWriteable();
         for (int i = 0; i < maxRetries && canWrite; i++) {
             long tagsCode = request.getTagsCode();
-            if (isExtWriteEnable()) {
+            if (isExtWriteEnable() && !isDispatchAlreadyApplied(request.getCommitLogOffset(), request.getMsgSize())) {
                 ConsumeQueueExt.CqExtUnit cqExtUnit = new ConsumeQueueExt.CqExtUnit();
                 cqExtUnit.setFilterBitMap(request.getBitMap());
                 cqExtUnit.setMsgStoreTime(request.getStoreTimestamp());
@@ -836,7 +836,7 @@ public class ConsumeQueue implements ConsumeQueueInterface {
     private boolean putMessagePositionInfo(final long offset, final int size, final long tagsCode,
         final long cqOffset) {
 
-        if (offset + size <= this.getMaxPhysicOffset()) {
+        if (isDispatchAlreadyApplied(offset, size)) {
             // During the recovery process after broker crashes, this logs will cause the scrolling of valid logs.
             if (messageStore.getStateMachine().getCurrentState().isAfter(MessageStoreStateMachine.MessageStoreState.RECOVER_COMMITLOG_OK) ||
                 messageStore.getMessageStoreConfig().isEnableLogConsumeQueueRepeatedlyBuildWhenRecover()) {
@@ -904,6 +904,10 @@ public class ConsumeQueue implements ConsumeQueueInterface {
             }
         }
         return false;
+    }
+
+    private boolean isDispatchAlreadyApplied(final long offset, final int size) {
+        return offset + size <= this.getMaxPhysicOffset();
     }
 
     private void fillPreBlank(final MappedFile mappedFile, final long untilWhere) {

--- a/store/src/test/java/org/apache/rocketmq/store/ConsumeQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/ConsumeQueueTest.java
@@ -775,4 +775,62 @@ public class ConsumeQueueTest {
             FileUtils.deleteQuietly(tmpDir);
         }
     }
+
+    @Test
+    public void testDuplicateDispatchDoesNotLeaveConsumeQueueExtOrphan() throws IOException {
+        File tmpDir = Files.createTempDirectory("duplicate-cq-ext").toFile();
+        MessageStoreConfig storeConfig = new MessageStoreConfig();
+        storeConfig.setStorePathRootDir(tmpDir.getAbsolutePath());
+        storeConfig.setMappedFileSizeConsumeQueue(4 * ConsumeQueue.CQ_STORE_UNIT_SIZE);
+        storeConfig.setMappedFileSizeConsumeQueueExt(10 * ConsumeQueueExt.CqExtUnit.MIN_EXT_UNIT_SIZE);
+        storeConfig.setEnableConsumeQueueExt(true);
+        DefaultMessageStore messageStore = Mockito.mock(DefaultMessageStore.class);
+        Mockito.when(messageStore.getMessageStoreConfig()).thenReturn(storeConfig);
+        Mockito.when(messageStore.getRunningFlags()).thenReturn(new RunningFlags());
+        Mockito.when(messageStore.getStoreCheckpoint()).thenReturn(Mockito.mock(StoreCheckpoint.class));
+        Mockito.when(messageStore.getStateMachine()).thenReturn(new MessageStoreStateMachine(null));
+
+        ConsumeQueue consumeQueue = new ConsumeQueue("duplicateExtTopic", 0, tmpDir.getAbsolutePath(),
+            storeConfig.getMappedFileSizeConsumeQueue(), messageStore);
+        ConsumeQueue reloadedConsumeQueue = null;
+        try {
+            DispatchRequest first = new DispatchRequest("duplicateExtTopic", 0, 0, 10,
+                100, 1000, 0, null, null, 0, 0, null);
+            consumeQueue.putMessagePositionInfoWrapper(first);
+            long firstExtAddress = getRawTagsCode(consumeQueue, 0);
+
+            consumeQueue.putMessagePositionInfoWrapper(first);
+
+            DispatchRequest second = new DispatchRequest("duplicateExtTopic", 0, 100, 10,
+                200, 2000, 1, null, null, 0, 0, null);
+            consumeQueue.putMessagePositionInfoWrapper(second);
+            long secondExtAddress = getRawTagsCode(consumeQueue, 1);
+            long expectedSecondExtAddress = firstExtAddress + ConsumeQueueExt.CqExtUnit.MIN_EXT_UNIT_SIZE;
+            consumeQueue.flush(0);
+
+            reloadedConsumeQueue = new ConsumeQueue("duplicateExtTopic", 0, tmpDir.getAbsolutePath(),
+                storeConfig.getMappedFileSizeConsumeQueue(), messageStore);
+            Assert.assertTrue(reloadedConsumeQueue.load());
+            reloadedConsumeQueue.recover();
+
+            Assert.assertEquals(200, reloadedConsumeQueue.getExt(expectedSecondExtAddress).getTagsCode());
+            Assert.assertEquals(expectedSecondExtAddress, secondExtAddress);
+        } finally {
+            consumeQueue.destroy();
+            if (reloadedConsumeQueue != null) {
+                reloadedConsumeQueue.destroy();
+            }
+            FileUtils.deleteQuietly(tmpDir);
+        }
+    }
+
+    private long getRawTagsCode(ConsumeQueue consumeQueue, long queueOffset) {
+        SelectMappedBufferResult result = consumeQueue.getIndexBuffer(queueOffset);
+        Assert.assertNotNull(result);
+        try {
+            return result.getByteBuffer().getLong(12);
+        } finally {
+            result.release();
+        }
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10756

### Brief Description

`ConsumeQueue.putMessagePositionInfoWrapper()` allocated a `ConsumeQueueExt` unit before the main CQ idempotency check. Replaying a duplicate dispatch therefore skipped the CQ append but still left an unreferenced Ext unit, which a later valid dispatch could seal inside the live Ext range.

This change reuses the main CQ physical-end idempotency predicate before allocating an Ext unit. Duplicate replay still follows the existing successful wrapper path, so checkpoint advancement and multi-dispatch behavior are preserved while the orphan allocation is avoided.

### How Did You Test This Change?

- Unmodified `develop`: the deterministic duplicate-dispatch regression failed in 5/5 isolated JDK 8 Maven processes.
- Fixed targeted regression: 20 isolated Maven/JVM processes, 1/1 each (20/20 total).
- Complete `ConsumeQueueTest`: 11/11.
- Full `store -am test`: common 241/241, remoting 174/174, and store 314 tests with 4 skips, 0 failures, and 0 errors.
- Maven validate and Checkstyle: 0 violations.
- SpotBugs: 0 bugs/errors across all four reactor modules.
- `git diff --check`: passed.

### Scope and Concurrency

The new guard reuses the physical-end idempotency predicate already applied by `putMessagePositionInfo()` on the same dispatch attempt. It introduces no new shared state or locking and leaves supported writes, checkpoint advancement, retries, and multi-dispatch handling unchanged. This PR is scoped to duplicate re-dispatch; cleanup after a genuine Ext-append/CQ-append failure remains a separate failure mode.

### Applicability and user-visible impact

`enableConsumeQueueExt` defaults to `false`. The affected path requires CQExt writes and duplicate Broker dispatch/recovery of an already-indexed physical message. This is internal index-build idempotency, not producer retry deduplication or an exactly-once delivery feature.

The demonstrated impact is unreferenced extension allocation and extra storage retained in the live Ext range. It is not evidence of lost message bodies or permanent retention under every cleanup policy. Total disk cost and eventual reclamation depend on duplicate volume, mapped-file boundaries and normal retention cleanup; no production byte estimate or occurrence rate is claimed.
