### PR TITLE
[ISSUE #10801] Surface unexpected topic route lookup errors

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
@@ -53,7 +53,7 @@ public class DefaultAdminService implements AdminService {
             if (TopicRouteHelper.isTopicNotExistError(e)) {
                 topicExist = false;
             } else {
-                throw new IllegalStateException("get topic route " + topic + " failed", e);
+                throw new IllegalStateException("get topic route for topic='" + topic + "' failed", e);
             }
         }
 

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminService.java
@@ -49,8 +49,12 @@ public class DefaultAdminService implements AdminService {
         try {
             topicRouteData = this.getTopicRouteDataDirectlyFromNameServer(topic);
             topicExist = topicRouteData != null;
-        } catch (Throwable e) {
-            topicExist = false;
+        } catch (Exception e) {
+            if (TopicRouteHelper.isTopicNotExistError(e)) {
+                topicExist = false;
+            } else {
+                throw new IllegalStateException("get topic route " + topic + " failed", e);
+            }
         }
 
         return topicExist;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.client.impl.mqclient.MQClientAPIExt;
 import org.apache.rocketmq.client.impl.mqclient.MQClientAPIFactory;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -96,12 +97,17 @@ public class DefaultAdminServiceTest {
         assertFalse(defaultAdminService.topicExist("missingTopic"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testTopicExistThrowsForUnexpectedRouteLookupFailure() throws Exception {
+        MQClientException cause = new MQClientException(ResponseCode.SYSTEM_ERROR, "namesrv unavailable");
         when(mqClientAPIExt.getTopicRouteInfoFromNameServer(eq("brokenTopic"), anyLong()))
-            .thenThrow(new MQClientException(ResponseCode.SYSTEM_ERROR, "namesrv unavailable"));
+            .thenThrow(cause);
 
-        defaultAdminService.topicExist("brokenTopic");
+        IllegalStateException exception = Assert.assertThrows(IllegalStateException.class,
+            () -> defaultAdminService.topicExist("brokenTopic"));
+
+        assertEquals("get topic route for topic='brokenTopic' failed", exception.getMessage());
+        assertEquals(cause, exception.getCause());
     }
 
     private TopicRouteData createTopicRouteData(int brokerNum) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/admin/DefaultAdminServiceTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -85,6 +86,22 @@ public class DefaultAdminServiceTest {
         assertEquals("createTopic", topicConfigArgumentCaptor.getValue().getTopicName());
         assertEquals(7, topicConfigArgumentCaptor.getValue().getWriteQueueNums());
         assertEquals(8, topicConfigArgumentCaptor.getValue().getReadQueueNums());
+    }
+
+    @Test
+    public void testTopicExistReturnsFalseForNotFound() throws Exception {
+        when(mqClientAPIExt.getTopicRouteInfoFromNameServer(eq("missingTopic"), anyLong()))
+            .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST, "topic not exist"));
+
+        assertFalse(defaultAdminService.topicExist("missingTopic"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testTopicExistThrowsForUnexpectedRouteLookupFailure() throws Exception {
+        when(mqClientAPIExt.getTopicRouteInfoFromNameServer(eq("brokenTopic"), anyLong()))
+            .thenThrow(new MQClientException(ResponseCode.SYSTEM_ERROR, "namesrv unavailable"));
+
+        defaultAdminService.topicExist("brokenTopic");
     }
 
     private TopicRouteData createTopicRouteData(int brokerNum) {


### PR DESCRIPTION
## Summary
- make DefaultAdminService.topicExist return false only for explicit topic-not-found errors
- surface unexpected NameServer route lookup failures instead of silently treating them as missing topics
- add regression coverage for not-found and unexpected failures

Fixes #10801

## Tests
- JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home mvn -pl proxy -Dtest=DefaultAdminServiceTest test
- git diff --check