### PR TITLE
[ISSUE #10819] Correct misleading CommitLog buffer comment

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -2092,7 +2092,7 @@ public class CommitLog implements Swappable {
 
             final long beginTimeMills = CommitLog.this.defaultMessageStore.now();
             CommitLog.this.getMessageStore().getPerfCounter().startTick("WRITE_MEMORY_TIME_MS");
-            // Write messages to the queue buffer
+            // Copy the encoded message into the current CommitLog write buffer
             byteBuffer.put(preEncodeBuffer);
             CommitLog.this.getMessageStore().getPerfCounter().endTick("WRITE_MEMORY_TIME_MS");
             msgInner.setEncodedBuff(null);

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -2092,7 +2092,7 @@ public class CommitLog implements Swappable {
 
             final long beginTimeMills = CommitLog.this.defaultMessageStore.now();
             CommitLog.this.getMessageStore().getPerfCounter().startTick("WRITE_MEMORY_TIME_MS");
-            // Copy the encoded message into the current CommitLog write buffer
+            // Append the encoded message to the current CommitLog buffer
             byteBuffer.put(preEncodeBuffer);
             CommitLog.this.getMessageStore().getPerfCounter().endTick("WRITE_MEMORY_TIME_MS");
             msgInner.setEncodedBuff(null);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10819

### Brief Description

Correct the misleading comment before `byteBuffer.put(preEncodeBuffer)` in `DefaultAppendMessageCallback#doAppend(...)`.

The destination buffer belongs to the CommitLog append path and may be backed by the mapped byte buffer, the transient write buffer, or the shared staging buffer used by `writeWithoutMmap`. It is not a queue or ConsumeQueue buffer. The revised comment makes clear that this line appends an already encoded message to the CommitLog buffer.

This is a documentation-only change with no runtime behavior, API, protocol, configuration, or persisted-format impact.

### How Did You Test This Change?

- Ran `git diff --check` successfully.
- No behavioral tests were added or run because only a source-code comment changed.
