### PR TITLE
[ISSUE #10788] Tolerate invalid metric collector address

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManager.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.broker.client.ConsumerGroupInfo;
 import org.apache.rocketmq.common.ServiceThread;
 import org.apache.rocketmq.common.constant.LoggerName;
@@ -117,13 +118,13 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
         final Metric.Builder metricBuilder = Metric.newBuilder();
         switch (metricCollectorMode) {
             case ON:
-                final String[] split = metricCollectorAddress.split(":");
-                final String host = split[0];
-                final int port = Integer.parseInt(split[1]);
-                Address address = Address.newBuilder().setHost(host).setPort(port).build();
-                final Endpoints endpoints = Endpoints.newBuilder().setScheme(AddressScheme.IPv4)
-                    .addAddresses(address).build();
-                metricBuilder.setOn(true).setEndpoints(endpoints);
+                Address address = parseMetricCollectorAddress(metricCollectorAddress);
+                if (address == null) {
+                    metricBuilder.setOn(false);
+                    break;
+                }
+                metricBuilder.setOn(true).setEndpoints(Endpoints.newBuilder().setScheme(AddressScheme.IPv4)
+                    .addAddresses(address).build());
                 break;
             case PROXY:
                 metricBuilder.setOn(true).setEndpoints(settings.getAccessPoint());
@@ -135,6 +136,39 @@ public class GrpcClientSettingsManager extends ServiceThread implements StartAnd
         }
         Metric metric = metricBuilder.build();
         return settings.toBuilder().setMetric(metric).build();
+    }
+
+    private Address parseMetricCollectorAddress(String metricCollectorAddress) {
+        if (StringUtils.isBlank(metricCollectorAddress)) {
+            log.warn("Disable gRPC client metric collection because metricCollectorAddress is blank");
+            return null;
+        }
+        String[] addressSegments = metricCollectorAddress.trim().split(":", -1);
+        if (addressSegments.length != 2) {
+            log.warn("Disable gRPC client metric collection because metricCollectorAddress is invalid: {}",
+                metricCollectorAddress);
+            return null;
+        }
+        String host = addressSegments[0].trim();
+        String portSegment = addressSegments[1].trim();
+        if (StringUtils.isBlank(host) || StringUtils.isBlank(portSegment)) {
+            log.warn("Disable gRPC client metric collection because metricCollectorAddress is invalid: {}",
+                metricCollectorAddress);
+            return null;
+        }
+        try {
+            int port = Integer.parseInt(portSegment);
+            if (port <= 0 || port > 65535) {
+                log.warn("Disable gRPC client metric collection because metricCollectorAddress port is out of range: {}",
+                    metricCollectorAddress);
+                return null;
+            }
+            return Address.newBuilder().setHost(host).setPort(port).build();
+        } catch (NumberFormatException e) {
+            log.warn("Disable gRPC client metric collection because metricCollectorAddress port is invalid: {}",
+                metricCollectorAddress);
+            return null;
+        }
     }
 
     protected static Settings mergeSubscriptionData(Settings settings, SubscriptionGroupConfig groupConfig) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.rocketmq.common.lite.LiteSubscriptionDTO;
 import org.apache.rocketmq.proxy.common.ContextVariable;
 import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.MetricCollectorMode;
 import org.apache.rocketmq.proxy.grpc.v2.BaseActivityTest;
 import org.apache.rocketmq.remoting.protocol.subscription.CustomizedRetryPolicy;
 import org.apache.rocketmq.remoting.protocol.subscription.ExponentialRetryPolicy;
@@ -74,6 +76,36 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
         Settings settings = this.grpcClientSettingsManager.getClientSettings(context);
         assertNotEquals(settings.getBackoffPolicy(), settings.getBackoffPolicy().getDefaultInstanceForType());
         assertNotEquals(settings.getPublishing(), settings.getPublishing().getDefaultInstanceForType());
+    }
+
+    @Test
+    public void testMergeMetricWithValidCollectorAddress() {
+        ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1:9090");
+        try {
+            Settings settings = this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance());
+
+            assertEquals(true, settings.getMetric().getOn());
+            assertEquals("127.0.0.1", settings.getMetric().getEndpoints().getAddresses(0).getHost());
+            assertEquals(9090, settings.getMetric().getEndpoints().getAddresses(0).getPort());
+        } finally {
+            ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.OFF.getModeString());
+            ConfigurationManager.getProxyConfig().setMetricCollectorAddress("");
+        }
+    }
+
+    @Test
+    public void testMergeMetricShouldDisableMetricForInvalidCollectorAddress() {
+        ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
+        ConfigurationManager.getProxyConfig().setMetricCollectorAddress("localhost");
+        try {
+            Settings settings = this.grpcClientSettingsManager.mergeMetric(Settings.getDefaultInstance());
+
+            assertEquals(false, settings.getMetric().getOn());
+        } finally {
+            ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.OFF.getModeString());
+            ConfigurationManager.getProxyConfig().setMetricCollectorAddress("");
+        }
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/common/GrpcClientSettingsManagerTest.java
@@ -80,6 +80,8 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
 
     @Test
     public void testMergeMetricWithValidCollectorAddress() {
+        String originalMetricCollectorMode = ConfigurationManager.getProxyConfig().getMetricCollectorMode();
+        String originalMetricCollectorAddress = ConfigurationManager.getProxyConfig().getMetricCollectorAddress();
         ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
         ConfigurationManager.getProxyConfig().setMetricCollectorAddress("127.0.0.1:9090");
         try {
@@ -89,13 +91,15 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
             assertEquals("127.0.0.1", settings.getMetric().getEndpoints().getAddresses(0).getHost());
             assertEquals(9090, settings.getMetric().getEndpoints().getAddresses(0).getPort());
         } finally {
-            ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.OFF.getModeString());
-            ConfigurationManager.getProxyConfig().setMetricCollectorAddress("");
+            ConfigurationManager.getProxyConfig().setMetricCollectorMode(originalMetricCollectorMode);
+            ConfigurationManager.getProxyConfig().setMetricCollectorAddress(originalMetricCollectorAddress);
         }
     }
 
     @Test
     public void testMergeMetricShouldDisableMetricForInvalidCollectorAddress() {
+        String originalMetricCollectorMode = ConfigurationManager.getProxyConfig().getMetricCollectorMode();
+        String originalMetricCollectorAddress = ConfigurationManager.getProxyConfig().getMetricCollectorAddress();
         ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.ON.getModeString());
         ConfigurationManager.getProxyConfig().setMetricCollectorAddress("localhost");
         try {
@@ -103,8 +107,8 @@ public class GrpcClientSettingsManagerTest extends BaseActivityTest {
 
             assertEquals(false, settings.getMetric().getOn());
         } finally {
-            ConfigurationManager.getProxyConfig().setMetricCollectorMode(MetricCollectorMode.OFF.getModeString());
-            ConfigurationManager.getProxyConfig().setMetricCollectorAddress("");
+            ConfigurationManager.getProxyConfig().setMetricCollectorMode(originalMetricCollectorMode);
+            ConfigurationManager.getProxyConfig().setMetricCollectorAddress(originalMetricCollectorAddress);
         }
     }
 


### PR DESCRIPTION
### What is changed
- Validate `metricCollectorAddress` before building gRPC client metric settings in `metricCollectorMode=on`.
- Disable client metric collection for that settings response when the configured address is blank, malformed, non-numeric, or outside the valid port range.
- Add coverage for valid and invalid collector addresses.

Fixes #10788
Closes #10683

### Verification
- mvn -pl proxy -Dtest=GrpcClientSettingsManagerTest test