### PR TITLE
[ISSUE #10870] fix(client): preserve maximum process queue offset

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
@@ -136,7 +136,7 @@ public class ProcessQueue {
                     MessageExt old = msgTreeMap.put(msg.getQueueOffset(), msg);
                     if (null == old) {
                         validMsgCnt++;
-                        this.queueOffsetMax = msg.getQueueOffset();
+                        this.queueOffsetMax = Math.max(this.queueOffsetMax, msg.getQueueOffset());
                         msgSize.addAndGet(null == msg.getBody() ? 0 : msg.getBody().length);
                     }
                 }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
@@ -81,6 +81,18 @@ public class ProcessQueueTest {
     }
 
     @Test
+    public void testRemoveMessagesReturnsOffsetAfterHighestOutOfOrderMessage() {
+        ProcessQueue pq = new ProcessQueue();
+        List<MessageExt> messages = createMessageList(2);
+        messages.get(0).setQueueOffset(10);
+        messages.get(1).setQueueOffset(5);
+
+        pq.putMessage(messages);
+
+        assertThat(pq.removeMessage(messages)).isEqualTo(11);
+    }
+
+    @Test
     public void testContainsMessage() {
         ProcessQueue pq = new ProcessQueue();
         final List<MessageExt> messageList = createMessageList(2);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10870

### Brief Description

ProcessQueue previously overwrote queueOffsetMax with the last newly inserted message. This change retains the numeric maximum so an out-of-order batch cannot make removeMessage return a stale next offset.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl client -am -DskipITs -Dtest=ProcessQueueTest -Dsurefire.failIfNoSpecifiedTests=false test (9 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.