### PR TITLE
[ISSUE #10969] Hoist per-batch constant min/max offset strings out of message loop in PullAPIWrapper

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapper.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/PullAPIWrapper.java
@@ -128,19 +128,21 @@ public class PullAPIWrapper {
                 this.executeHook(filterMessageContext);
             }
 
-            for (MessageExt msg : msgListFilterAgain) {
-                String traFlag = msg.getProperty(MessageConst.PROPERTY_TRANSACTION_PREPARED);
-                if (Boolean.parseBoolean(traFlag)) {
-                    msg.setTransactionId(msg.getProperty(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX));
-                }
-                MessageAccessor.putProperty(msg, MessageConst.PROPERTY_MIN_OFFSET,
-                    Long.toString(pullResult.getMinOffset()));
-                MessageAccessor.putProperty(msg, MessageConst.PROPERTY_MAX_OFFSET,
-                    Long.toString(pullResult.getMaxOffset()));
-                msg.setBrokerName(mq.getBrokerName());
-                msg.setQueueId(mq.getQueueId());
-                if (pullResultExt.getOffsetDelta() != null) {
-                    msg.setQueueOffset(pullResultExt.getOffsetDelta() + msg.getQueueOffset());
+            if (!msgListFilterAgain.isEmpty()) {
+                String minOffset = Long.toString(pullResult.getMinOffset());
+                String maxOffset = Long.toString(pullResult.getMaxOffset());
+                for (MessageExt msg : msgListFilterAgain) {
+                    String traFlag = msg.getProperty(MessageConst.PROPERTY_TRANSACTION_PREPARED);
+                    if (Boolean.parseBoolean(traFlag)) {
+                        msg.setTransactionId(msg.getProperty(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX));
+                    }
+                    MessageAccessor.putProperty(msg, MessageConst.PROPERTY_MIN_OFFSET, minOffset);
+                    MessageAccessor.putProperty(msg, MessageConst.PROPERTY_MAX_OFFSET, maxOffset);
+                    msg.setBrokerName(mq.getBrokerName());
+                    msg.setQueueId(mq.getQueueId());
+                    if (pullResultExt.getOffsetDelta() != null) {
+                        msg.setQueueOffset(pullResultExt.getOffsetDelta() + msg.getQueueOffset());
+                    }
                 }
             }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10969

### Brief Description

In `PullAPIWrapper#processPullResult`, the per-message loop calls `Long.toString(pullResult.getMinOffset())` and `Long.toString(pullResult.getMaxOffset())` for every message, although both values are constant within one pull response. A 32-message batch allocates 64 identical short-lived strings where 2 suffice, on every pull response of every push/pull consumer.

This PR hoists the two `Long.toString` calls out of the loop and reuses the two strings for the whole batch. No behavior change: property values are identical and `putProperty` semantics are untouched.

### How Did You Test This Change?

- `PullAPIWrapperTest` passes (11/11).
- Joint A/B benchmark on a 4-node cluster (producer 64 threads + consumer 20 threads, 1 KiB body; only the consumer-side client jar swapped per arm; 3 interleaved 60 s trials): consumer young GC per million consumed messages 1.10/1.06/1.17 (base) vs 1.08/1.06/1.07 (patch), consume TPS flat — no regression. The saving itself is tens of short-lived strings per batch, below GC-count resolution; this is a cleanup-level optimization on a hot path.
