### PR TITLE
[ISSUE #10838] fix(route): skip malformed ordered topic entries

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -237,8 +237,16 @@ public class MQClientInstance {
         if (route.getOrderTopicConf() != null && route.getOrderTopicConf().length() > 0) {
             String[] brokers = route.getOrderTopicConf().split(";");
             for (String broker : brokers) {
-                String[] item = broker.split(":");
-                int nums = Integer.parseInt(item[1]);
+                String[] item = broker.split(":", 2);
+                if (item.length != 2) {
+                    continue;
+                }
+                int nums;
+                try {
+                    nums = Integer.parseInt(item[1]);
+                } catch (NumberFormatException e) {
+                    continue;
+                }
                 for (int i = 0; i < nums; i++) {
                     MessageQueue mq = new MessageQueue(topic, item[0], i);
                     info.getMessageQueueList().add(mq);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
@@ -252,6 +252,17 @@ public class MQClientInstanceTest {
     }
 
     @Test
+    public void testTopicRouteData2TopicPublishInfoSkipsMalformedOrderTopicConf() {
+        TopicRouteData topicRouteData = createTopicRouteData();
+        topicRouteData.setOrderTopicConf("missing-count;invalid:not-a-number;127.0.0.1:2");
+
+        TopicPublishInfo actual = MQClientInstance.topicRouteData2TopicPublishInfo(topic, topicRouteData);
+
+        assertTrue(actual.isOrderTopic());
+        assertEquals(2, actual.getMessageQueueList().size());
+    }
+
+    @Test
     public void testTopicRouteData2TopicPublishInfoWithTopicQueueMappingByBroker() {
         TopicRouteData topicRouteData = createTopicRouteData();
         topicRouteData.setTopicQueueMappingByBroker(Collections.singletonMap(topic, new TopicQueueMappingInfo()));

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelector.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelector.java
@@ -109,14 +109,22 @@ public class MessageQueueSelector {
         if (StringUtils.isNotBlank(topicRoute.getOrderTopicConf())) {
             String[] brokers = topicRoute.getOrderTopicConf().split(";");
             for (String broker : brokers) {
-                String[] item = broker.split(":");
+                String[] item = broker.split(":", 2);
+                if (item.length != 2) {
+                    continue;
+                }
                 String brokerName = item[0];
                 String brokerAddr = topicRoute.getMasterAddr(brokerName);
                 if (brokerAddr == null) {
                     continue;
                 }
 
-                int nums = Integer.parseInt(item[1]);
+                int nums;
+                try {
+                    nums = Integer.parseInt(item[1]);
+                } catch (NumberFormatException e) {
+                    continue;
+                }
                 for (int i = 0; i < nums; i++) {
                     AddressableMessageQueue mq = new AddressableMessageQueue(
                         new MessageQueue(topicRoute.getTopicName(), brokerName, i),

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelectorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/route/MessageQueueSelectorTest.java
@@ -81,4 +81,14 @@ public class MessageQueueSelectorTest extends BaseServiceTest {
         messageQueueSelector.selectOne(false);
         assertEquals(queue, messageQueueSelector.selectOne(false));
     }
+
+    @Test
+    public void testWriteMessageQueueSkipsMalformedOrderTopicConf() {
+        topicRouteData.setOrderTopicConf("missing-count;" + BROKER_NAME + ":not-a-number;" + BROKER_NAME + ":2");
+
+        MessageQueueSelector messageQueueSelector =
+            new MessageQueueSelector(new TopicRouteWrapper(topicRouteData, TOPIC), false);
+
+        assertEquals(2, messageQueueSelector.getQueues().size());
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10838

### Brief Description

Skip malformed ordered-topic entries in both client and proxy route conversion while retaining valid broker queue definitions.

### How Did You Test This Change?

- `mise x java@temurin-17 -- mvn -pl client -am -Dtest=MQClientInstanceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mise x java@temurin-17 -- mvn -pl proxy -am -Dtest=MessageQueueSelectorTest -Dsurefire.failIfNoSpecifiedTests=false test`

