### PR TITLE
[ISSUE #10976] Reduce per-message allocation on the proxy gRPC path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ bazel-testlogs
 .vscode
 MODULE.bazel.lock
 *.flattened-pom.xml
+.qoder/
+profiling-docs/
+profiling-tools/
+.gorepro/
+.gotmp/

--- a/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
@@ -23,13 +23,21 @@ import java.security.NoSuchAlgorithmException;
 import org.apache.commons.codec.binary.Hex;
 
 public class BinaryUtil {
-    public static byte[] calculateMd5(byte[] binaryData) {
-        MessageDigest messageDigest = null;
+    /**
+     * MessageDigest is not thread safe, so keep one instance per thread instead of
+     * looking it up from the provider on every call.
+     */
+    private static final ThreadLocal<MessageDigest> MD5_DIGEST = ThreadLocal.withInitial(() -> {
         try {
-            messageDigest = MessageDigest.getInstance("MD5");
+            return MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD5 algorithm not found.");
+            throw new RuntimeException("MD5 algorithm not found.", e);
         }
+    });
+
+    public static byte[] calculateMd5(byte[] binaryData) {
+        MessageDigest messageDigest = MD5_DIGEST.get();
+        messageDigest.reset();
         messageDigest.update(binaryData);
         return messageDigest.digest();
     }

--- a/common/src/test/java/org/apache/rocketmq/common/utils/BinaryUtilTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/BinaryUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BinaryUtilTest {
+
+    @Test
+    public void testGenerateMd5MatchesFreshDigestAndIsStableAcrossCalls() throws Exception {
+        byte[] payload = "rocketmq-md5-test".getBytes(StandardCharsets.UTF_8);
+        String expected = Hex.encodeHexString(MessageDigest.getInstance("MD5").digest(payload), false);
+
+        String first = BinaryUtil.generateMd5(payload);
+        // interleave another digest to verify the reused per-thread instance is reset between calls
+        BinaryUtil.generateMd5("another-payload".getBytes(StandardCharsets.UTF_8));
+        String second = BinaryUtil.generateMd5(payload);
+
+        assertEquals(expected, first);
+        assertEquals(expected, second);
+    }
+
+    @Test
+    public void testGenerateMd5FromString() throws Exception {
+        String body = "string-body-\u4e2d\u6587";
+        String expected = Hex.encodeHexString(
+            MessageDigest.getInstance("MD5").digest(body.getBytes(StandardCharsets.UTF_8)), false);
+        assertEquals(expected, BinaryUtil.generateMd5(body));
+    }
+}

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -29,7 +29,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -166,7 +165,7 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             if (maxSize <= 0) {
                 return;
             }
-            if (messageGroup.getBytes(StandardCharsets.UTF_8).length >= maxSize) {
+            if (utf8Length(messageGroup) >= maxSize) {
                 throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_GROUP, "message group exceed the max size " + maxSize);
             }
             if (GrpcValidator.getInstance().containControlCharacter(messageGroup)) {
@@ -214,8 +213,8 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             if (GrpcValidator.getInstance().containControlCharacter(userPropertiesEntry.getValue())) {
                 throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_PROPERTY_KEY, "the value of property cannot contain control character");
             }
-            userPropertySize += userPropertiesEntry.getKey().getBytes(StandardCharsets.UTF_8).length;
-            userPropertySize += userPropertiesEntry.getValue().getBytes(StandardCharsets.UTF_8).length;
+            userPropertySize += utf8Length(userPropertiesEntry.getKey());
+            userPropertySize += utf8Length(userPropertiesEntry.getValue());
         }
         MessageAccessor.setProperties(messageWithHeader, Maps.newHashMap(userProperties));
 
@@ -223,13 +222,13 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         String tag = message.getSystemProperties().getTag();
         GrpcValidator.getInstance().validateTag(tag);
         messageWithHeader.setTags(tag);
-        userPropertySize += tag.getBytes(StandardCharsets.UTF_8).length;
+        userPropertySize += utf8Length(tag);
 
         // set keys
         List<String> keysList = message.getSystemProperties().getKeysList();
         for (String key : keysList) {
             validateMessageKey(key);
-            userPropertySize += key.getBytes(StandardCharsets.UTF_8).length;
+            userPropertySize += utf8Length(key);
         }
         if (keysList.size() > 0) {
             messageWithHeader.setKeys(keysList);
@@ -309,6 +308,35 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         }
 
         return messageWithHeader.getProperties();
+    }
+
+    /**
+     * Length of the UTF-8 encoding of {@code str} without materializing the byte array.
+     * Matches {@code str.getBytes(StandardCharsets.UTF_8).length}, including the
+     * single-byte replacement for unpaired surrogates.
+     */
+    static int utf8Length(String str) {
+        int len = 0;
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (c < 0x80) {
+                len += 1;
+            } else if (c < 0x800) {
+                len += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                if (i + 1 < str.length() && Character.isLowSurrogate(str.charAt(i + 1))) {
+                    len += 4;
+                    i++;
+                } else {
+                    len += 1;
+                }
+            } else if (Character.isLowSurrogate(c)) {
+                len += 1;
+            } else {
+                len += 3;
+            }
+        }
+        return len;
     }
 
     protected void fillDelayMessageProperty(apache.rocketmq.v2.Message message, org.apache.rocketmq.common.message.Message messageWithHeader) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivityTest.java
