### PR TITLE
[ISSUE #10760] Avoid logging full system message data

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/AbstractSystemMessageSyncer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/AbstractSystemMessageSyncer.java
@@ -93,7 +93,7 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
 
     protected void sendSystemMessage(Object data) {
         String targetTopic = this.getBroadcastTopicName();
-        String dataSummary = summarizeSystemMessageData(data);
+        String dataSummary = safelySummarizeSystemMessageData(data);
         try {
             Message message = new Message(
                 targetTopic,
@@ -111,12 +111,12 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
             ).whenCompleteAsync((result, throwable) -> {
                 if (throwable != null) {
                     log.error("send system message failed. dataSummary: {}, topic: {}",
-                        dataSummary, getBroadcastTopicName(), throwable);
+                        dataSummary, targetTopic, throwable);
                     return;
                 }
                 if (SendStatus.SEND_OK != result.getSendStatus()) {
                     log.error("send system message failed. dataSummary: {}, topic: {}, sendResult:{}",
-                        dataSummary, getBroadcastTopicName(), result);
+                        dataSummary, targetTopic, result);
                 }
             });
         } catch (Throwable t) {
@@ -134,13 +134,20 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
                 ? 0 : heartbeatData.getSubscriptionDataSet().size();
             return "HeartbeatSyncerData{"
                 + "heartbeatType=" + heartbeatData.getHeartbeatType()
-                + ", clientId=" + heartbeatData.getClientId()
-                + ", group=" + heartbeatData.getGroup()
                 + ", subscriptionCount=" + subscriptionCount
                 + ", channelDataPresent=" + (heartbeatData.getChannelData() != null)
                 + '}';
         }
