### PR TITLE
[ISSUE #10810] Redact authentication signatures in audit logs

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authentication/provider/DefaultAuthenticationProvider.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authentication/provider/DefaultAuthenticationProvider.java
@@ -35,6 +35,9 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultAuthenticationProvider implements AuthenticationProvider<DefaultAuthenticationContext> {
 
+    private static final int SIGNATURE_VISIBLE_CHARS = 4;
+    private static final String REDACTED_SIGNATURE = "****";
+
     protected final Logger log = LoggerFactory.getLogger(LoggerName.ROCKETMQ_AUTH_AUDIT_LOGGER_NAME);
     protected AuthConfig authConfig;
     protected Supplier<?> metadataService;
@@ -72,10 +75,23 @@ public class DefaultAuthenticationProvider implements AuthenticationProvider<Def
         if (StringUtils.isBlank(context.getUsername())) {
             return;
         }
+        String signature = maskSignature(context.getSignature());
         if (ex != null) {
-            log.info("[AUTHENTICATION] User:{} is authenticated failed with Signature = {}.", context.getUsername(), context.getSignature());
+            log.info("[AUTHENTICATION] User:{} is authenticated failed with Signature = {}.", context.getUsername(), signature);
         } else {
-            log.debug("[AUTHENTICATION] User:{} is authenticated success with Signature = {}.", context.getUsername(), context.getSignature());
+            log.debug("[AUTHENTICATION] User:{} is authenticated success with Signature = {}.", context.getUsername(), signature);
         }
+    }
+
+    static String maskSignature(String signature) {
+        if (StringUtils.isBlank(signature)) {
+            return REDACTED_SIGNATURE;
+        }
+        if (signature.length() <= SIGNATURE_VISIBLE_CHARS * 2) {
+            return REDACTED_SIGNATURE;
+        }
+        return signature.substring(0, SIGNATURE_VISIBLE_CHARS)
+            + REDACTED_SIGNATURE
+            + signature.substring(signature.length() - SIGNATURE_VISIBLE_CHARS);
     }
 }

--- a/auth/src/test/java/org/apache/rocketmq/auth/authentication/provider/DefaultAuthenticationProviderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authentication/provider/DefaultAuthenticationProviderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.auth.authentication.provider;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DefaultAuthenticationProviderTest {
+
+    @Test
+    public void maskSignatureShouldRedactShortSignatures() {
+        Assert.assertEquals("****", DefaultAuthenticationProvider.maskSignature("test"));
+        Assert.assertEquals("****", DefaultAuthenticationProvider.maskSignature("abcd1234"));
+        Assert.assertEquals("****", DefaultAuthenticationProvider.maskSignature(null));
+    }
+
+    @Test
+    public void maskSignatureShouldKeepOnlyPrefixAndSuffix() {
+        String signature = "DJRRXBXlCVuKh6ULoN87847QX+Y=";
+
+        String masked = DefaultAuthenticationProvider.maskSignature(signature);
+
+        Assert.assertEquals("DJRR****X+Y=", masked);
+        Assert.assertFalse(masked.contains("XBXlCVuKh6ULoN87847Q"));
+    }
+}


### PR DESCRIPTION
### What
- Mask authentication request signatures before writing audit logs.
- Keep only a short prefix/suffix for long signatures and fully redact short or blank signatures.
- Add tests for short and long signature masking.

### Why
Authentication signatures are security-sensitive request material. Audit logs should preserve useful diagnostics without emitting the raw signature value.

### Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl auth -am -DskipITs -DskipCheckStyle -Dtest=DefaultAuthenticationProviderTest -DfailIfNoTests=false test`
- `git diff --check`

Closes #10810
