### PR TITLE
[ISSUE #10764] Complete expired invocation futures

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationChannel.java
@@ -65,11 +65,14 @@ public class InvocationChannel extends SimpleChannel {
     public void clearExpireContext() {
         Iterator<Map.Entry<Integer, InvocationContextInterface>> iterator = inFlightRequestMap.entrySet().iterator();
         int count = 0;
+        long expirationSeconds = ConfigurationManager.getProxyConfig().getChannelExpiredInSeconds();
         while (iterator.hasNext()) {
             Map.Entry<Integer, InvocationContextInterface> entry = iterator.next();
-            if (entry.getValue().expired(ConfigurationManager.getProxyConfig().getChannelExpiredInSeconds())) {
+            if (entry.getValue().expired(expirationSeconds)) {
                 iterator.remove();
-                entry.getValue().expire(new RemotingTimeoutException("Invocation context expired. opaque=" + entry.getKey()));
+                entry.getValue().expire(new RemotingTimeoutException("Invocation context expired after "
+                    + expirationSeconds + " seconds. opaque=" + entry.getKey() + ", remoteAddress="
+                    + remoteAddress + ", localAddress=" + localAddress));
                 count++;
                 log.debug("An expired request is found, request: {}", entry.getValue());
             }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationChannel.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationChannel.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 
 public class InvocationChannel extends SimpleChannel {
@@ -68,6 +69,7 @@ public class InvocationChannel extends SimpleChannel {
             Map.Entry<Integer, InvocationContextInterface> entry = iterator.next();
             if (entry.getValue().expired(ConfigurationManager.getProxyConfig().getChannelExpiredInSeconds())) {
                 iterator.remove();
+                entry.getValue().expire(new RemotingTimeoutException("Invocation context expired. opaque=" + entry.getKey()));
                 count++;
                 log.debug("An expired request is found, request: {}", entry.getValue());
             }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationContext.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationContext.java
@@ -40,4 +40,9 @@ public class InvocationContext implements InvocationContextInterface {
     public void handle(RemotingCommand remotingCommand) {
         response.complete(remotingCommand);
     }
+
+    @Override
+    public void expire(Throwable throwable) {
+        response.completeExceptionally(throwable);
+    }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationContextInterface.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationContextInterface.java
@@ -23,4 +23,7 @@ public interface InvocationContextInterface {
     void handle(RemotingCommand remotingCommand);
 
     boolean expired(long expiredTimeSec);
+
+    default void expire(Throwable throwable) {
+    }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationContextInterface.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/channel/InvocationContextInterface.java
@@ -24,6 +24,11 @@ public interface InvocationContextInterface {
 
     boolean expired(long expiredTimeSec);
 
+    /**
+     * Notifies a waiting invocation that its channel context has expired.
+     * Implementations that retain an asynchronous response future must override this method.
+     */
     default void expire(Throwable throwable) {
+        // Stateless contexts have no waiting caller to notify.
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/InvocationChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/InvocationChannelTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.proxy.service.channel;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
@@ -25,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class InvocationChannelTest {
@@ -86,6 +88,10 @@ public class InvocationChannelTest {
 
             assertFalse(channel.isWritable());
             assertTrue(responseFuture.isCompletedExceptionally());
+            CompletionException exception = assertThrows(CompletionException.class, responseFuture::join);
+            assertTrue(exception.getCause().getMessage().contains("after 0 seconds"));
+            assertTrue(exception.getCause().getMessage().contains("remoteAddress=127.0.0.1:8080"));
+            assertTrue(exception.getCause().getMessage().contains("localAddress=127.0.0.1:8081"));
         } finally {
             ConfigurationManager.getProxyConfig().setChannelExpiredInSeconds(originalExpiredInSeconds);
         }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/InvocationChannelTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/channel/InvocationChannelTest.java
@@ -17,15 +17,23 @@
 
 package org.apache.rocketmq.proxy.service.channel;
 
-import org.apache.rocketmq.remoting.protocol.RemotingCommand;
-import org.junit.Test;
-
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class InvocationChannelTest {
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ConfigurationManager.initEnv();
+        ConfigurationManager.initConfig();
+    }
 
     @Test
     public void testWriteAndFlushShouldNotRemoveReRegisteredContext() {
@@ -63,5 +71,23 @@ public class InvocationChannelTest {
         channel.writeAndFlush(response);
         assertTrue(nextContextHandled.get());
         assertFalse(channel.isWritable());
+    }
+
+    @Test
+    public void testClearExpireContextShouldCompleteResponseFutureExceptionally() {
+        int originalExpiredInSeconds = ConfigurationManager.getProxyConfig().getChannelExpiredInSeconds();
+        ConfigurationManager.getProxyConfig().setChannelExpiredInSeconds(0);
+        try {
+            InvocationChannel channel = new InvocationChannel("127.0.0.1:8080", "127.0.0.1:8081");
+            CompletableFuture<RemotingCommand> responseFuture = new CompletableFuture<>();
+            channel.registerInvocationContext(1, new InvocationContext(responseFuture));
+
+            channel.clearExpireContext();
+
+            assertFalse(channel.isWritable());
+            assertTrue(responseFuture.isCompletedExceptionally());
+        } finally {
+            ConfigurationManager.getProxyConfig().setChannelExpiredInSeconds(originalExpiredInSeconds);
+        }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10764

### Brief Description

`InvocationChannel.clearExpireContext()` now completes expired invocation contexts exceptionally before removing them from the in-flight request map. This prevents local proxy send/pop callers from waiting forever after cleanup has already expired their request context.

### How Did You Test This Change?

- `mvn -pl proxy -Dtest=InvocationChannelTest test`
