### PR TITLE
[ISSUE #10876] fix(controller): compare partial broker identities safely

### DIFF
--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/BrokerIdentityInfo.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/BrokerIdentityInfo.java
@@ -17,9 +17,8 @@
 package org.apache.rocketmq.controller.impl.heartbeat;
 
 import java.io.Serializable;
-import org.apache.rocketmq.common.UtilAll;
-
 import java.util.Objects;
+import org.apache.rocketmq.common.UtilAll;
 
 public class BrokerIdentityInfo implements Serializable {
 
@@ -63,7 +62,8 @@ public class BrokerIdentityInfo implements Serializable {
 
         if (obj instanceof BrokerIdentityInfo) {
             BrokerIdentityInfo addr = (BrokerIdentityInfo) obj;
-            return clusterName.equals(addr.clusterName) && brokerName.equals(addr.brokerName) && brokerId.equals(addr.brokerId);
+            return Objects.equals(clusterName, addr.clusterName) && Objects.equals(brokerName, addr.brokerName)
+                && Objects.equals(brokerId, addr.brokerId);
         }
         return false;
     }

--- a/controller/src/test/java/org/apache/rocketmq/controller/impl/heartbeat/BrokerIdentityInfoTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/impl/heartbeat/BrokerIdentityInfoTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.controller.impl.heartbeat;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BrokerIdentityInfoTest {
+
+    @Test
+    public void testEqualsCompleteIdentity() {
+        BrokerIdentityInfo identity = new BrokerIdentityInfo("cluster", "broker", 1L);
+        BrokerIdentityInfo sameIdentity = new BrokerIdentityInfo("cluster", "broker", 1L);
+
+        assertThat(identity).isEqualTo(sameIdentity);
+        assertThat(identity.hashCode()).isEqualTo(sameIdentity.hashCode());
+    }
+
+    @Test
+    public void testEqualsPartialIdentity() {
+        assertThat(new BrokerIdentityInfo(null, "broker", null))
+            .isEqualTo(new BrokerIdentityInfo(null, "broker", null));
+        assertThat(new BrokerIdentityInfo("cluster", null, null))
+            .isEqualTo(new BrokerIdentityInfo("cluster", null, null));
+        assertThat(new BrokerIdentityInfo("cluster", "broker", null))
+            .isEqualTo(new BrokerIdentityInfo("cluster", "broker", null));
+    }
+
+    @Test
+    public void testEqualsDifferentIdentity() {
+        BrokerIdentityInfo identity = new BrokerIdentityInfo("cluster", "broker", 1L);
+
+        assertThat(identity).isNotEqualTo(new BrokerIdentityInfo("other-cluster", "broker", 1L));
+        assertThat(identity).isNotEqualTo(new BrokerIdentityInfo("cluster", "other-broker", 1L));
+        assertThat(identity).isNotEqualTo(new BrokerIdentityInfo("cluster", "broker", 2L));
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10876

### Brief Description

BrokerIdentityInfo.equals now uses Objects.equals for every nullable identity component. This supports the partial identities already created by the Raft controller and aligns equals with the existing null-safe hashCode.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl controller -am -DskipITs -Dtest=BrokerIdentityInfoTest -Dsurefire.failIfNoSpecifiedTests=false test (3 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.