### PR TITLE
[ISSUE #10990] Skip pop retry arrival notification when properties are null

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLongPollingService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLongPollingService.java
@@ -180,6 +180,12 @@ public class PopLongPollingService extends ServiceThread {
 
     private void notifyMessageArrivingFromRetry(String topic, int queueId, Long tagsCode, long msgStoreTime, byte[] filterBitMap,
         Map<String, String> properties) {
+        if (properties == null) {
+            // A retry topic message without properties can't be mapped back to its origin group,
+            // so there is no long polling request to wake up. Throwing here would poison the
+            // reput thread for every following message.
+            return;
+        }
         String prefix = MixAll.RETRY_GROUP_TOPIC_PREFIX;
         String originGroup = properties.get(MessageConst.PROPERTY_ORIGIN_GROUP);
         // In the case of pop consumption, there is no long polling hanging on the retry topic, so the wake-up is skipped.

--- a/broker/src/test/java/org/apache/rocketmq/broker/longpolling/PopLongPollingServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/longpolling/PopLongPollingServiceTest.java
@@ -47,8 +47,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -108,6 +113,19 @@ public class PopLongPollingServiceTest {
         // pop retry v2
         popLongPollingService.notifyMessageArrivingWithRetryTopic(popRetryTopicV2, queueId, queueId, -1L, 0L, null, properties);
         verify(popLongPollingService, times(2)).notifyMessageArriving(defaultTopic, queueId, group, true, -1L, 0L, null, properties, null);
+    }
+
+    @Test
+    public void testNotifyMessageArrivingFromRetryWithoutProperties() {
+        int queueId = -1;
+        String group = "group";
+        String pullRetryTopic = MixAll.getRetryTopic(group);
+        // A message stored on a retry topic without any properties (properties map is null,
+        // e.g. written by a non-Java client) must not throw, otherwise the reput thread
+        // stalls dispatch of every following message.
+        popLongPollingService.notifyMessageArrivingWithRetryTopic(pullRetryTopic, queueId, queueId, -1L, 0L, null, null);
+        verify(popLongPollingService, never()).notifyMessageArriving(anyString(), anyInt(), anyString(), anyBoolean(),
+            any(), anyLong(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

- Fixes #10990

### Brief Description

`PopLongPollingService#notifyMessageArrivingFromRetry` dereferences the dispatch request's properties map without a null check:

```java
String originGroup = properties.get(MessageConst.PROPERTY_ORIGIN_GROUP);   // NPE when properties == null
```

A `DispatchRequest` legitimately carries a null properties map (`MessageDecoder.string2messageProperties` returns null for a message stored without properties — e.g. written by a non-Java client on a `%RETRY%`-prefixed topic). The store's own code acknowledges nullability: `DefaultMessageStore#notifyMessageArrive4MultiQueue` guards `prop == null` and `PullRequestHoldService#notifyMessageArriving` guards `properties != null` — only the pop retry branch misses it.

The blast radius is broker-wide: the listener is invoked from `DefaultMessageStore.ReputMessageService#doReput` **before** `reputFromOffset` is advanced, and `doReput` only catches `RocksDBException`. The NPE propagates to `ServiceThread.run`, which logs and loops — then re-reads the same commitlog record and throws again forever, so all dispatch stops (consume queues stop advancing, consumers see a full outage) until manual intervention, and the poison message survives restarts.

This PR returns early when `properties == null`: a retry-topic message without properties cannot be mapped back to an origin group, so there is no long-polling request to wake up. This matches the guards used by the sibling listeners.

### Priority

PRIORITY = 88: impact 38 (the NPE is thrown on the single reput/dispatch thread before `reputFromOffset` advances; the thread logs, loops, and re-reads the same commitlog record forever — consume queues stop advancing for the whole broker, an outage that survives restarts until manual intervention) + scope 16 (one retry-topic record without properties is enough to poison every subsequent dispatch) + reproducibility 18 (deterministic unit test) + maintenance 16 (guard identical to the sibling listeners `DefaultMessageStore#notifyMessageArrive4MultiQueue` and `PullRequestHoldService#notifyMessageArriving`). FIX_CONFIDENCE = 95.

### How Did You Test This Change?

Added `PopLongPollingServiceTest#testNotifyMessageArrivingFromRetryWithoutProperties`, which invokes `notifyMessageArrivingWithRetryTopic` on a `%RETRY%` topic with a null properties map.

Verified results (re-run 2026-09-05; after = branch tip 1db39b7b7, before = base commit e348efa66 with the same test file):

- After fix: `mvn -pl broker test -Dtest=PopLongPollingServiceTest` → **12/12 pass**.
- Before fix: `testNotifyMessageArrivingFromRetryWithoutProperties` → ERROR: `java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because "properties" is null`.

### Risk

Low: when `properties == null` the method returns early — a retry-topic message without properties cannot be mapped back to its origin group, so no wakable long-polling request can exist; all paths with a properties map are unchanged. No public API or data format change.
