### PR TITLE
[ISSUE #10898] Wake NettyEventExecutor immediately on shutdown

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerRocksdbStore.java
@@ -147,9 +147,11 @@ public class PopConsumerRocksdbStore extends AbstractRocksDBStorage implements P
         // configure prefix indexing to improve the performance of scans.
         // However, in the current implementation, this is not the bottleneck.
         List<PopConsumerRecord> consumerRecordList = new ArrayList<>();
-        try (ReadOptions scanOptions = new ReadOptions()
-            .setIterateLowerBound(new Slice(ByteBuffer.allocate(Long.BYTES).putLong(lower).array()))
-            .setIterateUpperBound(new Slice(ByteBuffer.allocate(Long.BYTES).putLong(upper).array()));
+        try (Slice lowerBound = new Slice(ByteBuffer.allocate(Long.BYTES).putLong(lower).array());
+             Slice upperBound = new Slice(ByteBuffer.allocate(Long.BYTES).putLong(upper).array());
+             ReadOptions scanOptions = new ReadOptions()
+                 .setIterateLowerBound(lowerBound)
+                 .setIterateUpperBound(upperBound);
              RocksIterator iterator = db.newIterator(this.columnFamilyHandle, scanOptions)) {
             iterator.seek(ByteBuffer.allocate(Long.BYTES).putLong(lower).array());
             while (iterator.isValid() && consumerRecordList.size() < maxCount) {

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -784,7 +784,7 @@ public abstract class NettyRemotingAbstract {
             while (!this.isStopped()) {
                 try {
                     NettyEvent event = this.eventQueue.poll(3000, TimeUnit.MILLISECONDS);
-                    if (event != null && listener != null) {
+                    if (event != null && event.getType() != null && listener != null) {
                         switch (event.getType()) {
                             case IDLE:
                                 listener.onChannelIdle(event.getRemoteAddr(), event.getChannel());
@@ -812,6 +812,14 @@ public abstract class NettyRemotingAbstract {
             }
 
             log.info(this.getServiceName() + " service end");
+        }
+
+        @Override
+        public void shutdown(final boolean interrupt) {
+            // wake up the thread blocked on eventQueue.poll() so it observes the stopped flag
+            // immediately instead of waiting for the next poll timeout
+            this.eventQueue.offer(new NettyEvent(null, null, null));
+            super.shutdown(interrupt);
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

Fix #10898.

NettyEventExecutor blocks in eventQueue.poll(3000, MILLISECONDS), but ServiceThread.shutdown() only signals the stopped flag and calls wakeup(), which unparks a parked thread and cannot release a thread blocked on a LinkedBlockingQueue. Every shutdown of a remoting instance therefore waited up to 3 seconds per NettyEventExecutor.

## Brief changelog

- NettyRemotingAbstract.NettyEventExecutor now overrides shutdown(boolean): it offers a sentinel event (null type) into the queue so the blocked poll returns immediately, then delegates to the superclass shutdown
- the run loop skips events with a null type, so the sentinel is consumed without touching the channel listener

## How was this patch verified

- Code review of the poll loop: the sentinel event makes poll return at once, the loop re-checks isStopped() and exits promptly
- `git diff --check` clean
