### PR TITLE
[ISSUE #10924] Fix gRPC FIFO batch send ordering

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.common.attribute.TopicMessageType;
 import org.apache.rocketmq.common.constant.PermName;
 import org.apache.rocketmq.common.help.FAQUrl;
 import org.apache.rocketmq.common.lite.LiteUtil;
+import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageAccessor;
 import org.apache.rocketmq.common.message.MessageClientIDSetter;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -68,6 +69,7 @@ import org.apache.rocketmq.store.config.StorePathConfigHelper;
 import org.apache.rocketmq.store.stats.BrokerStatsManager;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -606,6 +608,23 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
         messageExtBatch.setFlag(requestHeader.getFlag());
         MessageAccessor.setProperties(messageExtBatch, MessageDecoder.string2messageProperties(requestHeader.getProperties()));
         messageExtBatch.setBody(request.getBody());
+
+        final String liteTopic;
+        try {
+            liteTopic = validateBatchLiteTopic(messageExtBatch.getBody());
+        } catch (Exception e) {
+            response.setCode(ResponseCode.MESSAGE_ILLEGAL);
+            response.setRemark(e.getMessage());
+            return response;
+        }
+        MessageAccessor.clearProperty(messageExtBatch, MessageConst.PROPERTY_LITE_TOPIC);
+        MessageAccessor.clearProperty(messageExtBatch, MessageConst.PROPERTY_INNER_MULTI_DISPATCH);
+        if (StringUtils.isNotEmpty(liteTopic)) {
+            MessageAccessor.setLiteTopic(messageExtBatch, liteTopic);
+            MessageAccessor.putProperty(messageExtBatch, MessageConst.PROPERTY_INNER_MULTI_DISPATCH,
+                LiteUtil.toLmqName(requestHeader.getTopic(), liteTopic));
+        }
+
         messageExtBatch.setBornTimestamp(requestHeader.getBornTimestamp());
         messageExtBatch.setBornHost(ctx.channel().remoteAddress());
         messageExtBatch.setStoreHost(this.getStoreHost());
@@ -665,6 +684,21 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
             sendMessageCallback.onComplete(sendMessageContext, response);
             return response;
         }
+    }
+
+    private String validateBatchLiteTopic(byte[] batchBody) throws Exception {
+        List<Message> messages = MessageDecoder.decodeMessages(ByteBuffer.wrap(batchBody), false);
+        if (messages.isEmpty()) {
+            throw new IllegalArgumentException("batch message cannot be empty");
+        }
+
+        String liteTopic = messages.get(0).getProperty(MessageConst.PROPERTY_LITE_TOPIC);
+        for (Message message : messages) {
+            if (!Objects.equals(liteTopic, message.getProperty(MessageConst.PROPERTY_LITE_TOPIC))) {
+                throw new IllegalArgumentException("all messages in a batch must have the same lite topic");
+            }
+        }
+        return liteTopic;
     }
 
     public void attachRecallHandle(RemotingCommand request, MessageExt msg, SendMessageResponseHeader responseHeader) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/SendMessageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/SendMessageProcessorTest.java
@@ -17,10 +17,13 @@
 package org.apache.rocketmq.broker.processor;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -38,11 +41,14 @@ import org.apache.rocketmq.broker.topic.TopicConfigManager;
 import org.apache.rocketmq.broker.transaction.TransactionalMessageService;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.common.lite.LiteUtil;
+import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageAccessor;
 import org.apache.rocketmq.common.message.MessageClientIDSetter;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageExtBatch;
 import org.apache.rocketmq.common.message.MessageExtBrokerInner;
 import org.apache.rocketmq.common.producer.RecallMessageHandle;
 import org.apache.rocketmq.common.sysflag.MessageSysFlag;
@@ -55,6 +61,7 @@ import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.header.ConsumerSendMsgBackRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeaderV2;
 import org.apache.rocketmq.remoting.protocol.header.SendMessageResponseHeader;
 import org.apache.rocketmq.store.AppendMessageResult;
 import org.apache.rocketmq.store.AppendMessageStatus;
@@ -66,6 +73,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -75,6 +83,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -86,6 +95,8 @@ public class SendMessageProcessorTest {
     private ChannelHandlerContext handlerContext;
     @Mock
     private Channel channel;
+    @Mock
+    private ChannelFuture channelFuture;
     @Spy
     private BrokerConfig brokerConfig;
     @Spy
@@ -196,6 +207,40 @@ public class SendMessageProcessorTest {
         when(messageStore.asyncPutMessage(any(MessageExtBrokerInner.class))).
             thenReturn(CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.PROPERTIES_SIZE_EXCEEDED, new AppendMessageResult(AppendMessageStatus.UNKNOWN_ERROR))));
         assertPutResult(ResponseCode.MESSAGE_ILLEGAL);
+    }
+
+    @Test
+    public void testBatchLiteTopicDispatchUsesValidatedMessageProperties() throws Exception {
+        brokerConfig.setAsyncSendEnable(false);
+        when(messageStore.putMessages(any(MessageExtBatch.class))).thenReturn(
+            new PutMessageResult(PutMessageStatus.PUT_OK, new AppendMessageResult(AppendMessageStatus.PUT_OK)));
+        when(channel.writeAndFlush(any(Object.class))).thenReturn(channelFuture);
+
+        String liteTopic = "lite-topic";
+        RemotingCommand request = createBatchSendMsgCommand(liteTopic, liteTopic, "untrusted-header-lite-topic");
+        RemotingCommand response = sendMessageProcessor.processRequest(handlerContext, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        ArgumentCaptor<MessageExtBatch> batchCaptor = ArgumentCaptor.forClass(MessageExtBatch.class);
+        verify(messageStore).putMessages(batchCaptor.capture());
+        MessageExtBatch batch = batchCaptor.getValue();
+        assertThat(batch.getProperty(MessageConst.PROPERTY_LITE_TOPIC)).isEqualTo(liteTopic);
+        assertThat(batch.getProperty(MessageConst.PROPERTY_INNER_MULTI_DISPATCH))
+            .isEqualTo(LiteUtil.toLmqName(topic, liteTopic));
+    }
+
+    @Test
+    public void testRejectBatchWithDifferentLiteTopics() throws Exception {
+        brokerConfig.setAsyncSendEnable(false);
+
+        RemotingCommand request = createBatchSendMsgCommand("lite-a", "lite-b", "lite-a");
+        RemotingCommand response = sendMessageProcessor.processRequest(handlerContext, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.MESSAGE_ILLEGAL);
+        assertThat(response.getRemark()).isEqualTo("all messages in a batch must have the same lite topic");
+        verify(messageStore, never()).putMessages(any(MessageExtBatch.class));
     }
 
     @Test
@@ -400,6 +445,25 @@ public class SendMessageProcessorTest {
 
         RemotingCommand request = RemotingCommand.createRequestCommand(requestCode, requestHeader);
         request.setBody(new byte[] {'a'});
+        request.makeCustomHeaderToNet();
+        return request;
+    }
+
+    private RemotingCommand createBatchSendMsgCommand(String firstLiteTopic, String secondLiteTopic,
+        String headerLiteTopic) {
+        SendMessageRequestHeader requestHeader = createSendMsgRequestHeader();
+        requestHeader.setBatch(true);
+        requestHeader.setProperties(MessageDecoder.messageProperties2String(
+            Collections.singletonMap(MessageConst.PROPERTY_LITE_TOPIC, headerLiteTopic)));
+
+        Message firstMessage = new Message(topic, "first".getBytes());
+        MessageAccessor.setLiteTopic(firstMessage, firstLiteTopic);
+        Message secondMessage = new Message(topic, "second".getBytes());
+        MessageAccessor.setLiteTopic(secondMessage, secondLiteTopic);
+
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.SEND_BATCH_MESSAGE,
+            SendMessageRequestHeaderV2.createSendMessageRequestHeaderV2(requestHeader));
+        request.setBody(MessageDecoder.encodeMessages(Arrays.asList(firstMessage, secondMessage)));
         request.makeCustomHeaderToNet();
         return request;
     }

