### PR TITLE
fix: validate every Lite consumer subscription against its bound topic [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ClientProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ClientProcessor.java
@@ -197,8 +197,10 @@ public class ClientProcessor extends AbstractProcessor {
         if (CollectionUtils.isEmpty(subList)) {
             return;
         }
-        // check bindTopic for sub list
-        validateLiteBindTopic(ctx, group, subList.iterator().next().getTopic());
+        // check bindTopic for every subscription in the sub list
+        for (SubscriptionData subscriptionData : subList) {
+            validateLiteBindTopic(ctx, group, subscriptionData.getTopic());
+        }
     }
 
     protected void validateLiteBindTopic(ProxyContext ctx, String group, String bindTopic) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ClientProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ClientProcessorTest.java
@@ -137,6 +137,27 @@ public class ClientProcessorTest {
     }
 
     @Test
+    public void testValidateLiteSubTopic_mismatchedSecondTopic_throwsException() {
+        String group = "group";
+        String bindTopic = "topic1";
+        SubscriptionData matching = new SubscriptionData();
+        matching.setTopic(bindTopic);
+        SubscriptionData mismatching = new SubscriptionData();
+        mismatching.setTopic("topic2");
+        Set<SubscriptionData> subList = new HashSet<>();
+        subList.add(matching);
+        subList.add(mismatching);
+
+        when(groupConfig.getLiteBindTopic()).thenReturn(bindTopic);
+        when(messagingProcessor.getSubscriptionGroupConfig(ctx, group)).thenReturn(groupConfig);
+
+        GrpcProxyException exception = assertThrows(GrpcProxyException.class, () -> {
+            clientProcessor.validateLiteSubTopic(ctx, group, subList);
+        });
+        assertTrue(exception.getMessage().contains("expected to bind topic"));
+    }
+
+    @Test
     public void testValidateLiteBindTopic_matchingTopics_noException() {
         String group = "group";
         String bindTopic = "topic1";


### PR DESCRIPTION
## What

`ClientProcessor.validateLiteSubTopic` now validates every subscription in the set against the group's bound topic, not just the first element.

## Why

`ClientProcessor.validateLiteSubTopic` called `subList.iterator().next().getTopic()`, which only checks the first element of the subscription set. A Lite consumer group with a configured `liteBindTopic` could include a second subscription for a different topic without being rejected.

## How

- Changed the single-element check to a `for` loop over all elements
- Added `testValidateLiteSubTopic_mismatchedSecondTopic_throwsException` to verify that a mismatching second subscription triggers `ILLEGAL_TOPIC`

Fixes #10895