### PR TITLE
[ISSUE #10795] Validate proxy check client config

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -121,6 +121,10 @@ public class ProxyConfig implements ConfigFile {
      */
     private boolean enableMessageBodyEmptyCheck = true;
     /**
+     * if true, proxy allows SQL/property filter expressions in client config checks.
+     */
+    private boolean enablePropertyFilter = false;
+    /**
      * max user property size, 0 or negative number means no limit for proxy
      */
     private int maxUserPropertySize = 16 * 1024;
@@ -1577,6 +1581,14 @@ public class ProxyConfig implements ConfigFile {
 
     public void setEnableMessageBodyEmptyCheck(boolean enableMessageBodyEmptyCheck) {
         this.enableMessageBodyEmptyCheck = enableMessageBodyEmptyCheck;
+    }
+
+    public boolean isEnablePropertyFilter() {
+        return enablePropertyFilter;
+    }
+
+    public void setEnablePropertyFilter(boolean enablePropertyFilter) {
+        this.enablePropertyFilter = enablePropertyFilter;
     }
 
     public int getMaxLiteTopicSize() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivity.java
@@ -24,7 +24,10 @@ import org.apache.rocketmq.broker.client.ConsumerGroupEvent;
 import org.apache.rocketmq.broker.client.ConsumerIdsChangeListener;
 import org.apache.rocketmq.broker.client.ProducerChangeListener;
 import org.apache.rocketmq.broker.client.ProducerGroupEvent;
+import org.apache.rocketmq.common.filter.ExpressionType;
+import org.apache.rocketmq.filter.FilterFactory;
 import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
 import org.apache.rocketmq.proxy.remoting.channel.RemotingChannel;
 import org.apache.rocketmq.proxy.remoting.channel.RemotingChannelManager;
@@ -35,11 +38,13 @@ import org.apache.rocketmq.remoting.netty.AttributeKeys;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.CheckClientRequestBody;
 import org.apache.rocketmq.remoting.protocol.header.UnregisterClientRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.UnregisterClientResponseHeader;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumerData;
 import org.apache.rocketmq.remoting.protocol.heartbeat.HeartbeatData;
 import org.apache.rocketmq.remoting.protocol.heartbeat.ProducerData;
+import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
 
 import java.util.Set;
 
@@ -158,8 +163,36 @@ public class ClientManagerActivity extends AbstractRemotingActivity {
     protected RemotingCommand checkClientConfig(ChannelHandlerContext ctx, RemotingCommand request,
         ProxyContext context) {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
+        CheckClientRequestBody requestBody = CheckClientRequestBody.decode(request.getBody(),
+            CheckClientRequestBody.class);
+        if (requestBody != null && requestBody.getSubscriptionData() != null) {
+            SubscriptionData subscriptionData = requestBody.getSubscriptionData();
+            if (ExpressionType.isTagType(subscriptionData.getExpressionType())) {
+                response.setCode(ResponseCode.SUCCESS);
+                response.setRemark(null);
+                return response;
+            }
+
+            if (!ConfigurationManager.getProxyConfig().isEnablePropertyFilter()) {
+                response.setCode(ResponseCode.SYSTEM_ERROR);
+                response.setRemark("The proxy does not support consumer to filter message by "
+                    + subscriptionData.getExpressionType());
+                return response;
+            }
+
+            try {
+                FilterFactory.INSTANCE.get(subscriptionData.getExpressionType()).compile(subscriptionData.getSubString());
+            } catch (Exception e) {
+                log.warn("Client {}@{} filter message, but failed to compile expression! sub={}, error={}",
+                    requestBody.getClientId(), requestBody.getGroup(), requestBody.getSubscriptionData(), e.getMessage());
+                response.setCode(ResponseCode.SUBSCRIPTION_PARSE_FAILED);
+                response.setRemark(e.getMessage());
+                return response;
+            }
+        }
+
         response.setCode(ResponseCode.SUCCESS);
-        response.setRemark("");
+        response.setRemark(null);
         return response;
     }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivity.java
@@ -163,8 +163,16 @@ public class ClientManagerActivity extends AbstractRemotingActivity {
     protected RemotingCommand checkClientConfig(ChannelHandlerContext ctx, RemotingCommand request,
         ProxyContext context) {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
-        CheckClientRequestBody requestBody = CheckClientRequestBody.decode(request.getBody(),
-            CheckClientRequestBody.class);
+        CheckClientRequestBody requestBody;
+        try {
+            if (request.getBody() == null) {
+                return invalidCheckClientConfigResponse(response, "Request body is required");
+            }
+            requestBody = CheckClientRequestBody.decode(request.getBody(), CheckClientRequestBody.class);
+        } catch (Exception e) {
+            log.warn("Failed to decode check client config request", e);
+            return invalidCheckClientConfigResponse(response, "Failed to decode request body");
+        }
         if (requestBody != null && requestBody.getSubscriptionData() != null) {
             SubscriptionData subscriptionData = requestBody.getSubscriptionData();
             if (ExpressionType.isTagType(subscriptionData.getExpressionType())) {
@@ -175,7 +183,7 @@ public class ClientManagerActivity extends AbstractRemotingActivity {
 
             if (!ConfigurationManager.getProxyConfig().isEnablePropertyFilter()) {
                 response.setCode(ResponseCode.SYSTEM_ERROR);
-                response.setRemark("The proxy does not support consumer to filter message by "
+                response.setRemark("Property filter is disabled; enablePropertyFilter must be true to use "
                     + subscriptionData.getExpressionType());
                 return response;
             }
@@ -183,8 +191,8 @@ public class ClientManagerActivity extends AbstractRemotingActivity {
             try {
                 FilterFactory.INSTANCE.get(subscriptionData.getExpressionType()).compile(subscriptionData.getSubString());
             } catch (Exception e) {
-                log.warn("Client {}@{} filter message, but failed to compile expression! sub={}, error={}",
-                    requestBody.getClientId(), requestBody.getGroup(), requestBody.getSubscriptionData(), e.getMessage());
+                log.warn("Client {}@{} failed to compile filter expression: {}",
+                    requestBody.getClientId(), requestBody.getGroup(), requestBody.getSubscriptionData(), e);
                 response.setCode(ResponseCode.SUBSCRIPTION_PARSE_FAILED);
                 response.setRemark(e.getMessage());
                 return response;
@@ -193,6 +201,12 @@ public class ClientManagerActivity extends AbstractRemotingActivity {
 
         response.setCode(ResponseCode.SUCCESS);
         response.setRemark(null);
+        return response;
+    }
+
+    private RemotingCommand invalidCheckClientConfigResponse(RemotingCommand response, String remark) {
+        response.setCode(ResponseCode.SUBSCRIPTION_PARSE_FAILED);
+        response.setRemark(remark);
         return response;
     }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivityTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.proxy.remoting.activity;
+
+import org.apache.rocketmq.common.filter.ExpressionType;
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.config.ConfigurationManager;
+import org.apache.rocketmq.proxy.config.InitConfigTest;
+import org.apache.rocketmq.proxy.processor.MessagingProcessor;
+import org.apache.rocketmq.proxy.remoting.channel.RemotingChannelManager;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.CheckClientRequestBody;
+import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientManagerActivityTest extends InitConfigTest {
+
+    private ClientManagerActivity clientManagerActivity;
+    @Mock
+    private MessagingProcessor messagingProcessor;
+    @Mock
+    private RemotingChannelManager remotingChannelManager;
+
+    @Before
+    public void setUp() {
+        this.clientManagerActivity = new ClientManagerActivity(null, messagingProcessor, remotingChannelManager);
+    }
+
+    @Test
+    public void testCheckClientConfigWithTagExpression() {
+        RemotingCommand response = clientManagerActivity.checkClientConfig(null,
+            createRequest(ExpressionType.TAG, "tagA || tagB"), ProxyContext.create());
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+    }
+
+    @Test
+    public void testCheckClientConfigRejectsPropertyFilterWhenDisabled() {
+        RemotingCommand response = clientManagerActivity.checkClientConfig(null,
+            createRequest(ExpressionType.SQL92, "a is not null"), ProxyContext.create());
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains(ExpressionType.SQL92);
+    }
+
+    @Test
+    public void testCheckClientConfigRejectsInvalidPropertyFilterExpression() {
+        ConfigurationManager.getProxyConfig().setEnablePropertyFilter(true);
+
+        RemotingCommand response = clientManagerActivity.checkClientConfig(null,
+            createRequest(ExpressionType.SQL92, "a = "), ProxyContext.create());
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUBSCRIPTION_PARSE_FAILED);
+    }
+
+    private RemotingCommand createRequest(String expressionType, String expression) {
+        SubscriptionData subscriptionData = new SubscriptionData();
+        subscriptionData.setTopic("topic");
+        subscriptionData.setExpressionType(expressionType);
+        subscriptionData.setSubString(expression);
+
+        CheckClientRequestBody requestBody = new CheckClientRequestBody();
+        requestBody.setClientId("clientId");
+        requestBody.setGroup("group");
+        requestBody.setSubscriptionData(subscriptionData);
+
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.CHECK_CLIENT_CONFIG, null);
+        request.setBody(requestBody.encode());
+        return request;
+    }
+}

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/ClientManagerActivityTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.CheckClientRequestBody;
 import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ClientManagerActivityTest extends InitConfigTest {
 
     private ClientManagerActivity clientManagerActivity;
+    private boolean originalEnablePropertyFilter;
     @Mock
     private MessagingProcessor messagingProcessor;
     @Mock
@@ -47,6 +49,12 @@ public class ClientManagerActivityTest extends InitConfigTest {
     @Before
     public void setUp() {
         this.clientManagerActivity = new ClientManagerActivity(null, messagingProcessor, remotingChannelManager);
+        this.originalEnablePropertyFilter = ConfigurationManager.getProxyConfig().isEnablePropertyFilter();
+    }
+
+    @After
+    public void tearDown() {
+        ConfigurationManager.getProxyConfig().setEnablePropertyFilter(originalEnablePropertyFilter);
     }
 
     @Test
@@ -63,7 +71,7 @@ public class ClientManagerActivityTest extends InitConfigTest {
             createRequest(ExpressionType.SQL92, "a is not null"), ProxyContext.create());
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
-        assertThat(response.getRemark()).contains(ExpressionType.SQL92);
+        assertThat(response.getRemark()).contains("enablePropertyFilter", ExpressionType.SQL92);
     }
 
     @Test
@@ -74,6 +82,26 @@ public class ClientManagerActivityTest extends InitConfigTest {
             createRequest(ExpressionType.SQL92, "a = "), ProxyContext.create());
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.SUBSCRIPTION_PARSE_FAILED);
+    }
+
+    @Test
+    public void testCheckClientConfigAcceptsValidPropertyFilterExpression() {
+        ConfigurationManager.getProxyConfig().setEnablePropertyFilter(true);
+
+        RemotingCommand response = clientManagerActivity.checkClientConfig(null,
+            createRequest(ExpressionType.SQL92, "a is not null"), ProxyContext.create());
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+    }
+
+    @Test
+    public void testCheckClientConfigRejectsRequestWithoutBody() {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.CHECK_CLIENT_CONFIG, null);
+
+        RemotingCommand response = clientManagerActivity.checkClientConfig(null, request, ProxyContext.create());
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUBSCRIPTION_PARSE_FAILED);
+        assertThat(response.getRemark()).contains("body");
     }
 
     private RemotingCommand createRequest(String expressionType, String expression) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10795

### Brief Description

- Validate Proxy remoting `CHECK_CLIENT_CONFIG` request bodies instead of always returning success
- Keep TAG expressions accepted
- Reject SQL/property filters when `enablePropertyFilter` is disabled, matching the default broker behavior
- Compile SQL/property filter expressions when enabled and return `SUBSCRIPTION_PARSE_FAILED` on parse errors
- Add regression coverage for TAG, disabled property filter, and invalid SQL expression cases

### How Did You Test This Change?

- `mvn -pl proxy -Dtest=ClientManagerActivityTest test`

The target test passed: 3 tests, 0 failures, 0 errors. The Maven run completed with BUILD SUCCESS; the output still includes existing Jacoco/JDK17 instrumentation warnings.