### PR TITLE
[ISSUE #10851] fix(broker): avoid cold threshold sort overflow

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/coldctr/ColdDataCgCtrService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/coldctr/ColdDataCgCtrService.java
@@ -145,7 +145,7 @@ public class ColdDataCgCtrService extends ServiceThread {
         configMapList.sort(new Comparator<Entry<String, Long>>() {
             @Override
             public int compare(Entry<String, Long> o1, Entry<String, Long> o2) {
-                return (int)(o2.getValue() - o1.getValue());
+                return Long.compare(o2.getValue(), o1.getValue());
             }
         });
         Iterator<Entry<String, Long>> iterator = configMapList.iterator();

--- a/broker/src/test/java/org/apache/rocketmq/broker/coldctr/ColdDataCgCtrServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/coldctr/ColdDataCgCtrServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.broker.coldctr;
 
+import java.lang.reflect.Method;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.BrokerConfig;
@@ -32,6 +33,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -61,6 +67,25 @@ public class ColdDataCgCtrServiceTest {
         assertTrue(actual.contains("\"globalColdReadThreshold\":0"));
         assertTrue(actual.contains("\"configTable\":{\"consumerGroup2\":2048}"));
         assertTrue(actual.contains("\"runtimeTable\":{\"consumerGroup1\":{\"coldAcc\":1,\"createTimeMills\":1,\"lastColdReadTimeMills\":1}}"));
+    }
+
+    @Test
+    public void testDeceleratesHighestThresholdsWithoutOverflow() throws Exception {
+        ConcurrentHashMap<String, Long> thresholds = new ConcurrentHashMap<>();
+        thresholds.put("highest||adaptive", Long.MAX_VALUE);
+        thresholds.put("medium2||adaptive", 2L);
+        thresholds.put("medium1||adaptive", 1L);
+        thresholds.put("lowest||adaptive", 0L);
+        ColdCtrStrategy strategy = mock(ColdCtrStrategy.class);
+        FieldUtils.writeField(coldDataCgCtrService, "cgColdThresholdMapConfig", thresholds, true);
+        FieldUtils.writeField(coldDataCgCtrService, "coldCtrStrategy", strategy, true);
+        Method method = ColdDataCgCtrService.class.getDeclaredMethod("sortAndDecelerate");
+        method.setAccessible(true);
+
+        method.invoke(coldDataCgCtrService);
+
+        verify(strategy).decelerate(eq("highest||adaptive"), anyLong());
+        verify(strategy, never()).decelerate(eq("lowest||adaptive"), anyLong());
     }
 
     private Map<String, AccAndTimeStamp> createCgColdThresholdMapRuntime() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10851

### Brief Description

Uses Long.compare when sorting cold-read thresholds so the highest eligible groups are not skipped when values differ beyond the int range. Adds a regression test covering the three-group deceleration limit.

### How Did You Test This Change?

`mise x java@temurin-17 -- mvn -Dmaven.repo.local=/private/tmp/rocketmq-m2 -Djacoco.skip=true -pl broker -am -DskipITs -Dtest=ColdDataCgCtrServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`

The targeted tests, Checkstyle, and SpotBugs completed successfully.