### PR TITLE
[ISSUE #10890] Validate gRPC client language metadata

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -146,7 +146,7 @@ public class ClientActivity extends AbstractMessagingActivity {
 
         try {
             String clientId = ctx.getClientID();
-            LanguageCode languageCode = LanguageCode.valueOf(ctx.getLanguage());
+            LanguageCode languageCode = parseLanguage(ctx);
             Settings clientSettings = grpcClientSettingsManager.removeAndGetClientSettings(ctx);
             if (clientSettings == null) {
                 future.complete(NotifyClientTerminationResponse.newBuilder()
@@ -415,7 +415,7 @@ public class ClientActivity extends AbstractMessagingActivity {
 
     protected GrpcClientChannel registerProducer(ProxyContext ctx, String topicName) {
         String clientId = ctx.getClientID();
-        LanguageCode languageCode = LanguageCode.valueOf(ctx.getLanguage());
+        LanguageCode languageCode = parseLanguage(ctx);
 
         GrpcClientChannel channel = this.grpcChannelManager.createChannel(ctx, clientId);
         // use topic name as producer group
@@ -431,7 +431,7 @@ public class ClientActivity extends AbstractMessagingActivity {
     protected GrpcClientChannel registerConsumer(ProxyContext ctx, String consumerGroup, ClientType clientType,
         List<SubscriptionEntry> subscriptionEntryList, boolean updateSubscription) {
         String clientId = ctx.getClientID();
-        LanguageCode languageCode = LanguageCode.valueOf(ctx.getLanguage());
+        LanguageCode languageCode = parseLanguage(ctx);
 
         GrpcClientChannel channel = this.grpcChannelManager.createChannel(ctx, clientId);
         ClientChannelInfo clientChannelInfo = new ClientChannelInfo(channel, clientId, languageCode, parseClientVersion(ctx.getClientVersion()));
@@ -459,6 +459,18 @@ public class ClientActivity extends AbstractMessagingActivity {
             }
         }
         return clientVersion;
+    }
+
+    private LanguageCode parseLanguage(ProxyContext ctx) {
+        String language = ctx.getLanguage();
+        if (StringUtils.isBlank(language)) {
+            throw new GrpcProxyException(Code.BAD_REQUEST, "language cannot be empty");
+        }
+        try {
+            return LanguageCode.valueOf(language);
+        } catch (IllegalArgumentException e) {
+            throw new GrpcProxyException(Code.BAD_REQUEST, "unsupported language: " + language, e);
+        }
     }
 
     protected void reportThreadStackTrace(ProxyContext ctx, Status status, ThreadStackTrace request) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
@@ -345,6 +345,25 @@ public class ClientActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testBlankLanguageIsReportedAsInvalidArgument() throws Throwable {
+        ProxyContext context = createContext().setLanguage("");
+        try {
+            this.sendClientTelemetry(
+                context,
+                Settings.newBuilder()
+                    .setClientType(ClientType.PRODUCER)
+                    .setPublishing(Publishing.newBuilder()
+                        .addTopics(Resource.newBuilder().setName(TOPIC).build())
+                        .build())
+                    .build()).get();
+            fail();
+        } catch (ExecutionException e) {
+            StatusRuntimeException exception = (StatusRuntimeException) e.getCause();
+            assertEquals(Status.Code.INVALID_ARGUMENT, exception.getStatus().getCode());
+        }
+    }
+
+    @Test
     public void testEmptySettings() throws Throwable {
         ProxyContext context = createContext();
         try {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
@@ -326,6 +326,25 @@ public class ClientActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testInvalidLanguageIsReportedAsInvalidArgument() throws Throwable {
+        ProxyContext context = createContext().setLanguage("UNKNOWN_LANGUAGE");
+        try {
+            this.sendClientTelemetry(
+                context,
+                Settings.newBuilder()
+                    .setClientType(ClientType.PRODUCER)
+                    .setPublishing(Publishing.newBuilder()
+                        .addTopics(Resource.newBuilder().setName(TOPIC).build())
+                        .build())
+                    .build()).get();
+            fail();
+        } catch (ExecutionException e) {
+            StatusRuntimeException exception = (StatusRuntimeException) e.getCause();
+            assertEquals(Status.Code.INVALID_ARGUMENT, exception.getStatus().getCode());
+        }
+    }
+
+    @Test
     public void testEmptySettings() throws Throwable {
         ProxyContext context = createContext();
         try {


### PR DESCRIPTION
## What is the purpose of the change

Malformed or missing gRPC language metadata reached `LanguageCode.valueOf` and was reported as a server-side `INTERNAL` error.

Closes #10890

## Brief changelog

- centralize gRPC client language parsing in `ClientActivity`;
- reject blank and unknown values with `Code.BAD_REQUEST`;
- use the same validation for telemetry registration and client termination;
- add a telemetry regression test that verifies invalid language maps to gRPC `INVALID_ARGUMENT`.

## Verifying this change

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 1.8) PATH="$JAVA_HOME/bin:$PATH" \
  mvn -q -pl proxy -am -Dtest=ClientActivityTest -DfailIfNoTests=false test
```