### PR TITLE
[ISSUE #10871] fix(common): validate statistics brief metadata

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/statistics/StatisticsBrief.java
+++ b/common/src/main/java/org/apache/rocketmq/common/statistics/StatisticsBrief.java
@@ -68,10 +68,22 @@ public class StatisticsBrief {
             return false;
         }
 
+        long previousRangeMax = 0;
+        long totalSlotNum = 0;
         for (long[] line : meta) {
             if (ArrayUtils.isEmpty(line) || line.length != 2) {
                 return false;
             }
+
+            long rangeMax = line[META_RANGE_INDEX];
+            long slotNum = line[META_SLOT_NUM_INDEX];
+            if (rangeMax <= previousRangeMax || slotNum <= 0
+                || slotNum > rangeMax - previousRangeMax
+                || slotNum > Integer.MAX_VALUE - 1 - totalSlotNum) {
+                return false;
+            }
+            previousRangeMax = rangeMax;
+            totalSlotNum += slotNum;
         }
 
         return true;

--- a/common/src/test/java/org/apache/rocketmq/common/statistics/StatisticsBriefTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/statistics/StatisticsBriefTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common.statistics;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class StatisticsBriefTest {
+
+    @Test
+    public void constructor_WithNonPositiveSlotCount_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new StatisticsBrief(new long[][] {{10, 0}}));
+        assertThrows(IllegalArgumentException.class, () -> new StatisticsBrief(new long[][] {{10, -1}}));
+    }
+
+    @Test
+    public void constructor_WithNonIncreasingRanges_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new StatisticsBrief(new long[][] {{10, 2}, {10, 2}}));
+        assertThrows(IllegalArgumentException.class,
+            () -> new StatisticsBrief(new long[][] {{10, 2}, {5, 2}}));
+    }
+
+    @Test
+    public void constructor_WithMoreSlotsThanRangeWidth_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new StatisticsBrief(new long[][] {{10, 11}}));
+        assertThrows(IllegalArgumentException.class,
+            () -> new StatisticsBrief(new long[][] {{10, 2}, {12, 3}}));
+    }
+
+    @Test
+    public void sample_WithValidMetadata_RecordsStatistics() {
+        StatisticsBrief brief = new StatisticsBrief(new long[][] {{10, 2}, {20, 2}});
+
+        brief.sample(5);
+        brief.sample(15);
+
+        assertEquals(2, brief.getCnt());
+        assertEquals(5, brief.getMin());
+        assertEquals(15, brief.getMax());
+        assertEquals(20, brief.getTotal());
+        assertEquals(10.0, brief.getAvg(), 0.0);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10871

### Brief Description

StatisticsBrief now rejects non-positive slot counts, non-increasing ranges, buckets wider than their value range, and aggregate slot counts that cannot fit the backing array. The focused tests cover every invalid shape plus a valid sampling path.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl common -DskipITs -Dtest=StatisticsBriefTest test (4 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.