### PR TITLE
[Bug] RocksDBConsumeQueue#iterateFrom returns a non-null iterator for offsets below minOffset, causing NPE in ScheduleMessageService

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/queue/RocksDBConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/RocksDBConsumeQueue.java
@@ -298,8 +298,9 @@ public class RocksDBConsumeQueue implements ConsumeQueueInterface {
 
     @Override
     public ReferredIterator<CqUnit> iterateFrom(final long startIndex) {
+        long minCqOffset = getMinOffsetInQueue();
         long maxCqOffset = getMaxOffsetInQueue();
-        if (startIndex < maxCqOffset && startIndex >= 0) {
+        if (startIndex >= minCqOffset && startIndex < maxCqOffset && startIndex >= 0) {
             int num = pullNum(startIndex, maxCqOffset);
             return new LargeRocksDBConsumeQueueIterator(startIndex, num);
         }
@@ -308,8 +309,9 @@ public class RocksDBConsumeQueue implements ConsumeQueueInterface {
 
     @Override
     public ReferredIterator<CqUnit> iterateFrom(long startIndex, int count) throws RocksDBException {
+        long minCqOffset = getMinOffsetInQueue();
         long maxCqOffset = getMaxOffsetInQueue();
-        if (startIndex < maxCqOffset) {
+        if (startIndex >= minCqOffset && startIndex < maxCqOffset) {
             int num = Math.min((int)(maxCqOffset - startIndex), count);
             return iterateFrom0(startIndex, num, maxCqOffset);
         }

--- a/store/src/test/java/org/apache/rocketmq/store/queue/RocksDBConsumeQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/queue/RocksDBConsumeQueueTest.java
@@ -121,6 +121,28 @@ public class RocksDBConsumeQueueTest extends QueueTestBase {
     }
 
     @Test
+    public void testIterateFrom_startIndexBelowMinOffset_returnsNull() throws Exception {
+        if (MixAll.isMac()) {
+            return;
+        }
+        DefaultMessageStore messageStore = mock(DefaultMessageStore.class);
+        RocksDBConsumeQueueStore rocksDBConsumeQueueStore = mock(RocksDBConsumeQueueStore.class);
+        when(messageStore.getQueueStore()).thenReturn(rocksDBConsumeQueueStore);
+        when(rocksDBConsumeQueueStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(9000L);
+        when(rocksDBConsumeQueueStore.getMaxOffsetInQueue(anyString(), anyInt())).thenReturn(10000L);
+
+        RocksDBConsumeQueue consumeQueue = new RocksDBConsumeQueue(messageStore.getMessageStoreConfig(), rocksDBConsumeQueueStore, "topic", 0);
+
+        // startIndex has already been purged (below the queue's current min offset); must not
+        // return a non-null iterator that later yields a null CqUnit and NPEs its caller.
+        assertNull(consumeQueue.iterateFrom(8000));
+        assertNull(consumeQueue.iterateFrom(8000, 10));
+
+        // startIndex within [min, max) still works as before.
+        assertNotNull(consumeQueue.iterateFrom(9000));
+    }
+
+    @Test
     public void testLmqCounter_running() throws ConsumeQueueException {
         messageStore.getMessageStoreConfig().setEnableMultiDispatch(true);
         messageStore.getMessageStoreConfig().setEnableLmq(true);


### PR DESCRIPTION
fix: RocksDBConsumeQueue.iterateFrom should reject offset below min offset
startIndex < minOffset was previously accepted as long as it stayed within [0, maxOffset), returning a non-null LargeRocksDBConsumeQueueIterator whose next() can yield a null CqUnit once the underlying data has been purged. Callers like ScheduleMessageService rely on iterateFrom returning null to detect and correct an out-of-range offset (matching ConsumeQueue's getMinLogicOffset() check); without it they NPE dereferencing the null CqUnit instead.

Add the same startIndex >= getMinOffsetInQueue() bound used by the file-based ConsumeQueue to both iterateFrom overloads.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10959

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
