### PR TITLE
[studio][ISSUE #10904] Tolerate malformed Proxy retry counters

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ProducerProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ProducerProcessor.java
@@ -211,13 +211,21 @@ public class ProducerProcessor extends AbstractProcessor {
         if (requestHeader.getTopic().startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) {
             String reconsumeTimes = MessageAccessor.getReconsumeTime(message);
             if (reconsumeTimes != null) {
-                requestHeader.setReconsumeTimes(Integer.valueOf(reconsumeTimes));
+                try {
+                    requestHeader.setReconsumeTimes(Integer.valueOf(reconsumeTimes));
+                } catch (NumberFormatException e) {
+                    log.warn("parse reconsume times error, with value:{}", reconsumeTimes);
+                }
                 MessageAccessor.clearProperty(message, MessageConst.PROPERTY_RECONSUME_TIME);
             }
 
             String maxReconsumeTimes = MessageAccessor.getMaxReconsumeTimes(message);
             if (maxReconsumeTimes != null) {
-                requestHeader.setMaxReconsumeTimes(Integer.valueOf(maxReconsumeTimes));
+                try {
+                    requestHeader.setMaxReconsumeTimes(Integer.valueOf(maxReconsumeTimes));
+                } catch (NumberFormatException e) {
+                    log.warn("parse max reconsume times error, with value:{}", maxReconsumeTimes);
+                }
                 MessageAccessor.clearProperty(message, MessageConst.PROPERTY_MAX_RECONSUME_TIMES);
             }
         }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ProducerProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ProducerProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.proxy.processor;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -53,6 +54,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -186,6 +188,21 @@ public class ProducerProcessorTest extends BaseProcessorTest {
         assertEquals(MixAll.getRetryTopic(CONSUMER_GROUP), requestHeader.getTopic());
         assertEquals(1, requestHeader.getReconsumeTimes().intValue());
         assertEquals(16, requestHeader.getMaxReconsumeTimes().intValue());
+    }
+
+    @Test
+    public void testBuildSendMessageRequestHeaderWithMalformedRetryCounters() {
+        Message message = createMessageExt(MixAll.getRetryTopic(CONSUMER_GROUP), "tag", 0, 0);
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_RECONSUME_TIME, "not-a-number");
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_MAX_RECONSUME_TIMES, "also-invalid");
+
+        SendMessageRequestHeader requestHeader = producerProcessor.buildSendMessageRequestHeader(
+            Collections.singletonList(message), PRODUCER_GROUP, 0, 0);
+
+        assertEquals(0, requestHeader.getReconsumeTimes().intValue());
+        assertNull(requestHeader.getMaxReconsumeTimes());
+        assertNull(MessageAccessor.getReconsumeTime(message));
+        assertNull(MessageAccessor.getMaxReconsumeTimes(message));
     }
 
     @Test


### PR DESCRIPTION
## What changed

- tolerate malformed reconsume-times values and keep the existing default of 0
- tolerate malformed max-reconsume-times values and leave the optional header field unset
- continue clearing both internal retry properties after handling them
- add a regression test for both malformed counters

## Why

ProducerProcessor parsed both retry counters with Integer.valueOf. A malformed stored property raised NumberFormatException while building the broker request header and aborted Proxy message forwarding. The same method already handles a malformed born timestamp defensively.

## Impact

Valid retry messages keep their current request-header values. Only malformed counters use safe defaults; no public API changes are introduced.

Fixes #10904

## Validation

- mvn -pl proxy -Dtest=ProducerProcessorTest -Djacoco.skip=true test
  - 7 tests, 0 failures, 0 errors
  - Checkstyle: 0 violations
  - SpotBugs: 0 issues

JaCoCo is skipped locally because the repository's JaCoCo 0.8.5 agent does not support Java 17 class files.