### PR TITLE
fix: validate Lite subscription topics and enforce quota

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImpl.java
@@ -79,24 +79,24 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
     }
 
     @Override
-    public void addPartialSubscription(String clientId, String group, String topic, Set<String> lmqNameSet,
+    public synchronized void addPartialSubscription(String clientId, String group, String topic, Set<String> lmqNameSet,
         OffsetOption offsetOption) {
-        long maxCount = brokerController.getBrokerConfig().getMaxLiteSubscriptionCount();
-        if (getActiveSubscriptionNum() >= maxCount) {
-            // No need to check existence, if reach here, it must be new.
-            throw new LiteQuotaException("lite subscription quota exceeded " + maxCount);
-        }
         if (LiteMetadataUtil.isWildcardGroup(group, brokerController)) {
             throw new IllegalStateException("subscribe lite operation is not supported for this group");
         }
+        if (brokerController.getBrokerConfig().getMaxLiteSubscriptionCount() <= 0
+            && !lmqNameSet.isEmpty()) {
+            throw new LiteQuotaException("lite subscription quota exceeded 0");
+        }
+
+        Set<String> activeLmqNames = lmqNameSet.stream()
+            .filter(lmqName -> liteLifecycleManager.isSubscriptionActive(topic, lmqName))
+            .collect(Collectors.toSet());
+        ClientGroup clientGroup = new ClientGroup(clientId, group);
+        ensureQuota(clientGroup, Collections.emptySet(), activeLmqNames);
 
         LiteSubscription thisSub = getOrCreateLiteSubscription(clientId, group, topic);
-        // Utilize existing string object
-        final ClientGroup clientGroup = new ClientGroup(clientId, thisSub.getGroup());
-        for (String lmqName : lmqNameSet) {
-            if (!liteLifecycleManager.isSubscriptionActive(topic, lmqName)) {
-                continue;
-            }
+        for (String lmqName : activeLmqNames) {
             thisSub.addLiteTopic(lmqName);
             // First remove the old subscription
             if (LiteMetadataUtil.isSubLiteExclusive(group, brokerController)) {
@@ -123,32 +123,37 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
     }
 
     @Override
-    public void addCompleteSubscription(String clientId, String group, String topic, Set<String> lmqNameAll, long version) {
+    public synchronized void addCompleteSubscription(String clientId, String group, String topic, Set<String> lmqNameAll, long version) {
         Set<String> lmqNameNew;
         if (LiteMetadataUtil.isWildcardGroup(group, brokerController)) {
             lmqNameNew = Collections.singleton(mockLmqNameForWildcardGroup(topic, group));
-            markWildcardGroup(topic, group);
         } else {
             lmqNameNew = lmqNameAll.stream()
                 .filter(lmqName -> liteLifecycleManager.isSubscriptionActive(topic, lmqName))
                 .collect(Collectors.toSet());
         }
 
-        LiteSubscription thisSub = getOrCreateLiteSubscription(clientId, group, topic);
-        Set<String> lmqNamePrev = thisSub.getLiteTopicSet();
-        // Find topics to remove (in current set but not in new set)
+        LiteSubscription existingSubscription = client2Subscription.get(clientId);
+        Set<String> lmqNamePrev = existingSubscription == null ? Collections.emptySet() : existingSubscription.getLiteTopicSet();
+        ClientGroup clientGroup = new ClientGroup(clientId, group);
         Set<String> lmqNameRemove = lmqNamePrev.stream()
             .filter(lmqName -> !lmqNameNew.contains(lmqName))
             .collect(Collectors.toSet());
+        ensureQuota(clientGroup, lmqNameRemove, lmqNameNew);
 
-        ClientGroup clientGroup = new ClientGroup(clientId, thisSub.getGroup());
+        if (LiteMetadataUtil.isWildcardGroup(group, brokerController)) {
+            markWildcardGroup(topic, group);
+        }
+        LiteSubscription thisSub = getOrCreateLiteSubscription(clientId, group, topic);
+
+        ClientGroup subscriptionClientGroup = new ClientGroup(clientId, thisSub.getGroup());
         lmqNameRemove.forEach(lmqName -> {
             thisSub.removeLiteTopic(lmqName);
-            removeTopicGroup(clientGroup, lmqName, false);
+            removeTopicGroup(subscriptionClientGroup, lmqName, false);
         });
         lmqNameNew.forEach(lmqName -> {
             thisSub.addLiteTopic(lmqName);
-            addTopicGroup(clientGroup, lmqName);
+            addTopicGroup(subscriptionClientGroup, lmqName);
         });
         // Tombstone operations only apply to exclusive groups.
         if (LiteMetadataUtil.isSubLiteExclusive(group, brokerController)) {
@@ -279,6 +284,20 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
                 listener.onRegister(clientGroup.clientId, clientGroup.group, lmqName);
             }
         }
+    }
+
+    private void ensureQuota(ClientGroup clientGroup, Set<String> lmqNameRemove, Set<String> lmqNameNew) {
+        long maxCount = brokerController.getBrokerConfig().getMaxLiteSubscriptionCount();
+        long removedCount = lmqNameRemove.stream().filter(lmqName -> containsClientGroup(lmqName, clientGroup)).count();
+        long addedCount = lmqNameNew.stream().filter(lmqName -> !containsClientGroup(lmqName, clientGroup)).count();
+        if ((long) getActiveSubscriptionNum() - removedCount + addedCount > maxCount) {
+            throw new LiteQuotaException("lite subscription quota exceeded " + maxCount);
+        }
+    }
+
+    private boolean containsClientGroup(String lmqName, ClientGroup clientGroup) {
+        Set<ClientGroup> clientGroups = liteTopic2Group.get(lmqName);
+        return clientGroups != null && clientGroups.contains(clientGroup);
     }
 
     protected void removeTopicGroup(ClientGroup clientGroup, String lmqName, boolean resetOffset) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImplTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImplTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.broker.lite;
 
 import io.netty.channel.Channel;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -123,6 +124,41 @@ public class LiteSubscriptionRegistryImplTest {
         assertThrows(LiteQuotaException.class, () -> {
             registry.addPartialSubscription(clientId, group, topic, lmqNameSet, null);
         });
+    }
+
+    @Test
+    public void testAddPartialSubscription_RejectsBatchThatExceedsQuota() {
+        when(mockBrokerConfig.getMaxLiteSubscriptionCount()).thenReturn(1L);
+        when(mockLifecycleManager.isSubscriptionActive(anyString(), anyString())).thenReturn(true);
+
+        assertThrows(LiteQuotaException.class, () -> registry.addPartialSubscription(
+            "testClient", "testGroup", "testTopic", new HashSet<>(Arrays.asList("lmq1", "lmq2")), null));
+
+        assertEquals(0, registry.getActiveSubscriptionNum());
+    }
+
+    @Test
+    public void testAddCompleteSubscription_RejectsQuotaOverflow() {
+        when(mockBrokerConfig.getMaxLiteSubscriptionCount()).thenReturn(1L);
+        when(mockLifecycleManager.isSubscriptionActive(anyString(), anyString())).thenReturn(true);
+
+        assertThrows(LiteQuotaException.class, () -> registry.addCompleteSubscription(
+            "testClient", "testGroup", "testTopic", new HashSet<>(Arrays.asList("lmq1", "lmq2")), 1L));
+
+        assertEquals(0, registry.getActiveSubscriptionNum());
+    }
+
+    @Test
+    public void testAddPartialSubscription_AllowsExistingSubscriptionAtQuota() {
+        when(mockBrokerConfig.getMaxLiteSubscriptionCount()).thenReturn(1L);
+        when(mockLifecycleManager.isSubscriptionActive(anyString(), anyString())).thenReturn(true);
+        Set<String> subscriptions = Collections.singleton("lmq1");
+
+        registry.addPartialSubscription("testClient", "testGroup", "testTopic", subscriptions, null);
+
+        registry.addPartialSubscription("testClient", "testGroup", "testTopic", subscriptions, null);
+
+        assertEquals(1, registry.getActiveSubscriptionNum());
     }
 
     /**

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ClientProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ClientProcessor.java
@@ -197,8 +197,9 @@ public class ClientProcessor extends AbstractProcessor {
         if (CollectionUtils.isEmpty(subList)) {
             return;
         }
-        // check bindTopic for sub list
-        validateLiteBindTopic(ctx, group, subList.iterator().next().getTopic());
+        for (SubscriptionData subscriptionData : subList) {
+            validateLiteBindTopic(ctx, group, subscriptionData.getTopic());
+        }
     }
 
     protected void validateLiteBindTopic(ProxyContext ctx, String group, String bindTopic) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ClientProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ClientProcessorTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.proxy.processor;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
@@ -134,6 +135,23 @@ public class ClientProcessorTest {
         assertDoesNotThrow(() -> {
             clientProcessor.validateLiteSubTopic(ctx, group, subList);
         });
+    }
+
+    @Test
+    public void testValidateLiteSubTopic_rejectsAnySubscriptionForAnotherTopic() {
+        String group = "group";
+        SubscriptionData matchingSubscription = new SubscriptionData();
+        matchingSubscription.setTopic("topic1");
+        SubscriptionData mismatchingSubscription = new SubscriptionData();
+        mismatchingSubscription.setTopic("topic2");
+        Set<SubscriptionData> subList = new LinkedHashSet<>();
+        subList.add(matchingSubscription);
+        subList.add(mismatchingSubscription);
+
+        when(groupConfig.getLiteBindTopic()).thenReturn("topic1");
+        when(messagingProcessor.getSubscriptionGroupConfig(ctx, group)).thenReturn(groupConfig);
+
+        assertThrows(GrpcProxyException.class, () -> clientProcessor.validateLiteSubTopic(ctx, group, subList));
     }
 
     @Test


### PR DESCRIPTION
## Summary\n- validate every Lite subscription topic before processing client subscription updates\n- enforce Lite subscription quota in the broker registry\n\nThis consolidates the adjacent quota change from #10896 into one Lite subscription integrity fix.\n\nCloses #10895\n\n## Validation\n-      [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.
     [java] JVM args ignored when same JVM is used.

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.rocketmq.broker.lite.LiteSubscriptionRegistryImplTest
05:50:55,860 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.3.5-rocketmq
05:50:55,874 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.LoggerContext[default] - Found resource [rmq.logback-test.xml] at [file:/private/tmp/rmq-lite-subscription-topic-validation/broker/target/test-classes/rmq.logback-test.xml]
05:50:55,954 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [CONSOLE]
05:50:55,954 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender]
05:50:55,980 |-WARN in org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender[CONSOLE] - This appender no longer admits a layout as a sub-component, set an encoder instead.
05:50:55,980 |-WARN in org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender[CONSOLE] - To ensure compatibility, wrapping your layout in LayoutWrappingEncoder.
05:50:55,980 |-WARN in org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender[CONSOLE] - See also http://logback.qos.ch/codes.html#layoutInsteadOfEncoder for details
05:50:55,980 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.rocketmq] to ERROR
05:50:55,980 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting additivity of logger [org.apache.rocketmq] to false
05:50:55,980 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[org.apache.rocketmq]
05:50:55,980 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to INFO
05:50:55,981 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[ROOT]
05:50:55,981 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.DefaultProcessor@671d97bc - End of configuration.
05:50:55,981 |-INFO in org.apache.rocketmq.common.logging.JoranConfiguratorExt@774f2992 - Registering current configuration as safe fallback point

2026-08-14 20:50:56.890  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.892  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.899  INFO [     RocketmqPopLite] [                          main] re-notify unsubscribe for tombstoned lmqName, clientId:clientA, group:exclusiveGroup, lmqName:lmq1
2026-08-14 20:50:56.899  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.906  INFO [     RocketmqPopLite] [                          main] try to reset lite offset. testGroup, lmq1, testClient, OffsetOption{type=POLICY, value=2}, current:100, target:500
2026-08-14 20:50:56.917  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:lmq1, group:testGroup, topic:testTopic, clientId:testClient
2026-08-14 20:50:56.924  INFO [     RocketmqPopLite] [                          main] try to reset lite offset. testGroup, lmq1, testClient, OffsetOption{type=POLICY, value=1}, current:100, target:0
2026-08-14 20:50:56.931  INFO [     RocketmqPopLite] [                          main] try to reset lite offset. testGroup, lmq1, testClient, OffsetOption{type=OFFSET, value=250}, current:100, target:250
2026-08-14 20:50:56.933  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.933  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.935  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.935  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.937  INFO [     RocketmqPopLite] [                          main] removeCompleteSubscription, topic:testTopic, group:exclusiveGroup, clientId:clientA
2026-08-14 20:50:56.937  INFO [     RocketmqPopLite] [                          main] Remove expired LiteSubscription, topic: testTopic, group: exclusiveGroup, clientId: clientA, timeout: 10000ms, expired: 60002ms
2026-08-14 20:50:56.940  INFO [     RocketmqPopLite] [                          main] removeCompleteSubscription, topic:testTopic, group:testGroup, clientId:testClient
2026-08-14 20:50:56.940  INFO [     RocketmqPopLite] [                          main] Remove expired LiteSubscription, topic: testTopic, group: testGroup, clientId: testClient, timeout: 10000ms, expired: 20000ms
2026-08-14 20:50:56.941  INFO [     RocketmqPopLite] [                          main] removeCompleteSubscription, topic:testTopic, group:testGroup, clientId:testClient
2026-08-14 20:50:56.944  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.945  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.945  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.945  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq2, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.946  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.946  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.947  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientB
2026-08-14 20:50:56.947  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientB -> clientA
2026-08-14 20:50:56.949  WARN [     RocketmqPopLite] [                          main] notifyUnsubscribeLite but channel is null, liteTopic:null, group:testGroup, topic:null, clientId:testClient1,
2026-08-14 20:50:56.949  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:testGroup, lmqName:lmq1, resetOffset:false, clientId:testClient1 -> testClient2
2026-08-14 20:50:56.951  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.951  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq1, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.952  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.952  INFO [     RocketmqPopLite] [                          main] excludeClientByLmqName group:exclusiveGroup, lmqName:lmq2, resetOffset:false, clientId:clientA -> clientB
2026-08-14 20:50:56.952  INFO [     RocketmqPopLite] [                          main] re-notify unsubscribe for tombstoned lmqName, clientId:clientA, group:exclusiveGroup, lmqName:lmq2
2026-08-14 20:50:56.952  INFO [     RocketmqPopLite] [                          main] notifyUnsubscribeLite liteTopic:null, group:exclusiveGroup, topic:null, clientId:clientA
2026-08-14 20:50:56.956  INFO [     RocketmqPopLite] [                          main] removeCompleteSubscription, topic:testTopic, group:testGroup, clientId:testClient
Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.113 sec - in org.apache.rocketmq.broker.lite.LiteSubscriptionRegistryImplTest

Results :

Tests run: 33, Failures: 0, Errors: 0, Skipped: 0

     [java] JVM args ignored when same JVM is used.

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.rocketmq.proxy.processor.ClientProcessorTest
05:51:07,637 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.3.5-rocketmq
05:51:07,661 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.LoggerContext[default] - Found resource [rmq.logback-test.xml] at [file:/private/tmp/rmq-lite-subscription-topic-validation/proxy/target/test-classes/rmq.logback-test.xml]
05:51:07,807 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [CONSOLE]
05:51:07,807 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender]
05:51:07,857 |-WARN in org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender[CONSOLE] - This appender no longer admits a layout as a sub-component, set an encoder instead.
05:51:07,857 |-WARN in org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender[CONSOLE] - To ensure compatibility, wrapping your layout in LayoutWrappingEncoder.
05:51:07,857 |-WARN in org.apache.rocketmq.logging.ch.qos.logback.core.ConsoleAppender[CONSOLE] - See also http://logback.qos.ch/codes.html#layoutInsteadOfEncoder for details
05:51:07,857 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.rocketmq] to ERROR
05:51:07,857 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting additivity of logger [org.apache.rocketmq] to false
05:51:07,857 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[org.apache.rocketmq]
05:51:07,858 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to ERROR
05:51:07,858 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[ROOT]
05:51:07,858 |-INFO in org.apache.rocketmq.logging.ch.qos.logback.core.model.processor.DefaultProcessor@61191222 - End of configuration.
05:51:07,859 |-INFO in org.apache.rocketmq.common.logging.JoranConfiguratorExt@58833798 - Registering current configuration as safe fallback point

Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.114 sec - in org.apache.rocketmq.proxy.processor.ClientProcessorTest

Results :

Tests run: 13, Failures: 0, Errors: 0, Skipped: 0