### PR TITLE
[ISSUE #10832] fix(remoting): reject malformed command frames

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingCommand.java
@@ -190,13 +190,21 @@ public class RemotingCommand {
 
     public static RemotingCommand decode(final ByteBuf byteBuffer) throws RemotingCommandException {
         int length = byteBuffer.readableBytes();
+        if (length < 4) {
+            throw new RemotingCommandException("decode error, frame is too short: " + length);
+        }
         int oriHeaderLen = byteBuffer.readInt();
         int headerLength = getHeaderLength(oriHeaderLen);
         if (headerLength > length - 4) {
             throw new RemotingCommandException("decode error, bad header length: " + headerLength);
         }
 
-        RemotingCommand cmd = headerDecode(byteBuffer, headerLength, getProtocolType(oriHeaderLen));
+        SerializeType protocolType = getProtocolType(oriHeaderLen);
+        if (protocolType == null) {
+            throw new RemotingCommandException("decode error, unknown serialize type: "
+                + ((oriHeaderLen >> 24) & 0xFF));
+        }
+        RemotingCommand cmd = headerDecode(byteBuffer, headerLength, protocolType);
 
         int bodyLength = length - 4 - headerLength;
         byte[] bodyData = null;

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
@@ -31,6 +31,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemotingCommandTest {
     @Test
+    public void testDecodeRejectsShortFrame() {
+        Assert.assertThrows(RemotingCommandException.class,
+            () -> RemotingCommand.decode(new byte[] {0, 0, 0}));
+    }
+
+    @Test
+    public void testDecodeRejectsUnknownSerializeType() {
+        Assert.assertThrows(RemotingCommandException.class,
+            () -> RemotingCommand.decode(new byte[] {Byte.MAX_VALUE, 0, 0, 0}));
+    }
+
+    @Test
     public void testMarkProtocolType_JSONProtocolType() {
         int source = 261;
         SerializeType type = SerializeType.JSON;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10832

### Brief Description

Reject short command frames and unknown serialization types with `RemotingCommandException` instead of unchecked exceptions.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl remoting -am -Dtest=RemotingCommandTest -Dsurefire.failIfNoSpecifiedTests=false test`

