### PR TITLE
[ISSUE #10849] fix(remoting): avoid static topic epoch sort overflow

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtils.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtils.java
@@ -338,7 +338,7 @@ public class TopicQueueMappingUtils {
 
 
     public static Map<Integer, TopicQueueMappingOne> checkAndBuildMappingItems(List<TopicQueueMappingDetail> mappingDetailList, boolean replace, boolean checkConsistence) {
-        mappingDetailList.sort((o1, o2) -> (int) (o2.getEpoch() - o1.getEpoch()));
+        mappingDetailList.sort((o1, o2) -> Long.compare(o2.getEpoch(), o1.getEpoch()));
 
         int maxNum = 0;
         Map<Integer, TopicQueueMappingOne> globalIdMap = new HashMap<>();

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/rpc/ClientMetadata.java
@@ -119,7 +119,7 @@ public class ClientMetadata {
             Map<String, TopicQueueMappingInfo> topicQueueMappingInfoMap =  mapEntry.getValue();
             ConcurrentMap<MessageQueue, TopicQueueMappingInfo> mqEndPoints = new ConcurrentHashMap<>();
             List<Map.Entry<String, TopicQueueMappingInfo>> mappingInfos = new ArrayList<>(topicQueueMappingInfoMap.entrySet());
-            mappingInfos.sort((o1, o2) -> (int) (o2.getValue().getEpoch() - o1.getValue().getEpoch()));
+            mappingInfos.sort((o1, o2) -> Long.compare(o2.getValue().getEpoch(), o1.getValue().getEpoch()));
             int maxTotalNums = 0;
             long maxTotalNumOfEpoch = -1;
             for (Map.Entry<String, TopicQueueMappingInfo> entry : mappingInfos) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtilsTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/statictopic/TopicQueueMappingUtilsTest.java
@@ -31,6 +31,23 @@ import org.junit.Test;
 
 public class TopicQueueMappingUtilsTest {
 
+    @Test
+    public void testCheckAndBuildMappingItemsChoosesLatestEpochWithoutOverflow() {
+        TopicQueueMappingDetail latest = buildMappingDetail("latest", Long.MAX_VALUE);
+        TopicQueueMappingDetail stale = buildMappingDetail("stale", 0);
+
+        Map<Integer, TopicQueueMappingOne> result = TopicQueueMappingUtils.checkAndBuildMappingItems(
+            new ArrayList<>(java.util.Arrays.asList(latest, stale)), true, false);
+
+        Assert.assertEquals("latest", result.get(0).getBname());
+    }
+
+    private TopicQueueMappingDetail buildMappingDetail(String brokerName, long epoch) {
+        TopicQueueMappingDetail detail = new TopicQueueMappingDetail("topic", 1, brokerName, epoch);
+        LogicQueueMappingItem item = new LogicQueueMappingItem(0, 0, brokerName, 0, 0, -1, -1, -1);
+        detail.getHostedQueues().put(0, new ArrayList<>(Collections.singletonList(item)));
+        return detail;
+    }
 
     private Set<String> buildTargetBrokers(int num) {
         return buildTargetBrokers(num, "");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10849

### Brief Description

Replaces narrowing subtraction in both static-topic epoch comparators with Long.compare. Adds a regression test proving that replacement mode selects the mapping with the latest epoch across the full long range.

### How Did You Test This Change?

`mise x java@temurin-17 -- mvn -Dmaven.repo.local=/private/tmp/rocketmq-m2 -pl remoting -am -DskipITs -Dtest=TopicQueueMappingUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`

The targeted tests, Checkstyle, and SpotBugs completed successfully.