### PR TITLE
[ISSUE #10806] Log proxy remoting cleanup failures

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java
@@ -393,8 +393,23 @@ public class RemotingProtocolServer implements StartAndShutdown, RemotingProxyOu
                 } else {
                     break;
                 }
-            } catch (Throwable ignored) {
+            } catch (Throwable t) {
+                log.warn("clean expired remoting request failed. queueSize:{}, maxWaitTimeMillsInQueue:{}",
+                    safeQueueSize(threadPoolExecutor), maxWaitTimeMillsInQueue, t);
+                break;
             }
+        }
+    }
+
+    private int safeQueueSize(ThreadPoolExecutor threadPoolExecutor) {
+        try {
+            BlockingQueue<Runnable> queue = threadPoolExecutor == null ? null : threadPoolExecutor.getQueue();
+            if (queue == null) {
+                return -1;
+            }
+            return queue.size();
+        } catch (Throwable ignored) {
+            return -1;
         }
     }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.proxy.remoting;
 
-<<<<<<< HEAD
 import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.rocketmq.remoting.RemotingServer;
 import org.apache.rocketmq.remoting.protocol.RequestHeaderRegistry;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServerTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.proxy.remoting;
 
+<<<<<<< HEAD
+import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.rocketmq.remoting.RemotingServer;
 import org.apache.rocketmq.remoting.protocol.RequestHeaderRegistry;
 import org.junit.Test;
@@ -43,5 +45,16 @@ public class RemotingProtocolServerTest {
 
             verify(requestHeaderRegistry).initialize();
         }
+    }
+
+    @Test(timeout = 1000)
+    public void testCleanExpiredRequestInQueueBreaksWhenQueueAccessFails() {
+        RemotingProtocolServer server = Mockito.mock(RemotingProtocolServer.class, Mockito.CALLS_REAL_METHODS);
+        ThreadPoolExecutor executor = Mockito.mock(ThreadPoolExecutor.class);
+        Mockito.when(executor.getQueue()).thenThrow(new RuntimeException("queue unavailable"));
+
+        server.cleanExpiredRequestInQueue(executor, 1);
+
+        Mockito.verify(executor, Mockito.atMost(2)).getQueue();
     }
 }


### PR DESCRIPTION
## Summary
- log unexpected failures from Proxy remoting expired request cleanup with compact queue context
- stop the current cleanup pass after such failures to avoid silent loop churn
- add regression coverage for queue access failures

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -DskipITs -DskipCheckStyle -Dtest=RemotingProtocolServerTest test
- git diff --check

Closes #10806