### PR TITLE
[ISSUE #10768] Continue queryRoute after missing broker data

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -78,7 +78,7 @@ public class RouteActivity extends AbstractMessagingActivity {
                 String brokerName = queueData.getBrokerName();
                 Map<Long, Broker> brokerIdMap = brokerMap.get(brokerName);
                 if (brokerIdMap == null) {
-                    break;
+                    continue;
                 }
                 for (Broker broker : brokerIdMap.values()) {
                     messageQueueList.addAll(this.genMessageQueueFromQueueData(queueData, request.getTopic(), topicMessageType, broker));

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -120,6 +120,29 @@ public class RouteActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testQueryRouteSkipsMissingBrokerAndContinues() throws Throwable {
+        when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
+            .thenReturn(createProxyTopicRouteDataWithMissingBrokerBeforeValidBroker());
+        when(this.messagingProcessor.getMetadataService().getTopicMessageType(any(), anyString()))
+            .thenReturn(TopicMessageType.NORMAL);
+
+        QueryRouteResponse response = this.routeActivity.queryRoute(
+            createContext(),
+            QueryRouteRequest.newBuilder()
+                .setEndpoints(grpcEndpoints)
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        assertEquals(4, response.getMessageQueuesCount());
+        for (MessageQueue messageQueue : response.getMessageQueuesList()) {
+            assertEquals(BROKER_NAME, messageQueue.getBroker().getName());
+            assertEquals(grpcEndpoints, messageQueue.getBroker().getEndpoints());
+        }
+    }
+
+    @Test
     public void testQueryRouteTopicExist() throws Throwable {
         when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
             .thenThrow(new MQBrokerException(ResponseCode.TOPIC_NOT_EXIST, ""));
@@ -223,6 +246,14 @@ public class RouteActivityTest extends BaseActivityTest {
         proxyBrokerData.getBrokerAddrs().put(0L, addressArrayList);
         proxyBrokerData.getBrokerAddrs().put(1L, addressArrayList);
         proxyTopicRouteData.getBrokerDatas().add(proxyBrokerData);
+        return proxyTopicRouteData;
+    }
+
+    private static ProxyTopicRouteData createProxyTopicRouteDataWithMissingBrokerBeforeValidBroker() {
+        ProxyTopicRouteData proxyTopicRouteData = createProxyTopicRouteData(2, 2, PermName.PERM_READ | PermName.PERM_WRITE);
+        QueueData missingBrokerQueueData = createQueueData(2, 2, PermName.PERM_READ | PermName.PERM_WRITE);
+        missingBrokerQueueData.setBrokerName("missingBrokerName");
+        proxyTopicRouteData.getQueueDatas().add(0, missingBrokerQueueData);
         return proxyTopicRouteData;
     }
 


### PR DESCRIPTION
### What changed

This PR makes Proxy gRPC `RouteActivity#queryRoute` skip only the malformed queue row when its broker name is absent from the built broker map.

Previously the loop used `break`, so one stale/malformed `QueueData` entry could stop processing later valid queue rows and truncate the route response.

### Why

A missing broker mapping should not hide valid queue routes that appear later in the same route data. This can affect gRPC route discovery when route metadata contains stale queue data.

Fixes #10768.

### Verification

```bash
mvn -pl proxy -Dtest=RouteActivityTest test
```

Result: BUILD SUCCESS. `RouteActivityTest` ran 8 tests with 0 failures/errors/skips. Checkstyle and SpotBugs also passed in the Maven run.
