### PR TITLE
[ISSUE #10998] Fix Tiered storage cannot dispatch messages larger than the group commit size

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
@@ -261,10 +261,10 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
             List<DispatchRequest> dispatchRequestList = new ArrayList<>();
             for (; offset < targetOffset; offset++) {
                 cqUnit = consumeQueue.get(offset);
-                bufferSize += cqUnit.getSize();
-                if (bufferSize >= groupCommitSize) {
+                if (bufferSize > 0 && bufferSize + cqUnit.getSize() >= groupCommitSize) {
                     break;
                 }
+                bufferSize += cqUnit.getSize();
                 message = defaultStore.selectOneMessageByOffset(cqUnit.getPos(), cqUnit.getSize());
                 appendingBufferList.add(message);
 

--- a/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
+++ b/tieredstore/src/test/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImplTest.java
@@ -165,6 +165,51 @@ public class MessageStoreDispatcherImplTest {
     }
 
     @Test
+    public void dispatchMessageAtGroupCommitSizeTest() throws Exception {
+        MessageStore defaultStore = Mockito.mock(MessageStore.class);
+        Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(100L);
+        Mockito.when(defaultStore.getMaxOffsetInQueue(anyString(), anyInt())).thenReturn(101L);
+
+        messageStore = Mockito.mock(TieredMessageStore.class);
+        IndexService indexService =
+            new IndexStoreService(new FlatFileFactory(metadataStore, storeConfig, executor), storePath);
+        indexService.start();
+        Mockito.when(messageStore.getDefaultStore()).thenReturn(defaultStore);
+        Mockito.when(messageStore.getStoreConfig()).thenReturn(storeConfig);
+        Mockito.when(messageStore.getStoreExecutor()).thenReturn(executor);
+        Mockito.when(messageStore.getFlatFileStore()).thenReturn(fileStore);
+        Mockito.when(messageStore.getIndexService()).thenReturn(indexService);
+
+        ByteBuffer buffer = MessageFormatUtilTest.buildMockedMessageBuffer();
+        storeConfig.setTieredStoreGroupCommitSize(buffer.remaining());
+        DispatchRequest request = new DispatchRequest(mq.getTopic(), mq.getQueueId(),
+            MessageFormatUtil.getCommitLogOffset(buffer), buffer.remaining(), 0L,
+            MessageFormatUtil.getStoreTimeStamp(buffer), 0L,
+            "", "", 0, 0L, new HashMap<>());
+
+        MessageStoreDispatcher dispatcher = new MessageStoreDispatcherImpl(messageStore);
+        dispatcher.dispatch(request);
+        FlatMessageFile flatFile = fileStore.getFlatFile(mq);
+        Assert.assertNotNull(flatFile);
+
+        dispatcher.doScheduleDispatch(flatFile, true).join();
+        Assert.assertEquals(100L, flatFile.getConsumeQueueCommitOffset());
+
+        ConsumeQueueInterface cq = Mockito.mock(ConsumeQueueInterface.class);
+        Mockito.when(defaultStore.getConsumeQueue(anyString(), anyInt())).thenReturn(cq);
+        Mockito.when(cq.get(100L)).thenReturn(new CqUnit(100, 1000, buffer.remaining(), 0L));
+        Mockito.when(defaultStore.selectOneMessageByOffset(anyLong(), anyInt())).thenReturn(
+            new SelectMappedBufferResult(0L, buffer.asReadOnlyBuffer(), buffer.remaining(), null));
+
+        dispatcher.doScheduleDispatch(flatFile, true).join();
+
+        Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+            Assert.assertEquals(101L, flatFile.getConsumeQueueMaxOffset());
+            Assert.assertEquals(101L, flatFile.getConsumeQueueCommitOffset());
+        });
+    }
+
+    @Test
     public void dispatchCommitFailedTest() throws Exception {
         MessageStore defaultStore = Mockito.mock(MessageStore.class);
         Mockito.when(defaultStore.getMinOffsetInQueue(anyString(), anyInt())).thenReturn(100L);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #<10998>

### Brief Description

The tiered storage dispatcher checks the accumulated batch size before
appending the current message. When the first message size is equal to or
larger than `tieredStoreGroupCommitSize`, the dispatch loop exits with an
empty dispatch request list.

As a result, no commit is triggered and the tiered consume queue offset
does not advance. The dispatcher repeatedly retries the same message,
preventing it and subsequent messages from being archived.

This change ensures that at least one message is included in each dispatch
batch. A message that reaches or exceeds the group commit size is dispatched
as a single-message batch.

A regression test has also been added to verify that the tiered consume
queue offset advances when a message size equals the configured group
commit size.

### How Did You Test This Change?

1. Added `dispatchMessageAtGroupCommitSizeTest` to reproduce the issue.
   Before the fix, the test timed out because the consume queue offset
   remained at 100 instead of advancing to 101.

2. Verified the regression test after the fix:

   `mvn -pl tieredstore -Dtest=MessageStoreDispatcherImplTest#dispatchMessageAtGroupCommitSizeTest test`

3. Ran the complete tiered storage module test suite:

   `mvn -pl tieredstore test`

   Result: 128 tests run, 0 failures, 0 errors, 0 skipped.

4. Checkstyle and SpotBugs validation also completed successfully.