### PR TITLE
[ISSUE #10879] Refresh update timestamp on replaced topic metadata

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/metadata/DefaultMetadataStore.java
@@ -144,7 +144,7 @@ public class DefaultMetadataStore extends ConfigManager implements MetadataStore
         if (metadata == null) {
             return;
         }
-        metadata.setUpdateTimestamp(System.currentTimeMillis());
+        topicMetadata.setUpdateTimestamp(System.currentTimeMillis());
         topicMetadataTable.put(topicMetadata.getTopic(), topicMetadata);
         persist();
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix #10879.

DefaultMetadataStore.updateTopic refreshed the update timestamp on the currently stored metadata object, then replaced the map entry with the caller-provided TopicMetadata. When the caller supplied a distinct replacement object, the stored entry kept a stale update timestamp.

## Brief changelog

- DefaultMetadataStore.updateTopic: set the update timestamp on the replacement TopicMetadata before storing it

## How was this patch verified

- Code review of the replace path
- `git diff --check` clean
