### PR TITLE
[ISSUE #10912] Close RocksDB Slice objects in scanExpiredRecords

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
@@ -147,9 +147,11 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
         // configure prefix indexing to improve the performance of scans.
         // However, in the current implementation, this is not the bottleneck.
         List<PopConsumerRecord> consumerRecordList = new ArrayList<>();
-        try (ReadOptions scanOptions = new ReadOptions()
-            .setIterateLowerBound(new Slice(ByteBuffer.allocate(Long.BYTES).putLong(lower).array()))
-            .setIterateUpperBound(new Slice(ByteBuffer.allocate(Long.BYTES).putLong(upper).array()));
+        try (Slice lowerBound = new Slice(ByteBuffer.allocate(Long.BYTES).putLong(lower).array());
+             Slice upperBound = new Slice(ByteBuffer.allocate(Long.BYTES).putLong(upper).array());
+             ReadOptions scanOptions = new ReadOptions()
+                 .setIterateLowerBound(lowerBound)
+                 .setIterateUpperBound(upperBound);
              RocksIterator iterator = db.newIterator(this.columnFamilyHandle, scanOptions)) {
             iterator.seek(ByteBuffer.allocate(Long.BYTES).putLong(lower).array());
             while (iterator.isValid() && consumerRecordList.size() < maxCount) {


### PR DESCRIPTION
## What is the purpose of the change

Fix #10912.

scanExpiredRecords() created two RocksDB Slice objects as iterator bounds and never closed them, leaking native memory on every POP revive scan. The slices are now created as named resources inside the try-with-resources block so they are closed together with the ReadOptions and iterator.

## Brief changelog

- PopConsumerRocksdbStore.scanExpiredRecords(): move the two Slice bounds into try-with-resources

## How was this patch verified

- RocksDB Slice implements AutoCloseable via AbstractNativeReference, so the try-with-resources block closes it deterministically alongside ReadOptions and RocksIterator
- git diff --check clean