### PR TITLE
[ISSUE #10762] Avoid exposing RemoteChannel extend attribute

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannel.java
@@ -110,7 +110,8 @@ public class RemoteChannel extends SimpleChannel implements ChannelExtendAttribu
             .add("channelId", id())
             .add("type", type)
             .add("remoteProxyIp", remoteProxyIp)
-            .add("extendAttribute", extendAttribute)
+            .add("extendAttributePresent", extendAttribute != null)
+            .add("extendAttributeLength", extendAttribute == null ? 0 : extendAttribute.length())
             .toString();
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannel.java
@@ -106,12 +106,13 @@ public class RemoteChannel extends SimpleChannel implements ChannelExtendAttribu
 
     @Override
     public String toString() {
+        String extendAttributeSnapshot = this.extendAttribute;
         return MoreObjects.toStringHelper(this)
             .add("channelId", id())
             .add("type", type)
             .add("remoteProxyIp", remoteProxyIp)
-            .add("extendAttributePresent", extendAttribute != null)
-            .add("extendAttributeLength", extendAttribute == null ? 0 : extendAttribute.length())
+            .add("extendAttributePresent", extendAttributeSnapshot != null)
+            .add("extendAttributeLength", extendAttributeSnapshot == null ? 0 : extendAttributeSnapshot.length())
             .toString();
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/channel/RemoteChannelTest.java
@@ -21,8 +21,10 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class RemoteChannelTest {
 
@@ -46,5 +48,23 @@ public class RemoteChannelTest {
         assertEquals(extendAttribute, decodedChannel.extendAttribute);
 
         assertNull(RemoteChannel.decode(""));
+    }
+
+    @Test
+    public void testToStringDoesNotExposeExtendAttribute() {
+        String extendAttribute = "sensitive-client-settings";
+        RemoteChannel remoteChannel = new RemoteChannel(
+            "11.193.0.1",
+            "10.152.39.53:9768",
+            "11.193.0.1:1210",
+            ChannelProtocolType.GRPC_V2,
+            extendAttribute
+        );
+
+        String output = remoteChannel.toString();
+
+        assertFalse(output.contains(extendAttribute));
+        assertTrue(output.contains("extendAttributePresent=true"));
+        assertTrue(output.contains("extendAttributeLength=" + extendAttribute.length()));
     }
 }


### PR DESCRIPTION
Fixes #10762.

### What changed
- Stop including raw `extendAttribute` in `RemoteChannel.toString()`.
- Keep diagnostic signal through `extendAttributePresent` and `extendAttributeLength`.
- Add regression coverage to ensure the raw attribute is not exposed.

### Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -Dtest=RemoteChannelTest test`