### PR TITLE
[ISSUE #10972] Encode timer message propertiesString after internal properties are cleared

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -1251,7 +1251,6 @@ public class TimerMessageStore {
         long tagsCodeValue =
             MessageExtBrokerInner.tagsString2tagsCode(topicFilterType, msgInner.getTags());
         msgInner.setTagsCode(tagsCodeValue);
-        msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgExt.getProperties()));
 
         msgInner.setSysFlag(msgExt.getSysFlag());
         msgInner.setBornTimestamp(msgExt.getBornTimestamp());
@@ -1270,6 +1269,9 @@ public class TimerMessageStore {
             MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_REAL_TOPIC);
             MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_REAL_QUEUE_ID);
         }
+        // Encode after the properties are finalized so that the wire data stays consistent
+        // with the property map, aligning with TimerMessageRocksDBStore#convertMessage.
+        msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgInner.getProperties()));
         return msgInner;
     }
 

--- a/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
@@ -180,6 +180,31 @@ public class TimerMessageStoreTest {
     }
 
     @Test
+    public void testConvertMessagePropertiesStringMatchesProperties() throws Exception {
+        final TimerMessageStore timerMessageStore = createTimerMessageStore(null, true);
+
+        MessageExtBrokerInner msgExt = buildMessage(3000, "TimerTest_testConvertMessage", false);
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_TOPIC, msgExt.getTopic());
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_QUEUE_ID, "0");
+        msgExt.setPropertiesString(MessageDecoder.messageProperties2String(msgExt.getProperties()));
+        msgExt.setTopic(TimerMessageStore.TIMER_TOPIC);
+
+        // delivered message: internal properties are cleared from both the map and the wire data
+        MessageExtBrokerInner delivered = timerMessageStore.convertMessage(msgExt, false);
+        assertEquals("TimerTest_testConvertMessage", delivered.getTopic());
+        assertFalse(delivered.getPropertiesString().contains(MessageConst.PROPERTY_REAL_TOPIC));
+        assertFalse(delivered.getPropertiesString().contains(MessageConst.PROPERTY_REAL_QUEUE_ID));
+        assertEquals(MessageDecoder.messageProperties2String(delivered.getProperties()), delivered.getPropertiesString());
+
+        // rolled message: keeps REAL_TOPIC and stays consistent between the map and the wire data
+        MessageExtBrokerInner rolled = timerMessageStore.convertMessage(msgExt, true);
+        assertEquals(TimerMessageStore.TIMER_TOPIC, rolled.getTopic());
+        assertTrue(rolled.getPropertiesString().contains(MessageConst.PROPERTY_REAL_TOPIC));
+        assertTrue(rolled.getPropertiesString().contains(MessageConst.PROPERTY_REAL_QUEUE_ID));
+        assertEquals(MessageDecoder.messageProperties2String(rolled.getProperties()), rolled.getPropertiesString());
+    }
+
+    @Test
     public void testPutTimerMessage() throws Exception {
         Assume.assumeFalse(MixAll.isWindows());
         String topic = "TimerTest_testPutTimerMessage";


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10972

### Brief Description

`TimerMessageStore#convertMessage` encoded `propertiesString` from the original property map and only afterwards cleared `REAL_TOPIC` / `REAL_QUEUE_ID` from the deep copy. As a result the delivered timer message carried the internal properties on the wire while the broker-side map had them cleared, and the file-based timer store observably diverged from `TimerMessageRocksDBStore#convertMessage`, which already clears first and encodes from the copied map.

This PR moves the encode after the clear block and encodes from `msgInner.getProperties()`, mirroring the RocksDB implementation. It also removes the map/wire mismatch where the deep copy was made but the encode still read the original map. `TIMER_DELIVER_MS` and other timer metadata are not in the clearing list, so the deliveryTimestamp exposed to gRPC consumers is unchanged.

### How Did You Test This Change?

- New regression test `testConvertMessagePropertiesStringMatchesProperties`: the delivered message drops `REAL_TOPIC`/`REAL_QUEUE_ID` from the wire and `propertiesString` equals the re-encoded map; the rolled message keeps them. `TimerMessageStoreTest` passes 11/11.
- 4-node cluster A/B (file-based timer store, `benchmark.timer.TimerProducer` 64 threads x 40 slots x 250 msgs/slot, 1 KiB, per arm clean store + page cache drop, 3 interleaved trials; the 2-minute first-slot offset isolates GC sampling to the pure delivery phase): every arm delivered 639,990/640,000 (report-sampling rounding) with zero send failures; delivery-phase young GC base 2/2/2 vs patch 1/2/2 — correctness intact, no regression.