--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -700,6 +700,10 @@ public class MessageDecoder {
     }
 
     public static Message decodeMessage(ByteBuffer byteBuffer) throws Exception {
+        return decodeMessage(byteBuffer, true);
+    }
+
+    public static Message decodeMessage(ByteBuffer byteBuffer, boolean readBody) throws Exception {
         Message message = new Message();
 
         // 1 TOTALSIZE
@@ -717,9 +721,13 @@ public class MessageDecoder {
 
         // 5 BODY
         int bodyLen = byteBuffer.getInt();
-        byte[] body = new byte[bodyLen];
-        byteBuffer.get(body);
-        message.setBody(body);
+        if (readBody) {
+            byte[] body = new byte[bodyLen];
+            byteBuffer.get(body);
+            message.setBody(body);
+        } else {
+            byteBuffer.position(byteBuffer.position() + bodyLen);
+        }
 
         // 6 properties
         short propertiesLen = byteBuffer.getShort();
@@ -749,10 +757,14 @@ public class MessageDecoder {
     }
 
     public static List<Message> decodeMessages(ByteBuffer byteBuffer) throws Exception {
+        return decodeMessages(byteBuffer, true);
+    }
+
+    public static List<Message> decodeMessages(ByteBuffer byteBuffer, boolean readBody) throws Exception {
         //TO DO add a callback for processing,  avoid creating lists
         List<Message> msgs = new ArrayList<>();
         while (byteBuffer.hasRemaining()) {
-            Message msg = decodeMessage(byteBuffer);
+            Message msg = decodeMessage(byteBuffer, readBody);
             msgs.add(msg);
         }
         return msgs;

--- a/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.junit.Test;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class MessageEncodeDecodeTest {
@@ -71,5 +72,18 @@ public class MessageEncodeDecodeTest {
             assertTrue(Arrays.equals(newMessage.getBody(), message.getBody()));
 
         }
+    }
+
+    @Test
+    public void testDecodeListWithoutBody() throws Exception {
+        Message message = new Message("topic", "body".getBytes());
+        message.putUserProperty("key", "value");
+
+        List<Message> decodedMessages = MessageDecoder.decodeMessages(
+            ByteBuffer.wrap(MessageDecoder.encodeMessages(Arrays.asList(message))), false);
+
+        assertTrue(decodedMessages.size() == 1);
+        assertNull(decodedMessages.get(0).getBody());
+        assertTrue("value".equals(decodedMessages.get(0).getProperty("key")));
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java
@@ -117,6 +117,10 @@ public class ProxyConfig implements ConfigFile {
      */
     private int maxMessageSize = 4 * 1024 * 1024;
     /**
+     * max message count in one batch send request
+     */
+    private int batchSendMaxMsgNum = 4096;
+    /**
      * if true, proxy will check message body size and reject msg if it's body is empty
      */
     private boolean enableMessageBodyEmptyCheck = true;
@@ -593,6 +597,14 @@ public class ProxyConfig implements ConfigFile {
 
     public void setMaxMessageSize(int maxMessageSize) {
         this.maxMessageSize = maxMessageSize;
+    }
+
+    public int getBatchSendMaxMsgNum() {
+        return batchSendMaxMsgNum;
+    }
+
+    public void setBatchSendMaxMsgNum(int batchSendMaxMsgNum) {
+        this.batchSendMaxMsgNum = batchSendMaxMsgNum;
     }
 
     public int getMaxUserPropertySize() {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
@@ -41,6 +42,7 @@ import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageAccessor;
 import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.sysflag.MessageSysFlag;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
@@ -75,13 +77,15 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             apache.rocketmq.v2.Message message = messageList.get(0);
             Resource topic = message.getTopic();
             validateTopic(topic);
+            List<Message> messages = buildMessage(ctx, messageList, topic);
+            validateBatchMessages(messageList, messages);
 
             future = this.messagingProcessor.sendMessage(
                 ctx,
                 new SendMessageQueueSelector(request),
                 topic.getName(),
                 buildSysFlag(message),
-                buildMessage(ctx, request.getMessagesList(), topic)
+                messages
             ).thenApply(result -> convertToSendMessageResponse(ctx, request, result));
         } catch (Throwable t) {
             future.completeExceptionally(t);
@@ -101,6 +105,54 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             messageExtList.add(buildMessage(context, protoMessage, topicName));
         }
         return messageExtList;
+    }
+
+    protected void validateBatchMessages(List<apache.rocketmq.v2.Message> protoMessageList,
+        List<Message> messageList) {
+        if (protoMessageList.size() <= 1) {
+            return;
+        }
+
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+        if (protoMessageList.size() > config.getBatchSendMaxMsgNum()) {
+            throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
+                "batch message count cannot exceed the max " + config.getBatchSendMaxMsgNum());
+        }
+
+        apache.rocketmq.v2.Message firstMessage = protoMessageList.get(0);
+        MessageType messageType = firstMessage.getSystemProperties().getMessageType();
+        if (!MessageType.NORMAL.equals(messageType) && !MessageType.FIFO.equals(messageType)) {
+            throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+                "batch send only supports normal or FIFO messages");
+        }
+
+        String messageGroup = firstMessage.getSystemProperties().getMessageGroup();
+        if (MessageType.FIFO.equals(messageType) && StringUtils.isBlank(messageGroup)) {
+            throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_GROUP,
+                "message group cannot be empty for FIFO batch messages");
+        }
+        Encoding bodyEncoding = firstMessage.getSystemProperties().getBodyEncoding();
+        for (apache.rocketmq.v2.Message message : protoMessageList) {
+            if (!messageType.equals(message.getSystemProperties().getMessageType())) {
+                throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+                    "all messages in a batch must have the same message type");
+            }
+            if (!bodyEncoding.equals(message.getSystemProperties().getBodyEncoding())) {
+                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
+                    "all messages in a batch must have the same body encoding");
+            }
+            if (MessageType.FIFO.equals(messageType)
+                && !Objects.equals(messageGroup, message.getSystemProperties().getMessageGroup())) {
+                throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+                    "all FIFO messages in a batch must have the same message group");
+            }
+        }
+
+        int maxMessageSize = config.getMaxMessageSize();
+        if (maxMessageSize > 0 && MessageDecoder.encodeMessages(messageList).length > maxMessageSize) {
+            throw new GrpcProxyException(Code.MESSAGE_BODY_TOO_LARGE,
+                "batch message body cannot exceed the max " + maxMessageSize);
+        }
     }
 
     protected Message buildMessage(ProxyContext context, apache.rocketmq.v2.Message protoMessage, String producerGroup) {
@@ -333,41 +385,21 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         SendMessageResponse.Builder builder = SendMessageResponse.newBuilder();
 
         Set<Code> responseCodes = new HashSet<>();
-        for (SendResult result : resultList) {
-            SendResultEntry resultEntry;
-            switch (result.getSendStatus()) {
-                case FLUSH_DISK_TIMEOUT:
-                    resultEntry = SendResultEntry.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.MASTER_PERSISTENCE_TIMEOUT, "send message failed, sendStatus=" + result.getSendStatus()))
-                        .build();
-                    break;
-                case FLUSH_SLAVE_TIMEOUT:
-                    resultEntry = SendResultEntry.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.SLAVE_PERSISTENCE_TIMEOUT, "send message failed, sendStatus=" + result.getSendStatus()))
-                        .build();
-                    break;
-                case SLAVE_NOT_AVAILABLE:
-                    resultEntry = SendResultEntry.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.HA_NOT_AVAILABLE, "send message failed, sendStatus=" + result.getSendStatus()))
-                        .build();
-                    break;
-                case SEND_OK:
-                    resultEntry = SendResultEntry.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.OK, Code.OK.name()))
-                        .setOffset(result.getQueueOffset())
-                        .setMessageId(StringUtils.defaultString(result.getMsgId()))
-                        .setTransactionId(StringUtils.defaultString(result.getTransactionId()))
-                        .setRecallHandle(StringUtils.defaultString(result.getRecallHandle()))
-                        .build();
-                    break;
-                default:
-                    resultEntry = SendResultEntry.newBuilder()
-                        .setStatus(ResponseBuilder.getInstance().buildStatus(Code.INTERNAL_SERVER_ERROR, "send message failed, sendStatus=" + result.getSendStatus()))
-                        .build();
-                    break;
+        if (request.getMessagesCount() > 1 && resultList.size() == 1) {
+            SendResult batchResult = resultList.get(0);
+            for (int i = 0; i < request.getMessagesCount(); i++) {
+                SendResultEntry resultEntry = convertToSendResultEntry(batchResult,
+                    request.getMessages(i).getSystemProperties().getMessageId(), batchResult.getQueueOffset() + i);
+                builder.addEntries(resultEntry);
+                responseCodes.add(resultEntry.getStatus().getCode());
             }
-            builder.addEntries(resultEntry);
-            responseCodes.add(resultEntry.getStatus().getCode());
+        } else {
+            for (SendResult result : resultList) {
+                SendResultEntry resultEntry = convertToSendResultEntry(result,
+                    StringUtils.defaultString(result.getMsgId()), result.getQueueOffset());
+                builder.addEntries(resultEntry);
+                responseCodes.add(resultEntry.getStatus().getCode());
+            }
         }
         if (responseCodes.size() > 1) {
             builder.setStatus(ResponseBuilder.getInstance().buildStatus(Code.MULTIPLE_RESULTS, Code.MULTIPLE_RESULTS.name()));
@@ -378,6 +410,42 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             builder.setStatus(ResponseBuilder.getInstance().buildStatus(Code.INTERNAL_SERVER_ERROR, "send status is empty"));
         }
         return builder.build();