-        return data.getClass().getSimpleName();
+        String simpleName = data.getClass().getSimpleName();
+        return StringUtils.isEmpty(simpleName) ? data.getClass().getName() : simpleName;
+    }
+
+    static String safelySummarizeSystemMessageData(Object data) {
+        try {
+            return summarizeSystemMessageData(data);
+        } catch (Throwable ignored) {
+            return "unavailable";
+        }
     }
 
     protected SendMessageRequestHeader buildSendMessageRequestHeader(Message message,

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/AbstractSystemMessageSyncer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/sysmessage/AbstractSystemMessageSyncer.java
@@ -93,6 +93,7 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
 
     protected void sendSystemMessage(Object data) {
         String targetTopic = this.getBroadcastTopicName();
+        String dataSummary = summarizeSystemMessageData(data);
         try {
             Message message = new Message(
                 targetTopic,
@@ -109,16 +110,37 @@ public abstract class AbstractSystemMessageSyncer implements StartAndShutdown, M
                 Duration.ofSeconds(3).toMillis()
             ).whenCompleteAsync((result, throwable) -> {
                 if (throwable != null) {
-                    log.error("send system message failed. data: {}, topic: {}", data, getBroadcastTopicName(), throwable);
+                    log.error("send system message failed. dataSummary: {}, topic: {}",
+                        dataSummary, getBroadcastTopicName(), throwable);
                     return;
                 }
                 if (SendStatus.SEND_OK != result.getSendStatus()) {
-                    log.error("send system message failed. data: {}, topic: {}, sendResult:{}", data, getBroadcastTopicName(), result);
+                    log.error("send system message failed. dataSummary: {}, topic: {}, sendResult:{}",
+                        dataSummary, getBroadcastTopicName(), result);
                 }
             });
         } catch (Throwable t) {
-            log.error("send system message failed. data: {}, topic: {}", data, targetTopic, t);
+            log.error("send system message failed. dataSummary: {}, topic: {}", dataSummary, targetTopic, t);
         }
+    }
+
+    static String summarizeSystemMessageData(Object data) {
+        if (data == null) {
+            return "null";
+        }
+        if (data instanceof HeartbeatSyncerData) {
+            HeartbeatSyncerData heartbeatData = (HeartbeatSyncerData) data;
+            int subscriptionCount = heartbeatData.getSubscriptionDataSet() == null
+                ? 0 : heartbeatData.getSubscriptionDataSet().size();
+            return "HeartbeatSyncerData{"
+                + "heartbeatType=" + heartbeatData.getHeartbeatType()
+                + ", clientId=" + heartbeatData.getClientId()
+                + ", group=" + heartbeatData.getGroup()
+                + ", subscriptionCount=" + subscriptionCount
+                + ", channelDataPresent=" + (heartbeatData.getChannelData() != null)
+                + '}';
+        }
+        return data.getClass().getSimpleName();
     }
 
     protected SendMessageRequestHeader buildSendMessageRequestHeader(Message message,

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncerTest.java
@@ -77,6 +77,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -215,6 +216,35 @@ public class HeartbeatSyncerTest extends InitConfigTest {
         heartbeatSyncer.localProxyId = RandomStringUtils.randomAlphabetic(10);
         heartbeatSyncer.consumeMessage(Lists.newArrayList(convertFromMessage(messageArgumentCaptor.getAllValues().get(1))), null);
         assertSame(channelInfoList.get(0).getChannel(), syncUnRegisterChannelInfoArgumentCaptor.getValue().getChannel());
+    }
+
+    @Test
+    public void testSummarizeSystemMessageDataAvoidsDetailedHeartbeatPayload() throws Exception {
+        HeartbeatSyncerData data = new HeartbeatSyncerData(
+            HeartbeatType.REGISTER,
+            clientId,
+            LanguageCode.JAVA,
+            5,
+            "sensitiveGroup",
+            ConsumeType.CONSUME_PASSIVELY,
+            MessageModel.CLUSTERING,
+            ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET,
+            "localProxyId",
+            "sensitiveChannelData"
+        );
+        data.setSubscriptionDataSet(Sets.newHashSet(FilterAPI.buildSubscriptionData("sensitiveTopic", "sensitiveTag")));
+
+        String summary = AbstractSystemMessageSyncer.summarizeSystemMessageData(data);
+
+        assertTrue(summary.contains("HeartbeatSyncerData"));
+        assertTrue(summary.contains("heartbeatType=REGISTER"));
+        assertTrue(summary.contains("clientId=" + clientId));
+        assertTrue(summary.contains("group=sensitiveGroup"));
+        assertTrue(summary.contains("subscriptionCount=1"));
+        assertTrue(summary.contains("channelDataPresent=true"));
+        assertFalse(summary.contains("sensitiveTopic"));
+        assertFalse(summary.contains("sensitiveTag"));
+        assertFalse(summary.contains("sensitiveChannelData"));
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/sysmessage/HeartbeatSyncerTest.java
@@ -238,13 +238,33 @@ public class HeartbeatSyncerTest extends InitConfigTest {
 
         assertTrue(summary.contains("HeartbeatSyncerData"));
         assertTrue(summary.contains("heartbeatType=REGISTER"));
-        assertTrue(summary.contains("clientId=" + clientId));
-        assertTrue(summary.contains("group=sensitiveGroup"));
         assertTrue(summary.contains("subscriptionCount=1"));
         assertTrue(summary.contains("channelDataPresent=true"));
+        assertFalse(summary.contains(clientId));
+        assertFalse(summary.contains("sensitiveGroup"));
         assertFalse(summary.contains("sensitiveTopic"));
         assertFalse(summary.contains("sensitiveTag"));
         assertFalse(summary.contains("sensitiveChannelData"));
+    }
+
+    @Test
+    public void testSummarizeSystemMessageDataUsesClassNameForAnonymousPayload() {
+        Object data = new Object() {
+        };
+
+        assertEquals(data.getClass().getName(), AbstractSystemMessageSyncer.summarizeSystemMessageData(data));
+    }
+
+    @Test
+    public void testSafelySummarizeSystemMessageDataDoesNotPropagateFailures() {
+        HeartbeatSyncerData data = new HeartbeatSyncerData() {
+            @Override
+            public Set<SubscriptionData> getSubscriptionDataSet() {
+                throw new IllegalStateException("summary failure");
+            }
+        };
+
+        assertEquals("unavailable", AbstractSystemMessageSyncer.safelySummarizeSystemMessageData(data));
     }
 
     @Test


### PR DESCRIPTION
Fixes #10760.

### What changed
- Replace full system-message `data` logging in `AbstractSystemMessageSyncer` failure paths with a compact `dataSummary`.
- Summarize `HeartbeatSyncerData` without dumping subscription details or channel data.
- Add regression coverage for the summary output.

### Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -Dtest=HeartbeatSyncerTest test`