### PR TITLE
[ISSUE #10782] Return error code for empty lock batch requests

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
@@ -136,6 +136,7 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         Set<MessageQueue> mqSet = requestBody.getMqSet();
         if (mqSet.isEmpty()) {
             response.setBody(requestBody.encode());
+            response.setCode(ResponseCode.SYSTEM_ERROR);
             response.setRemark("MessageQueue set is empty");
             return response;
         }
@@ -157,6 +158,7 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         Set<MessageQueue> mqSet = requestBody.getMqSet();
         if (mqSet.isEmpty()) {
             response.setBody(requestBody.encode());
+            response.setCode(ResponseCode.SYSTEM_ERROR);
             response.setRemark("MessageQueue set is empty");
             return response;
         }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
@@ -45,6 +45,8 @@ import org.apache.rocketmq.proxy.remoting.pipeline.RequestPipeline;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 
 public class ConsumerManagerActivity extends AbstractRemotingActivity {
+    static final String EMPTY_QUEUE_REMARK = "MessageQueue set is empty";
+
     public ConsumerManagerActivity(RequestPipeline requestPipeline, MessagingProcessor messagingProcessor) {
         super(requestPipeline, messagingProcessor);
     }
@@ -136,8 +138,8 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         Set<MessageQueue> mqSet = requestBody.getMqSet();
         if (mqSet.isEmpty()) {
             response.setBody(requestBody.encode());
-            response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark("MessageQueue set is empty");
+            response.setCode(ResponseCode.INVALID_PARAMETER);
+            response.setRemark(EMPTY_QUEUE_REMARK);
             return response;
         }
 
@@ -158,8 +160,8 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         Set<MessageQueue> mqSet = requestBody.getMqSet();
         if (mqSet.isEmpty()) {
             response.setBody(requestBody.encode());
-            response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark("MessageQueue set is empty");
+            response.setCode(ResponseCode.INVALID_PARAMETER);
+            response.setRemark(EMPTY_QUEUE_REMARK);
             return response;
         }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
@@ -38,8 +38,6 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConsumerManagerActivityTest extends InitConfigTest {
-    private static final String EMPTY_QUEUE_REMARK = "MessageQueue set is empty";
-
     ConsumerManagerActivity consumerManagerActivity;
 
     @Mock
@@ -58,8 +56,9 @@ public class ConsumerManagerActivityTest extends InitConfigTest {
 
         RemotingCommand response = consumerManagerActivity.lockBatchMQ(null, request, null);
 
-        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
-        assertThat(response.getRemark()).isEqualTo(EMPTY_QUEUE_REMARK);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.INVALID_PARAMETER);
+        assertThat(response.getRemark()).isEqualTo(ConsumerManagerActivity.EMPTY_QUEUE_REMARK);
+        assertThat(response.getBody()).isEqualTo(requestBody.encode());
         verify(messagingProcessorMock, never()).request(any(), any(), any(), anyLong());
     }
 
@@ -71,8 +70,9 @@ public class ConsumerManagerActivityTest extends InitConfigTest {
 
         RemotingCommand response = consumerManagerActivity.unlockBatchMQ(null, request, null);
 
-        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
-        assertThat(response.getRemark()).isEqualTo(EMPTY_QUEUE_REMARK);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.INVALID_PARAMETER);
+        assertThat(response.getRemark()).isEqualTo(ConsumerManagerActivity.EMPTY_QUEUE_REMARK);
+        assertThat(response.getBody()).isEqualTo(requestBody.encode());
         verify(messagingProcessorMock, never()).request(any(), any(), any(), anyLong());
     }
 }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.remoting.activity;
+
+import org.apache.rocketmq.proxy.config.InitConfigTest;
+import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.LockBatchRequestBody;
+import org.apache.rocketmq.remoting.protocol.body.UnlockBatchRequestBody;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerManagerActivityTest extends InitConfigTest {
+    private static final String EMPTY_QUEUE_REMARK = "MessageQueue set is empty";
+
+    ConsumerManagerActivity consumerManagerActivity;
+
+    @Mock
+    MessagingProcessor messagingProcessorMock;
+
+    @Before
+    public void setup() {
+        consumerManagerActivity = new ConsumerManagerActivity(null, messagingProcessorMock);
+    }
+
+    @Test
+    public void testLockBatchMQWithEmptyQueueSetReturnsErrorCode() throws Exception {
+        LockBatchRequestBody requestBody = new LockBatchRequestBody();
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.LOCK_BATCH_MQ, null);
+        request.setBody(requestBody.encode());
+
+        RemotingCommand response = consumerManagerActivity.lockBatchMQ(null, request, null);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).isEqualTo(EMPTY_QUEUE_REMARK);
+        verify(messagingProcessorMock, never()).request(any(), any(), any(), anyLong());
+    }
+
+    @Test
+    public void testUnlockBatchMQWithEmptyQueueSetReturnsErrorCode() throws Exception {
+        UnlockBatchRequestBody requestBody = new UnlockBatchRequestBody();
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.UNLOCK_BATCH_MQ, null);
+        request.setBody(requestBody.encode());
+
+        RemotingCommand response = consumerManagerActivity.unlockBatchMQ(null, request, null);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).isEqualTo(EMPTY_QUEUE_REMARK);
+        verify(messagingProcessorMock, never()).request(any(), any(), any(), anyLong());
+    }
+}


### PR DESCRIPTION
## What is changed
- Set ResponseCode.SYSTEM_ERROR when remoting LOCK_BATCH_MQ or UNLOCK_BATCH_MQ receives an empty MessageQueue set.
- Add unit coverage for both empty queue set paths.

## Why
- Fixes #10782.

## Verification
- mvn -pl proxy -Dtest=ConsumerManagerActivityTest test

Note: the local run completed with BUILD SUCCESS; it also printed existing JaCoCo 0.8.5 instrumentation warnings on the local JDK.