### PR TITLE
[ISSUE #10808] Tolerate proxy delay level whitespace

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -43,6 +43,8 @@ public class ProxyConfig implements ConfigFile {
     public final static String DEFAULT_CONFIG_FILE_NAME = "rmq-proxy.json";
     private static final int PROCESSOR_NUMBER = Runtime.getRuntime().availableProcessors();
     private static final String DEFAULT_CLUSTER_NAME = "DefaultCluster";
+    private static final String DEFAULT_MESSAGE_DELAY_LEVEL =
+        "1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h";
 
     private static String localHostName;
 
@@ -229,7 +231,7 @@ public class ProxyConfig implements ConfigFile {
     private boolean enableAclRpcHookForClusterMode = false;
 
     private boolean useDelayLevel = false;
-    private String messageDelayLevel = "1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h";
+    private String messageDelayLevel = DEFAULT_MESSAGE_DELAY_LEVEL;
     private transient ConcurrentSkipListMap<Integer /* level */, Long/* delay timeMillis */> delayLevelTable = new ConcurrentSkipListMap<>();
 
     private String metricCollectorMode = MetricCollectorMode.OFF.getModeString();
@@ -330,8 +332,12 @@ public class ProxyConfig implements ConfigFile {
         timeUnitTable.put("d", 1000L * 60 * 60 * 24);
 
         String levelString = this.getMessageDelayLevel();
+        if (StringUtils.isBlank(levelString)) {
+            log.warn("messageDelayLevel is blank, use default delay level config");
+            levelString = DEFAULT_MESSAGE_DELAY_LEVEL;
+        }
         try {
-            String[] levelArray = levelString.split(" ");
+            String[] levelArray = levelString.trim().split("\\s+");
             for (int i = 0; i < levelArray.length; i++) {
                 String value = levelArray[i];
                 String ch = value.substring(value.length() - 1);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/config/ProxyConfigTest.java
@@ -35,4 +35,31 @@ public class ProxyConfigTest {
         assertThat(StringUtils.isBlank(proxyConfig.getLocalServeAddr())).isFalse();
         assertThat(proxyConfig.getRemotingAccessAddr()).isEqualTo(proxyConfig.getLocalServeAddr());
     }
+
+    @Test
+    public void parseDelayLevelShouldTolerateExtraWhitespace() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+        proxyConfig.setMessageDelayLevel(" 1s   5s\n10s\t30s ");
+
+        proxyConfig.parseDelayLevel();
+
+        assertThat(proxyConfig.getDelayLevelTable())
+            .containsEntry(1, 1000L)
+            .containsEntry(2, 5000L)
+            .containsEntry(3, 10000L)
+            .containsEntry(4, 30000L);
+    }
+
+    @Test
+    public void parseDelayLevelShouldUseDefaultWhenConfigIsBlank() {
+        ProxyConfig proxyConfig = new ProxyConfig();
+        proxyConfig.setMessageDelayLevel(" \t ");
+
+        proxyConfig.parseDelayLevel();
+
+        assertThat(proxyConfig.getDelayLevelTable())
+            .containsEntry(1, 1000L)
+            .containsEntry(2, 5000L)
+            .containsEntry(18, 7200000L);
+    }
 }


### PR DESCRIPTION
### What
- Parse Proxy `messageDelayLevel` with trimmed `\s+` tokens instead of splitting only on a single space.
- Fall back to the default delay level config when the value is blank, so `useDelayLevel` does not later read an empty table.
- Add `ProxyConfigTest` coverage for repeated whitespace and blank config values.

### Why
`messageDelayLevel` is a config-file value. Repeated spaces, tabs, newlines, or blank input should not leave Proxy delay-level parsing partially populated or empty.

### Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl proxy -DskipITs -DskipCheckStyle -Dtest=ProxyConfigTest test`
- `git diff --check`

Closes #10808
