### PR TITLE
[ISSUE #10850] fix(tools): avoid overflow in mqadmin sorting

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java
@@ -349,7 +349,7 @@ class GroupConsumeInfo implements Comparable<GroupConsumeInfo> {
             return o.count - this.count;
         }
 
-        return (int) (o.diffTotal - diffTotal);
+        return Long.compare(o.diffTotal, diffTotal);
     }
 
     public int getConsumeTps() {

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java
@@ -250,7 +250,7 @@ public class PrintMessageByQueueCommand implements SubCommand {
 
         @Override
         public int compareTo(final TagCountBean o) {
-            return (int) (o.getCount().get() - this.count.get());
+            return Long.compare(o.getCount().get(), this.count.get());
         }
     }
 }

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByUniqueKeySubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByUniqueKeySubCommand.java
@@ -20,6 +20,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -39,6 +40,9 @@ import org.apache.rocketmq.tools.command.SubCommand;
 import org.apache.rocketmq.tools.command.SubCommandException;
 
 public class QueryMsgByUniqueKeySubCommand implements SubCommand {
+
+    static final Comparator<MessageExt> STORE_TIMESTAMP_COMPARATOR =
+        Comparator.comparingLong(MessageExt::getStoreTimestamp);
 
     private DefaultMQAdminExt defaultMQAdminExt;
 
@@ -73,7 +77,7 @@ public class QueryMsgByUniqueKeySubCommand implements SubCommand {
         if (list == null || list.size() == 0) {
             return;
         }
-        list.sort((o1, o2) -> (int) (o1.getStoreTimestamp() - o2.getStoreTimestamp()));
+        list.sort(STORE_TIMESTAMP_COMPARATOR);
         for (int i = 0; i < (showAll ? list.size() : 1); i++) {
             showMessage(admin, list.get(i), i);
         }

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/consumer/GroupConsumeInfoTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/consumer/GroupConsumeInfoTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.consumer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class GroupConsumeInfoTest {
+
+    @Test
+    public void testCompareByDiffTotalWithoutOverflow() {
+        GroupConsumeInfo highLag = new GroupConsumeInfo();
+        highLag.setCount(1);
+        highLag.setDiffTotal(Long.MAX_VALUE);
+        GroupConsumeInfo lowLag = new GroupConsumeInfo();
+        lowLag.setCount(1);
+        lowLag.setDiffTotal(0);
+
+        assertTrue(highLag.compareTo(lowLag) < 0);
+        assertTrue(lowLag.compareTo(highLag) > 0);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommandTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.message;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class PrintMessageByQueueCommandTest {
+
+    @Test
+    public void testTagCountComparisonWithoutOverflow() {
+        PrintMessageByQueueCommand.TagCountBean most =
+            new PrintMessageByQueueCommand.TagCountBean("most", new AtomicLong(Long.MAX_VALUE));
+        PrintMessageByQueueCommand.TagCountBean least =
+            new PrintMessageByQueueCommand.TagCountBean("least", new AtomicLong(0));
+
+        assertTrue(most.compareTo(least) < 0);
+        assertTrue(least.compareTo(most) > 0);
+    }
+}

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/message/QueryMsgByUniqueKeySubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/message/QueryMsgByUniqueKeySubCommandTest.java
@@ -65,6 +65,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +79,17 @@ public class QueryMsgByUniqueKeySubCommandTest {
 
     private static MQClientAPIImpl mQClientAPIImpl;
     private static MQAdminImpl mQAdminImpl;
+
+    @Test
+    public void testStoreTimestampComparatorWithoutOverflow() {
+        MessageExt earliest = new MessageExt();
+        earliest.setStoreTimestamp(0);
+        MessageExt latest = new MessageExt();
+        latest.setStoreTimestamp(Long.MAX_VALUE);
+
+        assertTrue(QueryMsgByUniqueKeySubCommand.STORE_TIMESTAMP_COMPARATOR.compare(earliest, latest) < 0);
+        assertTrue(QueryMsgByUniqueKeySubCommand.STORE_TIMESTAMP_COMPARATOR.compare(latest, earliest) > 0);
+    }
 
     @Before
     public void before() throws NoSuchFieldException, IllegalAccessException, InterruptedException, RemotingException, MQClientException, MQBrokerException {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10850

### Brief Description

Uses overflow-safe long comparison for consumer lag, tag counts, and message store timestamps in mqadmin commands. Adds focused regression coverage for each comparator.

### How Did You Test This Change?

`mise x java@temurin-17 -- mvn -Dmaven.repo.local=/private/tmp/rocketmq-m2 -Djacoco.skip=true -pl tools -am -DskipITs -Dtest=GroupConsumeInfoTest,PrintMessageByQueueCommandTest,QueryMsgByUniqueKeySubCommandTest#testStoreTimestampComparatorWithoutOverflow -Dsurefire.failIfNoSpecifiedTests=false test`

The targeted tests, Checkstyle, and SpotBugs completed successfully.