### PR TITLE
[ISSUE #10873] Guard BrokerData.selectBrokerAddr against empty address table

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/route/BrokerData.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/route/BrokerData.java
@@ -89,6 +89,9 @@ public class BrokerData implements Comparable<BrokerData> {
      * @return Broker address.
      */
     public String selectBrokerAddr() {
+        if (this.brokerAddrs == null || this.brokerAddrs.isEmpty()) {
+            return null;
+        }
         String masterAddress = this.brokerAddrs.get(MixAll.MASTER_ID);
 
         if (masterAddress == null) {


### PR DESCRIPTION
## What is the purpose of the change

Fix #10873.

BrokerData.selectBrokerAddr assumed brokerAddrs is non-null and non-empty. A default BrokerData instance threw NullPointerException, while an empty map reached Random.nextInt(0) and threw IllegalArgumentException.

## Brief changelog

- BrokerData.selectBrokerAddr: return null for a null or empty address table

## How was this patch verified

- Code review of the master/slave selection path
- `git diff --check` clean
