### PR TITLE
[ISSUE #10898] Unblock the NettyEventExecutor event queue on shutdown

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -765,6 +765,12 @@ public abstract class NettyRemotingAbstract {
     class NettyEventExecutor extends ServiceThread {
         private final LinkedBlockingQueue<NettyEvent> eventQueue = new LinkedBlockingQueue<>();
 
+        /**
+         * Sentinel used to unblock {@link #eventQueue} on shutdown. It carries no channel event and
+         * is skipped by the dispatch loop.
+         */
+        private final NettyEvent wakeupEvent = new NettyEvent(null, null, null);
+
         public void putNettyEvent(final NettyEvent event) {
             int currentSize = this.eventQueue.size();
             int maxSize = 10000;
@@ -776,6 +782,16 @@ public abstract class NettyRemotingAbstract {
         }
 
         @Override
+        public void wakeup() {
+            super.wakeup();
+            // This service blocks in eventQueue.poll(...) instead of waitForRunning, so the unpark
+            // done by super.wakeup() cannot release it and shutdown would wait for the poll timeout
+            // to expire. Offer a sentinel to make the poll return at once, letting the loop observe
+            // the stopped flag immediately.
+            this.eventQueue.offer(this.wakeupEvent);
+        }
+
+        @Override
         public void run() {
             log.info(this.getServiceName() + " service started");
 
@@ -784,7 +800,7 @@ public abstract class NettyRemotingAbstract {
             while (!this.isStopped()) {
                 try {
                     NettyEvent event = this.eventQueue.poll(3000, TimeUnit.MILLISECONDS);
-                    if (event != null && listener != null) {
+                    if (event != null && event != this.wakeupEvent && listener != null) {
                         switch (event.getType()) {
                             case IDLE:
                                 listener.onChannelIdle(event.getRemoteAddr(), event.getChannel());

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstractTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstractTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.remoting.netty;
 
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.common.SemaphoreReleaseOnlyOnce;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
@@ -167,5 +168,25 @@ public class NettyRemotingAbstractTest {
         // Acquire the release permit after call back
         semaphore.acquire(1);
         assertThat(semaphore.availablePermits()).isEqualTo(0);
+    }
+
+    @Test
+    public void testNettyEventExecutorShutdownDoesNotWaitForPollTimeout() throws InterruptedException {
+        // NettyEventExecutor blocks in eventQueue.poll(3000ms) rather than waitForRunning, so the
+        // wakeup() performed by ServiceThread.shutdown() cannot interrupt it: the thread only
+        // notices the stopped flag once the poll expires, making every shutdown wait up to 3s.
+        // A broker or client shutdown pays this for each remoting instance it owns.
+        NettyRemotingAbstract remoting = new NettyRemotingClient(new NettyClientConfig());
+        remoting.nettyEventExecutor.start();
+
+        // let the thread reach the blocking poll
+        TimeUnit.MILLISECONDS.sleep(300);
+
+        long begin = System.currentTimeMillis();
+        remoting.nettyEventExecutor.shutdown();
+        long elapsed = System.currentTimeMillis() - begin;
+
+        assertThat(remoting.nettyEventExecutor.isStopped()).isTrue();
+        assertThat(elapsed).isLessThan(1000);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #10898

### Brief Description

`NettyEventExecutor` blocks in `eventQueue.poll(3000ms)` instead of `waitForRunning`, so the `LockSupport.unpark` performed by `ServiceThread.shutdown()` cannot release it: the thread only notices the stopped flag once the poll expires, and every shutdown of a remoting instance pays up to 3 seconds for nothing.

This PR overrides `wakeup()` to offer a sentinel `NettyEvent` into the queue after `super.wakeup()`, making the blocking poll return immediately; the dispatch loop skips the sentinel. No behavior change apart from the faster exit.

### How Did You Test This Change?

- New deterministic test `testNettyEventExecutorShutdownDoesNotWaitForPollTimeout`: on current develop it fails after 3.66s (the thread waits out the full poll timeout); with this patch it passes in under 1s. `NettyRemotingAbstractTest` 6/6, checkstyle clean.
- Server-side isolated A/B on an 8C32G ECS (Dragonwell 21), driving `NettyEventExecutor` start/shutdown directly, 5 runs per arm:
  - base (current jar): 2700.3 / 2700.4 / 2700.3 / 2700.3 / 2700.3 ms
  - patched: 0.4 / 0.3 / 0.2 / 0.2 / 0.2 ms
- `NettyEventExecutor` is a package-private inner class, so there is no external subclassing surface affected by the new `wakeup()` override.

