### PR TITLE
[ISSUE-10861] Fix brokerControllerIdsToClean validation not actually parsing IDs

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommand.java
@@ -83,7 +83,7 @@ public class CleanControllerBrokerMetaSubCommand implements SubCommand {
         if (commandLine.hasOption('b')) {
             brokerControllerIdsToClean = commandLine.getOptionValue('b').trim();
             try {
-                Arrays.stream(brokerControllerIdsToClean.split(";")).map(idStr -> Long.parseLong(idStr));
+                Arrays.stream(brokerControllerIdsToClean.split(";")).forEach(idStr -> Long.parseLong(idStr));
             } catch (NumberFormatException numberFormatException) {
                 throw new IllegalArgumentException("please set the option <brokerControllerIdsToClean> according to the format", numberFormatException);
             }

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommandTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.controller;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.junit.Test;
+
+public class CleanControllerBrokerMetaSubCommandTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExecuteWithMalformedBrokerControllerIds() throws Exception {
+        CleanControllerBrokerMetaSubCommand cmd = new CleanControllerBrokerMetaSubCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = new String[]{
+            "-a", "127.0.0.1:9878",
+            "-bn", "broker-a",
+            "-c", "cluster-a",
+            "-b", "1;not-a-number"
+        };
+        CommandLine commandLine = ServerUtil.parseCmdLine(
+            "mqadmin " + cmd.commandName(),
+            subargs,
+            cmd.buildCommandlineOptions(options),
+            new DefaultParser()
+        );
+        cmd.execute(commandLine, options, null);
+    }
+}


### PR DESCRIPTION
### Bug Description

`cleanBrokerMetadata` command uses `Arrays.stream(...).map(Long::parseLong)` to validate broker controller IDs. Since `map()` is a lazy intermediate operation without a terminal operation, `Long.parseLong()` is never executed, allowing malformed IDs like `not-a-number` to pass validation.

### Fix

Changed `map()` to `forEach()` so the stream is actually consumed and `Long.parseLong()` is evaluated for each ID.

### Testing

Added `CleanControllerBrokerMetaSubCommandTest` with a test case that verifies malformed input throws `IllegalArgumentException`.

Closes #10861