@@ -28,6 +28,7 @@ import apache.rocketmq.v2.SystemProperties;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,6 +88,23 @@ public class SendMessageActivityTest extends BaseActivityTest {
     public void before() throws Throwable {
         super.before();
         this.sendMessageActivity = new SendMessageActivity(messagingProcessor, grpcClientSettingsManager, grpcChannelManager);
+    }
+
+    @Test
+    public void testUtf8Length() {
+        String[] samples = {
+            "",
+            "abc123",
+            "\u4e2d\u6587\u5c5e\u6027\u503c",
+            "mixed\u4e2d\u6587and😀emoji",
+            "\uD83D\uDE00",
+            "\uD800",
+            "abc\uDC00def",
+            "߿ࠀ"
+        };
+        for (String sample : samples) {
+            assertEquals(sample, sample.getBytes(StandardCharsets.UTF_8).length, SendMessageActivity.utf8Length(sample));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10976

### Brief Description

Two per-message allocation sources removed on the proxy gRPC path:

1. `BinaryUtil.calculateMd5` performed a `MessageDigest.getInstance("MD5")` provider lookup and created a fresh digest on every call; `GrpcConverter#buildSystemProperties` hits this for every message delivered to a gRPC consumer. The digest is now kept per thread in a `ThreadLocal` (`MessageDigest` is not thread safe) and `reset()` before each use.
2. `SendMessageActivity#buildMessageProperty` (and `validateMessageGroup`) called `getBytes(StandardCharsets.UTF_8)` on every user-property key/value, the tag, each message key, and the message group, only to read `.length` for size validation. A new `utf8Length(String)` helper computes the encoded length without materializing the array, matching `String.getBytes(UTF_8).length` exactly (including the single-byte replacement for unpaired surrogates); the five call sites now use it.

### How Did You Test This Change?

- `BinaryUtilTest` (new): result matches a fresh `MessageDigest`, and stays stable across interleaved calls on the reused per-thread instance.
- `SendMessageActivityTest#testUtf8Length`: sample-by-sample equality with `getBytes(UTF_8).length` covering ASCII, CJK, supplementary (emoji), and unpaired surrogates; full class 12/12.
- Dedicated gRPC A/B on a 4-node cluster: proxy in cluster mode plus a loopback load tool built on `rocketmq-client-java` 5.0.7 (producer 8 threads with multi-byte user properties exercising `utf8Length`; SimpleConsumer 4 threads exercising the digest path), swapping the proxy's `rocketmq-common`/`rocketmq-proxy` jars per arm, 3 interleaved trials plus 1 reversed-order control: ~9.4k send TPS / ~5.1k consume TPS with zero failures in all 8 arms; proxy young GC counts showed a pure positional artifact (first arm of each pair always 9, second always 10, independent of the jar — confirmed by the reversed-order control), i.e. parity after correction. No regression; the allocation saving is below GC-count resolution, so this is a cleanup-level optimization on the proxy hot path.
