### PR TITLE
[ISSUE #10879] fix(tieredstore): refresh replaced topic metadata timestamp

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
@@ -144,7 +144,7 @@ public class DefaultMetadataStore extends ConfigManager implements MetadataStore
         if (metadata == null) {
             return;
         }
-        metadata.setUpdateTimestamp(System.currentTimeMillis());
+        topicMetadata.setUpdateTimestamp(System.currentTimeMillis());
         topicMetadataTable.put(topicMetadata.getTopic(), topicMetadata);
         persist();
     }

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStoreTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStoreTest.java
@@ -145,6 +145,18 @@ public class DefaultMetadataStoreTest {
         Assert.assertNotNull(metadataStore.getTopic(topic1));
     }
 
+    @Test
+    public void testUpdateTopicRefreshesReplacementTimestamp() {
+        TopicMetadata existing = metadataStore.addTopic(mq0.getTopic(), 1);
+        TopicMetadata replacement = new TopicMetadata(existing.getTopicId(), existing.getTopic(), 2);
+        replacement.setUpdateTimestamp(0);
+
+        metadataStore.updateTopic(replacement);
+
+        Assert.assertSame(replacement, metadataStore.getTopic(mq0.getTopic()));
+        Assert.assertTrue(replacement.getUpdateTimestamp() > 0);
+    }
+
     private long countFileSegment(MetadataStore metadataStore) {
         AtomicLong count = new AtomicLong();
         metadataStore.iterateFileSegment(segmentMetadata -> count.incrementAndGet());


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10879

### Brief Description

DefaultMetadataStore.updateTopic now refreshes the timestamp on the caller-provided TopicMetadata that is actually stored, instead of mutating the old object immediately before replacing it.

### How Did You Test This Change?

- mise exec java@zulu-8.94.0.17 -- mvn -pl tieredstore -am -DskipITs -Dtest=DefaultMetadataStoreTest -Dsurefire.failIfNoSpecifiedTests=false test (7 tests passed)
- Checkstyle and SpotBugs passed in the same Maven reactor.
- git diff --check and the 400-line scope gate passed.
- Not run: full repository build, container tests, or end-to-end tests.