### PR TITLE
[ISSUE #10987] Fix queryMinOffsetInAllGroup deleting consumer offsets from the live offset table

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
@@ -327,21 +327,21 @@ public class ConsumerOffsetManager extends ConfigManager {
     public Map<Integer, Long> queryMinOffsetInAllGroup(final String topic, final String filterGroups) {
 
         Map<Integer, Long> queueMinOffset = new HashMap<>();
-        Set<String> topicGroups = this.offsetTable.keySet();
+        // Work on a snapshot of the keys: offsetTable must never be mutated by a query.
+        Set<String> topicGroups = new HashSet<>(this.offsetTable.keySet());
         if (!UtilAll.isBlank(filterGroups)) {
             for (String group : filterGroups.split(",")) {
-                Iterator<String> it = topicGroups.iterator();
-                while (it.hasNext()) {
-                    String topicAtGroup = it.next();
-                    if (group.equals(topicAtGroup.split(TOPIC_GROUP_SEPARATOR)[1])) {
-                        it.remove();
-                        removeConsumerOffset(topicAtGroup);
-                    }
-                }
+                topicGroups.removeIf(topicAtGroup -> {
+                    String[] arrays = topicAtGroup.split(TOPIC_GROUP_SEPARATOR);
+                    return arrays.length == 2 && group.equals(arrays[1]);
+                });
             }
         }
 
         for (Map.Entry<String, ConcurrentMap<Integer, Long>> offSetEntry : this.offsetTable.entrySet()) {
+            if (!topicGroups.contains(offSetEntry.getKey())) {
+                continue;
+            }
             String topicGroup = offSetEntry.getKey();
             String[] topicGroupArr = topicGroup.split(TOPIC_GROUP_SEPARATOR);
             if (topic.equals(topicGroupArr[0])) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
@@ -19,11 +19,13 @@ package org.apache.rocketmq.broker.offset;
 
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.store.MessageStore;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.mockito.Mockito;
@@ -120,5 +122,39 @@ public class ConsumerOffsetManagerTest {
         consumerOffsetManager.eraseResetOffset(topic, group, 1);
         Assert.assertFalse(consumerOffsetManager.hasOffsetReset(topic, group, 1));
         Assert.assertFalse(consumerOffsetManager.resetOffsetTable.containsKey(key));
+    }
+
+    @Test
+    public void testQueryMinOffsetInAllGroupDoesNotDeleteOffsets() {
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
+        MessageStore messageStore = Mockito.mock(MessageStore.class);
+        Mockito.when(brokerController.getMessageStore()).thenReturn(messageStore);
+        Mockito.when(messageStore.getMinOffsetInQueue(Mockito.anyString(), Mockito.anyInt())).thenReturn(0L);
+
+        String topic = "Topic";
+        String group1 = "G1";
+        String group2 = "G2";
+        ConcurrentHashMap<Integer, Long> offsets1 = new ConcurrentHashMap<>();
+        offsets1.put(0, 50L);
+        ConcurrentHashMap<Integer, Long> offsets2 = new ConcurrentHashMap<>();
+        offsets2.put(0, 30L);
+        ConcurrentHashMap<String, ConcurrentMap<Integer, Long>> offsetTable = new ConcurrentHashMap<>();
+        offsetTable.put(topic + TOPIC_GROUP_SEPARATOR + group1, offsets1);
+        offsetTable.put(topic + TOPIC_GROUP_SEPARATOR + group2, offsets2);
+        // malformed key without '@' must not break the query either
+        offsetTable.put("MalformedKey", new ConcurrentHashMap<>());
+        consumerOffsetManager.setOffsetTable(offsetTable);
+
+        // filtering out G2 must exclude its offsets from the min computation
+        Map<Integer, Long> result = consumerOffsetManager.queryMinOffsetInAllGroup(topic, group2);
+        assertThat(result).containsEntry(0, 50L);
+
+        // but the query must not destroy the filtered group's offsets
+        assertThat(offsetTable).containsKey(topic + TOPIC_GROUP_SEPARATOR + group2);
+        assertThat(consumerOffsetManager.queryOffset(group2, topic, 0)).isEqualTo(30L);
+
+        // without filter, the min across all groups is returned
+        result = consumerOffsetManager.queryMinOffsetInAllGroup(topic, "");
+        assertThat(result).containsEntry(0, 30L);
     }
 }

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
@@ -141,8 +141,6 @@ public class ConsumerOffsetManagerTest {
         ConcurrentHashMap<String, ConcurrentMap<Integer, Long>> offsetTable = new ConcurrentHashMap<>();
         offsetTable.put(topic + TOPIC_GROUP_SEPARATOR + group1, offsets1);
         offsetTable.put(topic + TOPIC_GROUP_SEPARATOR + group2, offsets2);
-        // malformed key without '@' must not break the query either
-        offsetTable.put("MalformedKey", new ConcurrentHashMap<>());
         consumerOffsetManager.setOffsetTable(offsetTable);
 
         // filtering out G2 must exclude its offsets from the min computation
@@ -156,5 +154,23 @@ public class ConsumerOffsetManagerTest {
         // without filter, the min across all groups is returned
         result = consumerOffsetManager.queryMinOffsetInAllGroup(topic, "");
         assertThat(result).containsEntry(0, 30L);
+    }
+
+    @Test
+    public void testQueryMinOffsetInAllGroupToleratesMalformedKeys() {
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
+        MessageStore messageStore = Mockito.mock(MessageStore.class);
+        Mockito.when(brokerController.getMessageStore()).thenReturn(messageStore);
+        Mockito.when(messageStore.getMinOffsetInQueue(Mockito.anyString(), Mockito.anyInt())).thenReturn(0L);
+
+        String topic = "Topic";
+        ConcurrentHashMap<String, ConcurrentMap<Integer, Long>> offsetTable = new ConcurrentHashMap<>();
+        offsetTable.put(topic + TOPIC_GROUP_SEPARATOR + "G1", new ConcurrentHashMap<>());
+        // malformed key without '@' must not break the query
+        offsetTable.put("MalformedKey", new ConcurrentHashMap<>());
+        consumerOffsetManager.setOffsetTable(offsetTable);
+
+        assertThat(consumerOffsetManager.queryMinOffsetInAllGroup(topic, "G1")).isEmpty();
+        assertThat(consumerOffsetManager.queryMinOffsetInAllGroup(topic, "")).isEmpty();
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

- Fixes #10987

### Brief Description

`ConsumerOffsetManager#queryMinOffsetInAllGroup(topic, filterGroups)` iterated the **live** `offsetTable.keySet()` and called `it.remove()` on it to exclude the filter groups. Since `ConcurrentHashMap.keySet()` is a live view, running the read-only admin operation `QUERY_CORRECTION_OFFSET` (`AdminBrokerProcessor#queryCorrectionOffset`, exposed via `DefaultMQAdminExt#queryCorrectionOffset`) **permanently deleted** every `topic@group` offset entry of the filtered groups:

- the in-memory offsets are gone and the next `persist()` makes the deletion permanent (`consumerOffset.json`);
- with `RocksDBConsumerOffsetManager`, `removeConsumerOffset` deletes the rows from RocksDB immediately;
- consumers of the filtered group then see `-1` from `queryOffset` and re-initialize per `consumeFromWhere` → mass duplicate consumption or skipping to max;
- `topicAtGroup.split(TOPIC_GROUP_SEPARATOR)[1]` also threw `ArrayIndexOutOfBoundsException` on a malformed key without `@`.

This PR makes the exclusion work on a **snapshot** of the key set, so the query no longer mutates `offsetTable` at all (and never calls `removeConsumerOffset`), while preserving the original filter semantics: offsets of the filter groups are excluded from the min-offset computation. The malformed-key AIOOBE is fixed by checking `arrays.length == 2`.

### Priority

PRIORITY = 76: impact 32 (a read-only admin query permanently deletes persisted consumer offsets — in memory, `consumerOffset.json`, and RocksDB rows — so filtered groups re-initialize per `consumeFromWhere`: mass duplicate consumption or skipping to max) + scope 12 (the `QUERY_CORRECTION_OFFSET` admin API path of every broker) + reproducibility 18 (two deterministic regression tests, one per failure mode) + maintenance 14 (small snapshot-based fix that preserves the existing filter semantics). FIX_CONFIDENCE = 95.

### How Did You Test This Change?

Two regression tests in `ConsumerOffsetManagerTest` (split so each failure mode is asserted independently):

- `testQueryMinOffsetInAllGroupDoesNotDeleteOffsets`: the filtered group is excluded from the min-offset computation, its offsets remain in the table (`queryOffset` still returns them) after the query, and the unfiltered query still returns the cross-group minimum.
- `testQueryMinOffsetInAllGroupToleratesMalformedKeys`: a stored key without `@` no longer breaks the query.

Verified results (re-run 2026-09-05; after = branch tip 906bab3c2, before = base commit e348efa66 with the same test files):

- After fix: `mvn -pl broker test -Dtest=ConsumerOffsetManagerTest` → **7/7 pass**.
- Before fix, each test fails on its own (run individually, because the project's surefire config `skipAfterFailureCount=1` aborts a class run after the first error):
  - `testQueryMinOffsetInAllGroupDoesNotDeleteOffsets` → FAILURE: `Expecting actual: {"Topic@G1"={0=50L}} to contain key: "Topic@G2"` — the query deleted the filtered group's entry from the live offset table.
  - `testQueryMinOffsetInAllGroupToleratesMalformedKeys` → ERROR: `java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1`.

### Risk

Very low: the query now iterates a snapshot of the key set and never mutates `offsetTable` (hence never calls `removeConsumerOffset`); the filter semantics — excluding filter-group offsets from the min computation — are unchanged, and the `arrays.length == 2` guard only skips keys that previously threw. No public API or persistence format change.
