### PR TITLE
[ISSUE #10939] Validate missing Remoting ext fields before forwarding

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivity.java
@@ -65,13 +65,13 @@ public abstract class AbstractRemotingActivity implements NettyRequestProcessor 
         ProxyContext context, long timeoutMillis) throws Exception {
         String brokerName;
         if (request.getCode() == RequestCode.SEND_MESSAGE_V2 || request.getCode() == RequestCode.SEND_BATCH_MESSAGE) {
-            if (request.getExtFields().get(BROKER_NAME_FIELD_FOR_SEND_MESSAGE_V2) == null) {
+            if (request.getExtFields() == null || request.getExtFields().get(BROKER_NAME_FIELD_FOR_SEND_MESSAGE_V2) == null) {
                 return RemotingCommand.buildErrorResponse(ResponseCode.VERSION_NOT_SUPPORTED,
                     "Request doesn't have field bname");
             }
             brokerName = request.getExtFields().get(BROKER_NAME_FIELD_FOR_SEND_MESSAGE_V2);
         } else {
-            if (request.getExtFields().get(BROKER_NAME_FIELD) == null) {
+            if (request.getExtFields() == null || request.getExtFields().get(BROKER_NAME_FIELD) == null) {
                 return RemotingCommand.buildErrorResponse(ResponseCode.VERSION_NOT_SUPPORTED,
                     "Request doesn't have field bname");
             }

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/activity/AbstractRemotingActivityTest.java
@@ -121,6 +121,28 @@ public class AbstractRemotingActivityTest extends InitConfigTest {
     }
 
     @Test
+    public void testRequestWithoutExtFieldsIsInvalid() throws Exception {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.PULL_MESSAGE, null);
+        request.setExtFields(null);
+
+        RemotingCommand remotingCommand = remotingActivity.request(ctx, request, null, 10000);
+
+        assertThat(remotingCommand.getCode()).isEqualTo(ResponseCode.VERSION_NOT_SUPPORTED);
+        verify(ctx, never()).writeAndFlush(any());
+    }
+
+    @Test
+    public void testSendMessageV2WithoutExtFieldsIsInvalid() throws Exception {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.SEND_MESSAGE_V2, null);
+        request.setExtFields(null);
+
+        RemotingCommand remotingCommand = remotingActivity.request(ctx, request, null, 10000);
+
+        assertThat(remotingCommand.getCode()).isEqualTo(ResponseCode.VERSION_NOT_SUPPORTED);
+        verify(ctx, never()).writeAndFlush(any());
+    }
+
+    @Test
     public void testRequestProxyException() throws Exception {
         ArgumentCaptor<RemotingCommand> captor = ArgumentCaptor.forClass(RemotingCommand.class);
         String brokerName = "broker";


### PR DESCRIPTION
## What does this PR do?

Returns the existing `VERSION_NOT_SUPPORTED` protocol response when a Proxy Remoting request has no `extFields` map, instead of dereferencing it and failing with a `NullPointerException`.

## Test

- `mvn -pl proxy -Dtest=AbstractRemotingActivityTest test`
- Adds coverage for normal forwarding and `SEND_MESSAGE_V2` requests with `extFields == null`.

Closes #10939.