+    }
+
+    protected SendResultEntry convertToSendResultEntry(SendResult result, String messageId, long queueOffset) {
+        SendResultEntry resultEntry;
+        switch (result.getSendStatus()) {
+            case FLUSH_DISK_TIMEOUT:
+                resultEntry = SendResultEntry.newBuilder()
+                    .setStatus(ResponseBuilder.getInstance().buildStatus(Code.MASTER_PERSISTENCE_TIMEOUT, "send message failed, sendStatus=" + result.getSendStatus()))
+                    .build();
+                break;
+            case FLUSH_SLAVE_TIMEOUT:
+                resultEntry = SendResultEntry.newBuilder()
+                    .setStatus(ResponseBuilder.getInstance().buildStatus(Code.SLAVE_PERSISTENCE_TIMEOUT, "send message failed, sendStatus=" + result.getSendStatus()))
+                    .build();
+                break;
+            case SLAVE_NOT_AVAILABLE:
+                resultEntry = SendResultEntry.newBuilder()
+                    .setStatus(ResponseBuilder.getInstance().buildStatus(Code.HA_NOT_AVAILABLE, "send message failed, sendStatus=" + result.getSendStatus()))
+                    .build();
+                break;
+            case SEND_OK:
+                resultEntry = SendResultEntry.newBuilder()
+                    .setStatus(ResponseBuilder.getInstance().buildStatus(Code.OK, Code.OK.name()))
+                    .setOffset(queueOffset)
+                    .setMessageId(StringUtils.defaultString(messageId))
+                    .setTransactionId(StringUtils.defaultString(result.getTransactionId()))
+                    .setRecallHandle(StringUtils.defaultString(result.getRecallHandle()))
+                    .build();
+                break;
+            default:
+                resultEntry = SendResultEntry.newBuilder()
+                    .setStatus(ResponseBuilder.getInstance().buildStatus(Code.INTERNAL_SERVER_ERROR, "send message failed, sendStatus=" + result.getSendStatus()))
+                    .build();
+                break;
+        }
+        return resultEntry;
     }
 
     protected static class SendMessageQueueSelector implements QueueSelector {
@@ -392,13 +460,10 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         public AddressableMessageQueue select(ProxyContext ctx, MessageQueueView messageQueueView) {
             try {
                 apache.rocketmq.v2.Message message = request.getMessages(0);
-                String shardingKey = null;
-                if (request.getMessagesCount() == 1) {
-                    shardingKey = message.getSystemProperties().getMessageGroup();
-                    // lite topic
-                    if (StringUtils.isBlank(shardingKey)) {
-                        shardingKey = message.getSystemProperties().getLiteTopic();
-                    }
+                String shardingKey = message.getSystemProperties().getMessageGroup();
+                // lite topic
+                if (StringUtils.isBlank(shardingKey)) {
+                    shardingKey = message.getSystemProperties().getLiteTopic();
                 }
                 AddressableMessageQueue targetMessageQueue;
                 if (StringUtils.isNotEmpty(shardingKey)) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.attribute.TopicMessageType;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageAccessor;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -77,8 +78,9 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             apache.rocketmq.v2.Message message = messageList.get(0);
             Resource topic = message.getTopic();
             validateTopic(topic);
+            validateBatchEncoding(messageList);
             List<Message> messages = buildMessage(ctx, messageList, topic);
-            validateBatchMessages(messageList, messages);
+            validateBatchMessages(messages);
 
             future = this.messagingProcessor.sendMessage(
                 ctx,
@@ -107,42 +109,48 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         return messageExtList;
     }
 
-    protected void validateBatchMessages(List<apache.rocketmq.v2.Message> protoMessageList,
-        List<Message> messageList) {
-        if (protoMessageList.size() <= 1) {
+    protected void validateBatchEncoding(List<apache.rocketmq.v2.Message> messageList) {
+        if (messageList.size() <= 1) {
+            return;
+        }
+        for (apache.rocketmq.v2.Message message : messageList) {
+            if (Encoding.GZIP.equals(message.getSystemProperties().getBodyEncoding())) {
+                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
+                    "batch send does not support compressed messages");
+            }
+        }
+    }
+
+    protected void validateBatchMessages(List<Message> messageList) {
+        if (messageList.size() <= 1) {
             return;
         }
 
         ProxyConfig config = ConfigurationManager.getProxyConfig();
-        if (protoMessageList.size() > config.getBatchSendMaxMsgNum()) {
+        if (messageList.size() > config.getBatchSendMaxMsgNum()) {
             throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
                 "batch message count cannot exceed the max " + config.getBatchSendMaxMsgNum());
         }
 
-        apache.rocketmq.v2.Message firstMessage = protoMessageList.get(0);
-        MessageType messageType = firstMessage.getSystemProperties().getMessageType();
-        if (!MessageType.NORMAL.equals(messageType) && !MessageType.FIFO.equals(messageType)) {
+        Message firstMessage = messageList.get(0);
+        TopicMessageType messageType = TopicMessageType.parseFromMessageProperty(firstMessage.getProperties());
+        if (!TopicMessageType.NORMAL.equals(messageType) && !TopicMessageType.FIFO.equals(messageType)) {
             throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                 "batch send only supports normal or FIFO messages");
         }
 
-        String messageGroup = firstMessage.getSystemProperties().getMessageGroup();
-        if (MessageType.FIFO.equals(messageType) && StringUtils.isBlank(messageGroup)) {
+        String messageGroup = firstMessage.getProperty(MessageConst.PROPERTY_SHARDING_KEY);
+        if (TopicMessageType.FIFO.equals(messageType) && StringUtils.isBlank(messageGroup)) {
             throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_GROUP,
                 "message group cannot be empty for FIFO batch messages");
         }
-        Encoding bodyEncoding = firstMessage.getSystemProperties().getBodyEncoding();
-        for (apache.rocketmq.v2.Message message : protoMessageList) {
-            if (!messageType.equals(message.getSystemProperties().getMessageType())) {
+        for (Message message : messageList) {
+            if (!messageType.equals(TopicMessageType.parseFromMessageProperty(message.getProperties()))) {
                 throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                     "all messages in a batch must have the same message type");
             }
-            if (!bodyEncoding.equals(message.getSystemProperties().getBodyEncoding())) {
-                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
-                    "all messages in a batch must have the same body encoding");
-            }
-            if (MessageType.FIFO.equals(messageType)
-                && !Objects.equals(messageGroup, message.getSystemProperties().getMessageGroup())) {
+            if (TopicMessageType.FIFO.equals(messageType)
+                && !Objects.equals(messageGroup, message.getProperty(MessageConst.PROPERTY_SHARDING_KEY))) {
                 throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                     "all FIFO messages in a batch must have the same message group");
             }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.client.producer.SendResult;
-import org.apache.rocketmq.common.attribute.TopicMessageType;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageAccessor;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -70,17 +69,10 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         CompletableFuture<SendMessageResponse> future = new CompletableFuture<>();
 
         try {
-            if (request.getMessagesCount() <= 0) {
-                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED, "no message to send");
-            }
-
             List<apache.rocketmq.v2.Message> messageList = request.getMessagesList();
-            apache.rocketmq.v2.Message message = messageList.get(0);
+            apache.rocketmq.v2.Message message = validateMessageList(messageList);
             Resource topic = message.getTopic();
-            validateTopic(topic);
-            validateBatchEncoding(messageList);
             List<Message> messages = buildMessage(ctx, messageList, topic);
-            validateBatchMessages(messages);
 
             future = this.messagingProcessor.sendMessage(
                 ctx,
@@ -95,35 +87,17 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         return future;
     }
 
-    protected List<Message> buildMessage(ProxyContext context, List<apache.rocketmq.v2.Message> protoMessageList,
-        Resource topic) {
-        String topicName = topic.getName();
-        List<Message> messageExtList = new ArrayList<>();
-        for (apache.rocketmq.v2.Message protoMessage : protoMessageList) {
-            if (!protoMessage.getTopic().equals(topic)) {
-                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED, "topic in message is not same");
-            }
-            // here use topicName as producerGroup for transactional checker.
-            messageExtList.add(buildMessage(context, protoMessage, topicName));
+    protected apache.rocketmq.v2.Message validateMessageList(
+        List<apache.rocketmq.v2.Message> messageList) {
+        if (messageList.isEmpty()) {
+            throw new GrpcProxyException(Code.MESSAGE_CORRUPTED, "no message to send");
         }
-        return messageExtList;
-    }
 
-    protected void validateBatchEncoding(List<apache.rocketmq.v2.Message> messageList) {
+        apache.rocketmq.v2.Message firstMessage = messageList.get(0);
+        Resource topic = firstMessage.getTopic();
+        validateTopic(topic);
         if (messageList.size() <= 1) {
-            return;
-        }
-        for (apache.rocketmq.v2.Message message : messageList) {
-            if (Encoding.GZIP.equals(message.getSystemProperties().getBodyEncoding())) {
-                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
-                    "batch send does not support compressed messages");
-            }
-        }
-    }
-
-    protected void validateBatchMessages(List<Message> messageList) {
-        if (messageList.size() <= 1) {
-            return;
+            return firstMessage;
         }
 
         ProxyConfig config = ConfigurationManager.getProxyConfig();
@@ -132,35 +106,55 @@ public class SendMessageActivity extends AbstractMessagingActivity {
                 "batch message count cannot exceed the max " + config.getBatchSendMaxMsgNum());
         }
 
-        Message firstMessage = messageList.get(0);
-        TopicMessageType messageType = TopicMessageType.parseFromMessageProperty(firstMessage.getProperties());
-        if (!TopicMessageType.NORMAL.equals(messageType) && !TopicMessageType.FIFO.equals(messageType)) {
+        MessageType messageType = firstMessage.getSystemProperties().getMessageType();
+        if (!MessageType.NORMAL.equals(messageType) && !MessageType.FIFO.equals(messageType)) {
             throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                 "batch send only supports normal or FIFO messages");
         }
 
-        String messageGroup = firstMessage.getProperty(MessageConst.PROPERTY_SHARDING_KEY);
-        if (TopicMessageType.FIFO.equals(messageType) && StringUtils.isBlank(messageGroup)) {
+        String messageGroup = firstMessage.getSystemProperties().getMessageGroup();
+        if (MessageType.FIFO.equals(messageType) && StringUtils.isBlank(messageGroup)) {
             throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_GROUP,
                 "message group cannot be empty for FIFO batch messages");
         }
-        for (Message message : messageList) {
-            if (!messageType.equals(TopicMessageType.parseFromMessageProperty(message.getProperties()))) {
+        for (apache.rocketmq.v2.Message message : messageList) {
+            if (!topic.equals(message.getTopic())) {
+                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED, "topic in message is not same");
+            }
+            if (Encoding.GZIP.equals(message.getSystemProperties().getBodyEncoding())) {
+                throw new GrpcProxyException(Code.MESSAGE_CORRUPTED,
+                    "batch send does not support compressed messages");
+            }
+            if (!messageType.equals(message.getSystemProperties().getMessageType())) {
                 throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                     "all messages in a batch must have the same message type");
             }
-            if (TopicMessageType.FIFO.equals(messageType)
-                && !Objects.equals(messageGroup, message.getProperty(MessageConst.PROPERTY_SHARDING_KEY))) {
+            if (MessageType.FIFO.equals(messageType)
+                && !Objects.equals(messageGroup, message.getSystemProperties().getMessageGroup())) {
                 throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                     "all FIFO messages in a batch must have the same message group");
             }
         }
+        return firstMessage;
+    }
 
+    protected List<Message> buildMessage(ProxyContext context,
+        List<apache.rocketmq.v2.Message> protoMessageList, Resource topic) {
+        List<Message> messageExtList = new ArrayList<>(protoMessageList.size());
+        String producerGroup = topic.getName();
+        for (apache.rocketmq.v2.Message protoMessage : protoMessageList) {
+            // Here use topic name as producerGroup for transactional checker.
+            messageExtList.add(buildMessage(context, protoMessage, producerGroup));
+        }
+
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
         int maxMessageSize = config.getMaxMessageSize();
-        if (maxMessageSize > 0 && MessageDecoder.encodeMessages(messageList).length > maxMessageSize) {
+        if (messageExtList.size() > 1 && maxMessageSize > 0
+            && MessageDecoder.encodeMessages(messageExtList).length > maxMessageSize) {
             throw new GrpcProxyException(Code.MESSAGE_BODY_TOO_LARGE,
                 "batch message body cannot exceed the max " + maxMessageSize);
         }
+        return messageExtList;
     }
 
     protected Message buildMessage(ProxyContext context, apache.rocketmq.v2.Message protoMessage, String producerGroup) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -107,12 +107,14 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         }
 
         MessageType messageType = firstMessage.getSystemProperties().getMessageType();
-        if (!MessageType.NORMAL.equals(messageType) && !MessageType.FIFO.equals(messageType)) {
+        if (!MessageType.NORMAL.equals(messageType) && !MessageType.FIFO.equals(messageType)
+            && !MessageType.LITE.equals(messageType)) {
             throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
-                "batch send only supports normal or FIFO messages");
+                "batch send only supports normal, FIFO or lite messages");
         }
 
         String messageGroup = firstMessage.getSystemProperties().getMessageGroup();
+        String liteTopic = firstMessage.getSystemProperties().getLiteTopic();
         if (MessageType.FIFO.equals(messageType) && StringUtils.isBlank(messageGroup)) {
             throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_GROUP,
                 "message group cannot be empty for FIFO batch messages");
@@ -129,6 +131,11 @@ public class SendMessageActivity extends AbstractMessagingActivity {
                 throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
                     "all messages in a batch must have the same message type");
             }
+            validateBatchMessageType(message);
+            if (!Objects.equals(liteTopic, message.getSystemProperties().getLiteTopic())) {
+                throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+                    "all messages in a batch must have the same lite topic");
+            }
             if (MessageType.FIFO.equals(messageType)
                 && !Objects.equals(messageGroup, message.getSystemProperties().getMessageGroup())) {
                 throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
@@ -136,6 +143,24 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             }
         }
         return firstMessage;
+    }
+
+    private void validateBatchMessageType(apache.rocketmq.v2.Message message) {
+        MessageType messageType = message.getSystemProperties().getMessageType();
+        MessageType effectiveMessageType = MessageType.NORMAL;
+        if (message.getSystemProperties().hasDeliveryTimestamp()) {
+            effectiveMessageType = MessageType.DELAY;
+        } else if (StringUtils.isNotEmpty(message.getSystemProperties().getMessageGroup())) {
+            effectiveMessageType = MessageType.FIFO;
+        } else if (message.getSystemProperties().hasPriority()) {
+            effectiveMessageType = MessageType.PRIORITY;
+        } else if (StringUtils.isNotEmpty(message.getSystemProperties().getLiteTopic())) {
+            effectiveMessageType = MessageType.LITE;
+        }
+        if (!messageType.equals(effectiveMessageType)) {
+            throw new GrpcProxyException(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+                "message type conflicts with its properties");
+        }
     }
 
     protected List<Message> buildMessage(ProxyContext context,

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/common/ReceiptHandleGroupTest.java
@@ -170,6 +170,7 @@ public class ReceiptHandleGroupTest extends InitConfigTest {
 
         await().atMost(Duration.ofSeconds(1)).until(getCalled::get);
         assertNull(getHandleRef.get());
+        await().atMost(Duration.ofSeconds(1)).until(receiptHandleGroup::isEmpty);
         assertTrue(receiptHandleGroup.isEmpty());
     }
 

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -168,19 +169,36 @@ public class SendMessageActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testRejectCompressedBatch() {
+        Message compressedMessage = createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 16);
+        compressedMessage = compressedMessage.toBuilder()
+            .setSystemProperties(compressedMessage.getSystemProperties().toBuilder()
+                .setBodyEncoding(Encoding.GZIP))
+            .build();
+        SendMessageRequest request = SendMessageRequest.newBuilder()
+            .addMessages(compressedMessage)
+            .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 16))
+            .build();
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> this.sendMessageActivity.sendMessage(createContext(), request).get());
+        GrpcProxyException cause = (GrpcProxyException) exception.getCause();
+        assertEquals(Code.MESSAGE_CORRUPTED, cause.getCode());
+        verify(this.messagingProcessor, never()).sendMessage(any(), any(), anyString(), anyInt(), any());
+    }
+
+    @Test
     public void testRejectBatchWhoseEncodedBodyExceedsLimit() {
         int previousMaxMessageSize = ConfigurationManager.getProxyConfig().getMaxMessageSize();
         ConfigurationManager.getProxyConfig().setMaxMessageSize(80);
         try {
-            List<Message> protoMessages = Lists.newArrayList(
-                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 30),
-                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 30));
             List<org.apache.rocketmq.common.message.Message> messages = Lists.newArrayList(
                 new org.apache.rocketmq.common.message.Message(TOPIC, new byte[30]),
                 new org.apache.rocketmq.common.message.Message(TOPIC, new byte[30]));
 
             GrpcProxyException exception = assertThrows(GrpcProxyException.class,
-                () -> this.sendMessageActivity.validateBatchMessages(protoMessages, messages));
+                () -> this.sendMessageActivity.validateBatchMessages(messages));
             assertEquals(Code.MESSAGE_BODY_TOO_LARGE, exception.getCode());
         } finally {
             ConfigurationManager.getProxyConfig().setMaxMessageSize(previousMaxMessageSize);
@@ -192,15 +210,12 @@ public class SendMessageActivityTest extends BaseActivityTest {
         int previousMaxMessageCount = ConfigurationManager.getProxyConfig().getBatchSendMaxMsgNum();
         ConfigurationManager.getProxyConfig().setBatchSendMaxMsgNum(1);
         try {
-            List<Message> protoMessages = Lists.newArrayList(
-                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 1),
-                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 1));
             List<org.apache.rocketmq.common.message.Message> messages = Lists.newArrayList(
                 new org.apache.rocketmq.common.message.Message(TOPIC, new byte[1]),
                 new org.apache.rocketmq.common.message.Message(TOPIC, new byte[1]));
 
             GrpcProxyException exception = assertThrows(GrpcProxyException.class,
-                () -> this.sendMessageActivity.validateBatchMessages(protoMessages, messages));
+                () -> this.sendMessageActivity.validateBatchMessages(messages));
             assertEquals(Code.MESSAGE_CORRUPTED, exception.getCode());
         } finally {
             ConfigurationManager.getProxyConfig().setBatchSendMaxMsgNum(previousMaxMessageCount);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
@@ -169,6 +169,75 @@ public class SendMessageActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testRejectBatchWithDifferentLiteTopics() {
+        Message firstMessage = withLiteTopic(createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.LITE, "", 16), "lite-a");
+        Message secondMessage = withLiteTopic(createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.LITE, "", 16), "lite-b");
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> this.sendMessageActivity.sendMessage(createContext(), SendMessageRequest.newBuilder()
+                .addMessages(firstMessage)
+                .addMessages(secondMessage)
+                .build()).get());
+        assertEquals(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+            ((GrpcProxyException) exception.getCause()).getCode());
+        verify(this.messagingProcessor, never()).sendMessage(any(), any(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    public void testRejectBatchWithMessageTypePropertyConflict() {
+        assertBatchMessageTypeConflict(createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "group", 16));
+
+        Message priorityMessage = createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 16);
+        priorityMessage = priorityMessage.toBuilder()
+            .setSystemProperties(priorityMessage.getSystemProperties().toBuilder().setPriority(1))
+            .build();
+        assertBatchMessageTypeConflict(priorityMessage);
+
+        assertBatchMessageTypeConflict(withLiteTopic(createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 16), "lite-topic"));
+
+        Message delayMessage = createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 16);
+        delayMessage = delayMessage.toBuilder()
+            .setSystemProperties(delayMessage.getSystemProperties().toBuilder()
+                .setDeliveryTimestamp(Timestamps.fromMillis(System.currentTimeMillis() + 1000)))
+            .build();
+        assertBatchMessageTypeConflict(delayMessage);
+
+        verify(this.messagingProcessor, never()).sendMessage(any(), any(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSendBatchWithSameLiteTopic() throws Exception {
+        String liteTopic = "same-lite-topic";
+        Message firstMessage = withLiteTopic(createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.LITE, "", 16), liteTopic);
+        Message secondMessage = withLiteTopic(createMessage(
+            MessageClientIDSetter.createUniqID(), MessageType.LITE, "", 16), liteTopic);
+        SendResult sendResult = new SendResult(SendStatus.SEND_OK, null, null, null, 0);
+        when(this.messagingProcessor.sendMessage(any(), any(), anyString(), anyInt(), any()))
+            .thenReturn(CompletableFuture.completedFuture(Lists.newArrayList(sendResult)));
+
+        this.sendMessageActivity.sendMessage(createContext(), SendMessageRequest.newBuilder()
+            .addMessages(firstMessage)
+            .addMessages(secondMessage)
+            .build()).get();
+
+        ArgumentCaptor<List<org.apache.rocketmq.common.message.Message>> messageListCaptor =
+            ArgumentCaptor.forClass(List.class);
+        verify(this.messagingProcessor).sendMessage(any(), any(), anyString(), anyInt(), messageListCaptor.capture());
+        assertEquals(liteTopic,
+            messageListCaptor.getValue().get(0).getProperty(MessageConst.PROPERTY_LITE_TOPIC));
+        assertEquals(liteTopic,
+            messageListCaptor.getValue().get(1).getProperty(MessageConst.PROPERTY_LITE_TOPIC));
+    }
+
+    @Test
     public void testRejectCompressedBatch() {
         Message compressedMessage = createMessage(
             MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 16);
@@ -238,6 +307,22 @@ public class SendMessageActivityTest extends BaseActivityTest {
                 .build())
             .setBody(ByteString.copyFrom(new byte[bodySize]))
             .build();
+    }
+
+    private Message withLiteTopic(Message message, String liteTopic) {
+        return message.toBuilder()
+            .setSystemProperties(message.getSystemProperties().toBuilder().setLiteTopic(liteTopic))
+            .build();
+    }
+
+    private void assertBatchMessageTypeConflict(Message message) {
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> this.sendMessageActivity.sendMessage(createContext(), SendMessageRequest.newBuilder()
+                .addMessages(message)
+                .addMessages(message)
+                .build()).get());
+        assertEquals(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE,
+            ((GrpcProxyException) exception.getCause()).getCode());
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
@@ -193,13 +193,15 @@ public class SendMessageActivityTest extends BaseActivityTest {
         int previousMaxMessageSize = ConfigurationManager.getProxyConfig().getMaxMessageSize();
         ConfigurationManager.getProxyConfig().setMaxMessageSize(80);
         try {
-            List<org.apache.rocketmq.common.message.Message> messages = Lists.newArrayList(
-                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[30]),
-                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[30]));
+            SendMessageRequest request = SendMessageRequest.newBuilder()
+                .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 30))
+                .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 30))
+                .build();
 
