### PR TITLE
[ISSUE #10861] Validate controller broker IDs eagerly

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommand.java
@@ -26,8 +26,6 @@ import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.apache.rocketmq.tools.command.SubCommand;
 import org.apache.rocketmq.tools.command.SubCommandException;
 
-import java.util.Arrays;
-
 public class CleanControllerBrokerMetaSubCommand implements SubCommand {
 
     @Override
@@ -83,7 +81,9 @@ public class CleanControllerBrokerMetaSubCommand implements SubCommand {
         if (commandLine.hasOption('b')) {
             brokerControllerIdsToClean = commandLine.getOptionValue('b').trim();
             try {
-                Arrays.stream(brokerControllerIdsToClean.split(";")).map(idStr -> Long.parseLong(idStr));
+                for (String brokerControllerId : brokerControllerIdsToClean.split(";")) {
+                    Long.parseLong(brokerControllerId);
+                }
             } catch (NumberFormatException numberFormatException) {
                 throw new IllegalArgumentException("please set the option <brokerControllerIdsToClean> according to the format", numberFormatException);
             }

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommandTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.controller;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.junit.Test;
+
+public class CleanControllerBrokerMetaSubCommandTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void executeRejectsNonNumericBrokerControllerId() throws Exception {
+        CleanControllerBrokerMetaSubCommand command = new CleanControllerBrokerMetaSubCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] args = {
+            "-a", "127.0.0.1:9878",
+            "-bn", "broker-a",
+            "-c", "cluster-a",
+            "-b", "1;not-a-number"
+        };
+        CommandLine commandLine = ServerUtil.parseCmdLine("mqadmin " + command.commandName(), args,
+            command.buildCommandlineOptions(options), new DefaultParser());
+
+        command.execute(commandLine, options, null);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10861

### Brief Description

`CleanControllerBrokerMetaSubCommand` built a lazy stream to parse controller broker IDs but never consumed it, so invalid values were not validated. This change eagerly parses every semicolon-separated ID before any admin request.

A regression test supplies `1;not-a-number` and verifies that command execution rejects it with `IllegalArgumentException`.

### How Did You Test This Change?

- `mise exec java@temurin-17.0.19+10 -- mvn -pl tools -am -DskipITs -Dtest=CleanControllerBrokerMetaSubCommandTest -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true test`
- Result: `BUILD SUCCESS`; 1 test, 0 failures, 0 errors, 0 skipped.
- Scope check: 2 files, 48 changed lines.