### PR TITLE
[ISSUE #10956] Protect Controller remoting requests with auth

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
@@ -538,6 +538,9 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
                     break;
                 case RequestCode.GET_BROKER_CONFIG:
                 case RequestCode.GET_BROKER_RUNTIME_INFO:
+                case RequestCode.GET_CONTROLLER_CONFIG:
+                case RequestCode.CONTROLLER_GET_METADATA_INFO:
+                case RequestCode.CONTROLLER_GET_SYNC_STATE_DATA:
                 case RequestCode.GET_ALL_CONSUMER_OFFSET:
                 case RequestCode.GET_TIMER_CHECK_POINT:
                 case RequestCode.GET_ALL_DELAY_OFFSET:
@@ -565,6 +568,8 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
                         Resource.of(ResourceType.GROUP, null, ResourcePattern.ANY), Action.LIST, sourceIp));
                     break;
                 case RequestCode.SET_COMMITLOG_READ_MODE:
+                case RequestCode.UPDATE_CONTROLLER_CONFIG:
+                case RequestCode.CLEAN_BROKER_DATA:
                 case RequestCode.CLEAN_EXPIRED_CONSUMEQUEUE:
                 case RequestCode.DELETE_EXPIRED_COMMITLOG:
                 case RequestCode.CLEAN_UNUSED_TOPIC:

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilderTest.java
@@ -574,6 +574,26 @@ public class DefaultAuthorizationContextBuilderTest {
         Assert.assertEquals("Cluster:DefaultCluster", result.get(0).getResource().getResourceKey());
         Assert.assertTrue(result.get(0).getActions().containsAll(Arrays.asList(Action.GET)));
         Assert.assertEquals(RequestCode.GET_BROKER_CONFIG + "", result.get(0).getRpcCode());
+
+        request = RemotingCommand.createRequestCommand(RequestCode.UPDATE_CONTROLLER_CONFIG, null);
+        request.setVersion(441);
+        request.addExtField("AccessKey", "rocketmq");
+        request.makeCustomHeaderToNet();
+        result = builder.build(channelHandlerContext, request);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("Cluster:DefaultCluster", result.get(0).getResource().getResourceKey());
+        Assert.assertTrue(result.get(0).getActions().containsAll(Arrays.asList(Action.UPDATE)));
+        Assert.assertEquals(RequestCode.UPDATE_CONTROLLER_CONFIG + "", result.get(0).getRpcCode());
+
+        request = RemotingCommand.createRequestCommand(RequestCode.GET_CONTROLLER_CONFIG, null);
+        request.setVersion(441);
+        request.addExtField("AccessKey", "rocketmq");
+        request.makeCustomHeaderToNet();
+        result = builder.build(channelHandlerContext, request);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("Cluster:DefaultCluster", result.get(0).getResource().getResourceKey());
+        Assert.assertTrue(result.get(0).getActions().containsAll(Arrays.asList(Action.GET)));
+        Assert.assertEquals(RequestCode.GET_CONTROLLER_CONFIG + "", result.get(0).getRpcCode());
     }
 
     @Test

