### PR TITLE
[ISSUE #10778] Skip empty priority queue groups

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueuePenalizer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueuePenalizer.java
@@ -120,8 +120,11 @@ public interface MessageQueuePenalizer<Q extends MessageQueue> {
         int bestPenalty = Integer.MAX_VALUE;
         for (List<Q> queues : queuesWithPriority) {
             Pair<Q, Integer> queueAndPenalty = selectLeastPenalty(queues, penalizers, startIndex);
-            int penalty =  queueAndPenalty.getRight();
-            if (queueAndPenalty.getRight() <= 0) {
+            if (queueAndPenalty == null) {
+                continue;
+            }
+            int penalty = queueAndPenalty.getRight();
+            if (penalty <= 0) {
                 return queueAndPenalty;
             }
             if (penalty < bestPenalty) {
@@ -129,6 +132,9 @@ public interface MessageQueuePenalizer<Q extends MessageQueue> {
                 bestQueue = queueAndPenalty.getLeft();
             }
         }
-        return Pair.of(bestQueue,  bestPenalty);
+        if (bestQueue == null) {
+            return null;
+        }
+        return Pair.of(bestQueue, bestPenalty);
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueuePenalizer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueuePenalizer.java
@@ -133,6 +133,7 @@ public interface MessageQueuePenalizer<Q extends MessageQueue> {
             }
         }
         if (bestQueue == null) {
+            // All priority groups were empty or absent.
             return null;
         }
         return Pair.of(bestQueue, bestPenalty);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/MessageQueuePenalizerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/MessageQueuePenalizerTest.java
@@ -283,6 +283,40 @@ public class MessageQueuePenalizerTest {
     }
 
     /**
+     * Test selectLeastPenaltyWithPriority with only empty priority groups should return null
+     */
+    @Test
+    public void testSelectLeastPenaltyWithPriority_AllEmptyPriorityGroups() {
+        List<MessageQueuePenalizer<MessageQueue>> penalizers = Collections.singletonList(mq -> 10);
+        AtomicInteger startIndex = new AtomicInteger(0);
+        Pair<MessageQueue, Integer> result = MessageQueuePenalizer.selectLeastPenaltyWithPriority(
+            Arrays.asList(Collections.emptyList(), Collections.emptyList()), penalizers, startIndex);
+        assertNull(result);
+    }
+
+    /**
+     * Test selectLeastPenaltyWithPriority skips empty priority groups and selects from non-empty groups
+     */
+    @Test
+    public void testSelectLeastPenaltyWithPriority_SkipEmptyPriorityGroup() {
+        MessageQueue mq0 = new MessageQueue("topic", "broker", 0);
+        MessageQueue mq1 = new MessageQueue("topic", "broker", 1);
+        List<MessageQueue> queues = Arrays.asList(mq0, mq1);
+
+        List<MessageQueuePenalizer<MessageQueue>> penalizers = Collections.singletonList(
+            mq -> mq.getQueueId() == 0 ? 20 : 10
+        );
+
+        AtomicInteger startIndex = new AtomicInteger(0);
+        Pair<MessageQueue, Integer> result = MessageQueuePenalizer.selectLeastPenaltyWithPriority(
+            Arrays.asList(Collections.emptyList(), queues), penalizers, startIndex);
+
+        assertNotNull(result);
+        assertEquals(mq1, result.getLeft());
+        assertEquals(10, result.getRight().intValue());
+    }
+
+    /**
      * Test selectLeastPenaltyWithPriority with single priority group delegates to selectLeastPenalty
      */
     @Test


### PR DESCRIPTION
### What changed

- Skip empty priority groups when selecting the least-penalty message queue.
- Return `null` when all priority groups are empty, matching the existing `selectLeastPenalty()` empty-list contract.
- Add regression coverage for both all-empty and partially-empty priority group inputs.

Fixes #10778.

### Verification

`mvn -pl proxy -Dtest=MessageQueuePenalizerTest test`

Result: BUILD SUCCESS. `MessageQueuePenalizerTest` ran 23 tests with 0 failures, errors, or skips. Checkstyle and SpotBugs also passed in the Maven run.
