### PR TITLE
[ISSUE #10862] Accept zero floating-point filter literals

### DIFF
--- a/filter/src/main/java/org/apache/rocketmq/filter/expression/ConstantExpression.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/expression/ConstantExpression.java
@@ -58,8 +58,8 @@ public class ConstantExpression implements Expression {
         if (value > Double.MAX_VALUE) {
             throw new RuntimeException(text + " is greater than " + Double.MAX_VALUE);
         }
-        if (value < Double.MIN_VALUE) {
-            throw new RuntimeException(text + " is less than " + Double.MIN_VALUE);
+        if (value < -Double.MAX_VALUE) {
+            throw new RuntimeException(text + " is less than " + -Double.MAX_VALUE);
         }
         return new ConstantExpression(value);
     }

--- a/filter/src/test/java/org/apache/rocketmq/filter/ExpressionTest.java
+++ b/filter/src/test/java/org/apache/rocketmq/filter/ExpressionTest.java
@@ -535,6 +535,17 @@ public class ExpressionTest {
     }
 
     @Test
+    public void testEvaluate_zeroFloatNumber() throws Exception {
+        Expression expression = genExp("a = 0.0");
+
+        EvaluationContext context = genContext(
+            KeyValue.c("a", "0.0")
+        );
+
+        eval(expression, context, Boolean.TRUE);
+    }
+
+    @Test
     public void testEvaluate_twoVariable() throws Exception {
         Expression expression = genExp("a > b");
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10862

### Brief Description

`ConstantExpression.createFloat` used `Double.MIN_VALUE`, the smallest positive value, as a lower bound and therefore rejected `0.0`. This change uses `-Double.MAX_VALUE` as the finite lower bound.

A selector regression test verifies that `a = 0.0` parses and evaluates successfully.

### How Did You Test This Change?

- `mise exec java@temurin-17.0.19+10 -- mvn -pl filter -am -DskipITs -Dtest=ExpressionTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Result: `BUILD SUCCESS`; 62 tests, 0 failures, 0 errors, 0 skipped.
- Scope check: 2 files, 15 changed lines.