### PR TITLE
[ISSUE #10927] Upgrade fastjson2 to 2.0.64 for JDK 8 compatibility

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,7 @@ maven_install(
     artifacts = [
         "junit:junit:4.13.2",
         "com.alibaba:fastjson:1.2.83",
-        "com.alibaba.fastjson2:fastjson2:2.0.59",
+        "com.alibaba.fastjson2:fastjson2:2.0.64",
         "org.hamcrest:hamcrest-library:1.3",
         "io.netty:netty-all:4.1.130.Final",
         "org.assertj:assertj-core:3.22.0",

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
         <fastjson.version>1.2.83</fastjson.version>
-        <fastjson2.version>2.0.63</fastjson2.version>
+        <fastjson2.version>2.0.64</fastjson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <jna.version>4.2.2</jna.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10927

### Brief Description

RocketMQ upgraded the Maven fastjson2 dependency to 2.0.63 in #10715. That version contains a JDK 8 cold-start regression which may throw:

```text
LambdaConversionException: Invalid caller
```

The regression is fixed upstream in fastjson2 2.0.64:

- https://github.com/alibaba/fastjson2/issues/7691
- https://github.com/alibaba/fastjson2/pull/7718
- https://github.com/alibaba/fastjson2/releases/tag/2.0.64

This change:

- upgrades the Maven fastjson2 version from 2.0.63 to 2.0.64;
- aligns the Bazel fastjson2 pin from 2.0.59 to 2.0.64;
- does not add a RocketMQ-specific initialization-order workaround.

### How Did You Test This Change?

Using Amazon Corretto `1.8.0_502-b07` in a fresh JVM, I ran:

```bash
mvn -B -ntp -nsu -pl remoting -am \
  -Djacoco.skip=true \
  -Dtest=RemotingSerializableCompatTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  clean test
```

Results under the same environment and test command:

| fastjson2 | Result |
|-----------|--------|
| 2.0.63 | FAILED — 2 tests, 1 error, `LambdaConversionException` |
| 2.0.64 | PASSED — 2 tests, 0 failures/errors |

Additional verification:

- `mvn -pl remoting -am -DskipTests package`: passed;
- Maven dependency tree for `common` and `remoting`: resolves fastjson2 2.0.64 only;
- Maven and Bazel dependency pins are aligned at 2.0.64;
- `git diff --check`: passed.