### PR TITLE
[ISSUE #10859] Fix exhausted tiered index write result

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/index/IndexStoreService.java
@@ -211,8 +211,9 @@ public class IndexStoreService extends ServiceThread implements IndexService {
             return AppendResult.SUCCESS;
         }
 
+        AppendResult result = AppendResult.UNKNOWN_ERROR;
         for (int i = 0; i < 3; i++) {
-            AppendResult result = this.currentWriteFile.putKey(
+            result = this.currentWriteFile.putKey(
                 topic, topicId, queueId, keySet, offset, size, timestamp);
 
             if (AppendResult.SUCCESS.equals(result)) {
@@ -225,7 +226,7 @@ public class IndexStoreService extends ServiceThread implements IndexService {
 
         log.error("IndexStoreService#putKey, put key three times return error, topic={}, topicId={}, queueId={}, keySize={}, timestamp={}",
             topic, topicId, queueId, keySet.size(), timestamp);
-        return AppendResult.SUCCESS;
+        return result;
     }
 
     @Override

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/index/IndexStoreServiceTest.java
@@ -50,6 +50,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,6 +109,22 @@ public class IndexStoreServiceTest {
         }
         ConcurrentSkipListMap<Long, IndexFile> timeStoreTable = indexService.getTimeStoreTable();
         Assert.assertEquals(3, timeStoreTable.size());
+    }
+
+    @Test
+    public void putKeyReturnsFileFullAfterRetriesExhausted() throws IllegalAccessException {
+        IndexStoreService service = Mockito.spy(new IndexStoreService(fileAllocator, filePath, false));
+        IndexFile fullIndexFile = Mockito.mock(IndexFile.class);
+        Mockito.when(fullIndexFile.putKey(
+            TOPIC_NAME, TOPIC_ID, QUEUE_ID, KEY_SET, MESSAGE_OFFSET, MESSAGE_SIZE, 1L))
+            .thenReturn(AppendResult.FILE_FULL);
+        FieldUtils.writeField(service, "currentWriteFile", fullIndexFile, true);
+        Mockito.doNothing().when(service).createNewIndexFile(Mockito.anyLong());
+
+        Assert.assertEquals(AppendResult.FILE_FULL, service.putKey(
+            TOPIC_NAME, TOPIC_ID, QUEUE_ID, KEY_SET, MESSAGE_OFFSET, MESSAGE_SIZE, 1L));
+        Mockito.verify(fullIndexFile, Mockito.times(3)).putKey(
+            TOPIC_NAME, TOPIC_ID, QUEUE_ID, KEY_SET, MESSAGE_OFFSET, MESSAGE_SIZE, 1L);
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10859

### Brief Description

`IndexStoreService.putKey` previously returned `SUCCESS` after all three index write attempts failed. This change keeps the last `AppendResult` and returns it when retries are exhausted, while preserving the existing success and file-rotation paths.

A regression test makes the index file return `FILE_FULL` three times and verifies both the returned error and retry count.

### How Did You Test This Change?

- `mise exec java@temurin-17.0.19+10 -- mvn -pl tieredstore -am -DskipITs -Dtest=IndexStoreServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Result: `BUILD SUCCESS`; 11 tests, 0 failures, 0 errors, 0 skipped.
- Scope check: 2 files, 24 changed lines.