### PR TITLE
[ISSUE #10793] Handle offline consumer list queries

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
@@ -86,7 +86,7 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         ConsumerGroupInfo consumerGroupInfo = messagingProcessor.getConsumerGroupInfo(context, header.getConsumerGroup());
         if (consumerGroupInfo == null) {
             response.setCode(ResponseCode.CONSUMER_NOT_ONLINE);
-            response.setRemark("the consumer group[" + header.getConsumerGroup() + "] not online");
+            response.setRemark(consumerNotOnlineRemark(header.getConsumerGroup()));
             return response;
         }
         List<String> clientIds = consumerGroupInfo.getAllClientId();
@@ -130,8 +130,12 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         }
 
         response.setCode(ResponseCode.CONSUMER_NOT_ONLINE);
-        response.setRemark("the consumer group[" + header.getConsumerGroup() + "] not online");
+        response.setRemark(consumerNotOnlineRemark(header.getConsumerGroup()));
         return response;
+    }
+
+    static String consumerNotOnlineRemark(String consumerGroup) {
+        return "the consumer group[" + consumerGroup + "] not online";
     }
 
     protected RemotingCommand lockBatchMQ(ChannelHandlerContext ctx, RemotingCommand request,

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivity.java
@@ -84,6 +84,11 @@ public class ConsumerManagerActivity extends AbstractRemotingActivity {
         RemotingCommand response = RemotingCommand.createResponseCommand(GetConsumerListByGroupResponseHeader.class);
         GetConsumerListByGroupRequestHeader header = (GetConsumerListByGroupRequestHeader) request.decodeCommandCustomHeader(GetConsumerListByGroupRequestHeader.class);
         ConsumerGroupInfo consumerGroupInfo = messagingProcessor.getConsumerGroupInfo(context, header.getConsumerGroup());
+        if (consumerGroupInfo == null) {
+            response.setCode(ResponseCode.CONSUMER_NOT_ONLINE);
+            response.setRemark("the consumer group[" + header.getConsumerGroup() + "] not online");
+            return response;
+        }
         List<String> clientIds = consumerGroupInfo.getAllClientId();
         GetConsumerListByGroupResponseBody body = new GetConsumerListByGroupResponseBody();
         body.setConsumerIdList(clientIds);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.remoting.activity;
+
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.config.InitConfigTest;
+import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.header.GetConsumerListByGroupRequestHeader;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerManagerActivityTest extends InitConfigTest {
+    private static final String CONSUMER_GROUP = "offline-group";
+
+    private ConsumerManagerActivity consumerManagerActivity;
+
+    @Mock
+    private MessagingProcessor messagingProcessor;
+
+    @Before
+    public void setup() {
+        this.consumerManagerActivity = new ConsumerManagerActivity(null, messagingProcessor);
+    }
+
+    @Test
+    public void testGetConsumerListByGroupShouldReturnNotOnlineWhenGroupMissing() throws Exception {
+        GetConsumerListByGroupRequestHeader header = new GetConsumerListByGroupRequestHeader();
+        header.setConsumerGroup(CONSUMER_GROUP);
+        RemotingCommand request = RemotingCommand.createRequestCommand(
+            RequestCode.GET_CONSUMER_LIST_BY_GROUP, header);
+        request.makeCustomHeaderToNet();
+        when(messagingProcessor.getConsumerGroupInfo(any(), eq(CONSUMER_GROUP))).thenReturn(null);
+
+        RemotingCommand response = consumerManagerActivity.getConsumerListByGroup(
+            null, request, ProxyContext.create());
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.CONSUMER_NOT_ONLINE);
+        assertThat(response.getRemark()).isEqualTo("the consumer group[offline-group] not online");
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ConsumerManagerActivityTest.java
@@ -62,6 +62,6 @@ public class ConsumerManagerActivityTest extends InitConfigTest {
             null, request, ProxyContext.create());
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.CONSUMER_NOT_ONLINE);
-        assertThat(response.getRemark()).isEqualTo("the consumer group[offline-group] not online");
+        assertThat(response.getRemark()).isEqualTo(ConsumerManagerActivity.consumerNotOnlineRemark(CONSUMER_GROUP));
     }
 }


### PR DESCRIPTION
### Summary

- make `GET_CONSUMER_LIST_BY_GROUP` return `CONSUMER_NOT_ONLINE` when the requested group has no online consumer info
- align its behavior with `GET_CONSUMER_CONNECTION_LIST` in the same activity
- add coverage for the offline-group path

### Tests

- `mvn -pl proxy -Dtest=ConsumerManagerActivityTest test`

Closes #10793