### PR TITLE
[ISSUE #10708] Trim config values before binding properties to objects

### DIFF
--- a/broker/src/test/java/org/apache/rocketmq/broker/BrokerControllerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/BrokerControllerTest.java
@@ -18,12 +18,14 @@
 package org.apache.rocketmq.broker;
 
 import java.io.File;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.future.FutureTaskExt;
 import org.apache.rocketmq.remoting.RPCHook;
@@ -181,5 +183,21 @@ public class BrokerControllerTest {
         // Test setting null ConfigContext
         brokerController.setConfigContext(null);
         assertThat(brokerController.getConfigContext()).isNull();
+    }
+
+    @Test
+    public void testFileReservedTimeWithTrailingWhitespaceIsPreserved() {
+        Properties properties = new Properties();
+        properties.setProperty("fileReservedTime", "168 ");
+        MixAll.properties2Object(properties, messageStoreConfig);
+
+        BrokerController brokerController = new BrokerController(
+            brokerConfig, nettyServerConfig, new NettyClientConfig(), messageStoreConfig);
+        brokerController.getConfiguration().registerConfig(properties);
+
+        Properties allConfigs = MixAll.string2Properties(brokerController.getConfiguration().getAllConfigsFormatString());
+
+        assertThat(messageStoreConfig.getFileReservedTime()).isEqualTo(168);
+        assertThat(allConfigs.getProperty("fileReservedTime")).isEqualTo("168");
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/common/MixAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MixAll.java
@@ -412,6 +412,7 @@ public class MixAll {
                     String key = first.toLowerCase() + tmp;
                     String property = p.getProperty(key);
                     if (property != null) {
+                        property = property.trim();
                         Class<?>[] pt = method.getParameterTypes();
                         if (pt.length > 0) {
                             String cn = pt[0].getSimpleName();
@@ -427,7 +428,6 @@ public class MixAll {
                             } else if (cn.equals("float") || cn.equals("Float")) {
                                 arg = Float.parseFloat(property);
                             } else if (cn.equals("String")) {
-                                property = property.trim();
                                 arg = property;
                             } else {
                                 continue;

--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -63,6 +63,29 @@ public class UtilAllTest {
     }
 
     @Test
+    public void testProperties2ObjectTrimsPrimitiveValues() {
+        DemoConfig demoConfig = new DemoConfig();
+        Properties properties = new Properties();
+        properties.setProperty("demoWidth", " 123 ");
+        properties.setProperty("demoLength", " 456 ");
+        properties.setProperty("demoOK", " true ");
+        properties.setProperty("demoLong", " 789 ");
+        properties.setProperty("demoDouble", " 1.5 ");
+        properties.setProperty("demoFloat", " 2.5 ");
+        properties.setProperty("demoName", " TestDemo ");
+
+        MixAll.properties2Object(properties, demoConfig);
+
+        assertThat(demoConfig.getDemoLength()).isEqualTo(456);
+        assertThat(demoConfig.getDemoWidth()).isEqualTo(123);
+        assertThat(demoConfig.isDemoOK()).isTrue();
+        assertThat(demoConfig.getDemoLong()).isEqualTo(789);
+        assertThat(demoConfig.getDemoDouble()).isEqualTo(1.5);
+        assertThat(demoConfig.getDemoFloat()).isEqualTo(2.5f);
+        assertThat(demoConfig.getDemoName()).isEqualTo("TestDemo");
+    }
+
+    @Test
     public void testProperties2String() {
         DemoSubConfig demoConfig = new DemoSubConfig();
         demoConfig.setDemoLength(123);
@@ -155,6 +178,9 @@ public class UtilAllTest {
         private int demoWidth = 0;
         private int demoLength = 0;
         private boolean demoOK = false;
+        private long demoLong = 0;
+        private double demoDouble = 0;
+        private float demoFloat = 0;
         private String demoName = "haha";
 
         int getDemoWidth() {
@@ -179,6 +205,30 @@ public class UtilAllTest {
 
         public void setDemoOK(boolean demoOK) {
             this.demoOK = demoOK;
+        }
+
+        public long getDemoLong() {
+            return demoLong;
+        }
+
+        public void setDemoLong(long demoLong) {
+            this.demoLong = demoLong;
+        }
+
+        public double getDemoDouble() {
+            return demoDouble;
+        }
+
+        public void setDemoDouble(double demoDouble) {
+            this.demoDouble = demoDouble;
+        }
+
+        public float getDemoFloat() {
+            return demoFloat;
+        }
+
+        public void setDemoFloat(float demoFloat) {
+            this.demoFloat = demoFloat;
         }
 
         public String getDemoName() {


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #10708

## Brief Description

This PR trims property values before binding them to config objects in MixAll.properties2Object.

Previously, only String values were trimmed. Numeric and boolean values were parsed as-is, so a value like fileReservedTime = 168  failed to parse and the config field kept its default value.

This change trims the value before type conversion, so int, long, double, float, boolean, and String values are handled consistently.

## How Did You Test This Change?

Added tests for:

- primitive config values with leading/trailing whitespace;
- fileReservedTime = 168  being parsed as 168 instead of keeping the default value.

## Test commands:

```
mvn -pl common -DskipITs -Dspotbugs.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dtest=org.apache.rocketmq.common.UtilAllTest#testProperties2ObjectTrimsPrimitiveValues test
mvn -pl broker -am -DskipITs -Dspotbugs.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -DfailIfNoTests=false -Dtest=org.apache.rocketmq.broker.BrokerControllerTest#testFileReservedTimeWithTrailingWhitespaceIsPreserved test
```

Both targeted tests passed locally.