### PR TITLE
[ISSUE #10833] fix(metrics): preserve colons in config values

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManager.java
@@ -353,7 +353,7 @@ public class BrokerMetricsManager {
         if (StringUtils.isNotBlank(labels)) {
             List<String> kvPairs = Splitter.on(',').omitEmptyStrings().splitToList(labels);
             for (String item : kvPairs) {
-                String[] split = item.split(":");
+                String[] split = item.split(":", 2);
                 if (split.length != 2) {
                     LOGGER.warn("metricsLabel is not valid: {}", labels);
                     continue;
@@ -400,7 +400,7 @@ public class BrokerMetricsManager {
                 Map<String, String> headerMap = new HashMap<>();
                 List<String> kvPairs = Splitter.on(',').omitEmptyStrings().splitToList(headers);
                 for (String item : kvPairs) {
-                    String[] split = item.split(":");
+                    String[] split = item.split(":", 2);
                     if (split.length != 2) {
                         LOGGER.warn("metricsGrpcExporterHeader is not valid: {}", headers);
                         continue;

--- a/broker/src/test/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/metrics/BrokerMetricsManagerTest.java
@@ -359,4 +359,25 @@ public class BrokerMetricsManagerTest {
 
         assertThat(metricsManager.getBrokerMeter()).isNotNull();
     }
+
+    @Test
+    public void testMetricsLabelValueContainingColon() throws CloneNotSupportedException {
+        BrokerConfig brokerConfig = new BrokerConfig();
+        brokerConfig.setMetricsExporterType(MetricsExporterType.LOG);
+        brokerConfig.setMetricsLabel("endpoint:https://collector:4317");
+
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setStorePathRootDir(System.getProperty("java.io.tmpdir") + File.separator + "store-"
+            + UUID.randomUUID());
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setListenPort(0);
+        BrokerController brokerController = new BrokerController(brokerConfig, nettyServerConfig,
+            new NettyClientConfig(), messageStoreConfig);
+        brokerController.initialize();
+
+        BrokerMetricsManager metricsManager = new BrokerMetricsManager(brokerController);
+        Attributes attributes = metricsManager.newAttributesBuilder().build();
+
+        assertThat(attributes.get(AttributeKey.stringKey("endpoint"))).isEqualTo("https://collector:4317");
+    }
 }

--- a/controller/src/main/java/org/apache/rocketmq/controller/metrics/ControllerMetricsManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/metrics/ControllerMetricsManager.java
@@ -303,7 +303,7 @@ public class ControllerMetricsManager {
         if (StringUtils.isNotBlank(labels)) {
             List<String> labelList = Splitter.on(',').omitEmptyStrings().splitToList(labels);
             for (String label : labelList) {
-                String[] pair = label.split(":");
+                String[] pair = label.split(":", 2);
                 if (pair.length != 2) {
                     logger.warn("metrics label is not valid: {}", label);
                     continue;
@@ -338,7 +338,7 @@ public class ControllerMetricsManager {
                 Map<String, String> headerMap = new HashMap<>();
                 List<String> headerList = Splitter.on(',').omitEmptyStrings().splitToList(headers);
                 for (String header : headerList) {
-                    String[] pair = header.split(":");
+                    String[] pair = header.split(":", 2);
                     if (pair.length != 2) {
                         logger.warn("metricsGrpcExporterHeader is not valid: {}", headers);
                         continue;

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/metrics/ProxyMetricsManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/metrics/ProxyMetricsManager.java
@@ -148,7 +148,7 @@ public class ProxyMetricsManager implements StartAndShutdown {
         if (StringUtils.isNotBlank(labels)) {
             List<String> kvPairs = Splitter.on(',').omitEmptyStrings().splitToList(labels);
             for (String item : kvPairs) {
-                String[] split = item.split(":");
+                String[] split = item.split(":", 2);
                 if (split.length != 2) {
                     log.warn("metricsLabel is not valid: {}", labels);
                     continue;
@@ -188,7 +188,7 @@ public class ProxyMetricsManager implements StartAndShutdown {
                 Map<String, String> headerMap = new HashMap<>();
                 List<String> kvPairs = Splitter.on(',').omitEmptyStrings().splitToList(headers);
                 for (String item : kvPairs) {
-                    String[] split = item.split(":");
+                    String[] split = item.split(":", 2);
                     if (split.length != 2) {
                         log.warn("metricsGrpcExporterHeader is not valid: {}", headers);
                         continue;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10833

### Brief Description

Split metrics labels and OTLP headers on the first colon so URL-like values remain intact across Broker, Proxy, and Controller.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl broker -am -Dtest=BrokerMetricsManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mise x java@temurin-17 -- mvn -pl proxy,controller -am -DskipTests test`