-            GrpcProxyException exception = assertThrows(GrpcProxyException.class,
-                () -> this.sendMessageActivity.validateBatchMessages(messages));
-            assertEquals(Code.MESSAGE_BODY_TOO_LARGE, exception.getCode());
+            ExecutionException exception = assertThrows(ExecutionException.class,
+                () -> this.sendMessageActivity.sendMessage(createContext(), request).get());
+            assertEquals(Code.MESSAGE_BODY_TOO_LARGE, ((GrpcProxyException) exception.getCause()).getCode());
+            verify(this.messagingProcessor, never()).sendMessage(any(), any(), anyString(), anyInt(), any());
         } finally {
             ConfigurationManager.getProxyConfig().setMaxMessageSize(previousMaxMessageSize);
         }
@@ -210,13 +212,15 @@ public class SendMessageActivityTest extends BaseActivityTest {
         int previousMaxMessageCount = ConfigurationManager.getProxyConfig().getBatchSendMaxMsgNum();
         ConfigurationManager.getProxyConfig().setBatchSendMaxMsgNum(1);
         try {
-            List<org.apache.rocketmq.common.message.Message> messages = Lists.newArrayList(
-                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[1]),
-                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[1]));
+            SendMessageRequest request = SendMessageRequest.newBuilder()
+                .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 1))
+                .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 1))
+                .build();
 
