### PR TITLE
[ISSUE #10776] Handle short HTTP2 protocol buffers

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandler.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandler.java
@@ -85,6 +85,9 @@ public class Http2ProtocolProxyHandler implements ProtocolHandler {
         if (!ConfigurationManager.getProxyConfig().isEnableRemotingLocalProxyGrpc()) {
             return false;
         }
+        if (in.readableBytes() < Integer.BYTES) {
+            return false;
+        }
 
         // If starts with 'PRI '
         return in.getInt(in.readerIndex()) == PRI_INT;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
@@ -17,15 +17,20 @@
 
 package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.haproxy.HAProxyMessageEncoder;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +49,8 @@ public class Http2ProtocolProxyHandlerTest {
 
     @Before
     public void setUp() throws Exception {
+        ConfigurationManager.initConfig();
+        ConfigurationManager.getProxyConfig().setEnableRemotingLocalProxyGrpc(true);
         http2ProtocolProxyHandler = new Http2ProtocolProxyHandler();
     }
 
@@ -54,5 +61,20 @@ public class Http2ProtocolProxyHandlerTest {
         when(outboundChannel.pipeline()).thenReturn(outboundPipeline);
         when(outboundPipeline.addFirst(any(HAProxyMessageEncoder.class))).thenReturn(outboundPipeline);
         http2ProtocolProxyHandler.configPipeline(inboundChannel, outboundChannel);
+    }
+
+    @Test
+    public void matchReturnsFalseForShortBuffers() {
+        assertFalse(http2ProtocolProxyHandler.match(Unpooled.EMPTY_BUFFER));
+
+        ByteBuf shortBuffer = Unpooled.wrappedBuffer(new byte[] {'P', 'R', 'I'});
+        assertFalse(http2ProtocolProxyHandler.match(shortBuffer));
+    }
+
+    @Test
+    public void matchReturnsTrueForHttp2PrefacePrefix() {
+        ByteBuf http2Prefix = Unpooled.wrappedBuffer(new byte[] {'P', 'R', 'I', ' '});
+
+        assertTrue(http2ProtocolProxyHandler.match(http2Prefix));
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProtocolProxyHandlerTest.java
@@ -23,6 +23,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.haproxy.HAProxyMessageEncoder;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.InitConfigTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,9 +37,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class Http2ProtocolProxyHandlerTest {
+public class Http2ProtocolProxyHandlerTest extends InitConfigTest {
 
     private Http2ProtocolProxyHandler http2ProtocolProxyHandler;
+    private boolean originalEnableRemotingLocalProxyGrpc;
     @Mock
     private Channel inboundChannel;
     @Mock
@@ -49,9 +52,14 @@ public class Http2ProtocolProxyHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        ConfigurationManager.initConfig();
+        originalEnableRemotingLocalProxyGrpc = ConfigurationManager.getProxyConfig().isEnableRemotingLocalProxyGrpc();
         ConfigurationManager.getProxyConfig().setEnableRemotingLocalProxyGrpc(true);
         http2ProtocolProxyHandler = new Http2ProtocolProxyHandler();
+    }
+
+    @After
+    public void tearDown() {
+        ConfigurationManager.getProxyConfig().setEnableRemotingLocalProxyGrpc(originalEnableRemotingLocalProxyGrpc);
     }
 
     @Test


### PR DESCRIPTION
### What changed

- Return `false` from `Http2ProtocolProxyHandler.match()` when fewer than 4 readable bytes are available.
- Add regression coverage for empty/short buffers and the valid HTTP/2 `PRI ` prefix.

Fixes #10776.

### Verification

`mvn -pl proxy -Dtest=Http2ProtocolProxyHandlerTest test`

Result: BUILD SUCCESS. `Http2ProtocolProxyHandlerTest` ran 3 tests with 0 failures, errors, or skips. Checkstyle and SpotBugs also passed in the Maven run.
