### PR TITLE
fix: harden Proxy Admin route lookup diagnostics

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
@@ -96,7 +96,13 @@ public class DefaultAdminService implements AdminService {
         Set<String> curBrokerAddr = new HashSet<>();
         if (curBrokerDataList != null) {
             for (BrokerData brokerData : curBrokerDataList) {
-                curBrokerAddr.add(brokerData.getBrokerAddrs().get(MixAll.MASTER_ID));
+                if (brokerData == null || brokerData.getBrokerAddrs() == null) {
+                    continue;
+                }
+                String addr = brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
+                if (addr != null) {
+                    curBrokerAddr.add(addr);
+                }
             }
         }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
@@ -53,7 +53,7 @@ public class DefaultAdminService implements AdminService {
             if (TopicRouteHelper.isTopicNotExistError(e)) {
                 topicExist = false;
             } else {
-                throw new IllegalStateException("get topic route " + topic + " failed", e);
+                throw new IllegalStateException("get topic route for topic='" + topic + "' failed", e);
             }
         }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
@@ -49,8 +49,12 @@ public class DefaultAdminService implements AdminService {
         try {
             topicRouteData = this.getTopicRouteDataDirectlyFromNameServer(topic);
             topicExist = topicRouteData != null;
-        } catch (Throwable e) {
-            topicExist = false;
+        } catch (Exception e) {
+            if (TopicRouteHelper.isTopicNotExistError(e)) {
+                topicExist = false;
+            } else {
+                throw new IllegalStateException("get topic route " + topic + " failed", e);
+            }
         }
 
         return topicExist;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.client.impl.mqclient.MQClientAPIExt;
 import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -121,12 +122,17 @@ public class DefaultAdminServiceTest {
         assertFalse(defaultAdminService.topicExist("missingTopic"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testTopicExistThrowsForUnexpectedRouteLookupFailure() throws Exception {
+        MQClientException cause = new MQClientException(ResponseCode.SYSTEM_ERROR, "namesrv unavailable");
         when(mqClientAPIExt.getTopicRouteInfoFromNameServer(eq("brokenTopic"), anyLong()))
-            .thenThrow(new MQClientException(ResponseCode.SYSTEM_ERROR, "namesrv unavailable"));
+            .thenThrow(cause);
 
-        defaultAdminService.topicExist("brokenTopic");
+        IllegalStateException exception = Assert.assertThrows(IllegalStateException.class,
+            () -> defaultAdminService.topicExist("brokenTopic"));
+
+        assertEquals("get topic route for topic='brokenTopic' failed", exception.getMessage());
+        assertEquals(cause, exception.getCause());
     }
 
     private TopicRouteData createTopicRouteData(int brokerNum) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -110,6 +111,22 @@ public class DefaultAdminServiceTest {
         assertEquals(1, addrArgumentCaptor.getAllValues().size());
         assertEquals("127.0.0.1:10911", addrArgumentCaptor.getAllValues().get(0));
         assertEquals("createTopic", topicConfigArgumentCaptor.getValue().getTopicName());
+    }
+
+    @Test
+    public void testTopicExistReturnsFalseForNotFound() throws Exception {
+        when(mqClientAPIExt.getTopicRouteInfoFromNameServer(eq("missingTopic"), anyLong()))
+            .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST, "topic not exist"));
+
+        assertFalse(defaultAdminService.topicExist("missingTopic"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testTopicExistThrowsForUnexpectedRouteLookupFailure() throws Exception {
+        when(mqClientAPIExt.getTopicRouteInfoFromNameServer(eq("brokenTopic"), anyLong()))
+            .thenThrow(new MQClientException(ResponseCode.SYSTEM_ERROR, "namesrv unavailable"));
+
+        defaultAdminService.topicExist("brokenTopic");
     }
 
     private TopicRouteData createTopicRouteData(int brokerNum) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
@@ -107,7 +107,8 @@ public class DefaultAdminServiceTest {
             0
         ));
 
-        assertEquals("127.0.0.1:10911", addrArgumentCaptor.getValue());
+        assertEquals(1, addrArgumentCaptor.getAllValues().size());
+        assertEquals("127.0.0.1:10911", addrArgumentCaptor.getAllValues().get(0));
         assertEquals("createTopic", topicConfigArgumentCaptor.getValue().getTopicName());
     }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.proxy.service.admin;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -85,6 +86,29 @@ public class DefaultAdminServiceTest {
         assertEquals("createTopic", topicConfigArgumentCaptor.getValue().getTopicName());
         assertEquals(7, topicConfigArgumentCaptor.getValue().getWriteQueueNums());
         assertEquals(8, topicConfigArgumentCaptor.getValue().getReadQueueNums());
+    }
+
+    @Test
+    public void testCreateTopicOnBrokerSkipsMalformedCurrentBrokerData() throws Exception {
+        BrokerData malformedBrokerData = new BrokerData();
+
+        ArgumentCaptor<String> addrArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<TopicConfig> topicConfigArgumentCaptor = ArgumentCaptor.forClass(TopicConfig.class);
+        doNothing().when(mqClientAPIExt)
+            .createTopic(addrArgumentCaptor.capture(), anyString(), topicConfigArgumentCaptor.capture(), anyLong());
+
+        assertTrue(defaultAdminService.createTopicOnBroker(
+            "createTopic",
+            7,
+            8,
+            Collections.singletonList(malformedBrokerData),
+            createTopicRouteData(1).getBrokerDatas(),
+            false,
+            0
+        ));
+
+        assertEquals("127.0.0.1:10911", addrArgumentCaptor.getValue());
+        assertEquals("createTopic", topicConfigArgumentCaptor.getValue().getTopicName());
     }
 
     private TopicRouteData createTopicRouteData(int brokerNum) {


### PR DESCRIPTION
## Summary

- Skip malformed current Broker records during Proxy Admin topic operations.
- Preserve expected not-found handling while surfacing unexpected NameServer route lookup failures.

## Validation

```bash
mvn -q -pl proxy -am -Dtest=DefaultAdminServiceTest -DfailIfNoTests=false test
```

Closes #10772
Closes #10801