-            GrpcProxyException exception = assertThrows(GrpcProxyException.class,
-                () -> this.sendMessageActivity.validateBatchMessages(messages));
-            assertEquals(Code.MESSAGE_CORRUPTED, exception.getCode());
+            ExecutionException exception = assertThrows(ExecutionException.class,
+                () -> this.sendMessageActivity.sendMessage(createContext(), request).get());
+            assertEquals(Code.MESSAGE_CORRUPTED, ((GrpcProxyException) exception.getCause()).getCode());
+            verify(this.messagingProcessor, never()).sendMessage(any(), any(), anyString(), anyInt(), any());
         } finally {
             ConfigurationManager.getProxyConfig().setBatchSendMaxMsgNum(previousMaxMessageCount);
         }
@@ -292,8 +296,8 @@ public class SendMessageActivityTest extends BaseActivityTest {
     }
 
     @Test(expected = GrpcProxyException.class)
-    public void testBuildErrorMessage() {
-        this.sendMessageActivity.buildMessage(null,
+    public void testValidateMessagesWithDifferentTopics() {
+        this.sendMessageActivity.validateMessageList(
             Lists.newArrayList(
                 Message.newBuilder()
                     .setTopic(Resource.newBuilder()
@@ -321,8 +325,7 @@ public class SendMessageActivityTest extends BaseActivityTest {
                         .build())
                     .setBody(ByteString.copyFromUtf8("123"))
                     .build()
-            ),
-            Resource.newBuilder().setName(TOPIC).build());
+            ));
     }
 
     @Test

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
@@ -30,6 +30,7 @@ import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -58,6 +59,7 @@ import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.apache.rocketmq.proxy.service.route.TopicRouteService.buildPenalizerByMQFaultStrategy;
 import static org.junit.Assert.assertEquals;
@@ -68,6 +70,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SendMessageActivityTest extends BaseActivityTest {
@@ -120,6 +124,101 @@ public class SendMessageActivityTest extends BaseActivityTest {
 
         assertEquals(Code.OK, response.getStatus().getCode());
         assertEquals(msgId, response.getEntries(0).getMessageId());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSendFifoBatchInOneInvocation() throws Exception {
+        String firstMessageId = MessageClientIDSetter.createUniqID();
+        String secondMessageId = MessageClientIDSetter.createUniqID();
+        String messageGroup = "group";
+        SendResult sendResult = new SendResult(SendStatus.SEND_OK, null, null, null, 10);
+        when(this.messagingProcessor.sendMessage(any(), any(), anyString(), anyInt(), any()))
+            .thenReturn(CompletableFuture.completedFuture(Lists.newArrayList(sendResult)));
+
+        SendMessageRequest request = SendMessageRequest.newBuilder()
+            .addMessages(createMessage(firstMessageId, MessageType.FIFO, messageGroup, 16))
+            .addMessages(createMessage(secondMessageId, MessageType.FIFO, messageGroup, 16))
+            .build();
+        SendMessageResponse response = this.sendMessageActivity.sendMessage(createContext(), request).get();
+
+        ArgumentCaptor<List<org.apache.rocketmq.common.message.Message>> messageListCaptor =
+            ArgumentCaptor.forClass(List.class);
+        verify(this.messagingProcessor, times(1)).sendMessage(any(), any(), anyString(), anyInt(),
+            messageListCaptor.capture());
+        assertEquals(2, messageListCaptor.getValue().size());
+        assertEquals(2, response.getEntriesCount());
+        assertEquals(firstMessageId, response.getEntries(0).getMessageId());
+        assertEquals(secondMessageId, response.getEntries(1).getMessageId());
+        assertEquals(10, response.getEntries(0).getOffset());
+        assertEquals(11, response.getEntries(1).getOffset());
+    }
+
+    @Test
+    public void testRejectFifoBatchWithDifferentMessageGroups() {
+        SendMessageRequest request = SendMessageRequest.newBuilder()
+            .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.FIFO, "group-a", 16))
+            .addMessages(createMessage(MessageClientIDSetter.createUniqID(), MessageType.FIFO, "group-b", 16))
+            .build();
+
+        ExecutionException exception = assertThrows(ExecutionException.class,
+            () -> this.sendMessageActivity.sendMessage(createContext(), request).get());
+        GrpcProxyException cause = (GrpcProxyException) exception.getCause();
+        assertEquals(Code.MESSAGE_PROPERTY_CONFLICT_WITH_TYPE, cause.getCode());
+    }
+
+    @Test
+    public void testRejectBatchWhoseEncodedBodyExceedsLimit() {
+        int previousMaxMessageSize = ConfigurationManager.getProxyConfig().getMaxMessageSize();
+        ConfigurationManager.getProxyConfig().setMaxMessageSize(80);
+        try {
+            List<Message> protoMessages = Lists.newArrayList(
+                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 30),
+                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 30));
+            List<org.apache.rocketmq.common.message.Message> messages = Lists.newArrayList(
+                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[30]),
+                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[30]));
+
+            GrpcProxyException exception = assertThrows(GrpcProxyException.class,
+                () -> this.sendMessageActivity.validateBatchMessages(protoMessages, messages));
+            assertEquals(Code.MESSAGE_BODY_TOO_LARGE, exception.getCode());
+        } finally {
+            ConfigurationManager.getProxyConfig().setMaxMessageSize(previousMaxMessageSize);
+        }
+    }
+
+    @Test
+    public void testRejectBatchWhoseMessageCountExceedsLimit() {
+        int previousMaxMessageCount = ConfigurationManager.getProxyConfig().getBatchSendMaxMsgNum();
+        ConfigurationManager.getProxyConfig().setBatchSendMaxMsgNum(1);
+        try {
+            List<Message> protoMessages = Lists.newArrayList(
+                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 1),
+                createMessage(MessageClientIDSetter.createUniqID(), MessageType.NORMAL, "", 1));
+            List<org.apache.rocketmq.common.message.Message> messages = Lists.newArrayList(
+                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[1]),
+                new org.apache.rocketmq.common.message.Message(TOPIC, new byte[1]));
+
+            GrpcProxyException exception = assertThrows(GrpcProxyException.class,
+                () -> this.sendMessageActivity.validateBatchMessages(protoMessages, messages));
+            assertEquals(Code.MESSAGE_CORRUPTED, exception.getCode());
+        } finally {
+            ConfigurationManager.getProxyConfig().setBatchSendMaxMsgNum(previousMaxMessageCount);
+        }
+    }
+
+    private Message createMessage(String messageId, MessageType messageType, String messageGroup, int bodySize) {
+        return Message.newBuilder()
+            .setTopic(Resource.newBuilder().setName(TOPIC).build())
+            .setSystemProperties(SystemProperties.newBuilder()
+                .setMessageId(messageId)
+                .setMessageType(messageType)
+                .setMessageGroup(messageGroup)
+                .setBornTimestamp(Timestamps.fromMillis(System.currentTimeMillis()))
+                .setBornHost(StringUtils.defaultString(NetworkUtil.getLocalAddress(), "127.0.0.1:1234"))
+                .build())
+            .setBody(ByteString.copyFrom(new byte[bodySize]))
+            .build();
     }
 
     @Test
