### PR TITLE
[ISSUE #10860] Make DefaultPromise.get wait for completion

### DIFF
--- a/openmessaging/src/main/java/io/openmessaging/rocketmq/promise/DefaultPromise.java
+++ b/openmessaging/src/main/java/io/openmessaging/rocketmq/promise/DefaultPromise.java
@@ -58,7 +58,7 @@ public class DefaultPromise<V> implements Promise<V> {
 
     @Override
     public V get() {
-        return result;
+        return get(0);
     }
 
     @Override
@@ -69,10 +69,14 @@ public class DefaultPromise<V> implements Promise<V> {
             }
 
             if (timeout <= 0) {
-                try {
-                    lock.wait();
-                } catch (Exception e) {
-                    cancel(e);
+                while (isDoing()) {
+                    try {
+                        lock.wait();
+                    } catch (InterruptedException e) {
+                        cancel(e);
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
                 }
                 return getValueOrThrowable();
             } else {
@@ -177,7 +181,6 @@ public class DefaultPromise<V> implements Promise<V> {
             Throwable e = exception.getCause() != null ? exception.getCause() : exception;
             throw new OMSRuntimeException("-1", e);
         }
-        notifyListeners();
         return result;
     }
 
@@ -222,4 +225,3 @@ public class DefaultPromise<V> implements Promise<V> {
         return true;
     }
 }
-

--- a/openmessaging/src/test/java/io/openmessaging/rocketmq/promise/DefaultPromiseTest.java
+++ b/openmessaging/src/test/java/io/openmessaging/rocketmq/promise/DefaultPromiseTest.java
@@ -20,6 +20,11 @@ import io.openmessaging.Future;
 import io.openmessaging.FutureListener;
 import io.openmessaging.Promise;
 import io.openmessaging.exception.OMSRuntimeException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,6 +55,52 @@ public class DefaultPromiseTest {
     public void testGet() throws Exception {
         promise.set("Done");
         assertThat(promise.get()).isEqualTo("Done");
+    }
+
+    @Test
+    public void testGetWaitsForCompletion() throws Exception {
+        CountDownLatch getStarted = new CountDownLatch(1);
+        FutureTask<String> getTask = new FutureTask<>(() -> {
+            getStarted.countDown();
+            return promise.get();
+        });
+        Thread getThread = new Thread(getTask, "DefaultPromiseTestGetThread");
+        getThread.setDaemon(true);
+        getThread.start();
+
+        assertThat(getStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        try {
+            getTask.get(200, TimeUnit.MILLISECONDS);
+            failBecauseExceptionWasNotThrown(TimeoutException.class);
+        } catch (TimeoutException expected) {
+            assertThat(expected).isNotNull();
+        }
+
+        promise.set("Done");
+        assertThat(getTask.get(5, TimeUnit.SECONDS)).isEqualTo("Done");
+    }
+
+    @Test
+    public void testGetPropagatesFailure() {
+        IllegalStateException failure = new IllegalStateException("Test failure");
+        promise.setFailure(failure);
+
+        try {
+            promise.get();
+            failBecauseExceptionWasNotThrown(OMSRuntimeException.class);
+        } catch (OMSRuntimeException e) {
+            assertThat(e.getCause()).isEqualTo(failure);
+        }
+    }
+
+    @Test
+    public void testGetDoesNotNotifyListenerAgain() {
+        AtomicInteger notificationCount = new AtomicInteger();
+        promise.addListener(future -> notificationCount.incrementAndGet());
+
+        promise.set("Done");
+        assertThat(promise.get()).isEqualTo("Done");
+        assertThat(notificationCount).hasValue(1);
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10860

### Brief Description

The no-argument OpenMessaging `DefaultPromise.get()` now uses the existing wait path instead of returning a pending `null` result. The indefinite wait uses a state loop to handle spurious wakeups and restores the interrupt flag when interrupted.

Reading a completed value no longer notifies listeners again. Regression tests cover waiting for completion, failure propagation, and single listener notification.

### How Did You Test This Change?

- `mise exec java@temurin-17.0.19+10 -- mvn -pl openmessaging -am -Dtest=DefaultPromiseTest -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true test`
- Result: `BUILD SUCCESS`; 12 tests, 0 failures, 0 errors, 0 skipped.
- Scope check: 2 files, 69 changed lines.