### PR TITLE
[ISSUE #10874] fix(common): compare message queue ids safely

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageQueue.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageQueue.java
@@ -119,6 +119,6 @@ public class MessageQueue implements Comparable<MessageQueue>, Serializable {
             }
         }
 
-        return this.queueId - o.queueId;
+        return Integer.compare(this.queueId, o.queueId);
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/message/MessageQueueTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/message/MessageQueueTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common.message;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessageQueueTest {
+
+    @Test
+    public void testCompareToHandlesQueueIdExtremes() {
+        MessageQueue minimum = new MessageQueue("topic", "broker", Integer.MIN_VALUE);
+        MessageQueue one = new MessageQueue("topic", "broker", 1);
+        MessageQueue maximum = new MessageQueue("topic", "broker", Integer.MAX_VALUE);
+
+        assertThat(minimum.compareTo(one)).isNegative();
+        assertThat(one.compareTo(minimum)).isPositive();
+        assertThat(maximum.compareTo(minimum)).isPositive();
+        assertThat(minimum.compareTo(maximum)).isNegative();
+    }
+
+    @Test
+    public void testCompareToReturnsZeroForEqualQueue() {
+        MessageQueue first = new MessageQueue("topic", "broker", 1);
+        MessageQueue second = new MessageQueue("topic", "broker", 1);
+
+        assertThat(first.compareTo(second)).isZero();
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10874

### Brief Description

MessageQueue.compareTo now uses Integer.compare for queue IDs, preventing subtraction overflow from reversing the ordering of extreme values. Regression tests cover both directions and equality.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl common -DskipITs -Dtest=MessageQueueTest test (2 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.