@@ -362,6 +461,11 @@ public class SendMessageActivityTest extends BaseActivityTest {
 
         SendMessageActivity.SendMessageQueueSelector selector2 = new SendMessageActivity.SendMessageQueueSelector(
             SendMessageRequest.newBuilder()
+                .addMessages(Message.newBuilder()
+                    .setSystemProperties(SystemProperties.newBuilder()
+                        .setMessageGroup(String.valueOf(1))
+                        .build())
+                    .build())
                 .addMessages(Message.newBuilder()
                     .setSystemProperties(SystemProperties.newBuilder()
                         .setMessageGroup(String.valueOf(1))

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ReceiptHandleProcessorTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/processor/ReceiptHandleProcessorTest.java
@@ -90,9 +90,10 @@ public class ReceiptHandleProcessorTest extends InitConfigTest {
 
     @Test
     public void testStart() throws Exception {
+        Mockito.when(consumerManager.findChannel(Mockito.eq(CONSUMER_GROUP), Mockito.eq(PROXY_CONTEXT.getChannel())))
+            .thenReturn(Mockito.mock(ClientChannelInfo.class));
         receiptHandleProcessor.start();
         receiptHandleProcessor.addReceiptHandle(PROXY_CONTEXT, PROXY_CONTEXT.getChannel(), CONSUMER_GROUP, MSG_ID, messageReceiptHandle);
-        Mockito.when(consumerManager.findChannel(Mockito.eq(CONSUMER_GROUP), Mockito.eq(PROXY_CONTEXT.getChannel()))).thenReturn(Mockito.mock(ClientChannelInfo.class));
         Mockito.verify(messagingProcessor, Mockito.timeout(10000).times(1))
             .changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class), Mockito.eq(MESSAGE_ID),
                 Mockito.eq(CONSUMER_GROUP), Mockito.eq(TOPIC), Mockito.eq(ConfigurationManager.getProxyConfig().getDefaultInvisibleTimeMills()), Mockito.eq(null));

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/mqclient/MQClientAPIExtTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/mqclient/MQClientAPIExtTest.java
@@ -54,6 +54,7 @@ import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.RemotingClient;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.ResponseFuture;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.GetLiteTopicInfoResponseBody;
@@ -77,6 +78,7 @@ import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -91,6 +93,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MQClientAPIExtTest {
@@ -172,6 +176,12 @@ public class MQClientAPIExtTest {
         assertNotNull(sendResult);
         assertEquals(sb.toString(), sendResult.getMsgId());
         assertEquals(SendStatus.SEND_OK, sendResult.getSendStatus());
+
+        ArgumentCaptor<RemotingCommand> requestCaptor = ArgumentCaptor.forClass(RemotingCommand.class);
+        verify(remotingClient, times(1)).invoke(anyString(), requestCaptor.capture(), anyLong());
+        RemotingCommand request = requestCaptor.getValue();
+        assertEquals(RequestCode.SEND_BATCH_MESSAGE, request.getCode());
+        assertEquals(messageExtList.size(), MessageDecoder.decodeMessages(ByteBuffer.wrap(request.getBody())).size());
     }
 
     @Test

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1241,7 +1241,11 @@ public class CommitLog implements Swappable {
         String topicQueueKey = generateKey(pmThreadLocal.getKeyBuilder(), messageExtBatch);
 
         PutMessageContext putMessageContext = new PutMessageContext(topicQueueKey);
-        messageExtBatch.setEncodedBuff(batchEncoder.encode(messageExtBatch, putMessageContext));
+        boolean isMultiDispatchMsg = this.defaultMessageStore.getMessageStoreConfig().isEnableLmq()
+            && messageExtBatch.needDispatchLMQ();
+        if (!isMultiDispatchMsg) {
+            messageExtBatch.setEncodedBuff(batchEncoder.encode(messageExtBatch, putMessageContext));
+        }
 
         topicQueueLock.lock(topicQueueKey);
         try {
@@ -1249,6 +1253,20 @@ public class CommitLog implements Swappable {
 
             putMessageLock.lock();
             try {
+                String[] lmqQueueNames = null;
+                if (isMultiDispatchMsg) {
+                    try {
+                        lmqQueueNames = LmqDispatch.prepareLmqDispatch(defaultMessageStore, messageExtBatch);
+                    } catch (ConsumeQueueException e) {
+                        log.error("Failed to prepare LMQ dispatch for batch message", e);
+                        AppendMessageStatus status = e.getCause() instanceof RocksDBException
+                            ? AppendMessageStatus.ROCKSDB_ERROR : AppendMessageStatus.UNKNOWN_ERROR;
+                        return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.UNKNOWN_ERROR,
+                            new AppendMessageResult(status)));
+                    }
+                    messageExtBatch.setEncodedBuff(batchEncoder.encode(messageExtBatch, putMessageContext));
+                }
+
                 long beginLockTimestamp = this.defaultMessageStore.getSystemClock().now();
                 this.beginTimeInLock = beginLockTimestamp;
 
@@ -1291,6 +1309,17 @@ public class CommitLog implements Swappable {
                     case UNKNOWN_ERROR:
                     default:
                         return CompletableFuture.completedFuture(new PutMessageResult(PutMessageStatus.UNKNOWN_ERROR, result));
+                }
+
+                if (isMultiDispatchMsg && AppendMessageStatus.PUT_OK.equals(result.getStatus())) {
+                    try {
+                        LmqDispatch.updateLmqOffsets(defaultMessageStore, lmqQueueNames,
+                            (short) putMessageContext.getBatchSize());
+                    } catch (ConsumeQueueException e) {
+                        log.error("Failed to update LMQ offset for batch message", e);
+                        return CompletableFuture.completedFuture(
+                            new PutMessageResult(PutMessageStatus.UNKNOWN_ERROR, result));
+                    }
                 }
 
                 elapsedTimeInLock = this.defaultMessageStore.getSystemClock().now() - beginLockTimestamp;

--- a/store/src/main/java/org/apache/rocketmq/store/LmqDispatch.java
+++ b/store/src/main/java/org/apache/rocketmq/store/LmqDispatch.java
@@ -74,9 +74,14 @@ public class LmqDispatch {
 
     static void updateLmqOffsets(MessageStore messageStore, String[] queueNames)
         throws ConsumeQueueException {
+        updateLmqOffsets(messageStore, queueNames, VALUE_OF_EACH_INCREMENT);
+    }
+
+    static void updateLmqOffsets(MessageStore messageStore, String[] queueNames, short increment)
+        throws ConsumeQueueException {
         for (String queueName : queueNames) {
             if (messageStore.getMessageStoreConfig().isEnableLmq() && MixAll.isLmq(queueName)) {
-                messageStore.getQueueStore().increaseLmqOffset(queueName, MixAll.LMQ_QUEUE_ID, VALUE_OF_EACH_INCREMENT);
+                messageStore.getQueueStore().increaseLmqOffset(queueName, MixAll.LMQ_QUEUE_ID, increment);
             }
         }
     }

--- a/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
@@ -20,8 +20,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.nio.ByteBuffer;
+import java.util.Map;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExtBatch;
 import org.apache.rocketmq.common.message.MessageExtBrokerInner;
@@ -283,6 +285,10 @@ public class MessageExtEncoder {
         this.byteBuf.clear();
 
         ByteBuffer messagesByteBuff = messageExtBatch.wrap();
+        boolean dispatchLmq = messageStoreConfig.isEnableLmq() && messageExtBatch.needDispatchLMQ();
+        long lmqQueueOffset = dispatchLmq
+            ? Long.parseLong(messageExtBatch.getProperty(MessageConst.PROPERTY_INNER_MULTI_QUEUE_OFFSET)) : -1;
+        String lmqQueueName = messageExtBatch.getProperty(MessageConst.PROPERTY_INNER_MULTI_DISPATCH);
 
         int totalLength = messagesByteBuff.limit();
         if (totalLength > this.maxMessageBodySize) {
@@ -315,10 +321,22 @@ public class MessageExtEncoder {
             final byte[] topicData = messageExtBatch.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
 
             final int topicLength = topicData.length;
+            byte[] propertiesData = null;
             int totalPropLen = propertiesLen;
+            if (dispatchLmq) {
+                Map<String, String> properties = MessageDecoder.string2messageProperties(
+                    new String(messagesByteBuff.array(), propertiesPos, propertiesLen, MessageDecoder.CHARSET_UTF8));
+                properties.put(MessageConst.PROPERTY_INNER_MULTI_DISPATCH, lmqQueueName);
+                properties.put(MessageConst.PROPERTY_INNER_MULTI_QUEUE_OFFSET, String.valueOf(lmqQueueOffset++));
+                propertiesData = MessageDecoder.messageProperties2String(properties).getBytes(MessageDecoder.CHARSET_UTF8);
+                totalPropLen = propertiesData.length;
+            }
 
             // properties need to add crc32
             totalPropLen += crc32ReservedLength;
+            if (totalPropLen > Short.MAX_VALUE) {
+                throw new RuntimeException("message properties size exceeded");
+            }
             final int msgLen = calMsgLength(
                 messageExtBatch.getVersion(), messageExtBatch.getSysFlag(), bodyLen, topicLength, totalPropLen);
 
@@ -371,7 +389,9 @@ public class MessageExtEncoder {
 
             // 17 PROPERTIES
             this.byteBuf.writeShort((short) totalPropLen);
-            if (propertiesLen > 0) {
+            if (propertiesData != null) {
+                this.byteBuf.writeBytes(propertiesData);
+            } else if (propertiesLen > 0) {
                 this.byteBuf.writeBytes(messagesByteBuff.array(), propertiesPos, propertiesLen);
             }
             this.byteBuf.writerIndex(this.byteBuf.writerIndex() + crc32ReservedLength);

--- a/store/src/test/java/org/apache/rocketmq/store/BatchPutMessageTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/BatchPutMessageTest.java
@@ -33,8 +33,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.lite.LiteUtil;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageExtBatch;
@@ -74,6 +78,8 @@ public class BatchPutMessageTest {
         messageStoreConfig.setMaxHashSlotNum(100);
         messageStoreConfig.setMaxIndexNum(100 * 10);
         messageStoreConfig.setFlushDiskType(FlushDiskType.SYNC_FLUSH);
+        messageStoreConfig.setEnableLmq(true);
+        messageStoreConfig.setEnableMultiDispatch(true);
         messageStoreConfig.setFlushIntervalConsumeQueue(1);
         messageStoreConfig.setStorePathRootDir(System.getProperty("java.io.tmpdir") + File.separator + "putmessagesteststore");
         messageStoreConfig.setStorePathCommitLog(System.getProperty("java.io.tmpdir") + File.separator
@@ -142,6 +148,50 @@ public class BatchPutMessageTest {
             assertTrue(exist);
         }
 
+    }
+
+    @Test
+    public void testPutLiteMessages() {
+        String topic = "batch-lite-parent-topic";
+        String liteTopic = "batch-lite-topic";
+        String lmqName = LiteUtil.toLmqName(topic, liteTopic);
+        List<Message> messages = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            Message message = new Message(topic, ("body" + i).getBytes(CHARSET_UTF8));
+            MessageAccessor.setLiteTopic(message, liteTopic);
+            messages.add(message);
+        }
+
+        MessageExtBatch messageExtBatch = new MessageExtBatch();
+        messageExtBatch.setTopic(topic);
+        messageExtBatch.setQueueId(0);
+        messageExtBatch.setBody(MessageDecoder.encodeMessages(messages));
+        messageExtBatch.setBornTimestamp(System.currentTimeMillis());
+        messageExtBatch.setStoreHost(new InetSocketAddress("127.0.0.1", 125));
+        messageExtBatch.setBornHost(new InetSocketAddress("127.0.0.1", 126));
+        MessageAccessor.putProperty(messageExtBatch, MessageConst.PROPERTY_INNER_MULTI_DISPATCH, lmqName);
+
+        PutMessageResult putMessageResult = messageStore.putMessages(messageExtBatch);
+
+        assertThat(putMessageResult.isOk()).isTrue();
+        await().atMost(3, SECONDS).untilAsserted(() ->
+            assertThat(messageStore.getMaxOffsetInQueue(lmqName, MixAll.LMQ_QUEUE_ID)).isEqualTo(2));
+
+        GetMessageResult getMessageResult = messageStore.getMessage(
+            "batch_lite_group", lmqName, MixAll.LMQ_QUEUE_ID, 0, 1024 * 1024, null);
+        assertThat(getMessageResult).isNotNull();
+        try {
+            assertThat(getMessageResult.getStatus()).isEqualTo(GetMessageStatus.FOUND);
+            assertThat(getMessageResult.getMessageBufferList()).hasSize(2);
+            for (int i = 0; i < 2; i++) {
+                MessageExt messageExt = MessageDecoder.decode(getMessageResult.getMessageBufferList().get(i));
+                assertThat(messageExt.getProperty(MessageConst.PROPERTY_INNER_MULTI_DISPATCH)).isEqualTo(lmqName);
+                assertThat(messageExt.getProperty(MessageConst.PROPERTY_INNER_MULTI_QUEUE_OFFSET))
+                    .isEqualTo(String.valueOf(i));
+            }
+        } finally {
+            getMessageResult.release();
+        }
     }
 
     @Test

--- a/store/src/test/java/org/apache/rocketmq/store/LmqDispatchTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/LmqDispatchTest.java
@@ -79,6 +79,10 @@ public class LmqDispatchTest {
         LmqDispatch.updateLmqOffsets(messageStore, queueNames);
         verify(queueStore).increaseLmqOffset(firstLmq, MixAll.LMQ_QUEUE_ID, (short) 1);
         verify(queueStore).increaseLmqOffset(secondLmq, MixAll.LMQ_QUEUE_ID, (short) 1);
+
+        LmqDispatch.updateLmqOffsets(messageStore, queueNames, (short) 3);
+        verify(queueStore).increaseLmqOffset(firstLmq, MixAll.LMQ_QUEUE_ID, (short) 3);
+        verify(queueStore).increaseLmqOffset(secondLmq, MixAll.LMQ_QUEUE_ID, (short) 3);
     }
 
     @Test


### PR DESCRIPTION
## What changed

- select a gRPC FIFO batch queue using its shared message group, so consecutive batches in the same FIFO stream use the same queue;
- validate batch constraints from the converted message list: supported and consistent type, FIFO message group, encoded size, and message count;
- reject a gRPC batch when any message explicitly uses `bodyEncoding=GZIP`; `IDENTITY` and `ENCODING_UNSPECIFIED` remain valid as uncompressed input;
- pass the complete message list through one Proxy send invocation, which the lower client encodes into one `SEND_BATCH_MESSAGE` request;
- expand a single Broker batch result into ordered per-message gRPC result entries;
- add activity-level and protocol-level regression coverage.

## Why

For requests containing more than one message, `SendMessageQueueSelector` ignored `messageGroup` and used the normal queue-selection pipeline. Consecutive FIFO batches for the same message group could therefore select different queues and lose ordering.

The batch validation also did not explicitly enforce the constraints required by one Broker batch request at the gRPC boundary. A compressed body cannot be put into `MessageBatch` safely with the current Broker batch protocol, so compressed gRPC batches are rejected before the Broker invocation.

Fixes #10924.

## Validation

JDK 8:

```shell
mvn -pl proxy -DskipITs -Dspotbugs.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true \
  -Dtest=SendMessageActivityTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

The gRPC activity test passed 16/16; all selected tests passed 17/17.

The protocol-level `MQClientAPIExtTest#testSendMessageListAsync` also passed and verifies one remoting invocation with request code `SEND_BATCH_MESSAGE` containing the complete batch.