### PR TITLE
[ISSUE #11000] Extract user-property validation in SendMessageActivity#buildMessageProperty into an overridable checkUserProperties method

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -195,12 +195,8 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         }
     }
 
-    protected Map<String, String> buildMessageProperty(ProxyContext context, apache.rocketmq.v2.Message message, String producerGroup) {
-        long userPropertySize = 0;
+    protected void checkUserProperties(Map<String, String> userProperties) {
         ProxyConfig config = ConfigurationManager.getProxyConfig();
-        org.apache.rocketmq.common.message.Message messageWithHeader = new org.apache.rocketmq.common.message.Message();
-        // set user properties
-        Map<String, String> userProperties = message.getUserPropertiesMap();
         if (userProperties.size() > config.getUserPropertyMaxNum()) {
             throw new GrpcProxyException(Code.MESSAGE_PROPERTIES_TOO_LARGE, "too many user properties, max is " + config.getUserPropertyMaxNum());
         }
@@ -214,6 +210,17 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             if (GrpcValidator.getInstance().containControlCharacter(userPropertiesEntry.getValue())) {
                 throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_PROPERTY_KEY, "the value of property cannot contain control character");
             }
+        }
+    }
+
+    protected Map<String, String> buildMessageProperty(ProxyContext context, apache.rocketmq.v2.Message message, String producerGroup) {
+        long userPropertySize = 0;
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+        org.apache.rocketmq.common.message.Message messageWithHeader = new org.apache.rocketmq.common.message.Message();
+        // set user properties
+        Map<String, String> userProperties = message.getUserPropertiesMap();
+        checkUserProperties(userProperties);
+        for (Map.Entry<String, String> userPropertiesEntry : userProperties.entrySet()) {
             userPropertySize += userPropertiesEntry.getKey().getBytes(StandardCharsets.UTF_8).length;
             userPropertySize += userPropertiesEntry.getValue().getBytes(StandardCharsets.UTF_8).length;
         }


### PR DESCRIPTION
…ctivity

Extract the user property validation logic (property count limit, reserved-key check, control character check) from buildMessageProperty() into a standalone protected checkUserProperties() method. The property size accumulation stays in buildMessageProperty().

This allows subclasses to customize validation (e.g. allow control characters in properties for specific scenarios) by overriding checkUserProperties() alone, instead of having to override the much larger buildMessageProperty() method.

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #11000 

### Brief Description

SendMessageActivity#buildMessageProperty() (grpc v2 producer) inlines the validation of user properties — max property count, reserved system-property keys, and control-character checks — directly inside a large method. This proposal extracts that validation block into a small, standalone protected void checkUserProperties(Map<String, String> userProperties) method that buildMessageProperty() calls, so it can be overridden independently.


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
