### PR TITLE
[ISSUE #10829] fix(common): handle negative version values

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
@@ -25,6 +25,9 @@ public class MQVersion {
     public static String getVersionDesc(int value) {
         Version[] versions = VERSION_VALUES;
         int length = versions.length;
+        if (value < 0) {
+            return versions[0].name();
+        }
         if (value >= length) {
             return versions[length - 1].name();
         }
@@ -34,6 +37,9 @@ public class MQVersion {
     public static Version value2Version(int value) {
         Version[] versions = VERSION_VALUES;
         int length = versions.length;
+        if (value < 0) {
+            return versions[0];
+        }
         if (value >= length) {
             return versions[length - 1];
         }

--- a/common/src/test/java/org/apache/rocketmq/common/MQVersionTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MQVersionTest.java
@@ -36,6 +36,11 @@ public class MQVersionTest {
     }
 
     @Test
+    public void testGetVersionDesc_NegativeVersion() {
+        assertThat(MQVersion.getVersionDesc(-1)).isEqualTo("V3_0_0_SNAPSHOT");
+    }
+
+    @Test
     public void testValue2Version() throws Exception {
         assertThat(MQVersion.value2Version(0)).isEqualTo(MQVersion.Version.V3_0_0_SNAPSHOT);
     }
@@ -43,5 +48,10 @@ public class MQVersionTest {
     @Test
     public void testValue2Version_HigherVersion() throws Exception {
         assertThat(MQVersion.value2Version(Integer.MAX_VALUE)).isEqualTo(MQVersion.Version.HIGHER_VERSION);
+    }
+
+    @Test
+    public void testValue2Version_NegativeVersion() {
+        assertThat(MQVersion.value2Version(-1)).isEqualTo(MQVersion.Version.V3_0_0_SNAPSHOT);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10829

### Brief Description

Clamp negative version values to the earliest known RocketMQ version so remote metadata cannot trigger an array index failure.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl common -Dtest=MQVersionTest test`

