### PR TITLE
[ISSUE #10877] Fix Boolean-to-string filter comparison

### DIFF
--- a/filter/src/main/java/org/apache/rocketmq/filter/expression/ComparisonExpression.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/expression/ComparisonExpression.java
@@ -536,7 +536,7 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
             try {
                 if (lc == Boolean.class) {
                     if (convertStringExpressions && rc == String.class) {
-                        lv = Boolean.valueOf((String) lv).booleanValue();
+                        rv = Boolean.valueOf((String) rv);
                     } else {
                         return -1;
                     }


### PR DESCRIPTION
## What is the purpose of the change

Fix #10877.

ComparisonExpression handled a Boolean left operand and String right operand by casting the Boolean left value to String. With string-expression conversion enabled by the selector parser, this branch always threw ClassCastException because a Boolean cannot be cast to String.

## Brief changelog

- ComparisonExpression.__compare: for a Boolean left operand against a String right operand, convert the right operand with Boolean.valueOf instead of casting the left Boolean to String

## How was this patch verified

- Code review: mirrors the symmetric String-left / Boolean-right branch which uses Boolean.valueOf on the String operand
- `git diff --check` clean
