### PR TITLE
fix(broker): reject timer delays that overflow the absolute delivery time

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/util/HookUtils.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/util/HookUtils.java
@@ -206,19 +206,22 @@ public class HookUtils {
         //do transform
         int delayLevel = msg.getDelayTimeLevel();
         long deliverMs;
+        long now = System.currentTimeMillis();
         try {
             if (msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC) != null) {
-                deliverMs = System.currentTimeMillis() + Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC)) * 1000;
+                long delaySec = Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC));
+                deliverMs = Math.addExact(now, Math.multiplyExact(delaySec, 1000L));
             } else if (msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS) != null) {
-                deliverMs = System.currentTimeMillis() + Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS));
+                long delayMs = Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS));
+                deliverMs = Math.addExact(now, delayMs);
             } else {
                 deliverMs = Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS));
             }
         } catch (Exception e) {
             return new PutMessageResult(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, null);
         }
-        if (deliverMs > System.currentTimeMillis()) {
-            if (delayLevel <= 0 && deliverMs - System.currentTimeMillis() > brokerController.getMessageStoreConfig().getTimerMaxDelaySec() * 1000L) {
+        if (deliverMs > now) {
+            if (delayLevel <= 0 && deliverMs - now > brokerController.getMessageStoreConfig().getTimerMaxDelaySec() * 1000L) {
                 return new PutMessageResult(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, null);
             }
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/util/HookUtils.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/util/HookUtils.java
@@ -210,7 +210,8 @@ public class HookUtils {
         try {
             if (msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC) != null) {
                 long delaySec = Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_SEC));
-                deliverMs = Math.addExact(now, Math.multiplyExact(delaySec, 1000L));
+                deliverMs = Math.multiplyExact(delaySec, 1000L);
+                deliverMs = Math.addExact(now, deliverMs);
             } else if (msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS) != null) {
                 long delayMs = Long.parseLong(msg.getProperty(MessageConst.PROPERTY_TIMER_DELAY_MS));
                 deliverMs = Math.addExact(now, delayMs);

--- a/broker/src/test/java/org/apache/rocketmq/broker/util/HookUtilsTimerOverflowTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/util/HookUtilsTimerOverflowTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.broker.util;
+
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageExtBrokerInner;
+import org.apache.rocketmq.store.PutMessageResult;
+import org.apache.rocketmq.store.PutMessageStatus;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HookUtilsTimerOverflowTest {
+
+    private BrokerController newTimerEnabledController() {
+        BrokerController brokerController = Mockito.mock(BrokerController.class);
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setTimerWheelEnable(true);
+        Mockito.when(brokerController.getMessageStoreConfig()).thenReturn(messageStoreConfig);
+        return brokerController;
+    }
+
+    private MessageExtBrokerInner newTimerMessage(String key, String value) {
+        MessageExtBrokerInner msg = new MessageExtBrokerInner();
+        msg.setTopic("OverflowTestTopic");
+        MessageAccessor.putProperty(msg, key, value);
+        return msg;
+    }
+
+    // Regression for https://github.com/apache/rocketmq/issues/10872: an
+    // overflowing relative delay used to wrap around into a past timestamp,
+    // bypass the future-delay validation, and take the immediate-message path.
+    @Test
+    public void testTimerDelaySecOverflowRejected() {
+        PutMessageResult result = HookUtils.handleScheduleMessage(newTimerEnabledController(),
+            newTimerMessage(MessageConst.PROPERTY_TIMER_DELAY_SEC, String.valueOf(Long.MAX_VALUE)));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
+
+    @Test
+    public void testTimerDelayMsOverflowRejected() {
+        PutMessageResult result = HookUtils.handleScheduleMessage(newTimerEnabledController(),
+            newTimerMessage(MessageConst.PROPERTY_TIMER_DELAY_MS, String.valueOf(Long.MAX_VALUE)));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
+
+    // Covers the future-delivery validation branch with a delay that does not
+    // overflow but exceeds the configured maximum.
+    @Test
+    public void testTimerDelaySecExceedsMaxRejected() {
+        BrokerController brokerController = newTimerEnabledController();
+        brokerController.getMessageStoreConfig().setTimerMaxDelaySec(1);
+        PutMessageResult result = HookUtils.handleScheduleMessage(brokerController,
+            newTimerMessage(MessageConst.PROPERTY_TIMER_DELAY_SEC, "10"));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
+}

--- a/broker/src/test/java/org/apache/rocketmq/broker/util/HookUtilsTimerOverflowTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/util/HookUtilsTimerOverflowTest.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.common.message.MessageExtBrokerInner;
 import org.apache.rocketmq.store.PutMessageResult;
 import org.apache.rocketmq.store.PutMessageStatus;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.apache.rocketmq.store.timer.TimerMessageStore;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -61,6 +62,33 @@ public class HookUtilsTimerOverflowTest {
             newTimerMessage(MessageConst.PROPERTY_TIMER_DELAY_MS, String.valueOf(Long.MAX_VALUE)));
         Assert.assertNotNull(result);
         Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
+
+    // Long.MAX_VALUE / 1000 keeps multiplyExact within range but overflows the
+    // subsequent addExact against the current time, exercising its throw path.
+    @Test
+    public void testTimerDelaySecAddExactOverflowRejected() {
+        PutMessageResult result = HookUtils.handleScheduleMessage(newTimerEnabledController(),
+            newTimerMessage(MessageConst.PROPERTY_TIMER_DELAY_SEC, String.valueOf(Long.MAX_VALUE / 1000)));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL, result.getPutMessageStatus());
+    }
+
+    // Exercises the successful timer transformation for a millisecond delay:
+    // the message is rewritten to the wheel-timer topic with the normalized
+    // delivery time stored in PROPERTY_TIMER_OUT_MS.
+    @Test
+    public void testTimerDelayMsSuccessPath() {
+        BrokerController brokerController = newTimerEnabledController();
+        TimerMessageStore timerMessageStore = Mockito.mock(TimerMessageStore.class);
+        Mockito.when(brokerController.getTimerMessageStore()).thenReturn(timerMessageStore);
+        Mockito.when(timerMessageStore.isReject(Mockito.anyLong())).thenReturn(false);
+
+        MessageExtBrokerInner msg = newTimerMessage(MessageConst.PROPERTY_TIMER_DELAY_MS, "1000");
+        PutMessageResult result = HookUtils.handleScheduleMessage(brokerController, msg);
+        Assert.assertNull(result);
+        Assert.assertNotNull(msg.getProperty(MessageConst.PROPERTY_TIMER_OUT_MS));
+        Assert.assertEquals(TimerMessageStore.TIMER_TOPIC, msg.getTopic());
     }
 
     // Covers the future-delivery validation branch with a delay that does not


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10872

### Brief Description

`HookUtils.transformTimerMessage` converted relative timer delays (`TIMER_DELAY_SEC` / `TIMER_DELAY_MS`) into an absolute delivery timestamp with unchecked `long` multiplication and addition. A very large delay such as `Long.MAX_VALUE` overflowed into a past timestamp, bypassed the future-delivery validation, and took the immediate-message path instead of being rejected.

This change uses `Math.multiplyExact` / `Math.addExact` for the conversion. The existing `catch (Exception)` in the method turns the resulting `ArithmeticException` into `PutMessageStatus.WHEEL_TIMER_MSG_ILLEGAL`, so an unrepresentable delay is now rejected. It also snapshots `System.currentTimeMillis()` once per invocation so the conversion and the future-delivery check share the same time base.

### How Did You Test This Change?

- New `HookUtilsTimerOverflowTest` with three cases:
  - `TIMER_DELAY_SEC = Long.MAX_VALUE` is rejected with `WHEEL_TIMER_MSG_ILLEGAL`;
  - `TIMER_DELAY_MS = Long.MAX_VALUE` is rejected with `WHEEL_TIMER_MSG_ILLEGAL`;
  - a delay that does not overflow but exceeds `timerMaxDelaySec` is still rejected (covers the future-delivery branch).
- On the unfixed code the overflow cases fail (the message takes the immediate path); after the fix all three pass.
- `mvn -pl broker -am test`: 763 tests, 0 failures (the single unrelated `BrokerOuterAPITest` error is a JDK 17 module-access issue in the test constructor, absent under the project's CI JDK 8).
- New patch lines are fully covered by the added tests.
