### PR TITLE
[ISSUE #10912] Fix native memory leak in PopConsumerRocksdbStore

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
@@ -147,9 +147,11 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
         // configure prefix indexing to improve the performance of scans.
         // However, in the current implementation, this is not the bottleneck.
         List<PopConsumerRecord> consumerRecordList = new ArrayList<>();
-        try (ReadOptions scanOptions = new ReadOptions()
-            .setIterateLowerBound(new Slice(ByteBuffer.allocate(Long.BYTES).putLong(lower).array()))
-            .setIterateUpperBound(new Slice(ByteBuffer.allocate(Long.BYTES).putLong(upper).array()));
+        try (Slice lowerBound = new Slice(ByteBuffer.allocate(Long.BYTES).putLong(lower).array());
+             Slice upperBound = new Slice(ByteBuffer.allocate(Long.BYTES).putLong(upper).array());
+             ReadOptions scanOptions = new ReadOptions()
+                 .setIterateLowerBound(lowerBound)
+                 .setIterateUpperBound(upperBound);
              RocksIterator iterator = db.newIterator(this.columnFamilyHandle, scanOptions)) {
             iterator.seek(ByteBuffer.allocate(Long.BYTES).putLong(lower).array());
             while (iterator.isValid() && consumerRecordList.size() < maxCount) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes


- Fixes #10912 

### Brief Description

Close the RocksDB Slice objects created in `scanExpiredRecords()` to prevent native memory leaks.

### How Did You Test This Change?

Ran the existing PopConsumerRocksdbStoreTest and verified that native memory remains stable during repeated scans.
