### PR TITLE
fix: Add nullability annotations and fix kotlin-stdlib transitive leak

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/Message.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/Message.java
@@ -18,6 +18,8 @@ package org.apache.rocketmq.common.message;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -98,10 +100,12 @@ public class Message implements Serializable {
         this.putProperty(name, value);
     }
 
+    @Nullable
     public String getUserProperty(final String name) {
         return this.getProperty(name);
     }
 
+    @Nullable
     public String getProperty(final String name) {
         if (null == this.properties) {
             this.properties = new HashMap<>();
@@ -125,6 +129,7 @@ public class Message implements Serializable {
         this.topic = topic;
     }
 
+    @Nullable
     public String getTags() {
         return this.getProperty(MessageConst.PROPERTY_TAGS);
     }
@@ -133,6 +138,7 @@ public class Message implements Serializable {
         this.putProperty(MessageConst.PROPERTY_TAGS, tags);
     }
 
+    @Nullable
     public String getKeys() {
         return this.getProperty(MessageConst.PROPERTY_KEYS);
     }
@@ -200,6 +206,7 @@ public class Message implements Serializable {
         this.body = body;
     }
 
+    @Nullable
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -208,6 +215,7 @@ public class Message implements Serializable {
         this.properties = properties;
     }
 
+    @Nullable
     public String getBuyerId() {
         return getProperty(MessageConst.PROPERTY_BUYER_ID);
     }
@@ -216,6 +224,7 @@ public class Message implements Serializable {
         putProperty(MessageConst.PROPERTY_BUYER_ID, buyerId);
     }
 
+    @Nullable
     public String getTransactionId() {
         return transactionId;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1009,6 +1009,24 @@
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-exporter-otlp</artifactId>
                 <version>${opentelemetry.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-jdk7</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-jdk8</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- #10978 

### Brief Description

This PR contains two independent fixes:

1. **`@Nullable` annotations on 7 getters in `Message.java`** that can return null at runtime. The methods are declared as returning plain `String`/`Map` with no nullability metadata, which produces silent NPEs in Kotlin consumers and gives no warning in Java IDEs. 

2. **Exclude leaked `kotlin-stdlib` from the `opentelemetry-exporter-otlp` dependency chain**. A pure-Java project depending on `rocketmq-client` transitively resolves `kotlin-stdlib` via: `opentelemetry-exporter-otlp` → `opentelemetry-exporter-sender-okhttp` → `okhttp` → `kotlin-stdlib-*`. Upstream already wrote `kotlin-stdlib` exclusions for the `okio-jvm` edge; this extends them to cover the okhttp path, enforcing a constraint upstream already intended.

