### PR TITLE
[ISSUE #10831] fix(store): handle minimum hash index in compaction offset map

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/kv/CompactionLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/kv/CompactionLog.java
@@ -965,7 +965,7 @@ public class CompactionLog {
 
         private int indexOf(byte[] hash, int tryNum) {
             int index = readInt(hash, Math.min(tryNum, hashSize - 4)) + Math.max(0, tryNum - hashSize + 4);
-            int entry = Math.abs(index) % capacity;
+            int entry = Math.floorMod(index, capacity);
             return entry * entrySize;
         }
 

--- a/store/src/test/java/org/apache/rocketmq/store/kv/OffsetMapTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/kv/OffsetMapTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store.kv;
 
+import java.security.MessageDigest;
 import org.apache.rocketmq.store.kv.CompactionLog.OffsetMap;
 import org.junit.Test;
 
@@ -49,5 +50,51 @@ public class OffsetMapTest {
         assertNotEquals(offsetMap.get("55"), 56);
         assertEquals(offsetMap.getLastOffset(), 99);
         assertThrows(IllegalArgumentException.class, () -> offsetMap.put(String.valueOf(100), 100));
+    }
+
+    @Test
+    public void testMinimumHashValue() throws Exception {
+        OffsetMap offsetMap = new OffsetMap(0, new MinimumHashDigest());
+
+        offsetMap.put("key", 7);
+
+        assertEquals(7, offsetMap.get("key"));
+    }
+
+    private static class MinimumHashDigest extends MessageDigest {
+        private MinimumHashDigest() {
+            super("minimum-hash");
+        }
+
+        @Override
+        protected int engineGetDigestLength() {
+            return 16;
+        }
+
+        @Override
+        protected void engineUpdate(byte input) {
+        }
+
+        @Override
+        protected void engineUpdate(byte[] input, int offset, int len) {
+        }
+
+        @Override
+        protected byte[] engineDigest() {
+            byte[] digest = new byte[16];
+            digest[0] = Byte.MIN_VALUE;
+            return digest;
+        }
+
+        @Override
+        protected int engineDigest(byte[] buf, int offset, int len) {
+            byte[] digest = engineDigest();
+            System.arraycopy(digest, 0, buf, offset, digest.length);
+            return digest.length;
+        }
+
+        @Override
+        protected void engineReset() {
+        }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10831

### Brief Description

Use floor modulus when mapping compaction hashes so `Integer.MIN_VALUE` always resolves to a valid offset-map entry.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl store -am -Dtest=OffsetMapTest -Dsurefire.failIfNoSpecifiedTests=false test`

