### PR TITLE
[ISSUE #10898] Wake NettyEventExecutor during shutdown

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -763,6 +763,7 @@ public abstract class NettyRemotingAbstract {
     }
 
     class NettyEventExecutor extends ServiceThread {
+        private final NettyEvent wakeupEvent = new NettyEvent(null, null, null);
         private final LinkedBlockingQueue<NettyEvent> eventQueue = new LinkedBlockingQueue<>();
 
         public void putNettyEvent(final NettyEvent event) {
@@ -776,6 +777,12 @@ public abstract class NettyRemotingAbstract {
         }
 
         @Override
+        public void wakeup() {
+            super.wakeup();
+            this.eventQueue.offer(wakeupEvent);
+        }
+
+        @Override
         public void run() {
             log.info(this.getServiceName() + " service started");
 
@@ -784,7 +791,7 @@ public abstract class NettyRemotingAbstract {
             while (!this.isStopped()) {
                 try {
                     NettyEvent event = this.eventQueue.poll(3000, TimeUnit.MILLISECONDS);
-                    if (event != null && listener != null) {
+                    if (event != null && event != wakeupEvent && listener != null) {
                         switch (event.getType()) {
                             case IDLE:
                                 listener.onChannelIdle(event.getRemoteAddr(), event.getChannel());

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstractTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstractTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.remoting.netty;
 
+import java.time.Duration;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.common.SemaphoreReleaseOnlyOnce;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
@@ -25,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
@@ -138,6 +141,24 @@ public class NettyRemotingAbstractTest {
     }
 
     @Test
+    public void testNettyEventExecutorShutdownWithoutPollDelay() {
+        TestNettyEventExecutor executor = new TestNettyEventExecutor(remotingAbstract);
+        executor.start();
+        try {
+            await().atMost(Duration.ofSeconds(3))
+                .until(() -> executor.getThreadState() == Thread.State.TIMED_WAITING);
+
+            long beginTime = System.nanoTime();
+            executor.shutdown();
+            long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - beginTime);
+
+            assertThat(elapsedMillis).isLessThan(1000L);
+        } finally {
+            executor.shutdown(true);
+        }
+    }
+
+    @Test
     public void testProcessRequestCommand() throws InterruptedException {
         final Semaphore semaphore = new Semaphore(0);
         RemotingCommand request = RemotingCommand.createRequestCommand(1, null);
@@ -167,5 +188,15 @@ public class NettyRemotingAbstractTest {
         // Acquire the release permit after call back
         semaphore.acquire(1);
         assertThat(semaphore.availablePermits()).isEqualTo(0);
+    }
+
+    private static class TestNettyEventExecutor extends NettyRemotingAbstract.NettyEventExecutor {
+        TestNettyEventExecutor(NettyRemotingAbstract remotingAbstract) {
+            remotingAbstract.super();
+        }
+
+        Thread.State getThreadState() {
+            return thread.getState();
+        }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10898

### Brief Description

NettyEventExecutor.wakeup() now offers a private sentinel event after delegating to ServiceThread.wakeup(). This releases a worker blocked in the event queue's three-second poll so shutdown can observe the stopped flag immediately. The dispatch loop skips the sentinel by identity, leaving normal channel events unchanged.

A regression test waits until the executor is blocked in the timed queue poll and verifies that shutdown completes in under one second.

### How Did You Test This Change?

- Maven focused test: NettyRemotingAbstractTest (6 tests passed)
- Checkstyle passed with 0 violations.
- SpotBugs passed with 0 issues.
- git diff --check passed.
- The full common + remoting suite was attempted on Windows with JDK 17, but did not complete because the existing RemotingServerTest#testInvokeAsync waits indefinitely in CountDownLatch.await(). The focused test class and unrelated compatibility test both pass.