### PR TITLE
[ISSUE #10834] fix(remoting): parse bracketed IPv6 broker addresses

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
@@ -265,12 +265,21 @@ public class RemotingHelper {
             return "";
         }
 
-        String[] addressSplits = address.split(":");
-        if (addressSplits.length < 1) {
-            return "";
+        if (address.startsWith("[")) {
+            int closingBracket = address.indexOf(']');
+            if (closingBracket > 0) {
+                return address.substring(1, closingBracket);
+            }
         }
 
-        return addressSplits[0];
+        int firstColon = address.indexOf(':');
+        if (firstColon < 0) {
+            return address;
+        }
+        if (firstColon == address.lastIndexOf(':')) {
+            return address.substring(0, firstColon);
+        }
+        return address;
     }
 
     public static String parseSocketAddressAddr(SocketAddress socketAddress) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemotingHelperTest {
+
+    @Test
+    public void testParseHostFromIpv4Address() {
+        assertThat(RemotingHelper.parseHostFromAddress("127.0.0.1:10911")).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    public void testParseHostFromBracketedIpv6Address() {
+        assertThat(RemotingHelper.parseHostFromAddress("[2001:db8::1]:10911")).isEqualTo("2001:db8::1");
+    }
+
+    @Test
+    public void testParseHostFromIpv6AddressWithoutPort() {
+        assertThat(RemotingHelper.parseHostFromAddress("2001:db8::1")).isEqualTo("2001:db8::1");
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10834

### Brief Description

Parse bracketed IPv6 broker addresses without truncating the host while preserving IPv4 and host-only behavior.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl remoting -am -Dtest=RemotingHelperTest -Dsurefire.failIfNoSpecifiedTests=false test`

