### PR TITLE
[ISSUE #10877] fix(filter): convert boolean string operands safely

### DIFF
--- a/filter/src/main/java/org/apache/rocketmq/filter/expression/ComparisonExpression.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/expression/ComparisonExpression.java
@@ -536,7 +536,7 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
             try {
                 if (lc == Boolean.class) {
                     if (convertStringExpressions && rc == String.class) {
-                        lv = Boolean.valueOf((String) lv).booleanValue();
+                        rv = Boolean.valueOf((String) rv);
                     } else {
                         return -1;
                     }

--- a/filter/src/test/java/org/apache/rocketmq/filter/ExpressionTest.java
+++ b/filter/src/test/java/org/apache/rocketmq/filter/ExpressionTest.java
@@ -599,6 +599,17 @@ public class ExpressionTest {
     }
 
     @Test
+    public void testEvaluate_booleanConstantComparedToStringProperty() throws Exception {
+        EvaluationContext trueContext = genContext(KeyValue.c("a", "true"));
+        EvaluationContext falseContext = genContext(KeyValue.c("a", "false"));
+
+        eval(genExp("TRUE=a"), trueContext, Boolean.TRUE);
+        eval(genExp("TRUE<>a"), falseContext, Boolean.TRUE);
+        eval(genExp("FALSE=a"), falseContext, Boolean.TRUE);
+        eval(genExp("FALSE<>a"), trueContext, Boolean.TRUE);
+    }
+
+    @Test
     public void testEvaluate_equal() throws Exception {
         Expression expression = genExp(equalExpression);
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10877

### Brief Description

ComparisonExpression now converts the String right operand when the left operand is Boolean. This removes the invalid Boolean-to-String cast while preserving the conversion semantics used by the reverse operand order.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl filter -am -DskipITs -Dtest=ExpressionTest -Dsurefire.failIfNoSpecifiedTests=false test (62 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.