### PR TITLE
[ISSUE #10989] Fix transactional message escape retry backoff (2 ^ n computed with XOR)

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -61,6 +61,10 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
     private static final int MAX_PROCESS_TIME_LIMIT = 60000;
     private static final int MAX_RETRY_TIMES_FOR_ESCAPE = 10;
 
+    static long escapeRetryBackoffMillis(int escapeFailCnt) {
+        return 100L * (1 << escapeFailCnt);
+    }
+
     private static final int MAX_RETRY_COUNT_WHEN_HALF_NULL = 1;
 
     private static final int OP_MSG_PULL_NUMS = 32;
@@ -250,7 +254,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                                     msgExt.getUserProperty(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX));
                                 if (escapeFailCnt < MAX_RETRY_TIMES_FOR_ESCAPE) {
                                     escapeFailCnt++;
-                                    Thread.sleep(100L * (2 ^ escapeFailCnt));
+                                    Thread.sleep(escapeRetryBackoffMillis(escapeFailCnt));
                                 } else {
                                     escapeFailCnt = 0;
                                     newOffset = i + 1;

--- a/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
@@ -85,6 +85,13 @@ public class TransactionalMessageServiceImplTest {
     }
 
     @Test
+    public void testEscapeRetryBackoffMillisIsExponential() {
+        for (int i = 1; i <= 10; i++) {
+            assertThat(TransactionalMessageServiceImpl.escapeRetryBackoffMillis(i)).isEqualTo(100L * (1L << i));
+        }
+    }
+
+    @Test
     public void testPrepareMessage() {
         MessageExtBrokerInner inner = createMessageBrokerInner();
         when(bridge.putHalfMessage(any(MessageExtBrokerInner.class)))


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

- Fixes #10989

### Brief Description

In `TransactionalMessageServiceImpl#check`, the retry delay between failed escape attempts (broker with `enableSlaveActingMaster`, `escapeMessage` failing) was computed as

```java
Thread.sleep(100L * (2 ^ escapeFailCnt));
```

In Java `^` is XOR, not exponentiation, so the actual sleep sequence for `escapeFailCnt` = 1..10 was `300, 0, 100, 600, 700, 400, 500, 1000, 1100, 800` ms — non-monotonic and including a **0 ms** delay on the second failure, which defeats the backoff entirely and hammers the store with immediate re-puts.

This PR extracts the computation into a package-private helper `escapeRetryBackoffMillis(int)` that returns the intended exponential backoff `100L * (1 << escapeFailCnt)` (200, 400, 800, ... ms), and uses it at the call site. No behavior other than the delay values changes.

### Priority

PRIORITY = 72: impact 28 (the designed exponential backoff is completely non-functional — non-monotonic delays including 0 ms — so a degraded broker with `enableSlaveActingMaster` re-puts escaped messages at full speed exactly when the store is already under failure pressure) + scope 12 (the transactional message check/escape path) + reproducibility 18 (formula-level deterministic, plus a unit test on the extracted helper) + maintenance 14 (one-line call-site fix plus a package-private helper). FIX_CONFIDENCE = 95.

### How Did You Test This Change?

Added `TransactionalMessageServiceImplTest#testEscapeRetryBackoffMillisIsExponential`, which asserts `escapeRetryBackoffMillis(i) == 100L * (1L << i)` for i = 1..10.

Verified results (re-run 2026-09-05; after = branch tip 29d7ce294, before = base commit e348efa66):

- After fix: `mvn -pl broker test -Dtest=TransactionalMessageServiceImplTest` → **9/9 pass**.
- Before fix the helper cannot exist (it is extracted by this PR), so the pre-fix behavior is shown at formula level: the old call site `Thread.sleep(100L * (2 ^ escapeFailCnt))` (base `TransactionalMessageServiceImpl.java:253`) evaluates `^` as XOR — `100L*(2^i)` for i = 1..10 yields `300, 0, 100, 600, 700, 400, 500, 1000, 1100, 800` ms (non-monotonic, 0 ms on the second failure), while the fix yields the intended `200, 400, 800, 1600, ...` ms.

### Risk

Low: only the delay values change, from the accidental XOR sequence to the intended exponential sequence (200 ms up to 102.4 s at the 10th failure, bounded by `MAX_RETRY_TIMES_FOR_ESCAPE`). Longer backoffs are the documented intent of the escape design (Issue #10989); no other behavior, API or data format changes.