--- a/controller/BUILD.bazel
+++ b/controller/BUILD.bazel
@@ -21,6 +21,7 @@ java_library(
     srcs = glob(["src/main/java/**/*.java"]),
     visibility = ["//visibility:public"],
     deps = [
+        "//auth",
         "//common",
         "//remoting",
         "//srvutil", 
@@ -62,6 +63,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         ":controller",
+        "//auth",
         "//common",
         "//remoting",
         "//srvutil", 

--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -32,6 +32,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>rocketmq-auth</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.openmessaging.storage</groupId>
             <artifactId>dledger</artifactId>
             <exclusions>

--- a/controller/src/main/java/org/apache/rocketmq/controller/ControllerManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/ControllerManager.java
@@ -28,12 +28,19 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.auth.authentication.factory.AuthenticationFactory;
+import org.apache.rocketmq.auth.authentication.manager.AuthenticationMetadataManager;
+import org.apache.rocketmq.auth.authorization.factory.AuthorizationFactory;
+import org.apache.rocketmq.auth.authorization.manager.AuthorizationMetadataManager;
+import org.apache.rocketmq.auth.config.AuthConfig;
 import org.apache.rocketmq.common.ControllerConfig;
 import org.apache.rocketmq.common.Pair;
 import org.apache.rocketmq.common.ThreadFactoryImpl;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.utils.ThreadUtils;
 import org.apache.rocketmq.controller.elect.impl.DefaultElectPolicy;
+import org.apache.rocketmq.controller.auth.pipeline.AuthenticationPipeline;
+import org.apache.rocketmq.controller.auth.pipeline.AuthorizationPipeline;
 import org.apache.rocketmq.controller.impl.DLedgerController;
 import org.apache.rocketmq.controller.impl.JRaftController;
 import org.apache.rocketmq.controller.impl.heartbeat.RaftBrokerHeartBeatManager;
@@ -47,8 +54,10 @@ import org.apache.rocketmq.remoting.RemotingServer;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyRemotingClient;
 import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.pipeline.RequestPipeline;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.RequestHeaderRegistry;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.BrokerMemberGroup;
 import org.apache.rocketmq.remoting.protocol.body.RoleChangeNotifyEntry;
@@ -62,6 +71,7 @@ public class ControllerManager {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.CONTROLLER_LOGGER_NAME);
 
     private final ControllerConfig controllerConfig;
+    private final AuthConfig authConfig;
     private final NettyServerConfig nettyServerConfig;
     private final NettyClientConfig nettyClientConfig;
     private final BrokerHousekeepingService brokerHousekeepingService;
@@ -73,16 +83,26 @@ public class ControllerManager {
     private BlockingQueue<Runnable> controllerRequestThreadPoolQueue;
     private final NotifyService notifyService;
     private ControllerMetricsManager controllerMetricsManager;
+    private AuthenticationMetadataManager authenticationMetadataManager;
+    private AuthorizationMetadataManager authorizationMetadataManager;
 
     public ControllerManager(ControllerConfig controllerConfig, NettyServerConfig nettyServerConfig,
         NettyClientConfig nettyClientConfig) {
+        this(controllerConfig, nettyServerConfig, nettyClientConfig, new AuthConfig());
+    }
+
+    public ControllerManager(ControllerConfig controllerConfig, NettyServerConfig nettyServerConfig,
+        NettyClientConfig nettyClientConfig, AuthConfig authConfig) {
         this.controllerConfig = controllerConfig;
+        this.authConfig = authConfig;
         this.nettyServerConfig = nettyServerConfig;
         this.nettyClientConfig = nettyClientConfig;
         this.brokerHousekeepingService = new BrokerHousekeepingService(this);
         this.configuration = new Configuration(log, this.controllerConfig, this.nettyServerConfig);
         this.configuration.setStorePathFromConfig(this.controllerConfig, "configStorePath");
         this.remotingClient = new NettyRemotingClient(nettyClientConfig);
+        this.authenticationMetadataManager = AuthenticationFactory.getMetadataManager(this.authConfig);
+        this.authorizationMetadataManager = AuthorizationFactory.getMetadataManager(this.authConfig);
         this.heartbeatManager = BrokerHeartbeatManager.newBrokerHeartbeatManager(controllerConfig);
         this.notifyService = new NotifyService();
     }
@@ -130,9 +150,19 @@ public class ControllerManager {
         // Register broker inactive listener
         this.heartbeatManager.registerBrokerLifecycleListener(this::onBrokerInactive);
         this.controller.registerBrokerLifecycleListener(this::onBrokerInactive);
+        initialRequestPipeline();
         registerProcessor();
         this.controllerMetricsManager = ControllerMetricsManager.getInstance(this);
         return true;
+    }
+
+    private void initialRequestPipeline() {
+        RequestHeaderRegistry.getInstance().initialize();
+        RequestPipeline pipeline = (ctx, request) -> {
+        };
+        pipeline = pipeline.pipe(new AuthorizationPipeline(authConfig))
+            .pipe(new AuthenticationPipeline(authConfig));
+        this.controller.getRemotingServer().setRequestPipeline(pipeline);
     }
 
     /**
@@ -276,6 +306,12 @@ public class ControllerManager {
         this.notifyService.shutdown();
         this.controller.shutdown();
         this.remotingClient.shutdown();
+        if (this.authenticationMetadataManager != null) {
+            this.authenticationMetadataManager.shutdown();
+        }
+        if (this.authorizationMetadataManager != null) {
+            this.authorizationMetadataManager.shutdown();
+        }
     }
 
     public BrokerHeartbeatManager getHeartbeatManager() {

--- a/controller/src/main/java/org/apache/rocketmq/controller/ControllerStartup.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/ControllerStartup.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.controller;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.rocketmq.auth.config.AuthConfig;
 import org.apache.rocketmq.common.ControllerConfig;
 import org.apache.rocketmq.common.JraftConfig;
 import org.apache.rocketmq.common.MixAll;
@@ -75,6 +77,7 @@ public class ControllerStartup {
         }
 
         final ControllerConfig controllerConfig = new ControllerConfig();
+        final AuthConfig authConfig = new AuthConfig();
         final JraftConfig jraftConfig = new JraftConfig();
         controllerConfig.setJraftConfig(jraftConfig);
         final NettyServerConfig nettyServerConfig = new NettyServerConfig();
@@ -88,6 +91,7 @@ public class ControllerStartup {
                 properties = new Properties();
                 properties.load(in);
                 MixAll.properties2Object(properties, controllerConfig);
+                MixAll.properties2Object(properties, authConfig);
                 MixAll.properties2Object(properties, jraftConfig);
                 MixAll.properties2Object(properties, nettyServerConfig);
                 MixAll.properties2Object(properties, nettyClientConfig);
@@ -118,7 +122,11 @@ public class ControllerStartup {
         MixAll.printObjectProperties(log, controllerConfig);
         MixAll.printObjectProperties(log, nettyServerConfig);
 
-        final ControllerManager controllerManager = new ControllerManager(controllerConfig, nettyServerConfig, nettyClientConfig);
+        authConfig.setConfigName("controller-" + controllerConfig.getControllerDLegerSelfId());
+        authConfig.setClusterName(controllerConfig.getControllerDLegerGroup());
+        authConfig.setAuthConfigPath(controllerConfig.getControllerStorePath() + File.separator + "config");
+
+        final ControllerManager controllerManager = new ControllerManager(controllerConfig, nettyServerConfig, nettyClientConfig, authConfig);
         // remember all configs to prevent discard
         controllerManager.getConfiguration().registerConfig(properties);
 

--- a/controller/src/main/java/org/apache/rocketmq/controller/auth/pipeline/AuthenticationPipeline.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/auth/pipeline/AuthenticationPipeline.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.controller.auth.pipeline;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.rocketmq.auth.authentication.AuthenticationEvaluator;
+import org.apache.rocketmq.auth.authentication.context.AuthenticationContext;
+import org.apache.rocketmq.auth.authentication.exception.AuthenticationException;
+import org.apache.rocketmq.auth.authentication.factory.AuthenticationFactory;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.common.AbortProcessException;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.remoting.pipeline.RequestPipeline;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+
+public class AuthenticationPipeline implements RequestPipeline {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(LoggerName.CONTROLLER_LOGGER_NAME);
+    private final AuthConfig authConfig;
+    private final AuthenticationEvaluator evaluator;
+
+    public AuthenticationPipeline(AuthConfig authConfig) {
+        this.authConfig = authConfig;
+        this.evaluator = AuthenticationFactory.getEvaluator(authConfig);
+    }
+
+    @Override
+    public void execute(ChannelHandlerContext ctx, RemotingCommand request) throws Exception {
+        if (!authConfig.isAuthenticationEnabled()) {
+            return;
+        }
+        try {
+            AuthenticationContext authenticationContext = AuthenticationFactory.newContext(authConfig, ctx, request);
+            evaluator.evaluate(authenticationContext);
+        } catch (AuthenticationException ex) {
+            throw new AbortProcessException(ResponseCode.NO_PERMISSION, ex.getMessage());
+        } catch (Throwable ex) {
+            LOGGER.error("authenticate failed, request:{}", request, ex);
+            throw ex;
+        }
+    }
+}

--- a/controller/src/main/java/org/apache/rocketmq/controller/auth/pipeline/AuthorizationPipeline.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/auth/pipeline/AuthorizationPipeline.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.controller.auth.pipeline;
+
+import io.netty.channel.ChannelHandlerContext;
+import java.util.List;
+import org.apache.rocketmq.auth.authentication.exception.AuthenticationException;
+import org.apache.rocketmq.auth.authorization.AuthorizationEvaluator;
+import org.apache.rocketmq.auth.authorization.context.AuthorizationContext;
+import org.apache.rocketmq.auth.authorization.exception.AuthorizationException;
+import org.apache.rocketmq.auth.authorization.factory.AuthorizationFactory;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.common.AbortProcessException;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
+import org.apache.rocketmq.remoting.pipeline.RequestPipeline;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+
+public class AuthorizationPipeline implements RequestPipeline {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(LoggerName.CONTROLLER_LOGGER_NAME);
+    private final AuthConfig authConfig;
+    private final AuthorizationEvaluator evaluator;
+
+    public AuthorizationPipeline(AuthConfig authConfig) {
+        this.authConfig = authConfig;
+        this.evaluator = AuthorizationFactory.getEvaluator(authConfig);
+    }
+
+    @Override
+    public void execute(ChannelHandlerContext ctx, RemotingCommand request) throws Exception {
+        if (!authConfig.isAuthorizationEnabled()) {
+            return;
+        }
+        try {
+            List<AuthorizationContext> contexts = AuthorizationFactory.newContexts(authConfig, ctx, request);
+            evaluator.evaluate(request, contexts);
+        } catch (AuthorizationException | AuthenticationException ex) {
+            throw new AbortProcessException(ResponseCode.NO_PERMISSION, ex.getMessage());
+        } catch (Throwable ex) {
+            LOGGER.error("authorization failed, request:{}", request, ex);
+            throw ex;
+        }
+    }
+}

--- a/controller/src/test/java/org/apache/rocketmq/controller/ControllerStartupTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/ControllerStartupTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.controller;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.reflect.Field;
+import java.util.Properties;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ControllerStartupTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void loadsAuthConfigurationForController() throws Exception {
+        File configFile = temporaryFolder.newFile("controller.properties");
+        File controllerStore = temporaryFolder.newFolder("controller-store");
+        Properties properties = new Properties();
+        properties.setProperty("rocketmqHome", temporaryFolder.getRoot().getAbsolutePath());
+        properties.setProperty("controllerDLegerSelfId", "n0");
+        properties.setProperty("controllerDLegerGroup", "controller-cluster");
+        properties.setProperty("controllerStorePath", controllerStore.getAbsolutePath());
+        properties.setProperty("authenticationEnabled", "true");
+        properties.setProperty("authorizationEnabled", "true");
+        try (FileOutputStream outputStream = new FileOutputStream(configFile)) {
+            properties.store(outputStream, null);
+        }
+
+        ControllerManager controllerManager = ControllerStartup.createControllerManager(
+            new String[] {"-c", configFile.getAbsolutePath()});
+        Field authConfigField = ControllerManager.class.getDeclaredField("authConfig");
+        authConfigField.setAccessible(true);
+        AuthConfig authConfig = (AuthConfig) authConfigField.get(controllerManager);
+
+        Assert.assertTrue(authConfig.isAuthenticationEnabled());
+        Assert.assertTrue(authConfig.isAuthorizationEnabled());
+        Assert.assertEquals("controller-n0", authConfig.getConfigName());
+        Assert.assertEquals("controller-cluster", authConfig.getClusterName());
+        Assert.assertEquals(new File(controllerStore, "config").getAbsolutePath(), authConfig.getAuthConfigPath());
+    }
+}

--- a/controller/src/test/java/org/apache/rocketmq/controller/auth/pipeline/ControllerAuthenticationPipelineTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/auth/pipeline/ControllerAuthenticationPipelineTest.java
@@ -50,10 +50,11 @@ public class ControllerAuthenticationPipelineTest {
     private NettyRemotingClient signedClient;
     private AuthenticationMetadataManager authenticationMetadataManager;
     private AuthorizationMetadataManager authorizationMetadataManager;
+    private AuthConfig authConfig;
 
     @Before
     public void setUp() throws Exception {
-        AuthConfig authConfig = new AuthConfig();
+        authConfig = new AuthConfig();
         authConfig.setConfigName("controller-auth-pipeline-" + System.nanoTime());
         authConfig.setClusterName("controller-cluster");
         authConfig.setAuthConfigPath(temporaryFolder.newFolder("auth").getAbsolutePath());
@@ -122,5 +123,15 @@ public class ControllerAuthenticationPipelineTest {
         RemotingCommand response = signedClient.invokeSync("127.0.0.1:" + server.localListenPort(), request, 3000);
 
         Assert.assertEquals(ResponseCode.SUCCESS, response.getCode());
+    }
+
+    @Test
+    public void skipsAuthenticationAndAuthorizationWhenDisabled() throws Exception {
+        authConfig.setAuthenticationEnabled(false);
+        authConfig.setAuthorizationEnabled(false);
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_CONTROLLER_CONFIG, null);
+
+        new AuthenticationPipeline(authConfig).execute(null, request);
+        new AuthorizationPipeline(authConfig).execute(null, request);
     }
 }

--- a/controller/src/test/java/org/apache/rocketmq/controller/auth/pipeline/ControllerAuthenticationPipelineTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/auth/pipeline/ControllerAuthenticationPipelineTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.controller.auth.pipeline;
+
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.apache.rocketmq.auth.authentication.factory.AuthenticationFactory;
+import org.apache.rocketmq.auth.authentication.manager.AuthenticationMetadataManager;
+import org.apache.rocketmq.auth.authentication.provider.LocalAuthenticationMetadataProvider;
+import org.apache.rocketmq.auth.authorization.factory.AuthorizationFactory;
+import org.apache.rocketmq.auth.authorization.manager.AuthorizationMetadataManager;
+import org.apache.rocketmq.auth.authorization.provider.LocalAuthorizationMetadataProvider;
+import org.apache.rocketmq.auth.config.AuthConfig;
+import org.apache.rocketmq.remoting.netty.NettyClientConfig;
+import org.apache.rocketmq.remoting.netty.NettyRemotingClient;
+import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
+import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.pipeline.RequestPipeline;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.RequestHeaderRegistry;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ControllerAuthenticationPipelineTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private NettyRemotingServer server;
+    private NettyRemotingClient unsignedClient;
+    private NettyRemotingClient signedClient;
+    private AuthenticationMetadataManager authenticationMetadataManager;
+    private AuthorizationMetadataManager authorizationMetadataManager;
+
+    @Before
+    public void setUp() throws Exception {
+        AuthConfig authConfig = new AuthConfig();
+        authConfig.setConfigName("controller-auth-pipeline-" + System.nanoTime());
+        authConfig.setClusterName("controller-cluster");
+        authConfig.setAuthConfigPath(temporaryFolder.newFolder("auth").getAbsolutePath());
+        authConfig.setAuthenticationEnabled(true);
+        authConfig.setAuthenticationMetadataProvider(LocalAuthenticationMetadataProvider.class.getName());
+        authConfig.setAuthorizationEnabled(true);
+        authConfig.setAuthorizationMetadataProvider(LocalAuthorizationMetadataProvider.class.getName());
+        authConfig.setInnerClientAuthenticationCredentials(
+            "{\"accessKey\":\"controller\",\"secretKey\":\"controller-secret\"}");
+
+        authenticationMetadataManager = AuthenticationFactory.getMetadataManager(authConfig);
+        authorizationMetadataManager = AuthorizationFactory.getMetadataManager(authConfig);
+        RequestHeaderRegistry.getInstance().initialize();
+
+        NettyServerConfig serverConfig = new NettyServerConfig();
+        serverConfig.setListenPort(0);
+        server = new NettyRemotingServer(serverConfig);
+        RequestPipeline pipeline = (ctx, request) -> {
+        };
+        pipeline = pipeline.pipe(new AuthorizationPipeline(authConfig))
+            .pipe(new AuthenticationPipeline(authConfig));
+        server.setRequestPipeline(pipeline);
+        server.registerProcessor(RequestCode.GET_CONTROLLER_CONFIG,
+            (ctx, request) -> RemotingCommand.createResponseCommand(ResponseCode.SUCCESS, null), null);
+        server.start();
+
+        unsignedClient = new NettyRemotingClient(new NettyClientConfig());
+        unsignedClient.start();
+        signedClient = new NettyRemotingClient(new NettyClientConfig());
+        signedClient.registerRPCHook(new AclClientRPCHook(new SessionCredentials("controller", "controller-secret")));
+        signedClient.start();
+    }
+
+    @After
+    public void tearDown() {
+        if (unsignedClient != null) {
+            unsignedClient.shutdown();
+        }
+        if (signedClient != null) {
+            signedClient.shutdown();
+        }
+        if (server != null) {
+            server.shutdown();
+        }
+        if (authenticationMetadataManager != null) {
+            authenticationMetadataManager.shutdown();
+        }
+        if (authorizationMetadataManager != null) {
+            authorizationMetadataManager.shutdown();
+        }
+    }
+
+    @Test
+    public void rejectsUnsignedControllerManagementRequest() throws Exception {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_CONTROLLER_CONFIG, null);
+
+        RemotingCommand response = unsignedClient.invokeSync("127.0.0.1:" + server.localListenPort(), request, 3000);
+
+        Assert.assertEquals(ResponseCode.NO_PERMISSION, response.getCode());
+    }
+
+    @Test
+    public void allowsSignedInnerControllerRequest() throws Exception {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_CONTROLLER_CONFIG, null);
+
+        RemotingCommand response = signedClient.invokeSync("127.0.0.1:" + server.localListenPort(), request, 3000);
+
+        Assert.assertEquals(ResponseCode.SUCCESS, response.getCode());
+    }
+}

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvStartup.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvStartup.java
@@ -52,7 +52,7 @@ public class NamesrvStartup {
     private static NettyServerConfig nettyServerConfig = null;
     private static NettyClientConfig nettyClientConfig = null;
     private static ControllerConfig controllerConfig = null;
-    private static AuthConfig controllerAuthConfig = null;
+    private static AuthConfig controllerAuthConfig = new AuthConfig();
 
     public static void main(String[] args) {
         main0(args);
@@ -109,7 +109,6 @@ public class NamesrvStartup {
                 MixAll.properties2Object(properties, nettyClientConfig);
                 if (namesrvConfig.isEnableControllerInNamesrv()) {
                     controllerConfig = new ControllerConfig();
-                    controllerAuthConfig = new AuthConfig();
                     JraftConfig jraftConfig = new JraftConfig();
                     controllerConfig.setJraftConfig(jraftConfig);
                     MixAll.properties2Object(properties, controllerConfig);

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvStartup.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/NamesrvStartup.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.namesrv;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -27,6 +28,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.rocketmq.common.ControllerConfig;
+import org.apache.rocketmq.auth.config.AuthConfig;
 import org.apache.rocketmq.common.JraftConfig;
 import org.apache.rocketmq.common.MQVersion;
 import org.apache.rocketmq.common.MixAll;
@@ -50,6 +52,7 @@ public class NamesrvStartup {
     private static NettyServerConfig nettyServerConfig = null;
     private static NettyClientConfig nettyClientConfig = null;
     private static ControllerConfig controllerConfig = null;
+    private static AuthConfig controllerAuthConfig = null;
 
     public static void main(String[] args) {
         main0(args);
@@ -106,9 +109,11 @@ public class NamesrvStartup {
                 MixAll.properties2Object(properties, nettyClientConfig);
                 if (namesrvConfig.isEnableControllerInNamesrv()) {
                     controllerConfig = new ControllerConfig();
+                    controllerAuthConfig = new AuthConfig();
                     JraftConfig jraftConfig = new JraftConfig();
                     controllerConfig.setJraftConfig(jraftConfig);
                     MixAll.properties2Object(properties, controllerConfig);
+                    MixAll.properties2Object(properties, controllerAuthConfig);
                     MixAll.properties2Object(properties, jraftConfig);
                 }
                 namesrvConfig.setConfigStorePath(file);
@@ -190,7 +195,11 @@ public class NamesrvStartup {
 
     public static ControllerManager createControllerManager() throws Exception {
         NettyServerConfig controllerNettyServerConfig = (NettyServerConfig) nettyServerConfig.clone();
-        ControllerManager controllerManager = new ControllerManager(controllerConfig, controllerNettyServerConfig, nettyClientConfig);
+        controllerAuthConfig.setConfigName("controller-" + controllerConfig.getControllerDLegerSelfId());
+        controllerAuthConfig.setClusterName(controllerConfig.getControllerDLegerGroup());
+        controllerAuthConfig.setAuthConfigPath(controllerConfig.getControllerStorePath() + File.separator + "config");
+        ControllerManager controllerManager = new ControllerManager(controllerConfig, controllerNettyServerConfig,
+            nettyClientConfig, controllerAuthConfig);
         // remember all configs to prevent discard
         controllerManager.getConfiguration().registerConfig(properties);
         return controllerManager;


### PR DESCRIPTION
Fixes #10956

### What changed
- Initialize Controller authentication and authorization metadata plus request pipelines.
- Parse Controller auth settings for standalone and embedded Nameserver startup paths.
- Map unannotated Controller management request codes to cluster authorization actions.
- Add remoting integration coverage for unsigned rejection and signed internal access.

### Validation
- `mvn -pl auth,controller -am -Dtest=DefaultAuthorizationContextBuilderTest,ControllerAuthenticationPipelineTest -DfailIfNoTests=false test`
- `mvn -pl namesrv -am -DskipTests compile`