### PR TITLE
[ISSUE #10966] Fix TransactionalOpBatchService busy loop when deleteContext is drained

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -745,6 +745,17 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
             if (!overSize && wakeupTimestamp > startTime) {
                 return wakeupTimestamp;
             }
+
+            // Nothing was batched in this round (e.g. every context in deleteContext
+            // is already drained but still present, so firstTimestamp falls back to a
+            // stale lastWriteTimestamp and the branch above does not fire). Returning 0
+            // would make TransactionalOpBatchService treat it as "run again immediately",
+            // busy-looping one CPU core at ~100%. Schedule the next scan after the batch
+            // interval instead; new deletes still wake the thread promptly via
+            // deletePrepareMessage() -> wakeup().
+            if (sendMap == null) {
+                return System.currentTimeMillis() + interval;
+            }
         } catch (Throwable t) {
             log.error("batchSendOp error.", t);
         }

--- a/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
@@ -174,6 +174,19 @@ public class TransactionalMessageServiceImplTest {
     }
 
     @Test
+    public void testBatchSendOpMessage_noPendingDataReturnsFutureWakeup() {
+        // Reproduce #10966: a drained context (all offsets already batched and sent)
+        // stays in deleteContext forever with a stale lastWriteTimestamp. Previously
+        // batchSendOpMessage() returned 0 in this state, which made
+        // TransactionalOpBatchService busy-loop at ~100% CPU.
+        ((TransactionalMessageServiceImpl) queueTransactionMsgService).getDeleteContext()
+            .put(0, new MessageQueueOpContext(0L, 1));
+        long wakeup = ((TransactionalMessageServiceImpl) queueTransactionMsgService).batchSendOpMessage();
+        // Should schedule the next scan after the batch interval, not 0.
+        assertThat(wakeup).isGreaterThan(System.currentTimeMillis());
+    }
+
+    @Test
     public void testOpen() {
         boolean isOpen = queueTransactionMsgService.open();
         assertThat(isOpen).isTrue();


### PR DESCRIPTION
### What

Fixes #10966 — the `TransactionalOpBatchService` thread busy-loops at ~100% CPU after a transaction-message workload goes idle.

### Root cause

`deleteContext` entries are only ever `putIfAbsent` in `deletePrepareMessage()` and never removed. Once a context has been fully drained (all offsets batched and sent), it stays in the map forever with a **stale `lastWriteTimestamp`**.

In `batchSendOpMessage()`, when every context is empty, the scan falls through to the stale-`firstTimestamp` branch:

- `firstTimestamp = min(startTime, staleLastWrite)` → stale value
- `wakeupTimestamp = stale + interval < startTime` → the `wakeupTimestamp > startTime` guard fails
- method returns `0L`

Back in `TransactionalOpBatchService.run()`:

```java
long interval = wakeupTimestamp - System.currentTimeMillis();   // 0 - now < 0
if (interval <= 0) { interval = 0; wakeup(); }
this.waitForRunning(interval);   // waitForRunning(0) returns immediately
```

→ tight loop, one CPU core pinned at ~100% indefinitely.

### Fix

When no op message was batched in the round (`sendMap == null`), return `System.currentTimeMillis() + transactionOpBatchInterval` instead of `0L`, so the thread sleeps until the next scheduled scan. New deletes still wake it promptly via `deletePrepareMessage() -> transactionalOpBatchService.wakeup()`.

### Verification

- New regression test `testBatchSendOpMessage_noPendingDataReturnsFutureWakeup` — places a drained context (stale `lastWriteTimestamp = 0`) in `deleteContext` and asserts the returned wakeup time is in the future.
- `mvn -am -pl broker test -Dtest=TransactionalMessageServiceImplTest` → **Tests run: 9, Failures: 0, Errors: 0** (8 pre-existing + 1 new).
- Standalone loop simulation of `TransactionalOpBatchService.run()` + `batchSendOpMessage()`: before fix **12,126,584 iterations/2s** (busy loop), after fix **13 iterations/2s** (sleeps normally).