### PR TITLE
[ISSUE #10836] fix(common): validate group when parsing POP retry topics

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/KeyBuilder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/KeyBuilder.java
@@ -42,14 +42,15 @@ public class KeyBuilder {
     }
 
     public static String parseNormalTopic(String topic, String cid) {
-        if (topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) {
-            if (topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX + cid + POP_RETRY_SEPARATOR_V2)) {
-                return topic.substring((MixAll.RETRY_GROUP_TOPIC_PREFIX + cid + POP_RETRY_SEPARATOR_V2).length());
-            }
-            return topic.substring((MixAll.RETRY_GROUP_TOPIC_PREFIX + cid + POP_RETRY_SEPARATOR_V1).length());
-        } else {
-            return topic;
+        String retryPrefixV2 = MixAll.RETRY_GROUP_TOPIC_PREFIX + cid + POP_RETRY_SEPARATOR_V2;
+        if (topic.startsWith(retryPrefixV2)) {
+            return topic.substring(retryPrefixV2.length());
         }
+        String retryPrefixV1 = MixAll.RETRY_GROUP_TOPIC_PREFIX + cid + POP_RETRY_SEPARATOR_V1;
+        if (topic.startsWith(retryPrefixV1)) {
+            return topic.substring(retryPrefixV1.length());
+        }
+        return topic;
     }
 
     public static String parseNormalTopic(String retryTopic) {

--- a/common/src/test/java/org/apache/rocketmq/common/KeyBuilderTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/KeyBuilderTest.java
@@ -48,6 +48,20 @@ public class KeyBuilderTest {
     }
 
     @Test
+    public void testParseNormalTopicDoesNotStripAnotherGroup() {
+        String retryTopic = KeyBuilder.buildPopRetryTopicV1(topic, "another-group");
+
+        assertThat(KeyBuilder.parseNormalTopic(retryTopic, group)).isEqualTo(retryTopic);
+    }
+
+    @Test
+    public void testParseNormalTopicDoesNotFailForRegularRetryTopic() {
+        String retryTopic = MixAll.RETRY_GROUP_TOPIC_PREFIX + group;
+
+        assertThat(KeyBuilder.parseNormalTopic(retryTopic, group)).isEqualTo(retryTopic);
+    }
+
+    @Test
     public void testParseGroup() {
         String popRetryTopic = KeyBuilder.buildPopRetryTopicV2(topic, group);
         assertThat(KeyBuilder.parseGroup(popRetryTopic)).isEqualTo(group);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10836

### Brief Description

Strip POP retry prefixes only when they exactly match the supplied consumer group and retry-topic format.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl common -Dtest=KeyBuilderTest test`

