### PR TITLE
[ISSUE #10935] Fix shared produce accumulator lifecycle

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class is the entry point for applications intending to send messages. </p>
@@ -162,6 +163,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
      * Instance for batching message automatically
      */
     private ProduceAccumulator produceAccumulator = null;
+    private final AtomicBoolean produceAccumulatorStarted = new AtomicBoolean(false);
 
     /**
      * Indicate whether to block message when asynchronous sending traffic is too heavy.
@@ -374,7 +376,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     public void start() throws MQClientException {
         this.setProducerGroup(withNamespace(this.producerGroup));
         this.defaultMQProducerImpl.start();
-        if (this.produceAccumulator != null) {
+        if (this.produceAccumulator != null && this.produceAccumulatorStarted.compareAndSet(false, true)) {
             this.produceAccumulator.start();
         }
         if (enableTrace) {
@@ -411,7 +413,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     @Override
     public void shutdown() {
         this.defaultMQProducerImpl.shutdown();
-        if (this.produceAccumulator != null) {
+        if (this.produceAccumulator != null && this.produceAccumulatorStarted.compareAndSet(true, false)) {
             this.produceAccumulator.shutdown();
         }
         if (null != traceDispatcher) {

--- a/client/src/main/java/org/apache/rocketmq/client/producer/ProduceAccumulator.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/ProduceAccumulator.java
@@ -56,6 +56,8 @@ public class ProduceAccumulator {
     private final Map<AggregateKey, MessageAccumulation> asyncSendBatchs = new ConcurrentHashMap<AggregateKey, MessageAccumulation>();
     private final AtomicLong currentlyHoldSize = new AtomicLong(0);
     private final String instanceName;
+    // Number of started producers sharing this accumulator through the same client ID.
+    private int producerCount;
 
     public ProduceAccumulator(String instanceName) {
         this.instanceName = instanceName;
@@ -155,12 +157,17 @@ public class ProduceAccumulator {
         }
     }
 
-    void start() {
-        guardThreadForSyncSend.start();
-        guardThreadForAsyncSend.start();
+    synchronized void start() {
+        if (producerCount++ == 0) {
+            guardThreadForSyncSend.start();
+            guardThreadForAsyncSend.start();
+        }
     }
 
-    void shutdown() {
+    synchronized void shutdown() {
+        if (producerCount == 0 || --producerCount > 0) {
+            return;
+        }
         guardThreadForSyncSend.shutdown();
         guardThreadForAsyncSend.shutdown();
     }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/ProduceAccumulator.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/ProduceAccumulator.java
@@ -231,7 +231,7 @@ public class ProduceAccumulator {
 
     SendResult send(Message msg,
         DefaultMQProducer defaultMQProducer) throws InterruptedException, MQBrokerException, RemotingException, MQClientException {
-        AggregateKey partitionKey = new AggregateKey(msg);
+        AggregateKey partitionKey = new AggregateKey(msg, defaultMQProducer);
         while (true) {
             MessageAccumulation batch = getOrCreateSyncSendBatch(partitionKey, defaultMQProducer);
             int index = batch.add(msg);
@@ -245,7 +245,7 @@ public class ProduceAccumulator {
 
     SendResult send(Message msg, MessageQueue mq,
         DefaultMQProducer defaultMQProducer) throws InterruptedException, MQBrokerException, RemotingException, MQClientException {
-        AggregateKey partitionKey = new AggregateKey(msg, mq);
+        AggregateKey partitionKey = new AggregateKey(msg, mq, defaultMQProducer);
         while (true) {
             MessageAccumulation batch = getOrCreateSyncSendBatch(partitionKey, defaultMQProducer);
             int index = batch.add(msg);
@@ -259,7 +259,7 @@ public class ProduceAccumulator {
 
     void send(Message msg, SendCallback sendCallback,
         DefaultMQProducer defaultMQProducer) throws InterruptedException, RemotingException, MQClientException {
-        AggregateKey partitionKey = new AggregateKey(msg);
+        AggregateKey partitionKey = new AggregateKey(msg, defaultMQProducer);
         while (true) {
             MessageAccumulation batch = getOrCreateAsyncSendBatch(partitionKey, defaultMQProducer);
             if (!batch.add(msg, sendCallback)) {
@@ -273,7 +273,7 @@ public class ProduceAccumulator {
     void send(Message msg, MessageQueue mq,
         SendCallback sendCallback,
         DefaultMQProducer defaultMQProducer) throws InterruptedException, RemotingException, MQClientException {
-        AggregateKey partitionKey = new AggregateKey(msg, mq);
+        AggregateKey partitionKey = new AggregateKey(msg, mq, defaultMQProducer);
         while (true) {
             MessageAccumulation batch = getOrCreateAsyncSendBatch(partitionKey, defaultMQProducer);
             if (!batch.add(msg, sendCallback)) {
@@ -303,20 +303,24 @@ public class ProduceAccumulator {
         public MessageQueue mq = null;
         public boolean waitStoreMsgOK = false;
         public String tag = null;
+        // Batches retain their creator's executor, hooks and lifecycle; groups alone are not enough.
+        public final DefaultMQProducer defaultMQProducer;
 
-        public AggregateKey(Message message) {
-            this(message.getTopic(), null, message.isWaitStoreMsgOK(), message.getTags());
+        public AggregateKey(Message message, DefaultMQProducer defaultMQProducer) {
+            this(message.getTopic(), null, message.isWaitStoreMsgOK(), message.getTags(), defaultMQProducer);
         }
 
-        public AggregateKey(Message message, MessageQueue mq) {
-            this(message.getTopic(), mq, message.isWaitStoreMsgOK(), message.getTags());
+        public AggregateKey(Message message, MessageQueue mq, DefaultMQProducer defaultMQProducer) {
+            this(message.getTopic(), mq, message.isWaitStoreMsgOK(), message.getTags(), defaultMQProducer);
         }
 
-        public AggregateKey(String topic, MessageQueue mq, boolean waitStoreMsgOK, String tag) {
+        public AggregateKey(String topic, MessageQueue mq, boolean waitStoreMsgOK, String tag,
+            DefaultMQProducer defaultMQProducer) {
             this.topic = topic;
             this.mq = mq;
             this.waitStoreMsgOK = waitStoreMsgOK;
             this.tag = tag;
+            this.defaultMQProducer = defaultMQProducer;
         }
 
         @Override
@@ -326,12 +330,15 @@ public class ProduceAccumulator {
             if (o == null || getClass() != o.getClass())
                 return false;
             AggregateKey key = (AggregateKey) o;
-            return waitStoreMsgOK == key.waitStoreMsgOK && topic.equals(key.topic) && Objects.equals(mq, key.mq) && Objects.equals(tag, key.tag);
+            return waitStoreMsgOK == key.waitStoreMsgOK && topic.equals(key.topic)
+                && Objects.equals(mq, key.mq) && Objects.equals(tag, key.tag)
+                && defaultMQProducer == key.defaultMQProducer;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(topic, mq, waitStoreMsgOK, tag);
+            return 31 * Objects.hash(topic, mq, waitStoreMsgOK, tag)
+                + System.identityHashCode(defaultMQProducer);
         }
     }
 
@@ -341,6 +348,7 @@ public class ProduceAccumulator {
         private LinkedList<SendCallback> sendCallbacks;
         private Set<String> keys;
         private final AtomicBoolean closed;
+        private final AtomicBoolean holdSizeReleased;
         private SendResult[] sendResults;
         private AggregateKey aggregateKey;
         private AtomicInteger messagesSize;
@@ -353,6 +361,7 @@ public class ProduceAccumulator {
             this.sendCallbacks = new LinkedList<SendCallback>();
             this.keys = new HashSet<String>();
             this.closed = new AtomicBoolean(false);
+            this.holdSizeReleased = new AtomicBoolean(false);
             this.messagesSize = new AtomicInteger(0);
             this.aggregateKey = aggregateKey;
             this.count = 0;
@@ -460,6 +469,15 @@ public class ProduceAccumulator {
             }
         }
 
+        private void releaseHoldSize() {
+            if (holdSizeReleased.compareAndSet(false, true)) {
+                currentlyHoldSize.addAndGet(-messagesSize.get());
+                // Do not retain a completed batch (and its producer) in the shared accumulator.
+                syncSendBatchs.remove(aggregateKey, this);
+                asyncSendBatchs.remove(aggregateKey, this);
+            }
+        }
+
         private void send() throws InterruptedException, MQClientException, MQBrokerException, RemotingException {
             synchronized (this.closed) {
                 if (this.closed.getAndSet(true)) {
@@ -476,7 +494,7 @@ public class ProduceAccumulator {
                     throw new IllegalArgumentException("defaultMQProducer is null, can not send message");
                 }
             } finally {
-                currentlyHoldSize.addAndGet(-messagesSize.get());
+                releaseHoldSize();
                 this.notifyAll();
             }
         }
@@ -491,7 +509,6 @@ public class ProduceAccumulator {
             SendResult sendResult = null;
             try {
                 if (defaultMQProducer != null) {
-                    final int size = messagesSize.get();
                     defaultMQProducer.sendDirect(messageBatch, aggregateKey.mq, new SendCallback() {
                         @Override
                         public void onSuccess(SendResult sendResult) {
@@ -506,26 +523,34 @@ public class ProduceAccumulator {
                                 if (i != count) {
                                     throw new IllegalArgumentException("sendResult is illegal");
                                 }
-                                currentlyHoldSize.addAndGet(-size);
                             } catch (Exception e) {
                                 onException(e);
+                            } finally {
+                                releaseHoldSize();
                             }
                         }
 
                         @Override
                         public void onException(Throwable e) {
-                            for (SendCallback v : sendCallbacks) {
-                                v.onException(e);
+                            try {
+                                for (SendCallback v : sendCallbacks) {
+                                    v.onException(e);
+                                }
+                            } finally {
+                                releaseHoldSize();
                             }
-                            currentlyHoldSize.addAndGet(-size);
                         }
                     });
                 } else {
                     throw new IllegalArgumentException("defaultMQProducer is null, can not send message");
                 }
             } catch (Exception e) {
-                for (SendCallback v : sendCallbacks) {
-                    v.onException(e);
+                try {
+                    for (SendCallback v : sendCallbacks) {
+                        v.onException(e);
+                    }
+                } finally {
+                    releaseHoldSize();
                 }
             }
         }

--- a/client/src/test/java/org/apache/rocketmq/client/producer/ProduceAccumulatorLifecycleTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/ProduceAccumulatorLifecycleTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.producer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.impl.producer.DefaultMQProducerImpl;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ProduceAccumulatorLifecycleTest {
+    @Test
+    public void testRunningProducerDoesNotJoinStoppedProducerBatch() throws Exception {
+        assertProducerIsolation(null, false);
+    }
+
+    @Test
+    public void testExplicitQueueBatchIsIsolatedByProducer() throws Exception {
+        assertProducerIsolation(new MessageQueue("testTopic", "broker", 0), false);
+    }
+
+    @Test
+    public void testReplacementProducerWithSameGroupUsesItsOwnBatch() throws Exception {
+        assertProducerIsolation(null, true);
+    }
+
+    private void assertProducerIsolation(MessageQueue queue, boolean replaceSameGroup) throws Exception {
+        ProduceAccumulator accumulator = newAccumulator();
+        RecordingProducer producerA = new RecordingProducer("producer-a");
+        RecordingProducer producerB = new RecordingProducer(replaceSameGroup ? "producer-a" : "producer-b");
+        prepareProducer(producerA, accumulator);
+        prepareProducer(producerB, accumulator);
+        SendCallback callbackA = mock(SendCallback.class);
+        SendCallback callbackB = mock(SendCallback.class);
+        producerA.start();
+        if (!replaceSameGroup) {
+            producerB.start();
+        }
+        try {
+            producerA.send(new Message("testTopic", new byte[] {1}), queue, callbackA);
+            producerA.shutdown();
+            if (replaceSameGroup) {
+                producerB.start();
+            }
+            producerB.send(new Message("testTopic", new byte[] {2}), queue, callbackB);
+            flushAsyncBatches(accumulator);
+
+            verify(callbackA, times(1)).onException(any(MQClientException.class));
+            verify(callbackB, times(1)).onSuccess(any(SendResult.class));
+            assertThat(producerA.directSends.get()).isEqualTo(1);
+            assertThat(producerB.directSends.get()).isEqualTo(1);
+            assertThat(heldBytes(accumulator)).isZero();
+            assertThat(asyncBatches(accumulator)).isEmpty();
+        } finally {
+            producerA.shutdown();
+            producerB.shutdown();
+        }
+    }
+
+    @Test
+    public void testCompletedBatchDoesNotRetainItsProducer() throws Exception {
+        ProduceAccumulator accumulator = newAccumulator();
+        DefaultMQProducer producer = mock(DefaultMQProducer.class);
+        doAnswer(invocation -> {
+            SendCallback callback = invocation.getArgument(2);
+            SendResult result = new SendResult();
+            result.setMsgId("123");
+            callback.onSuccess(result);
+            return result;
+        }).when(producer).sendDirect(any(Message.class), isNull(), any(SendCallback.class));
+        enqueue(accumulator, producer, mock(SendCallback.class));
+        flushAsyncBatches(accumulator);
+        assertThat(heldBytes(accumulator)).isZero();
+        assertThat(asyncBatches(accumulator)).isEmpty();
+    }
+
+    @Test
+    public void testSynchronousSendInitiationFailureReleasesHeldBytes() throws Exception {
+        ProduceAccumulator accumulator = newAccumulator();
+        DefaultMQProducer producer = mock(DefaultMQProducer.class);
+        SendCallback callback = mock(SendCallback.class);
+        doAnswer(invocation -> {
+            throw new MQClientException("send initiation failed", null);
+        }).when(producer).sendDirect(any(Message.class), isNull(), any(SendCallback.class));
+        enqueue(accumulator, producer, callback);
+        flushAsyncBatches(accumulator);
+        verify(callback).onException(any(MQClientException.class));
+        assertThat(heldBytes(accumulator)).isZero();
+    }
+
+    @Test
+    public void testInlineCallbackThenThrowDoesNotReleaseQuotaTwice() throws Exception {
+        ProduceAccumulator accumulator = newAccumulator();
+        DefaultMQProducer producer = mock(DefaultMQProducer.class);
+        doAnswer(invocation -> {
+            SendCallback callback = invocation.getArgument(2);
+            callback.onException(new MQClientException("callback failure", null));
+            throw new MQClientException("send invocation also failed", null);
+        }).when(producer).sendDirect(any(Message.class), isNull(), any(SendCallback.class));
+        enqueue(accumulator, producer, mock(SendCallback.class));
+        flushAsyncBatches(accumulator);
+        assertThat(heldBytes(accumulator)).isZero();
+    }
+
+    @Test
+    public void testThrowingFailureCallbackStillReleasesHeldBytes() throws Exception {
+        ProduceAccumulator accumulator = newAccumulator();
+        DefaultMQProducer producer = mock(DefaultMQProducer.class);
+        SendCallback callback = mock(SendCallback.class);
+        doAnswer(invocation -> {
+            throw new MQClientException("send initiation failed", null);
+        }).when(producer).sendDirect(any(Message.class), isNull(), any(SendCallback.class));
+        doAnswer(invocation -> {
+            throw new IllegalStateException("user callback failed");
+        }).when(callback).onException(any(Throwable.class));
+        enqueue(accumulator, producer, callback);
+        try {
+            flushAsyncBatches(accumulator);
+        } catch (InvocationTargetException expected) {
+            assertThat(expected.getCause()).isInstanceOf(IllegalStateException.class);
+        }
+        assertThat(heldBytes(accumulator)).isZero();
+    }
+
+    private ProduceAccumulator newAccumulator() {
+        ProduceAccumulator accumulator = spy(new ProduceAccumulator("lifecycle-test"));
+        // Exercise real batch ownership without background flushing. Guard lifetime is tested separately.
+        doNothing().when(accumulator).start();
+        doNothing().when(accumulator).shutdown();
+        accumulator.batchMaxDelayMs(30000);
+        return accumulator;
+    }
+
+    private void enqueue(ProduceAccumulator accumulator, DefaultMQProducer producer, SendCallback callback)
+        throws Exception {
+        Message message = new Message("testTopic", new byte[] {1});
+        assertThat(accumulator.tryAddMessage(message)).isTrue();
+        accumulator.send(message, callback, producer);
+        assertThat(heldBytes(accumulator)).isEqualTo(1);
+    }
+
+    private void prepareProducer(DefaultMQProducer producer, ProduceAccumulator accumulator) throws Exception {
+        producer.setAutoBatch(true);
+        Field implementation = DefaultMQProducer.class.getDeclaredField("defaultMQProducerImpl");
+        implementation.setAccessible(true);
+        implementation.set(producer, mock(DefaultMQProducerImpl.class));
+        Field sharedAccumulator = DefaultMQProducer.class.getDeclaredField("produceAccumulator");
+        sharedAccumulator.setAccessible(true);
+        sharedAccumulator.set(producer, accumulator);
+    }
+
+    private Map<?, ?> asyncBatches(ProduceAccumulator accumulator) throws Exception {
+        Field batchesField = ProduceAccumulator.class.getDeclaredField("asyncSendBatchs");
+        batchesField.setAccessible(true);
+        return (Map<?, ?>) batchesField.get(accumulator);
+    }
+
+    private void flushAsyncBatches(ProduceAccumulator accumulator) throws Exception {
+        for (Object batch : new ArrayList<>(asyncBatches(accumulator).values())) {
+            Method send = batch.getClass().getDeclaredMethod("send", SendCallback.class);
+            send.setAccessible(true);
+            send.invoke(batch, new Object[] {null});
+        }
+    }
+
+    private long heldBytes(ProduceAccumulator accumulator) throws Exception {
+        Field field = ProduceAccumulator.class.getDeclaredField("currentlyHoldSize");
+        field.setAccessible(true);
+        return ((AtomicLong) field.get(accumulator)).get();
+    }
+
+    private static class RecordingProducer extends DefaultMQProducer {
+        private boolean stopped;
+        private final AtomicInteger directSends = new AtomicInteger();
+
+        RecordingProducer(String group) {
+            super(group);
+        }
+
+        @Override
+        public void shutdown() {
+            super.shutdown();
+            stopped = true;
+        }
+
+        @Override
+        public SendResult sendDirect(Message message, MessageQueue queue, SendCallback callback)
+            throws MQClientException {
+            directSends.incrementAndGet();
+            if (stopped) {
+                throw new MQClientException("producer already shut down", null);
+            }
+            SendResult result = new SendResult();
+            result.setMsgId("123");
+            if (callback != null) {
+                callback.onSuccess(result);
+            }
+            return result;
+        }
+    }
+}

--- a/client/src/test/java/org/apache/rocketmq/client/producer/ProduceAccumulatorTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/ProduceAccumulatorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.client.producer;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.impl.producer.DefaultMQProducerImpl;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageBatch;
 import org.apache.rocketmq.common.message.MessageQueue;
@@ -31,8 +33,17 @@ import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ProduceAccumulatorTest {
+    private void setProducerField(DefaultMQProducer producer, String fieldName, Object value) throws Exception {
+        Field field = DefaultMQProducer.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(producer, value);
+    }
+
     private boolean compareMessageBatch(MessageBatch a, MessageBatch b) {
         if (!a.getTopic().equals(b.getTopic())) {
             return false;
@@ -99,6 +110,61 @@ public class ProduceAccumulatorTest {
         messageBatch2.setBody(messageBatch2.encode());
 
         assertThat(compareMessageBatch(messageBatch1, messageBatch2)).isTrue();
+    }
+
+    @Test
+    public void testSharedAccumulatorRemainsRunningUntilLastProducerShutdown() throws Exception {
+        MockMQProducer mockMQProducer = new MockMQProducer();
+        ProduceAccumulator produceAccumulator = new ProduceAccumulator("shared-client");
+        produceAccumulator.batchMaxDelayMs(50);
+        DefaultMQProducer producerA = new DefaultMQProducer("producer-a");
+        DefaultMQProducer producerB = new DefaultMQProducer("producer-b");
+        producerA.setInstanceName("shared-client");
+        producerB.setInstanceName("shared-client");
+        setProducerField(producerA, "defaultMQProducerImpl", mock(DefaultMQProducerImpl.class));
+        setProducerField(producerB, "defaultMQProducerImpl", mock(DefaultMQProducerImpl.class));
+        setProducerField(producerA, "produceAccumulator", produceAccumulator);
+        setProducerField(producerB, "produceAccumulator", produceAccumulator);
+
+        // Two producers with the same client ID share this accumulator.
+        producerA.start();
+        producerB.start();
+        producerA.shutdown();
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        try {
+            produceAccumulator.send(new Message("testTopic", "1".getBytes()), new SendCallback() {
+                @Override
+                public void onSuccess(SendResult sendResult) {
+                    countDownLatch.countDown();
+                }
+
+                @Override
+                public void onException(Throwable e) {
+                    countDownLatch.countDown();
+                }
+            }, mockMQProducer);
+
+            assertThat(countDownLatch.await(3, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            producerB.shutdown();
+        }
+    }
+
+    @Test
+    public void testProducerAcquiresAndReleasesSharedAccumulatorOnlyOnce() throws Exception {
+        DefaultMQProducer producer = new DefaultMQProducer("testProducerGroup");
+        ProduceAccumulator produceAccumulator = mock(ProduceAccumulator.class);
+        setProducerField(producer, "defaultMQProducerImpl", mock(DefaultMQProducerImpl.class));
+        setProducerField(producer, "produceAccumulator", produceAccumulator);
+
+        producer.start();
+        producer.start();
+        producer.shutdown();
+        producer.shutdown();
+
+        verify(produceAccumulator, times(1)).start();
+        verify(produceAccumulator, times(1)).shutdown();
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10935

### Brief Description

`MQClientManager` can return the same `ProduceAccumulator` to multiple producers that share a RocketMQ client ID. Previously, every `DefaultMQProducer.shutdown()` stopped that shared accumulator, even while another producer was running. Under low traffic, small synchronous auto-batched sends could then wait indefinitely, while asynchronous messages remained queued without timeout flushing.

Keeping the guard threads alive is necessary but not sufficient: a pending batch also retains the producer that created it. A second producer must not join that batch after the first producer shuts down.

This change:

- reference-counts started producer owners; starts the guards for the first owner and stops them after the last owner;
- tracks each producer's ownership with an `AtomicBoolean`, making repeated shutdown release idempotent;
- includes the concrete producer's identity in both synchronous and asynchronous aggregation keys, including explicit-queue sends; a replacement instance with the same group is still a different owner;
- releases held bytes exactly once after send completion or a synchronous send-initiation failure, including when a user failure callback throws;
- removes the exact completed batch from the maps so producer-specific keys do not retain completed batches or remove a newer replacement.

There is no public API or wire-format change.

### Applicability and tradeoffs

Automatic batching is disabled by default (`autoBatch=false`). The shared-lifecycle failure requires producers sharing an accumulator and one shutting down while another remains active; it is not a claim that ordinary non-batched sends are affected.

Producer identity intentionally prevents cross-producer coalescing, because producers may have different executors, hooks, credentials, and lifetimes. Batching within one producer is preserved. The aggregation/throughput tradeoff has not been benchmarked. This does not promise graceful draining of the producer that is shutting down, nor redesign user-callback exception/notification semantics.

### How Did You Test This Change?

Latest local verification (2026-09-13), head `f3901017f89509118835cd90b40109b3b51aa9c3`, JDK 8 / Maven 3.8.1:

```bash
mvn -pl client -am -DskipITs \
  -Dtest=ProduceAccumulatorTest,DefaultMQProducerTest,ProduceAccumulatorLifecycleTest \
  -Dsurefire.failIfNoSpecifiedTests=false clean test
```

The local run used offline mode and settings pointing to the existing dependency cache; no project build configuration was changed and no Checkstyle/SpotBugs skip flags were used.

- `ProduceAccumulatorTest`: 5 passed, including real guard lifetime and repeated shutdown.
- `DefaultMQProducerTest`: 41 passed.
- `ProduceAccumulatorLifecycleTest`: 7 passed: stopped/running producer isolation, explicit queue, same-group replacement, completed-map cleanup, synchronous initiation failure, inline callback followed by throw, and throwing failure callback.
- Total: **53 tests, 0 failures/errors/skips**; all four reactor modules succeeded.
- Checkstyle and SpotBugs enabled; `git diff --check` passed.

The new ownership tests disable background guards and explicitly flush real batches, making batch ownership deterministic; the existing accumulator suite separately exercises guard lifecycle. Re-running these seven new cases against the previous PR's production classes (`ce2e9b171`) produced **6 failures / 7 tests**; the updated production classes passed all seven. This comparison is against the previous PR head, not a fresh full-suite run of current upstream `develop`.

The original guard-lifetime regression also failed on unmodified `develop` at `e348efa66` before the reference-count fix. The PR retains that base and adds a fast-forward follow-up commit; it was not rebased. CI for the new head must be checked independently of these local results.
