### PR TITLE
[ISSUE #10988] Fix concurrent commitOffset race losing queue offsets for a new topic@group

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
@@ -203,16 +203,13 @@ public class ConsumerOffsetManager extends ConfigManager {
     }
 
     private void commitOffset(final String clientHost, final String key, final int queueId, final long offset) {
-        ConcurrentMap<Integer, Long> map = this.offsetTable.get(key);
-        if (null == map) {
-            map = new ConcurrentHashMap<>(2);
-            map.put(queueId, offset);
-            this.offsetTable.put(key, map);
-        } else {
-            Long storeOffset = map.put(queueId, offset);
-            if (storeOffset != null && offset < storeOffset) {
-                LOG.warn("[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, requestOffset={}, storeOffset={}", clientHost, key, queueId, offset, storeOffset);
-            }
+        // computeIfAbsent, so concurrent commits for different queues of a new topic@group
+        // all land in the same map instead of overwriting each other's entries.
+        ConcurrentMap<Integer, Long> map = this.offsetTable.computeIfAbsent(key,
+            k -> new ConcurrentHashMap<>(2));
+        Long storeOffset = map.put(queueId, offset);
+        if (storeOffset != null && offset < storeOffset) {
+            LOG.warn("[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, requestOffset={}, storeOffset={}", clientHost, key, queueId, offset, storeOffset);
         }
         if (versionChangeCounter.incrementAndGet() % brokerController.getBrokerConfig().getConsumerOffsetUpdateVersionStep() == 0) {
             updateDataVersion();

--- a/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManagerTest.java
@@ -24,8 +24,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 
 import static org.apache.rocketmq.broker.offset.ConsumerOffsetManager.TOPIC_GROUP_SEPARATOR;
@@ -120,5 +125,36 @@ public class ConsumerOffsetManagerTest {
         consumerOffsetManager.eraseResetOffset(topic, group, 1);
         Assert.assertFalse(consumerOffsetManager.hasOffsetReset(topic, group, 1));
         Assert.assertFalse(consumerOffsetManager.resetOffsetTable.containsKey(key));
+    }
+
+    @Test
+    public void testConcurrentCommitOffsetDoesNotLoseQueues() throws InterruptedException {
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
+
+        final int queueCount = 8;
+        final int keyCount = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(queueCount);
+        CountDownLatch latch = new CountDownLatch(queueCount);
+        for (int queueId = 0; queueId < queueCount; queueId++) {
+            final int qid = queueId;
+            executor.submit(() -> {
+                try {
+                    // every thread commits a distinct queue of the same brand-new keys,
+                    // so creation of each topic@group entry races
+                    for (int i = 0; i < keyCount; i++) {
+                        consumerOffsetManager.commitOffset("host", "group", "topic" + i, qid, i);
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        Assert.assertTrue(latch.await(60, TimeUnit.SECONDS));
+        executor.shutdownNow();
+
+        for (int i = 0; i < keyCount; i++) {
+            Map<Integer, Long> offsets = consumerOffsetManager.queryOffset("group", "topic" + i);
+            assertThat(offsets).as("offsets of topic" + i).hasSize(queueCount);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes / Relates To

- Fixes #10988 — the narrow tracker for the classic `ConsumerOffsetManager` initialization race (closed as a subset duplicate of #10700 on 2026-09-05 after an issue-mapping audit).
- Related to #10700 — the earlier, broader issue (filed 2026-07-30) that covers this same classic-manager race plus a RocksDB v1 incremental-persistence race, with an open fix in PR #10701 by the issue author. This PR was created on 2026-08-29 without knowledge of #10700/#10701; it addresses only the classic-manager initialization race and includes a deterministic regression test. If maintainers prefer to consolidate with #10701, this PR can be closed in its favor.

### Brief Description

`ConsumerOffsetManager#commitOffset` used a non-atomic check-then-act to create the per `topic@group` map:

```java
ConcurrentMap<Integer, Long> map = this.offsetTable.get(key);
if (null == map) {
    map = new ConcurrentHashMap<>(2);
    map.put(queueId, offset);
    this.offsetTable.put(key, map);      // last put wins, the other thread's map is dropped
} else { ... }
```

When two remoting threads commit offsets for different queues of the same brand-new `topic@group` concurrently (the normal situation right after a consumer group starts on a multi-queue topic, or while a pop consumer acks several queues), both see `null`, both install their own map, and the second `put` silently drops the first queue's offset. `queryOffset` then returns `-1` for that queue until its next commit, so a consumer reconnect/restart in the window re-initializes per `consumeFromWhere` (duplicate consumption or skipping to max). The same race re-arms after `removeOffset(group)` / `cleanOffsetByTopic` while the group is still consuming.

The fix replaces the get/put pair with `offsetTable.computeIfAbsent(key, k -> new ConcurrentHashMap<>(2))` — the same idiom the class already uses in `commitPullOffset` — so concurrent commits always land in the same map. The less-than-store warn behavior is unchanged.

### Priority

PRIORITY = 74: impact 28 (a brand-new `topic@group`'s first concurrent commits can silently lose queue offsets; `queryOffset` then returns `-1`, and a consumer reconnect/restart in that window re-initializes per `consumeFromWhere` — duplicate consumption or skipping to max; the race re-arms after `removeOffset(group)`/`cleanOffsetByTopic` while the group is still consuming) + scope 14 (every `commitOffset` path: consumer submissions and pop acks) + reproducibility 17 (deterministic concurrency test, 8 threads × 500 keys) + maintenance 15 (standard `computeIfAbsent` idiom already used by `commitPullOffset` in the same class). FIX_CONFIDENCE = 95.

### How Did You Test This Change?

Added `ConsumerOffsetManagerTest#testConcurrentCommitOffsetDoesNotLoseQueues`: 8 threads commit a distinct queue for 500 brand-new `topic@group` keys each, then the test asserts every key retains all 8 queue offsets.

Verified results (re-run 2026-09-05; after = branch tip 549aa9acb, before = base commit e348efa66 with the same test file):

- After fix: `mvn -pl broker test -Dtest=ConsumerOffsetManagerTest` → **6/6 pass**.
- Before fix: `testConcurrentCommitOffsetDoesNotLoseQueues` → FAILURE: `Expected size: 8 but was: 6 in: {0=1L, 1=1L, 3=1L, 4=1L, 5=1L, 7=1L}` — the offsets of queues 2 and 6 were silently dropped by the race.

### Risk

Very low: the non-atomic get/put pair is replaced by `computeIfAbsent`, so concurrent commits always land in the same map; the "update consumer offset less than store" warn behavior is unchanged, and the fast path (map already present) behaves as before. No public API or persistence format change.
