### PR TITLE
[ISSUE #10968] Copy transaction message properties directly instead of encode/decode roundtrip

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/EndTransactionProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/EndTransactionProcessor.java
@@ -288,7 +288,7 @@ public class EndTransactionProcessor implements NettyRequestProcessor {
                 msgExt.putUserProperty(MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES, String.valueOf(checkTimesRocksDB));
             }
         }
-        MessageAccessor.setProperties(msgInner, MessageDecoder.string2messageProperties(MessageDecoder.messageProperties2String(msgExt.getProperties())));
+        MessageAccessor.setProperties(msgInner, MessageAccessor.deepCopyProperties(msgExt.getProperties()));
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_REAL_TOPIC);
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_REAL_QUEUE_ID);
         msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgInner.getProperties()));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10968

### Brief Description

`EndTransactionProcessor#endMessageTransaction` deep-copied the prepare message's properties by encoding them to a String and immediately decoding that String back to a map:

```java
MessageAccessor.setProperties(msgInner,
    MessageDecoder.string2messageProperties(MessageDecoder.messageProperties2String(msgExt.getProperties())));
```

That is a full map traversal + StringBuilder + String, then a second traversal + per-entry substring allocations — on every transaction commit/rollback — just to copy a map. This PR replaces the round-trip with `MessageAccessor.deepCopyProperties(...)`. The real encode after `clearProperty` (which produces the wire-format `propertiesString`) is untouched, so the stored message is byte-identical.

Behavior parity note: the old round-trip silently dropped entries with null/empty values, but at this call site `msgExt` is decoded from the store — the properties parser never yields null/empty values and `putUserProperty` rejects blank values, so that path is unreachable here.

### How Did You Test This Change?

- `EndTransactionProcessorTest` passes (7/7).
- A/B benchmark on a 4-node cluster (8C32G, ESSD): `benchmark.TransactionProducer`, 32 threads, 1 KiB body, all-commit; per arm clean store + broker restart + page cache drop; 25 s warmup + 60 s collect; 3 interleaved trials:

| trial | arm | TPS | young GC | GC / million msgs | send failed |
|---|---|---|---|---|---|
| 1 | base | 64,927 | 25 | 6.42 | 0 |
| 1 | patch | 66,767 | 24 | 5.99 | 0 |
| 2 | base | 66,078 | 26 | 6.56 | 0 |
| 2 | patch | 64,868 | 24 | 6.17 | 0 |
| 3 | base | 66,781 | 25 | 6.24 | 0 |
| 3 | patch | 65,184 | 24 | 6.14 | 0 |

Broker young GC per million messages: median 6.42 -> 6.14 (-4.4%), patch below base in all three trials; TPS flat; zero send failures.
