### PR TITLE
[ISSUE #10817] Upgrade SpotBugs for JDK 21 compatibility

### DIFF
--- a/example/src/main/java/org/apache/rocketmq/example/benchmark/BatchProducer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/benchmark/BatchProducer.java
@@ -20,10 +20,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
@@ -322,7 +322,7 @@ public class BatchProducer {
                 msg.getProperties().clear();
             }
 
-            int startValue = (new Random(System.currentTimeMillis())).nextInt(100);
+            int startValue = ThreadLocalRandom.current().nextInt(100);
             int size = 0;
             for (int i = 0; ; i++) {
                 String prop1 = "prop" + i, prop1V = "hello" + startValue;

--- a/example/src/main/java/org/apache/rocketmq/example/benchmark/Producer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/benchmark/Producer.java
@@ -43,13 +43,13 @@ import org.apache.rocketmq.srvutil.ServerUtil;
 
 import java.util.Arrays;
 import java.util.LinkedList;
-import java.util.Random;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class Producer {
@@ -197,7 +197,7 @@ public class Producer {
                                     msg.getProperties().clear();
                                 }
                                 int i = 0;
-                                int startValue = (new Random(System.currentTimeMillis())).nextInt(100);
+                                int startValue = ThreadLocalRandom.current().nextInt(100);
                                 int size = 0;
                                 while (true) {
                                     String prop1 = "prop" + i, prop1V = "hello" + startValue;

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
         <sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
-        <spotbugs-plugin.version>4.2.2</spotbugs-plugin.version>
+        <spotbugs-plugin.version>4.8.6.8</spotbugs-plugin.version>
         <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
@@ -451,7 +451,6 @@
                 <configuration>
                     <failOnError>true</failOnError>
                     <fork>false</fork>
-                    <spotbugsXmlOutput>true</spotbugsXmlOutput>
                     <excludeFilterFile>${project.root}/style/spotbugs-suppressions.xml</excludeFilterFile>
                     <threshold>High</threshold>
                     <effort>Max</effort>

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelector.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelector.java
@@ -24,9 +24,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
@@ -67,9 +67,8 @@ public class MessageQueueSelector {
             this.queues.addAll(buildWrite(topicRouteWrapper));
         }
         buildBrokerActingQueues(topicRouteWrapper.getTopicName(), this.queues);
-        Random random = new Random();
-        this.queueIndex = new AtomicInteger(random.nextInt());
-        this.brokerIndex = new AtomicInteger(random.nextInt());
+        this.queueIndex = new AtomicInteger(ThreadLocalRandom.current().nextInt());
+        this.brokerIndex = new AtomicInteger(ThreadLocalRandom.current().nextInt());
 
         if (priorityProvider == null) {
             priorityProvider = new DefaultMessageQueuePriorityProvider();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -78,7 +78,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -86,6 +85,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -180,8 +180,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
     }
 
     private static int initValueIndex() {
-        Random r = new Random();
-        return r.nextInt(999);
+        return ThreadLocalRandom.current().nextInt(999);
     }
 
     private void loadSocksProxyJson() {

--- a/store/src/main/java/org/apache/rocketmq/store/kv/CompactionStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/kv/CompactionStore.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.TopicConfig;
@@ -149,7 +149,7 @@ public class CompactionStore {
                 try {
                     v = new CompactionLog(defaultMessageStore, this, topic, queueId);
                     v.load(true);
-                    int randomDelay = 1000 + new Random(System.currentTimeMillis()).nextInt(compactionInterval);
+                    int randomDelay = 1000 + ThreadLocalRandom.current().nextInt(compactionInterval);
                     compactionSchedule.scheduleWithFixedDelay(v::doCompaction, compactionInterval + randomDelay, compactionInterval + randomDelay, TimeUnit.MILLISECONDS);
                 } catch (IOException e) {
                     log.error("create compactionLog exception: ", e);

--- a/test/src/main/java/org/apache/rocketmq/test/util/RandomUtil.java
+++ b/test/src/main/java/org/apache/rocketmq/test/util/RandomUtil.java
@@ -262,7 +262,6 @@ public final class RandomUtil {
         }
 
         int[] result = new int[n];
-        Random rd = new Random();
         int index = 0;
         for (int i = 0; i < result.length; i++) {
             index = rd.nextInt(len--);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10817

### Brief Description

Upgrade `spotbugs-maven-plugin` from 4.2.2 to 4.8.6.8 so that SpotBugs can run on JDK 21 while retaining JDK 8 compatibility.

The old plugin fails on JDK 21 because it invokes the deprecated Security Manager API and bundles an ASM version that cannot analyze Java 21 class files. This change also removes the obsolete `spotbugsXmlOutput` parameter, which is not supported by 4.8.6.8.

The newer SpotBugs version detects several High-priority `DMI_RANDOM_USED_ONLY_ONCE` findings. Replace those one-shot `Random` instances with `ThreadLocalRandom`, or reuse the existing shared `Random` in `RandomUtil`, while preserving the original value ranges and behavior.

### How Did You Test This Change?

- JDK 21: `mvn -B -ntp -Dstyle.color=never -DskipTests compile`
- JDK 8: `mvn -B -ntp -Dstyle.color=never -DskipTests clean compile`

Both full 19-module reactor builds completed successfully with Checkstyle and SpotBugs reporting no violations.
