### PR TITLE
[ISSUE #10933] Retain receipt handles when offline cleanup cannot complete

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -89,7 +90,8 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
             proxyConfig.getReturnHandleGroupThreadPoolNums() * 2,
             1, TimeUnit.MINUTES,
             "ReturnHandleGroupWorkerThread",
-            proxyConfig.getRenewThreadPoolQueueCapacity()
+            proxyConfig.getRenewThreadPoolQueueCapacity(),
+            new ThreadPoolExecutor.AbortPolicy()
         );
         consumerManager.appendConsumerIdsChangeListener(new ConsumerIdsChangeListener() {
             @Override
@@ -251,7 +253,14 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
             return;
         }
         ReceiptHandleGroup handleGroup = receiptHandleGroupMap.remove(key);
-        returnHandleGroupWorkerService.submit(() -> returnHandleGroup(key, handleGroup));
+        try {
+            returnHandleGroupWorkerService.submit(() -> returnHandleGroup(key, handleGroup));
+        } catch (RejectedExecutionException e) {
+            if (handleGroup != null) {
+                receiptHandleGroupMap.putIfAbsent(key, handleGroup);
+            }
+            log.warn("submit clear handle group task failed, will retry in the next schedule. key:{}", key, e);
+        }
     }
 
     // There is no longer any waiting for lock, and only the locked handles will be processed immediately,

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -266,7 +266,7 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
                 handleGroup.computeIfPresent(msgID, handle, messageReceiptHandle -> {
                     CompletableFuture<AckResult> future = new CompletableFuture<>();
                     eventListener.fireEvent(new RenewEvent(key, messageReceiptHandle, proxyConfig.getInvisibleTimeMillisWhenClear(), RenewEvent.EventType.CLEAR_GROUP, future));
-                    return CompletableFuture.completedFuture(null);
+                    return future.thenApply(ackResult -> null);
                 }, 0);
             } catch (Exception e) {
                 log.error("error when clear handle for group. key:{}", key, e);

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -475,6 +475,18 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
     }
 
     @Test
+    public void testClearGroupRetainsHandlesWhenCleanupSubmissionIsRejected() {
+        Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
+        ReceiptHandleGroupKey key = new ReceiptHandleGroupKey(channel, GROUP);
+        receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, messageReceiptHandle);
+        receiptHandleManager.returnHandleGroupWorkerService.shutdownNow();
+
+        receiptHandleManager.clearGroup(key);
+
+        assertTrue(receiptHandleManager.receiptHandleGroupMap.containsKey(key));
+    }
+
+    @Test
     public void testClientOffline() {
         ArgumentCaptor<ConsumerIdsChangeListener> listenerArgumentCaptor = ArgumentCaptor.forClass(ConsumerIdsChangeListener.class);
         Mockito.verify(consumerManager, Mockito.times(1)).appendConsumerIdsChangeListener(listenerArgumentCaptor.capture());

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -60,6 +60,7 @@ import org.mockito.stubbing.Answer;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
@@ -452,6 +453,25 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
         Mockito.verify(messagingProcessor, Mockito.timeout(1000).times(1))
             .changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class), Mockito.eq(MESSAGE_ID),
                 Mockito.eq(GROUP), Mockito.eq(TOPIC), Mockito.eq(ConfigurationManager.getProxyConfig().getInvisibleTimeMillisWhenClear()));
+    }
+
+    @Test
+    public void testClearGroupRetainsHandleWhenRenewalFails() {
+        Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
+        ReceiptHandleGroupKey key = new ReceiptHandleGroupKey(channel, GROUP);
+        receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, messageReceiptHandle);
+        CompletableFuture<AckResult> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new MQClientException(0, "renew failed"));
+        Mockito.when(messagingProcessor.changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class),
+                Mockito.eq(MESSAGE_ID), Mockito.eq(GROUP), Mockito.eq(TOPIC),
+                Mockito.eq(ConfigurationManager.getProxyConfig().getInvisibleTimeMillisWhenClear())))
+            .thenReturn(failedFuture);
+
+        receiptHandleManager.clearGroup(key);
+
+        await().atMost(Duration.ofSeconds(1)).until(() ->
+            receiptHandleManager.receiptHandleGroupMap.containsKey(key));
+        assertFalse(receiptHandleManager.receiptHandleGroupMap.get(key).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Keep POP receipt handles in the cleanup group whenever offline CLEAR_GROUP work cannot complete:

- retain groups when asynchronous renewal fails so the scheduler can retry;
- restore groups when the cleanup executor rejects task submission.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl proxy -Dtest=DefaultReceiptHandleManagerTest test`

Closes #10933
Closes #10941