### PR TITLE
[ISSUE #10894] Enforce Lite subscription quota for complete and batch updates

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/lite/LiteSubscriptionRegistryImpl.java
@@ -97,6 +97,9 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
             if (!liteLifecycleManager.isSubscriptionActive(topic, lmqName)) {
                 continue;
             }
+            if (!isLiteTopicSubscribed(clientGroup, lmqName) && getActiveSubscriptionNum() >= maxCount) {
+                throw new LiteQuotaException("lite subscription quota exceeded " + maxCount);
+            }
             thisSub.addLiteTopic(lmqName);
             // First remove the old subscription
             if (LiteMetadataUtil.isSubLiteExclusive(group, brokerController)) {
@@ -147,6 +150,10 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
             removeTopicGroup(clientGroup, lmqName, false);
         });
         lmqNameNew.forEach(lmqName -> {
+            long maxCount = brokerController.getBrokerConfig().getMaxLiteSubscriptionCount();
+            if (!isLiteTopicSubscribed(clientGroup, lmqName) && getActiveSubscriptionNum() >= maxCount) {
+                throw new LiteQuotaException("lite subscription quota exceeded " + maxCount);
+            }
             thisSub.addLiteTopic(lmqName);
             addTopicGroup(clientGroup, lmqName);
         });
@@ -267,6 +274,11 @@ public class LiteSubscriptionRegistryImpl extends ServiceThread implements LiteS
                 activeNum.decrementAndGet();
             }
         }
+    }
+
+    protected boolean isLiteTopicSubscribed(ClientGroup clientGroup, String lmqName) {
+        Set<ClientGroup> topicGroupSet = liteTopic2Group.get(lmqName);
+        return topicGroupSet != null && topicGroupSet.contains(clientGroup);
     }
 
     protected void addTopicGroup(ClientGroup clientGroup, String lmqName) {


### PR DESCRIPTION
## What is the purpose of the change

Fix #10894.

LiteSubscriptionRegistryImpl.addPartialSubscription checked only the current active count before processing, so a request adding multiple active Lite subscriptions could exceed maxLiteSubscriptionCount. addCompleteSubscription did not check the limit at all. At the same time an idempotent retry for an already active subscription was rejected once the quota was full.

## Brief changelog

- LiteSubscriptionRegistryImpl.addPartialSubscription: check the quota per newly added lmqName, skipping entries the client already subscribes to
- LiteSubscriptionRegistryImpl.addCompleteSubscription: apply the same per-entry quota check
- added isLiteTopicSubscribed() helper that returns whether a client group is already registered for an lmqName, so idempotent retries are not rejected

## How was this patch verified

- Code review of the quota arithmetic around addTopicGroup/removeTopicGroup
- `git diff --check` clean
