### PR TITLE
[ISSUE #10875] fix(controller): detect inactive raft masters

### DIFF
--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/manager/RaftReplicasInfoManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/manager/RaftReplicasInfoManager.java
@@ -126,7 +126,7 @@ public class RaftReplicasInfoManager extends ReplicasInfoManager {
         List<String> needReElectBrokerNames = scanNeedReelectBrokerSets(new BrokerValidPredicate() {
             @Override
             public boolean check(String clusterName, String brokerName, Long brokerId) {
-                return !isBrokerActive(clusterName, brokerName, brokerId, checkTime);
+                return isBrokerActive(clusterName, brokerName, brokerId, checkTime);
             }
         });
         Set<String> alreadyReportedBrokerName = notActiveBrokerIdentityInfoList.stream()

--- a/controller/src/test/java/org/apache/rocketmq/controller/impl/manager/RaftReplicasInfoManagerTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/impl/manager/RaftReplicasInfoManagerTest.java
@@ -35,8 +35,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -140,6 +143,39 @@ public class RaftReplicasInfoManagerTest {
         assertNotNull(result);
         assertEquals(ResponseCode.SUCCESS, result.getResponseCode());
         assertNotNull(result.getBody());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCheckNotActiveBrokerReportsInactiveMasterWithActiveSlave() throws IllegalAccessException {
+        String clusterName = "cluster";
+        String brokerName = "broker";
+        BrokerReplicaInfo brokerReplicaInfo = new BrokerReplicaInfo(clusterName, brokerName);
+        brokerReplicaInfo.addBroker(1L, "127.0.0.1:10911", "master");
+        brokerReplicaInfo.addBroker(2L, "127.0.0.1:10912", "slave");
+        Map<String, BrokerReplicaInfo> replicaInfoTable = (Map<String, BrokerReplicaInfo>)
+            FieldUtils.readField(raftReplicasInfoManager, "replicaInfoTable", true);
+        replicaInfoTable.put(brokerName, brokerReplicaInfo);
+
+        SyncStateInfo syncStateInfo = new SyncStateInfo(clusterName, brokerName);
+        syncStateInfo.updateMasterInfo(1L);
+        syncStateInfo.updateSyncStateSetInfo(new HashSet<>(Arrays.asList(1L, 2L)));
+        Map<String, SyncStateInfo> syncStateSetInfoTable = (Map<String, SyncStateInfo>)
+            FieldUtils.readField(raftReplicasInfoManager, "syncStateSetInfoTable", true);
+        syncStateSetInfoTable.put(brokerName, syncStateInfo);
+
+        Map<BrokerIdentityInfo, BrokerLiveInfo> brokerLiveTable = new HashMap<>();
+        brokerLiveTable.put(new BrokerIdentityInfo(clusterName, brokerName, 2L),
+            new BrokerLiveInfo(brokerName, "127.0.0.1:10912", 2L, System.currentTimeMillis(),
+                60_000L, null, 1, 100L, 1));
+        FieldUtils.writeDeclaredField(raftReplicasInfoManager, "brokerLiveTable", brokerLiveTable, true);
+
+        ControllerResult<CheckNotActiveBrokerResponse> result = raftReplicasInfoManager
+            .checkNotActiveBroker(new CheckNotActiveBrokerRequest());
+
+        assertEquals(ResponseCode.SUCCESS, result.getResponseCode());
+        assertTrue(new String(result.getBody(), StandardCharsets.UTF_8)
+            .contains("\"brokerName\":\"broker\""));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10875

### Brief Description

RaftReplicasInfoManager now passes the actual broker-active predicate to the shared re-election scanner. This lets an inactive master with a live slave be reported for re-election instead of being hidden by a double negation.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl controller -am -DskipITs -Dtest=RaftReplicasInfoManagerTest -Dsurefire.failIfNoSpecifiedTests=false test (16 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.