### PR TITLE
[ISSUE #10941] Retain receipt handles when cleanup submission is rejected

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManager.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -89,7 +90,8 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
             proxyConfig.getReturnHandleGroupThreadPoolNums() * 2,
             1, TimeUnit.MINUTES,
             "ReturnHandleGroupWorkerThread",
-            proxyConfig.getRenewThreadPoolQueueCapacity()
+            proxyConfig.getRenewThreadPoolQueueCapacity(),
+            new ThreadPoolExecutor.AbortPolicy()
         );
         consumerManager.appendConsumerIdsChangeListener(new ConsumerIdsChangeListener() {
             @Override
@@ -251,7 +253,14 @@ public class DefaultReceiptHandleManager extends AbstractStartAndShutdown implem
             return;
         }
         ReceiptHandleGroup handleGroup = receiptHandleGroupMap.remove(key);
-        returnHandleGroupWorkerService.submit(() -> returnHandleGroup(key, handleGroup));
+        try {
+            returnHandleGroupWorkerService.submit(() -> returnHandleGroup(key, handleGroup));
+        } catch (RejectedExecutionException e) {
+            if (handleGroup != null) {
+                receiptHandleGroupMap.putIfAbsent(key, handleGroup);
+            }
+            log.warn("submit clear handle group task failed, will retry in the next schedule. key:{}", key, e);
+        }
     }
 
     // There is no longer any waiting for lock, and only the locked handles will be processed immediately,

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -455,6 +455,18 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
     }
 
     @Test
+    public void testClearGroupRetainsHandlesWhenCleanupSubmissionIsRejected() {
+        Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
+        ReceiptHandleGroupKey key = new ReceiptHandleGroupKey(channel, GROUP);
+        receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, messageReceiptHandle);
+        receiptHandleManager.returnHandleGroupWorkerService.shutdownNow();
+
+        receiptHandleManager.clearGroup(key);
+
+        assertTrue(receiptHandleManager.receiptHandleGroupMap.containsKey(key));
+    }
+
+    @Test
     public void testClientOffline() {
         ArgumentCaptor<ConsumerIdsChangeListener> listenerArgumentCaptor = ArgumentCaptor.forClass(ConsumerIdsChangeListener.class);
         Mockito.verify(consumerManager, Mockito.times(1)).appendConsumerIdsChangeListener(listenerArgumentCaptor.capture());


### PR DESCRIPTION
## What does this PR do?

Prevents offline receipt-handle cleanup from silently losing a removed group when its worker queue cannot accept the task. The cleanup executor now rejects explicitly, and `clearGroup` restores the group for the next scheduled retry.

## Test

- `mvn -pl proxy -Dtest=DefaultReceiptHandleManagerTest test`
- Adds a regression that shuts down the cleanup executor and verifies the receipt-handle group remains tracked.

Closes #10941.