### PR TITLE
[ISSUE #10852] fix(broker): sort revive offsets without overflow

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -725,7 +725,7 @@ public class PopReviveService extends ServiceThread {
                 return sortList;
             }
             sortList = new ArrayList<>(map.values());
-            sortList.sort((o1, o2) -> (int) (o1.getReviveOffset() - o2.getReviveOffset()));
+            sortList.sort((o1, o2) -> Long.compare(o1.getReviveOffset(), o2.getReviveOffset()));
             return sortList;
         }
     }

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
@@ -86,6 +86,20 @@ public class PopReviveServiceTest {
     private static final SocketAddress STORE_HOST = NetworkUtil.string2SocketAddress("127.0.0.1:8080");
     private static final Long INVISIBLE_TIME = 1000L;
 
+    @Test
+    public void testConsumeReviveObjSortsLargeOffsetsWithoutOverflow() {
+        PopCheckPoint earliest = buildPopCheckPoint(0, 0, 0);
+        PopCheckPoint latest = buildPopCheckPoint(1, 0, Long.MAX_VALUE);
+        PopReviveService.ConsumeReviveObj consumeReviveObj = new PopReviveService.ConsumeReviveObj();
+        consumeReviveObj.map.put("latest", latest);
+        consumeReviveObj.map.put("earliest", earliest);
+
+        List<PopCheckPoint> result = consumeReviveObj.genSortList();
+
+        assertEquals(earliest, result.get(0));
+        assertEquals(latest, result.get(1));
+    }
+
     @Mock
     private MessageStore messageStore;
     @Mock


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10852

### Brief Description

Uses Long.compare to keep Pop revive checkpoints ordered by their full-width long offsets. Adds a regression test with offsets spanning the long range.

### How Did You Test This Change?

`mise x java@temurin-17 -- mvn -Dmaven.repo.local=/private/tmp/rocketmq-m2 -pl broker -am -DskipITs -Dtest=PopReviveServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`

The targeted tests, Checkstyle, and SpotBugs completed successfully.