### PR TITLE
[ISSUE #10822] Classify BrokerShutdownTest as a medium Bazel test

### DIFF
--- a/broker/BUILD.bazel
+++ b/broker/BUILD.bazel
@@ -109,6 +109,9 @@ GenTestRules(
             "src/test/java/org/apache/rocketmq/broker/controller/ReplicasManagerRegisterTest",
             "src/test/java/org/apache/rocketmq/broker/BrokerOuterAPITest",
         ],
+    medium_tests = [
+        "src/test/java/org/apache/rocketmq/broker/BrokerShutdownTest",
+    ],
     deps = [
         ":tests",
     ],


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10822

### Brief Description

Classify `BrokerShutdownTest` as a Bazel `medium` test so that its generated test rule receives a timeout appropriate for its workload.

`BrokerShutdownTest` performs four complete broker initialize, start, and shutdown cycles. Broker shutdown serially stops Netty event executors, message-store services, POP services, timer services, and other background resources. In the observed GitHub Actions failure, the target inherited the default `small` classification and timed out after 61.6 seconds while the fourth shutdown was progressing normally.

The same timeout was also observed on unrelated pull requests, so this is an existing test-size classification issue rather than a regression from the triggering change.

Observed failure: https://github.com/apache/rocketmq/actions/runs/31065433437/job/92502049511

This change only adjusts the Bazel timeout classification. Production code and test behavior are unchanged.

### How Did You Test This Change?

- Ran `git diff --check` successfully.
- Verified that `GenTestRules` maps entries in `medium_tests` to `size = "medium"`.
- Confirmed that the PR contains only the three-line `broker/BUILD.bazel` classification change.
- Local Bazel execution was not run because Bazel is not installed in the local environment; GitHub Actions will provide the end-to-end Bazel validation.
