### PR TITLE
[ISSUE #10830] fix(common): preserve hyphens in DLedger peer addresses

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java
@@ -225,8 +225,9 @@ public class ControllerConfig {
 
     public String getDLedgerAddress() {
         return Arrays.stream(this.controllerDLegerPeers.split(";"))
-            .filter(x -> this.controllerDLegerSelfId.equals(x.split("-")[0]))
-            .map(x -> x.split("-")[1]).findFirst().get();
+            .map(x -> x.split("-", 2))
+            .filter(x -> x.length == 2 && this.controllerDLegerSelfId.equals(x[0]))
+            .map(x -> x[1]).findFirst().get();
     }
 
     public MetricsExporterType getMetricsExporterType() {

--- a/common/src/test/java/org/apache/rocketmq/common/ControllerConfigTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/ControllerConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ControllerConfigTest {
+
+    @Test
+    public void testGetDLedgerAddressWithHyphenatedHost() {
+        ControllerConfig config = new ControllerConfig();
+        config.setControllerDLegerSelfId("n0");
+        config.setControllerDLegerPeers("n0-controller-host:9878;n1-controller-backup:9878");
+
+        assertThat(config.getDLedgerAddress()).isEqualTo("controller-host:9878");
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10830

### Brief Description

Split DLedger peer entries only once so addresses containing hyphens are returned intact.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl common -Dtest=ControllerConfigTest test`

