### PR TITLE
fix: harden gRPC route and assignment Broker validation

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -78,7 +78,7 @@ public class RouteActivity extends AbstractMessagingActivity {
                 String brokerName = queueData.getBrokerName();
                 Map<Long, Broker> brokerIdMap = brokerMap.get(brokerName);
                 if (brokerIdMap == null) {
-                    break;
+                    continue;
                 }
                 for (Broker broker : brokerIdMap.values()) {
                     messageQueueList.addAll(this.genMessageQueueFromQueueData(queueData, request.getTopic(), topicMessageType, broker));

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -125,6 +125,9 @@ public class RouteActivity extends AbstractMessagingActivity {
                     Map<Long, Broker> brokerIdMap = brokerMap.get(queueData.getBrokerName());
                     if (brokerIdMap != null) {
                         Broker broker = brokerIdMap.get(MixAll.MASTER_ID);
+                        if (broker == null) {
+                            continue;
+                        }
                         Permission permission = this.convertToPermission(queueData.getPerm());
                         if (isFifo && !isLite) {
                             for (int i = 0; i < queueData.getReadQueueNums(); i++) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -174,6 +174,24 @@ public class RouteActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testQueryAssignmentWithMissingMasterBroker() throws Throwable {
+        when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
+            .thenReturn(createProxyTopicRouteDataWithoutMasterBroker());
+
+        QueryAssignmentResponse response = this.routeActivity.queryAssignment(
+            createContext(),
+            QueryAssignmentRequest.newBuilder()
+                .setEndpoints(grpcEndpoints)
+                .setTopic(GRPC_TOPIC)
+                .setGroup(GRPC_GROUP)
+                .build()
+        ).get();
+
+        assertEquals(Code.FORBIDDEN, response.getStatus().getCode());
+        assertEquals(0, response.getAssignmentsCount());
+    }
+
+    @Test
     public void testQueryAssignment() throws Throwable {
         when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
             .thenReturn(createProxyTopicRouteData(2, 2, 6));
@@ -221,6 +239,17 @@ public class RouteActivityTest extends BaseActivityTest {
         proxyBrokerData.setCluster(CLUSTER);
         proxyBrokerData.setBrokerName(BROKER_NAME);
         proxyBrokerData.getBrokerAddrs().put(0L, addressArrayList);
+        proxyBrokerData.getBrokerAddrs().put(1L, addressArrayList);
+        proxyTopicRouteData.getBrokerDatas().add(proxyBrokerData);
+        return proxyTopicRouteData;
+    }
+
+    private static ProxyTopicRouteData createProxyTopicRouteDataWithoutMasterBroker() {
+        ProxyTopicRouteData proxyTopicRouteData = new ProxyTopicRouteData();
+        proxyTopicRouteData.getQueueDatas().add(createQueueData(2, 2, PermName.PERM_READ | PermName.PERM_WRITE));
+        ProxyTopicRouteData.ProxyBrokerData proxyBrokerData = new ProxyTopicRouteData.ProxyBrokerData();
+        proxyBrokerData.setCluster(CLUSTER);
+        proxyBrokerData.setBrokerName(BROKER_NAME);
         proxyBrokerData.getBrokerAddrs().put(1L, addressArrayList);
         proxyTopicRouteData.getBrokerDatas().add(proxyBrokerData);
         return proxyTopicRouteData;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -120,6 +120,29 @@ public class RouteActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testQueryRouteSkipsMissingBrokerAndContinues() throws Throwable {
+        when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
+            .thenReturn(createProxyTopicRouteDataWithMissingBrokerBeforeValidBroker());
+        when(this.messagingProcessor.getMetadataService().getTopicMessageType(any(), anyString()))
+            .thenReturn(TopicMessageType.NORMAL);
+
+        QueryRouteResponse response = this.routeActivity.queryRoute(
+            createContext(),
+            QueryRouteRequest.newBuilder()
+                .setEndpoints(grpcEndpoints)
+                .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        assertEquals(4, response.getMessageQueuesCount());
+        for (MessageQueue messageQueue : response.getMessageQueuesList()) {
+            assertEquals(BROKER_NAME, messageQueue.getBroker().getName());
+            assertEquals(grpcEndpoints, messageQueue.getBroker().getEndpoints());
+        }
+    }
+
+    @Test
     public void testQueryRouteTopicExist() throws Throwable {
         when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
             .thenThrow(new MQBrokerException(ResponseCode.TOPIC_NOT_EXIST, ""));
@@ -252,6 +275,14 @@ public class RouteActivityTest extends BaseActivityTest {
         proxyBrokerData.setBrokerName(BROKER_NAME);
         proxyBrokerData.getBrokerAddrs().put(1L, addressArrayList);
         proxyTopicRouteData.getBrokerDatas().add(proxyBrokerData);
+        return proxyTopicRouteData;
+    }
+
+    private static ProxyTopicRouteData createProxyTopicRouteDataWithMissingBrokerBeforeValidBroker() {
+        ProxyTopicRouteData proxyTopicRouteData = createProxyTopicRouteData(2, 2, PermName.PERM_READ | PermName.PERM_WRITE);
+        QueueData missingBrokerQueueData = createQueueData(2, 2, PermName.PERM_READ | PermName.PERM_WRITE);
+        missingBrokerQueueData.setBrokerName("missingBrokerName");
+        proxyTopicRouteData.getQueueDatas().add(0, missingBrokerQueueData);
         return proxyTopicRouteData;
     }
 


### PR DESCRIPTION
## Summary

- Skip invalid route entries that lack Broker data while retaining valid queues during gRPC route lookup.
- Reject assignment responses safely when no master Broker is available.

## Validation

```bash
mvn -q -pl proxy -am -Dtest=RouteActivityTest -DfailIfNoTests=false test
```

Closes #10770
Closes #10768