### PR TITLE
[ISSUE #10995] Stabilize client offline receipt handle test

### DIFF
--- a/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/service/receipt/DefaultReceiptHandleManagerTest.java
@@ -460,7 +460,16 @@ public class DefaultReceiptHandleManagerTest extends BaseServiceTest {
         Mockito.verify(consumerManager, Mockito.times(1)).appendConsumerIdsChangeListener(listenerArgumentCaptor.capture());
         Channel channel = PROXY_CONTEXT.getVal(ContextVariable.CHANNEL);
         receiptHandleManager.addReceiptHandle(PROXY_CONTEXT, channel, GROUP, MSG_ID, messageReceiptHandle);
+        Mockito.when(messagingProcessor.changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class),
+                Mockito.eq(MESSAGE_ID), Mockito.eq(GROUP), Mockito.eq(TOPIC),
+                Mockito.eq(ConfigurationManager.getProxyConfig().getInvisibleTimeMillisWhenClear())))
+            .thenReturn(CompletableFuture.completedFuture(new AckResult()));
         listenerArgumentCaptor.getValue().handle(ConsumerGroupEvent.CLIENT_UNREGISTER, GROUP, new ClientChannelInfo(channel, "", LanguageCode.JAVA, 0));
-        assertTrue(receiptHandleManager.receiptHandleGroupMap.isEmpty());
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
+            Mockito.verify(messagingProcessor, Mockito.times(1))
+                .changeInvisibleTime(Mockito.any(ProxyContext.class), Mockito.any(ReceiptHandle.class), Mockito.eq(MESSAGE_ID),
+                    Mockito.eq(GROUP), Mockito.eq(TOPIC), Mockito.eq(ConfigurationManager.getProxyConfig().getInvisibleTimeMillisWhenClear()));
+            assertTrue(receiptHandleManager.receiptHandleGroupMap.isEmpty());
+        });
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10995

### Brief Description

`DefaultReceiptHandleManagerTest#testClientOffline` triggers asynchronous receipt-handle cleanup after `CLIENT_UNREGISTER`.

The test previously did not stub `messagingProcessor.changeInvisibleTime()` for the cleanup path. The unstubbed Mockito invocation returns `null`, and the asynchronous `ReturnHandleGroupWorkerThread` can then throw a `NullPointerException` when the test listener calls `whenComplete()`.

When this happens, the receipt handle is not removed and `returnHandleGroup()` may insert the non-empty group back into `receiptHandleGroupMap`. Because the test immediately asserted that the map was empty after triggering `CLIENT_UNREGISTER`, the assertion was timing-sensitive and could fail in Coverage CI.

This change is test-only:

- stub `changeInvisibleTime()` with a completed `CompletableFuture` for the cleanup path;
- use Awaitility to wait for the asynchronous cleanup and verify the expected invocation;
- keep the final map-empty assertion inside the asynchronous wait;
- do not change production behavior.

### How Did You Test This Change?

Tested with JDK 8:

- `DefaultReceiptHandleManagerTest#testClientOffline`: 50/50 repeated runs passed
- `DefaultReceiptHandleManagerTest`: 12/12 tests passed
- proxy module: 308 tests run, 0 failures, 0 errors, 3 skipped
- Maven result: `BUILD SUCCESS`
- `git diff --check`: passed
