### PR TITLE
[ISSUE #10872] fix(broker): reject overflowing timer delays

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/util/HookUtils.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/util/HookUtils.java
@@ -208,9 +208,12 @@ public class HookUtils {
         long deliverMs;
         try {
             if (msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC) != null) {
-                deliverMs = System.currentTimeMillis() + Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC)) * 1000;
+                long delayMs = Math.multiplyExact(
+                    Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC)), 1000L);
+                deliverMs = Math.addExact(System.currentTimeMillis(), delayMs);
             } else if (msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS) != null) {
-                deliverMs = System.currentTimeMillis() + Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS));
+                deliverMs = Math.addExact(System.currentTimeMillis(),
+                    Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS)));
             } else {
                 deliverMs = Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS));
             }

--- a/broker/src/test/java/org/apache/rocketmq/broker/util/HookUtilsTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/util/HookUtilsTest.java
@@ -21,7 +21,9 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageExtBrokerInner;
 import org.apache.rocketmq.store.MessageStore;
+import org.apache.rocketmq.store.PutMessageResult;
 import org.apache.rocketmq.store.PutMessageStatus;
 import org.apache.rocketmq.store.RunningFlags;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
@@ -30,6 +32,36 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class HookUtilsTest {
+
+    @Test
+    public void testHandleScheduleMessageRejectsOverflowingTimerDelaySeconds() {
+        BrokerController brokerController = Mockito.mock(BrokerController.class);
+        Mockito.when(brokerController.getMessageStoreConfig()).thenReturn(new MessageStoreConfig());
+
+        MessageExtBrokerInner message = new MessageExtBrokerInner();
+        message.setTopic("topic");
+        message.setDelayTimeSec(Long.MAX_VALUE);
+
+        PutMessageResult result = HookUtils.handleScheduleMessage(brokerController, message);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
+
+    @Test
+    public void testHandleScheduleMessageRejectsOverflowingTimerDelayMillis() {
+        BrokerController brokerController = Mockito.mock(BrokerController.class);
+        Mockito.when(brokerController.getMessageStoreConfig()).thenReturn(new MessageStoreConfig());
+
+        MessageExtBrokerInner message = new MessageExtBrokerInner();
+        message.setTopic("topic");
+        message.setDelayTimeMs(Long.MAX_VALUE);
+
+        PutMessageResult result = HookUtils.handleScheduleMessage(brokerController, message);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
 
     @Test
     public void testCheckBeforePutMessage() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10872

### Brief Description

Relative timer delay conversion now uses exact long arithmetic. Seconds-to-milliseconds and current-time addition overflow are rejected through the existing WHEEL_TIMER_MSG_ILLEGAL path instead of wrapping into an immediate timestamp.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl broker -am -DskipITs -Dtest=HookUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test (3 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.