### PR TITLE
[ISSUE #10953] Clamp shifted message count range to queue bounds

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/DefaultMessageStore.java
@@ -3184,12 +3184,19 @@ public class DefaultMessageStore implements MessageStore {
             return 0;
         }
 
-        // correct the "from" argument to min offset in queue if it is too small
+        // shift the range to min offset if it is too small, then clamp it to the current queue bounds
         long minOffset = consumeQueue.getMinOffsetInQueue();
+        long maxOffset = consumeQueue.getMaxOffsetInQueue();
         if (from < minOffset) {
             long diff = to - from;
             from = minOffset;
-            to = from + diff;
+            to = diff > maxOffset - from ? maxOffset : from + diff;
+        }
+
+        from = Math.min(from, maxOffset);
+        to = Math.min(to, maxOffset);
+        if (from >= to) {
+            return 0;
         }
 
         long msgCount = consumeQueue.estimateMessageCount(from, to, filter);

--- a/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/DefaultMessageStoreTest.java
@@ -20,10 +20,15 @@ package org.apache.rocketmq.store;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.mockito.ArgumentCaptor;
 
@@ -344,6 +349,69 @@ public class DefaultMessageStoreTest {
             long messageStoreTimeStamp = messageStore.getMessageStoreTimeStamp(topic, queueId, i);
             assertThat(messageStoreTimeStamp).isEqualTo(appendMessageResults[i].getStoreTimestamp());
         }
+    }
+
+    @Test
+    public void testEstimateMessageCountShiftsRangeWithinQueueBounds() {
+        String topic = "FooBar";
+        int queueId = 0;
+        long minOffset = 100;
+        long to = 200;
+        long expectedCount = 50;
+        MessageFilter filter = mock(MessageFilter.class);
+        ConsumeQueueInterface consumeQueue = mock(ConsumeQueueInterface.class);
+        DefaultMessageStore store = spy(getDefaultMessageStore());
+        doReturn(consumeQueue).when(store).findConsumeQueue(topic, queueId);
+        when(consumeQueue.getMinOffsetInQueue()).thenReturn(minOffset);
+        when(consumeQueue.getMaxOffsetInQueue()).thenReturn(to);
+        when(consumeQueue.estimateMessageCount(minOffset, to, filter)).thenReturn(expectedCount);
+
+        long count = store.estimateMessageCount(topic, queueId, 0, to, filter);
+
+        assertThat(count).isEqualTo(expectedCount);
+        verify(consumeQueue).estimateMessageCount(minOffset, to, filter);
+    }
+
+    @Test
+    public void testEstimateMessageCountPreservesLengthWhenShiftedRangeFits() {
+        String topic = "FooBar";
+        int queueId = 0;
+        long minOffset = 100;
+        long maxOffset = 200;
+        long to = 50;
+        long shiftedTo = 150;
+        long expectedCount = 25;
+        MessageFilter filter = mock(MessageFilter.class);
+        ConsumeQueueInterface consumeQueue = mock(ConsumeQueueInterface.class);
+        DefaultMessageStore store = spy(getDefaultMessageStore());
+        doReturn(consumeQueue).when(store).findConsumeQueue(topic, queueId);
+        when(consumeQueue.getMinOffsetInQueue()).thenReturn(minOffset);
+        when(consumeQueue.getMaxOffsetInQueue()).thenReturn(maxOffset);
+        when(consumeQueue.estimateMessageCount(minOffset, shiftedTo, filter)).thenReturn(expectedCount);
+
+        long count = store.estimateMessageCount(topic, queueId, 0, to, filter);
+
+        assertThat(count).isEqualTo(expectedCount);
+        verify(consumeQueue).estimateMessageCount(minOffset, shiftedTo, filter);
+    }
+
+    @Test
+    public void testEstimateMessageCountReturnsZeroWhenRangeIsAfterMaxOffset() {
+        String topic = "FooBar";
+        int queueId = 0;
+        long minOffset = 100;
+        long maxOffset = 200;
+        MessageFilter filter = mock(MessageFilter.class);
+        ConsumeQueueInterface consumeQueue = mock(ConsumeQueueInterface.class);
+        DefaultMessageStore store = spy(getDefaultMessageStore());
+        doReturn(consumeQueue).when(store).findConsumeQueue(topic, queueId);
+        when(consumeQueue.getMinOffsetInQueue()).thenReturn(minOffset);
+        when(consumeQueue.getMaxOffsetInQueue()).thenReturn(maxOffset);
+
+        long count = store.estimateMessageCount(topic, queueId, 250, 300, filter);
+
+        assertThat(count).isZero();
+        verify(consumeQueue, never()).estimateMessageCount(anyLong(), anyLong(), same(filter));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10953

### Brief Description

`DefaultMessageStore.estimateMessageCount` shifts a filtered estimation range to the ConsumeQueue minimum offset when the requested lower bound has expired. The shifted upper bound was not constrained by the current maximum offset, so the range could extend beyond readable ConsumeQueue data. File-based ConsumeQueue scans could then emit `selectMappedBuffer request pos invalid` warnings and report a zero estimate without examining any entries.

This change:

- preserves the existing right-shift behavior and the requested interval length when space is available;
- clamps both shifted endpoints to the current ConsumeQueue bounds;
- truncates the shifted upper bound at `maxOffset` without overflowing;
- returns zero when clamping produces an empty range.

Regression tests cover a shifted range truncated at the maximum offset, a shifted range that preserves its full length, and a range that starts after the maximum offset.

### How Did You Test This Change?

Ran with Amazon Corretto JDK 11:

```bash
mvn -pl store "-Dtest=DefaultMessageStoreTest#testEstimateMessageCountShiftsRangeWithinQueueBounds+testEstimateMessageCountPreservesLengthWhenShiftedRangeFits+testEstimateMessageCountReturnsZeroWhenRangeIsAfterMaxOffset" test
```

Result: 3 tests run, 0 failures, 0 errors, 0 skipped. The same Maven run also completed Checkstyle and SpotBugs with no violations or findings.
