### PR TITLE
[ISSUE #10827] fix(broker): spin for the lock on same-attemptId pop orderly retry to avoid empty response

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -360,7 +360,7 @@ public class PopConsumerService extends ServiceThread {
             new PopConsumerContext(clientHost, popTime, invisibleTime, groupId, fifo, initMode, attemptId);
 
         TopicConfig topicConfig = brokerController.getTopicConfigManager().selectTopicConfig(topicId);
-        if (topicConfig == null || !consumerLockService.tryLock(groupId, topicId)) {
+        if (topicConfig == null || !this.tryLockForPop(groupId, topicId, fifo, attemptId)) {
             return CompletableFuture.completedFuture(popConsumerContext);
         }
 
@@ -468,6 +468,30 @@ public class PopConsumerService extends ServiceThread {
         }
 
         return getMessageFuture;
+    }
+
+    /**
+     * Fifo pops carrying an attemptId are in-flight retries of the same receive attempt,
+     * whose batch has already been registered in OrderInfo. Instead of failing fast on
+     * lock contention (which leaves the retry empty and burns the reentrant attemptId),
+     * retry the lock briefly; other requests keep the fail-fast behavior.
+     */
+    private boolean tryLockForPop(String groupId, String topicId, boolean fifo, String attemptId) {
+        if (consumerLockService.tryLock(groupId, topicId)) {
+            return true;
+        }
+        if (!fifo || attemptId == null || attemptId.isEmpty()) {
+            return false;
+        }
+        // The lock holder always releases on pop completion, and stale locks are
+        // removed by PopConsumerLockService.removeTimeout(), so keep retrying until
+        // the lock is acquired to make sure the in-flight retry is not left empty.
+        // Same-attemptId contention is rare and the wait is normally milliseconds,
+        // so a plain spin is fine here.
+        while (!consumerLockService.tryLock(groupId, topicId)) {
+            Thread.yield();
+        }
+        return true;
     }
 
     // Notify polling request when receive orderly ack

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -471,16 +471,18 @@ public class PopConsumerService extends ServiceThread {
     }
 
     /**
-     * Fifo pops carrying an attemptId are in-flight retries of the same receive attempt,
-     * whose batch has already been registered in OrderInfo. Instead of failing fast on
-     * lock contention (which leaves the retry empty and burns the reentrant attemptId),
-     * retry the lock briefly; other requests keep the fail-fast behavior.
+     * Fifo pops carrying an attemptId already registered in OrderInfo are in-flight retries
+     * of the same receive attempt. Instead of failing fast on lock contention (which leaves
+     * the retry empty and burns the reentrant attemptId), keep retrying the lock; pops with
+     * a different attemptId would be blocked by checkBlock anyway, so they keep the
+     * fail-fast behavior.
      */
     private boolean tryLockForPop(String groupId, String topicId, boolean fifo, String attemptId) {
         if (consumerLockService.tryLock(groupId, topicId)) {
             return true;
         }
-        if (!fifo || attemptId == null || attemptId.isEmpty()) {
+        if (!fifo || attemptId == null || attemptId.isEmpty()
+            || !brokerController.getConsumerOrderInfoManager().isAttemptIdMatched(attemptId, topicId, groupId)) {
             return false;
         }
         // The lock holder always releases on pop completion, and stale locks are

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/orderly/ConsumerOrderInfoManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/orderly/ConsumerOrderInfoManager.java
@@ -69,6 +69,18 @@ public interface ConsumerOrderInfoManager {
     boolean checkBlock(String attemptId, String topic, String group, int queueId, long invisibleTime);
 
     /**
+     * Check whether the given attemptId has already been registered in the order info of
+     * the topic and group, i.e. the request is an in-flight retry of a previous delivery
+     * of the same receive attempt
+     *
+     * @param attemptId Attempt ID
+     * @param topic     Topic name
+     * @param group     Consumer group name
+     * @return true indicates the attemptId is registered in some queue's order info
+     */
+    boolean isAttemptIdMatched(String attemptId, String topic, String group);
+
+    /**
      * Remove the specified topic and group
      * Usually called during topic deletion
      *

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/orderly/QueueLevelConsumerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/orderly/QueueLevelConsumerManager.java
@@ -172,6 +172,20 @@ public class QueueLevelConsumerManager extends ConfigManager implements Consumer
     }
 
     @Override
+    public boolean isAttemptIdMatched(String attemptId, String topic, String group) {
+        ConcurrentHashMap<Integer/*queueId*/, OrderInfo> qs = table.get(buildKey(topic, group));
+        if (qs == null || attemptId == null) {
+            return false;
+        }
+        for (OrderInfo orderInfo : qs.values()) {
+            if (orderInfo != null && attemptId.equals(orderInfo.getAttemptId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void clearBlock(String topic, String group, int queueId) {
         table.computeIfPresent(buildKey(topic, group), (key, val) -> {
             val.remove(queueId);

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceLockRetryTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceLockRetryTest.java
@@ -56,6 +56,7 @@ public class PopConsumerServiceLockRetryTest {
     private PopConsumerLockService consumerLockService;
     private SubscriptionGroupManager subscriptionGroupManager;
     private ConsumerOffsetManager consumerOffsetManager;
+    private ConsumerOrderInfoManager consumerOrderInfoManager;
     private MessageStore messageStore;
     private PopConsumerService consumerService;
 
@@ -68,7 +69,7 @@ public class PopConsumerServiceLockRetryTest {
         TopicConfigManager topicConfigManager = Mockito.mock(TopicConfigManager.class);
         subscriptionGroupManager = Mockito.mock(SubscriptionGroupManager.class);
         consumerOffsetManager = Mockito.mock(ConsumerOffsetManager.class);
-        ConsumerOrderInfoManager consumerOrderInfoManager = Mockito.mock(ConsumerOrderInfoManager.class);
+        consumerOrderInfoManager = Mockito.mock(ConsumerOrderInfoManager.class);
         consumerLockService = Mockito.mock(PopConsumerLockService.class);
         messageStore = Mockito.mock(MessageStore.class);
 
@@ -110,6 +111,8 @@ public class PopConsumerServiceLockRetryTest {
         AtomicInteger attempts = new AtomicInteger();
         Mockito.when(consumerLockService.tryLock(Mockito.anyString(), Mockito.anyString()))
             .thenAnswer(invocation -> attempts.incrementAndGet() > 50);
+        Mockito.when(consumerOrderInfoManager.isAttemptIdMatched(ATTEMPT_ID, TOPIC_ID, GROUP_ID))
+            .thenReturn(true);
         Mockito.when(subscriptionGroupManager.findSubscriptionGroupConfig(Mockito.anyString()))
             .thenReturn(new SubscriptionGroupConfig());
         stubEmptyStore();
@@ -120,6 +123,23 @@ public class PopConsumerServiceLockRetryTest {
         assertNotNull(result);
         Mockito.verify(consumerLockService, Mockito.times(51)).tryLock(Mockito.anyString(), Mockito.anyString());
         Mockito.verify(subscriptionGroupManager).findSubscriptionGroupConfig(GROUP_ID);
+    }
+
+    @Test
+    public void popAsyncUnregisteredAttemptIdFailFastTest() {
+        // a fifo pop whose attemptId is not registered in OrderInfo is not an in-flight
+        // retry of a previous delivery, so it must keep the fail-fast behavior
+        Mockito.when(consumerLockService.tryLock(Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(false);
+        Mockito.when(consumerOrderInfoManager.isAttemptIdMatched(ATTEMPT_ID, TOPIC_ID, GROUP_ID))
+            .thenReturn(false);
+
+        PopConsumerContext result = consumerService.popAsync("127.0.0.1", System.currentTimeMillis(),
+            INVISIBLE_TIME, GROUP_ID, TOPIC_ID, 0, 32, true, ATTEMPT_ID, ConsumeInitMode.MIN, null).join();
+
+        assertNotNull(result);
+        assertEquals(0, result.getMessageCount());
+        Mockito.verify(consumerLockService, Mockito.times(1)).tryLock(Mockito.anyString(), Mockito.anyString());
     }
 
     @Test

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceLockRetryTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerServiceLockRetryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.broker.pop;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.broker.offset.ConsumerOffsetManager;
+import org.apache.rocketmq.broker.pop.orderly.ConsumerOrderInfoManager;
+import org.apache.rocketmq.broker.subscription.SubscriptionGroupManager;
+import org.apache.rocketmq.broker.topic.TopicConfigManager;
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.common.constant.ConsumeInitMode;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.store.GetMessageResult;
+import org.apache.rocketmq.store.GetMessageStatus;
+import org.apache.rocketmq.store.MessageStore;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PopConsumerServiceLockRetryTest {
+
+    private static final String GROUP_ID = "groupId";
+    private static final String TOPIC_ID = "topicId";
+    private static final String ATTEMPT_ID = "attempt-id-lock-retry";
+    private static final long INVISIBLE_TIME = 300_000L;
+
+    private final String filePath = PopConsumerRocksdbStoreTest.getRandomStorePath();
+
+    private BrokerController brokerController;
+    private PopConsumerLockService consumerLockService;
+    private SubscriptionGroupManager subscriptionGroupManager;
+    private ConsumerOffsetManager consumerOffsetManager;
+    private MessageStore messageStore;
+    private PopConsumerService consumerService;
+
+    @Before
+    public void init() throws IOException, IllegalAccessException {
+        BrokerConfig brokerConfig = new BrokerConfig();
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setStorePathRootDir(filePath);
+
+        TopicConfigManager topicConfigManager = Mockito.mock(TopicConfigManager.class);
+        subscriptionGroupManager = Mockito.mock(SubscriptionGroupManager.class);
+        consumerOffsetManager = Mockito.mock(ConsumerOffsetManager.class);
+        ConsumerOrderInfoManager consumerOrderInfoManager = Mockito.mock(ConsumerOrderInfoManager.class);
+        consumerLockService = Mockito.mock(PopConsumerLockService.class);
+        messageStore = Mockito.mock(MessageStore.class);
+
+        brokerController = Mockito.mock(BrokerController.class);
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(brokerConfig);
+        Mockito.when(brokerController.getMessageStoreConfig()).thenReturn(messageStoreConfig);
+        Mockito.when(brokerController.getTopicConfigManager()).thenReturn(topicConfigManager);
+        Mockito.when(brokerController.getSubscriptionGroupManager()).thenReturn(subscriptionGroupManager);
+        Mockito.when(brokerController.getConsumerOffsetManager()).thenReturn(consumerOffsetManager);
+        Mockito.when(brokerController.getConsumerOrderInfoManager()).thenReturn(consumerOrderInfoManager);
+        Mockito.when(brokerController.getMessageStore()).thenReturn(messageStore);
+        Mockito.when(topicConfigManager.selectTopicConfig(Mockito.anyString()))
+            .thenReturn(new TopicConfig(TOPIC_ID));
+
+        consumerService = new PopConsumerService(brokerController);
+        // the lock service is built inside the constructor, replace it for verification
+        FieldUtils.writeField(consumerService, "consumerLockService", consumerLockService, true);
+    }
+
+    @After
+    public void shutdown() throws IOException {
+        FileUtils.deleteDirectory(new File(filePath));
+    }
+
+    private void stubEmptyStore() {
+        GetMessageResult result = new GetMessageResult();
+        result.setStatus(GetMessageStatus.NO_MESSAGE_IN_QUEUE);
+        result.setNextBeginOffset(0L);
+        Mockito.when(messageStore.getMessageAsync(Mockito.anyString(), Mockito.anyString(),
+                Mockito.anyInt(), Mockito.anyLong(), Mockito.anyInt(), Mockito.any()))
+            .thenReturn(CompletableFuture.completedFuture(result));
+        Mockito.when(consumerOffsetManager.queryOffset(Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyInt())).thenReturn(0L);
+    }
+
+    @Test
+    public void popAsyncOrderlyLockRetryPersistsTest() {
+        // the retry keeps spinning until the lock holder releases, no early give-up
+        AtomicInteger attempts = new AtomicInteger();
+        Mockito.when(consumerLockService.tryLock(Mockito.anyString(), Mockito.anyString()))
+            .thenAnswer(invocation -> attempts.incrementAndGet() > 50);
+        Mockito.when(subscriptionGroupManager.findSubscriptionGroupConfig(Mockito.anyString()))
+            .thenReturn(new SubscriptionGroupConfig());
+        stubEmptyStore();
+
+        PopConsumerContext result = consumerService.popAsync("127.0.0.1", System.currentTimeMillis(),
+            INVISIBLE_TIME, GROUP_ID, TOPIC_ID, 0, 32, true, ATTEMPT_ID, ConsumeInitMode.MIN, null).join();
+
+        assertNotNull(result);
+        Mockito.verify(consumerLockService, Mockito.times(51)).tryLock(Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(subscriptionGroupManager).findSubscriptionGroupConfig(GROUP_ID);
+    }
+
+    @Test
+    public void popAsyncNonFifoFailFastTest() {
+        Mockito.when(consumerLockService.tryLock(Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(false);
+
+        PopConsumerContext result = consumerService.popAsync("127.0.0.1", System.currentTimeMillis(),
+            INVISIBLE_TIME, GROUP_ID, TOPIC_ID, 0, 32, false, null, ConsumeInitMode.MIN, null).join();
+
+        assertNotNull(result);
+        assertEquals(0, result.getMessageCount());
+        // non-fifo requests must keep the fail-fast behavior
+        Mockito.verify(consumerLockService, Mockito.times(1)).tryLock(Mockito.anyString(), Mockito.anyString());
+    }
+}

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/orderly/ConsumerOrderInfoManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/orderly/ConsumerOrderInfoManagerTest.java
@@ -536,6 +536,28 @@ public class ConsumerOrderInfoManagerTest {
     }
 
     @Test
+    public void isAttemptIdMatchTest() {
+        StringBuilder orderInfoBuilder = new StringBuilder();
+        String attemptId = UUID.randomUUID().toString();
+        consumerOrderInfoManager.update(
+            attemptId,
+            false,
+            TOPIC,
+            GROUP,
+            QUEUE_ID_0,
+            popTime,
+            3000,
+            Lists.newArrayList(1L, 2L, 3L),
+            orderInfoBuilder
+        );
+
+        assertTrue(consumerOrderInfoManager.isAttemptIdMatched(attemptId, TOPIC, GROUP));
+        assertFalse(consumerOrderInfoManager.isAttemptIdMatched(UUID.randomUUID().toString(), TOPIC, GROUP));
+        assertFalse(consumerOrderInfoManager.isAttemptIdMatched(attemptId, "unknownTopic", GROUP));
+        assertFalse(consumerOrderInfoManager.isAttemptIdMatched(null, TOPIC, GROUP));
+    }
+
+    @Test
     public void testGetMaxLockFreeTimestamp() {
         QueueLevelConsumerManager.OrderInfo orderInfo = new QueueLevelConsumerManager.OrderInfo();
         orderInfo.setOffsetList(new ArrayList<>());


### PR DESCRIPTION
## What is the purpose of the change

Fixes #10827.

An orderly (fifo / PopKv) retry carrying the same attemptId is an idempotent reentrant request, but `PopConsumerService.popAsync` fails fast with an empty response when the group@topic lock is contended. The retry then suspends in long polling, burns the only reentrant opportunity, times out, and the client rotates to a new attemptId — permanently losing reentrancy and blocking the queue head (up to one invisibleTime, or ~3h when proxy autoRenew keeps extending nextVisibleTime). See the issue for the full failure chain, verified step by step against code in a real incident (a patrol system consuming orderly messages through Proxy intermittently hung for a long time).

## Brief description of the change

Introduce `tryLockForPop` in `PopConsumerService`: a fifo request whose attemptId is already registered in OrderInfo (i.e. a genuine in-flight retry of a previous delivery of the same receive attempt, checked via the new `ConsumerOrderInfoManager.isAttemptIdMatched`) spin-retries `tryLock` until the lock is acquired instead of failing fast; all other requests keep the fail-fast behavior — pops with a different attemptId would be blocked by checkBlock even after acquiring the lock, so spinning would only waste request threads while the lock may be held for seconds on slow paths.

Correctness rationale:
- The lock holder always releases on pop completion (`whenComplete` unlock), with the lock service's 2-minute expiry sweep as the worst-case backstop, so the spin cannot wait forever.
- Same-attemptId contention is rare and the wait is normally milliseconds, so busy-wait cost is negligible.
- Once the lock is acquired, the existing re-pop path runs (checkBlock passes for the same attemptId, consumedCount is not incremented), fully preserving the reentrant semantics.
- The wakeUp long-polling re-execution path benefits as well.

A lock-free read-only replay of the previous OrderInfo batch was evaluated first; it works but is much larger, and further analysis showed the existing re-pop path is already self-consistent (invalidating the receipt handle of the lost delivery is normal at-least-once semantics) — the real defect is only that lock contention leaves the retry empty, hence this minimal fix (one new interface method with a small lookup, no config switch).

## Does this pull request affect any existing functionality?

No. Only fifo requests whose attemptId is already registered in OrderInfo change behavior (spin instead of empty response on lock contention); all other requests keep fail-fast.

## Verification

- New unit tests `PopConsumerServiceLockRetryTest`: spin until the lock is acquired and the pop path proceeds when the attemptId is registered; unregistered attemptId and non-fifo keep fail-fast. `ConsumerOrderInfoManagerTest` covers `isAttemptIdMatched`. All 17 existing `PopConsumerServiceTest` cases pass, checkstyle clean, JDK 8 compile verified.
- Real-environment verification (k8s micro setup, broker image with this fix):
  - End-to-end: first pop FOUND/2 unacked → same-attemptId re-pop FOUND/2 within milliseconds → ack succeeds → fresh-attemptId pop finds the queue drained.
  - Contention probe: 5 rounds × 16 concurrent same-attemptId pops, all 80 returned the same batch with zero empty responses; broker logs confirmed all 16 requests per round executed inside the lock, i.e. the contention window was genuinely exercised.
