### PR TITLE
[ISSUE #10985] Handle exceptional POP revive reads without losing retry

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -568,7 +568,13 @@ public class PopReviveService extends ServiceThread {
             // retry msg
             long msgOffset = popCheckPoint.ackOffsetByIndex((byte) j);
             CompletableFuture<Pair<Long, Boolean>> future = getBizMessage(popCheckPoint, msgOffset)
-                .thenApply(rst -> {
+                .handle((rst, throwable) -> {
+                    if (throwable != null) {
+                        POP_LOGGER.error("reviveQueueId={}, get biz msg failed, topic:{}, qid:{}, offset:{}, brokerName:{}",
+                            queueId, popCheckPoint.getTopic(), popCheckPoint.getQueueId(), msgOffset,
+                            popCheckPoint.getBrokerName(), throwable);
+                        return new Pair<>(msgOffset, false);
+                    }
                     MessageExt message = rst.getLeft();
                     if (message == null) {
                         POP_LOGGER.info("reviveQueueId={}, can not get biz msg, topic:{}, qid:{}, offset:{}, brokerName:{}, info:{}, retry:{}, then continue",

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.broker.processor;
 
 import com.alibaba.fastjson2.JSON;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.failover.EscapeBridge;
@@ -58,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -387,6 +389,33 @@ public class PopReviveServiceTest {
         Assert.assertEquals(INVISIBLE_TIME + 10 * 1000L, actualInvisibleTime.get()); // first interval is 10s
         verify(escapeBridge, times(0)).putMessageToSpecificQueue(any(MessageExtBrokerInner.class)); // write retry
         verify(messageStore, times(1)).putMessage(any(MessageExtBrokerInner.class)); // rewrite CK
+    }
+
+    @Test
+    public void testReviveMsgFromCk_getBizMessageExceptional_rewriteCK() throws Throwable {
+        PopCheckPoint ck = buildPopCheckPoint(0, 0, 1);
+        PopReviveService.ConsumeReviveObj reviveObj = new PopReviveService.ConsumeReviveObj();
+        reviveObj.map.put("", ck);
+        reviveObj.endTime = System.currentTimeMillis();
+
+        ArgumentCaptor<Long> commitOffsetCaptor = ArgumentCaptor.forClass(Long.class);
+        doNothing().when(consumerOffsetManager).commitOffset(anyString(), anyString(), anyString(), anyInt(),
+            commitOffsetCaptor.capture());
+
+        CompletableFuture<Triple<MessageExt, String, Boolean>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("store read failed"));
+        when(escapeBridge.getMessageAsync(anyString(), anyLong(), anyInt(), anyString(), anyBoolean()))
+            .thenReturn(failed);
+
+        popReviveService.mergeAndRevive(reviveObj);
+
+        NavigableMap<?, ?> inflight = (NavigableMap<?, ?>) FieldUtils.readField(
+            popReviveService, "inflightReviveRequestMap", true);
+        assertEquals(1, reviveObj.newOffset);
+        assertEquals(1, commitOffsetCaptor.getValue().longValue());
+        assertEquals(0, inflight.size());
+        // An exceptional async read must retain retryability by rewriting the checkpoint.
+        verify(messageStore, times(1)).putMessage(any(MessageExtBrokerInner.class));
     }
 
     @Test

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PopReviveServiceTest.java
@@ -39,6 +39,7 @@ import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.store.AppendMessageResult;
 import org.apache.rocketmq.store.AppendMessageStatus;
+import org.apache.rocketmq.store.GetMessageResult;
 import org.apache.rocketmq.store.MessageStore;
 import org.apache.rocketmq.store.PutMessageResult;
 import org.apache.rocketmq.store.PutMessageStatus;
@@ -402,9 +403,13 @@ public class PopReviveServiceTest {
         doNothing().when(consumerOffsetManager).commitOffset(anyString(), anyString(), anyString(), anyInt(),
             commitOffsetCaptor.capture());
 
-        CompletableFuture<Triple<MessageExt, String, Boolean>> failed = new CompletableFuture<>();
+        CompletableFuture<GetMessageResult> failed = new CompletableFuture<>();
         failed.completeExceptionally(new RuntimeException("store read failed"));
-        when(escapeBridge.getMessageAsync(anyString(), anyLong(), anyInt(), anyString(), anyBoolean()))
+        // Exercise the real bridge; inject the fault only at the MessageStore async boundary.
+        EscapeBridge realEscapeBridge = new EscapeBridge(brokerController);
+        when(brokerController.getEscapeBridge()).thenReturn(realEscapeBridge);
+        when(brokerController.getMessageStoreByBrokerName(ck.getBrokerName())).thenReturn(messageStore);
+        when(messageStore.getMessageAsync(anyString(), anyString(), anyInt(), anyLong(), anyInt(), any()))
             .thenReturn(failed);
 
         popReviveService.mergeAndRevive(reviveObj);
@@ -415,6 +420,35 @@ public class PopReviveServiceTest {
         assertEquals(1, commitOffsetCaptor.getValue().longValue());
         assertEquals(0, inflight.size());
         // An exceptional async read must retain retryability by rewriting the checkpoint.
+        verify(messageStore, times(1)).putMessage(any(MessageExtBrokerInner.class));
+    }
+
+    @Test
+    public void testReviveMsgFromCk_storeFailsAfterOffsetCommit_rewriteCK() throws Throwable {
+        PopCheckPoint ck = buildPopCheckPoint(0, 0, 1);
+        PopReviveService.ConsumeReviveObj reviveObj = new PopReviveService.ConsumeReviveObj();
+        reviveObj.map.put("", ck);
+        reviveObj.endTime = System.currentTimeMillis();
+        CompletableFuture<GetMessageResult> readFuture = new CompletableFuture<>();
+        EscapeBridge realEscapeBridge = new EscapeBridge(brokerController);
+        when(brokerController.getEscapeBridge()).thenReturn(realEscapeBridge);
+        when(brokerController.getMessageStoreByBrokerName(ck.getBrokerName())).thenReturn(messageStore);
+        when(messageStore.getMessageAsync(anyString(), anyString(), anyInt(), anyLong(), anyInt(), any()))
+            .thenReturn(readFuture);
+
+        popReviveService.mergeAndRevive(reviveObj);
+
+        NavigableMap<?, ?> inflight = (NavigableMap<?, ?>) FieldUtils.readField(
+            popReviveService, "inflightReviveRequestMap", true);
+        assertEquals(1, reviveObj.newOffset);
+        assertEquals(1, inflight.size());
+        verify(consumerOffsetManager).commitOffset(PopAckConstants.LOCAL_HOST, PopAckConstants.REVIVE_GROUP,
+            REVIVE_TOPIC, REVIVE_QUEUE_ID, 1);
+        verify(messageStore, times(0)).putMessage(any(MessageExtBrokerInner.class));
+
+        readFuture.completeExceptionally(new RuntimeException("delayed store read failure"));
+
+        assertEquals(0, inflight.size());
         verify(messageStore, times(1)).putMessage(any(MessageExtBrokerInner.class));
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10985

### Brief Description

`PopReviveService` records a checkpoint as in flight, schedules asynchronous business-message reads, and then advances the revive offset. If one read completes exceptionally, `allOf(...).whenComplete(...)` runs but `future.getNow(...)` throws `CompletionException`. This aborts the callback before it rewrites the checkpoint or clears the in-flight entry. Since timeout cleanup only runs while the map contains more than three entries, a low-traffic failure can lose the message's retry path indefinitely.

This change:

- handles exceptional completion of the upstream `getBizMessage` future;
- logs the failed topic, queue, offset, and broker context;
- converts the failed read to `(msgOffset, false)`, allowing the existing `rePutCK` path to retain retryability;
- deliberately does not catch exceptions raised later by `reviveRetry`, keeping the change scoped to asynchronous reads;
- adds regressions asserting that the original offset is committed, a replacement CK is submitted to the store, and the in-flight entry is removed, for both immediately failed and later-failing reads.

There is no protocol, storage-format, or public API change.

### Applicability and limits

This repairs exceptional completion of the POP revive business-message read future. It is not a claim that every missing message or ordinary remote timeout reaches this branch: some upstream failures are already normalized into the existing retry result.

The new tests exercise `PopReviveService -> EscapeBridge -> MessageStore.getMessageAsync`, using a real `EscapeBridge` and injecting the fault at the mocked store-future boundary. They validate exceptional propagation and the existing checkpoint-rewrite/cleanup path, not physical disk/cloud/network failure, durable CK persistence, or exactly-once delivery. Failures of the replacement CK write itself are outside this patch.

### How Did You Test This Change?

Latest verification (2026-09-13): head `a191a2953750e946c2ffc6d8ba1d9cb547e85036`, based on `develop` at `1a50c6e4e35524ac22055b76fc0ff2a6d3cff99f`, JDK 8 / Maven 3.8.1:

```bash
git submodule update --init --depth 1 -- rocketmq-apis
mvn -pl broker -am -DskipITs -Dtest=PopReviveServiceTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

The local run used offline mode and settings for the existing dependency cache, without changing project configuration or disabling Checkstyle/SpotBugs.

- `PopReviveServiceTest`: **14 passed, 0 failures/errors/skips**.
- All 11 targeted reactor modules succeeded, including the protocol module.
- Checkstyle and SpotBugs enabled for project code: no violations or findings. Generated protocol code follows upstream's configured exclusions.
- `git diff --check`: passed.

The immediate-failure regression now traverses the real bridge instead of mocking its return value. The added delayed-failure case first holds the store future incomplete, confirms that revive offset 1 has been committed while one request remains in flight and no CK rewrite has occurred, then fails the future. It asserts that the in-flight entry is removed and the replacement CK is submitted exactly once. The failure timing is controlled by the future, not a sleep.

Historical red evidence: the earlier regression mocked `EscapeBridge.getMessageAsync` directly. On unmodified `develop` at `e348efa66`, two independent runs reproduced:

```text
reviveObj.newOffset = 1
committed revive offset = 1
inflightReviveRequestMap.size() = 1
expected messageStore.putMessage(rewritten CK): 1
actual: 0
```

That red result is for the original test setup, not a fresh baseline execution of the two strengthened tests. The September 11 head passed 13 tests and all 10 GitHub checks when checked on September 13 before this test-only follow-up. CI for the new head must be evaluated independently; the production fix has not changed.

### Related PR coordination

#11023 also fixes #10985 using the same `handle`-based retry path. At the time of comparison (2026-09-11), that PR changes only the production file and records no local Maven run. This PR additionally contains the deterministic regression for offset advancement, checkpoint rewrite, and in-flight cleanup, along with the verification above. The production behavior is equivalent apart from logging level/context. Please coordinate review around one implementation and retain the regression coverage when consolidating.
