### PR TITLE
[ISSUE #10936] Avoid temporary buffers during batch message encoding

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -661,20 +661,29 @@ public class MessageDecoder {
     }
 
     public static byte[] encodeMessage(Message message) {
-        //only need flag, body, properties
         byte[] body = message.getBody();
-        int bodyLen = body.length;
         String properties = messageProperties2String(message.getProperties());
         byte[] propertiesBytes = properties.getBytes(CHARSET_UTF8);
-        //note properties length must not more than Short.MAX
+        int storeSize = encodedMessageSize(body, propertiesBytes);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(storeSize);
+        encodeMessage(message, body, propertiesBytes, storeSize, byteBuffer);
+        return byteBuffer.array();
+    }
+
+    private static int encodedMessageSize(byte[] body, byte[] propertiesBytes) {
+        // Note properties length must not be greater than Short.MAX_VALUE.
         short propertiesLength = (short) propertiesBytes.length;
-        int storeSize = 4 // 1 TOTALSIZE
+        return 4 // 1 TOTALSIZE
             + 4 // 2 MAGICCOD
             + 4 // 3 BODYCRC
             + 4 // 4 FLAG
-            + 4 + bodyLen // 4 BODY
+            + 4 + body.length // 5 BODY
             + 2 + propertiesLength;
-        ByteBuffer byteBuffer = ByteBuffer.allocate(storeSize);
+    }
+
+    private static void encodeMessage(Message message, byte[] body, byte[] propertiesBytes, int storeSize,
+        ByteBuffer byteBuffer) {
+        short propertiesLength = (short) propertiesBytes.length;
         // 1 TOTALSIZE
         byteBuffer.putInt(storeSize);
 
@@ -689,14 +698,12 @@ public class MessageDecoder {
         byteBuffer.putInt(flag);
 
         // 5 BODY
-        byteBuffer.putInt(bodyLen);
+        byteBuffer.putInt(body.length);
         byteBuffer.put(body);
 
         // 6 properties
         byteBuffer.putShort(propertiesLength);
         byteBuffer.put(propertiesBytes);
-
-        return byteBuffer.array();
     }
 
     public static Message decodeMessage(ByteBuffer byteBuffer) throws Exception {
@@ -731,21 +738,26 @@ public class MessageDecoder {
     }
 
     public static byte[] encodeMessages(List<Message> messages) {
-        //TO DO refactor, accumulate in one buffer, avoid copies
-        List<byte[]> encodedMessages = new ArrayList<>(messages.size());
-        int allSize = 0;
+        byte[][] bodies = new byte[messages.size()][];
+        byte[][] propertiesBytes = new byte[messages.size()][];
+        int totalSize = 0;
+        int index = 0;
         for (Message message : messages) {
-            byte[] tmp = encodeMessage(message);
-            encodedMessages.add(tmp);
-            allSize += tmp.length;
+            byte[] body = message.getBody();
+            byte[] encodedProperties = messageProperties2String(message.getProperties()).getBytes(CHARSET_UTF8);
+            bodies[index] = body;
+            propertiesBytes[index++] = encodedProperties;
+            totalSize += encodedMessageSize(body, encodedProperties);
         }
-        byte[] allBytes = new byte[allSize];
-        int pos = 0;
-        for (byte[] bytes : encodedMessages) {
-            System.arraycopy(bytes, 0, allBytes, pos, bytes.length);
-            pos += bytes.length;
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate(totalSize);
+        index = 0;
+        for (Message message : messages) {
+            byte[] body = bodies[index];
+            byte[] encodedProperties = propertiesBytes[index++];
+            encodeMessage(message, body, encodedProperties, encodedMessageSize(body, encodedProperties), byteBuffer);
         }
-        return allBytes;
+        return byteBuffer.array();
     }
 
     public static List<Message> decodeMessages(ByteBuffer byteBuffer) throws Exception {

--- a/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MessageEncodeDecodeTest.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MessageEncodeDecodeTest {
@@ -71,5 +72,62 @@ public class MessageEncodeDecodeTest {
             assertTrue(Arrays.equals(newMessage.getBody(), message.getBody()));
 
         }
+    }
+
+    @Test
+    public void testMessageEncodingWireFormatGoldenBytes() {
+        Message message = new Message();
+        message.setBody(new byte[] {0x01, 0x02});
+        message.setFlag(0x01020304);
+
+        byte[] encodedProperties = new byte[0];
+        int storeSize = 4 + 4 + 4 + 4 + 4 + message.getBody().length + 2 + encodedProperties.length;
+        ByteBuffer expected = ByteBuffer.allocate(storeSize);
+        expected.putInt(storeSize);
+        expected.putInt(0);
+        expected.putInt(0);
+        expected.putInt(message.getFlag());
+        expected.putInt(message.getBody().length);
+        expected.put(message.getBody());
+        expected.putShort((short) encodedProperties.length);
+        expected.put(encodedProperties);
+
+        assertArrayEquals(expected.array(), MessageDecoder.encodeMessage(message));
+        assertArrayEquals(expected.array(), MessageDecoder.encodeMessages(Arrays.asList(message)));
+    }
+
+    @Test
+    public void testBatchEncodingMatchesConcatenatedSingleMessages() {
+        Message emptyMessage = new Message();
+        emptyMessage.setBody(new byte[0]);
+        emptyMessage.setFlag(-1);
+
+        Message unicodeMessage = new Message("topic", "payload".getBytes(MessageDecoder.CHARSET_UTF8));
+        unicodeMessage.setFlag(7);
+        unicodeMessage.putUserProperty("region", "\u534e\u4e1c");
+
+        byte[] largeBody = new byte[4096];
+        Arrays.fill(largeBody, (byte) 0x5A);
+        Message largeMessage = new Message("topic", largeBody);
+        largeMessage.setFlag(Integer.MAX_VALUE);
+        largeMessage.putUserProperty("key", "value");
+        largeMessage.putUserProperty("trace", "enabled");
+
+        List<Message> messages = Arrays.asList(emptyMessage, unicodeMessage, largeMessage);
+        List<byte[]> individuallyEncoded = new ArrayList<>(messages.size());
+        int expectedLength = 0;
+        for (Message message : messages) {
+            byte[] encoded = MessageDecoder.encodeMessage(message);
+            individuallyEncoded.add(encoded);
+            expectedLength += encoded.length;
+        }
+
+        ByteBuffer expected = ByteBuffer.allocate(expectedLength);
+        for (byte[] encoded : individuallyEncoded) {
+            expected.put(encoded);
+        }
+
+        assertArrayEquals(expected.array(), MessageDecoder.encodeMessages(messages));
+        assertArrayEquals(new byte[0], MessageDecoder.encodeMessages(new ArrayList<Message>()));
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10936
- Related to #2931, #2932, #10442, #10444, and #10588

### Brief Description

`MessageDecoder.encodeMessages` currently encodes every message into its own complete `byte[]`, retains those arrays, then allocates a final result and copies every message again.

This change removes those temporary full-message buffers:

- the first pass caches each body reference and the serialized property bytes while computing the exact aggregate size;
- one final `ByteBuffer` is allocated;
- the second pass writes every message directly into that buffer;
- single-message and batch encoding share internal size and field-writing helpers;
- a byte-for-byte compatibility test covers an empty body, Unicode properties, a 4 KiB body, edge flag values and an empty list;
- an independent fixed golden vector verifies the wire field layout without relying on the shared helper as its oracle.

The public API and encoded wire format are unchanged.

### Scope of the performance claim

This is a performance enhancement for the batch-encoding path used by `MessageBatch.encode()` and automatic producer batching, not a correctness fix or a claim about every send mode. The JMH figures below measure encoding operations and bytes allocated per encoding operation only. They do not establish a corresponding end-to-end RocketMQ throughput or latency improvement.

A system-level comparison would additionally need fixed producer/broker/consumer topology, batch sizes, persistence/replication settings, and CPU/GC/throughput/latency measurements. No such end-to-end result is claimed here; the published microbenchmark and wire-compatibility evidence remain the basis for review.

### How Did You Test This Change?

#### Correctness

The new tests compare `encodeMessages(messages)` with the concatenation of `encodeMessage(message)` for every input and verify an independent fixed wire vector. The complete `common` module suite passes:

```text
Tests run: 245, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Command:

```bash
mvn -o \
  -Dspotbugs-plugin.version=4.2.2 -Dspotbugs.skip=true \
  -Dcheckstyle.skip=true -Drat.skip=true \
  -pl common test
```

Relevant downstream tests also pass:

```text
AppendCallbackTest + BatchPutMessageTest + AppendPropCRCTest:
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0

ProduceAccumulatorTest:
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

#### JMH benchmark

JMH 1.36 configuration:

- throughput mode with GC profiler;
- one thread pinned to CPU 5;
- 3 forks;
- 5 warm-up and 7 measurement iterations per fork, 500 ms each;
- fixed `-Xms512m -Xmx512m` heap;
- OpenJDK 11.0.31, Ubuntu 22.04.4, Intel Xeon Gold 6133.

The benchmark's `baseline()` method reconstructs the previous aggregation algorithm in the same binary (per-message full encodings followed by a final copy), so the table labels it as a reconstructed baseline.

| Scenario | Reconstructed baseline ops/s | This PR ops/s | Change | Baseline B/op | This PR B/op | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 10 x 128 B | 340,743 +/- 6,348 | 381,842 +/- 9,236 | +12.06% | 6,760 | 4,552 | -32.66% |
| 100 x 128 B | 32,247 +/- 1,099 | 36,246 +/- 242 | +12.40% | 67,152 | 45,192 | -32.70% |
| 10 x 1 KiB | 179,223 +/- 3,518 | 240,718 +/- 10,326 | +34.31% | 24,680 | 13,512 | -45.25% |
| 100 x 1 KiB | 16,954 +/- 594 | 22,411 +/- 594 | +32.19% | 246,352 | 134,792 | -45.28% |

Values are means plus or minus JMH's 99.9% confidence-interval half-width. The baseline and optimized throughput confidence intervals do not overlap in any scenario.

The 100 x 1 KiB case was repeated on OpenJDK 8u492:

```text
Throughput: 14,472.346 +/- 329.526 -> 18,954.609 +/- 113.257 ops/s (+30.97%)
Allocation: 288,568 -> 173,832 B/op (-39.76%)
```

Its throughput confidence intervals are also disjoint.

I also benchmarked the actual production method from separate baseline and optimized checkouts in A-B-A order for 100 x 1 KiB:

| Production checkout | Throughput ops/s | 99.9% CI | Allocation B/op |
| --- | ---: | ---: | ---: |
| Baseline A1 | 17,352.526 +/- 400.418 | [16,952.108, 17,752.943] | 246,352.044 |
| This PR | 22,600.219 +/- 880.650 | [21,719.569, 23,480.870] | 134,792.035 |
| Baseline A2 | 16,876.707 +/- 671.661 | [16,205.046, 17,548.368] | 246,352.045 |

This is +30.24%/+33.91% throughput versus the two baseline runs and -45.28% allocation. The confidence intervals are disjoint.

Benchmark source, methodology, checksums, and all raw per-fork/per-iteration JSON results: https://gist.github.com/ai-yang/c3e3f65351054263dec6f7b8d67ad3cd

`git diff --check` also passes.
