### PR TITLE
[ISSUE #11002] Cache topic bytes in MessageExtEncoder and CRC32 property key bytes in MessageDecoder

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -44,6 +44,9 @@ public class MessageDecoder {
     public final static int MESSAGE_PHYSIC_OFFSET_POSITION = 28;
     public final static int MESSAGE_STORE_TIMESTAMP_POSITION = 56;
 
+    // Pre-encoded constant to avoid per-message getBytes() allocation in createCrc32()
+    private static final byte[] PROPERTY_CRC32_BYTES = MessageConst.PROPERTY_CRC32.getBytes(StandardCharsets.UTF_8);
+
     // Set message magic code v2 if topic length > 127
     public final static int MESSAGE_MAGIC_CODE = -626843481;
     public final static int MESSAGE_MAGIC_CODE_V2 = -626843477;
@@ -154,7 +157,7 @@ public class MessageDecoder {
     }
 
     public static void createCrc32(final ByteBuffer input, int crc32) {
-        input.put(MessageConst.PROPERTY_CRC32.getBytes(StandardCharsets.UTF_8));
+        input.put(PROPERTY_CRC32_BYTES);
         input.put((byte) NAME_VALUE_SEPARATOR);
         for (int i = 0; i < 10; i++) {
             byte b = '0';
@@ -168,7 +171,7 @@ public class MessageDecoder {
     }
 
     public static void createCrc32(final ByteBuf input, int crc32) {
-        input.writeBytes(MessageConst.PROPERTY_CRC32.getBytes(StandardCharsets.UTF_8));
+        input.writeBytes(PROPERTY_CRC32_BYTES);
         input.writeByte((byte) NAME_VALUE_SEPARATOR);
         for (int i = 0; i < 10; i++) {
             byte b = '0';

--- a/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
@@ -41,6 +41,11 @@ public class MessageExtEncoder {
     private final int crc32ReservedLength;
     private MessageStoreConfig messageStoreConfig;
 
+    // Cache topic bytes to avoid per-message getBytes() allocation.
+    // Safe without synchronization because MessageExtEncoder is ThreadLocal.
+    private String cachedTopic;
+    private byte[] cachedTopicData;
+
     public MessageExtEncoder(final int maxMessageBodySize, final MessageStoreConfig messageStoreConfig) {
         this(messageStoreConfig);
     }
@@ -82,6 +87,16 @@ public class MessageExtEncoder {
             + 2 + (Math.max(propertiesLength, 0)); //propertiesLength
     }
 
+    private byte[] getTopicBytes(String topic) {
+        if (topic == cachedTopic || topic.equals(cachedTopic)) {
+            return cachedTopicData;
+        }
+        byte[] data = topic.getBytes(MessageDecoder.CHARSET_UTF8);
+        cachedTopic = topic;
+        cachedTopicData = data;
+        return data;
+    }
+
     public static int calMsgLengthNoProperties(MessageVersion messageVersion,
                                                int sysFlag, int bodyLength, int topicLength) {
 
@@ -108,7 +123,7 @@ public class MessageExtEncoder {
 
     public PutMessageResult encodeWithoutProperties(MessageExtBrokerInner msgInner) {
 
-        final byte[] topicData = msgInner.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
+        final byte[] topicData = getTopicBytes(msgInner.getTopic());
         final int topicLength = topicData.length;
 
         final int bodyLength = msgInner.getBody() == null ? 0 : msgInner.getBody().length;
@@ -195,7 +210,7 @@ public class MessageExtEncoder {
             return new PutMessageResult(PutMessageStatus.PROPERTIES_SIZE_EXCEEDED, null);
         }
 
-        final byte[] topicData = msgInner.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
+        final byte[] topicData = getTopicBytes(msgInner.getTopic());
         final int topicLength = topicData.length;
 
         final int bodyLength = msgInner.getBody() == null ? 0 : msgInner.getBody().length;
@@ -312,7 +327,7 @@ public class MessageExtEncoder {
             int propertiesPos = messagesByteBuff.position();
             messagesByteBuff.position(propertiesPos + propertiesLen);
 
-            final byte[] topicData = messageExtBatch.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
+            final byte[] topicData = getTopicBytes(messageExtBatch.getTopic());
 
             final int topicLength = topicData.length;
             int totalPropLen = propertiesLen;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #11002

### Brief Description

Two per-message `String.getBytes()` allocations on the broker write path are avoided:

- `MessageExtEncoder`: the topic is re-encoded to UTF-8 bytes for every message. The encoder instance is already `ThreadLocal`, so a single-slot `cachedTopic`/`cachedTopicData` pair is safe without synchronization: a hit returns the cached bytes; a miss falls back to `getBytes` and refreshes the slot.
- `MessageDecoder.createCrc32()`: the constant property key `PROPERTY_CRC32` is now pre-encoded into a `private static final byte[]`.

### How Did You Test This Change?

- Functional: `AppendCallbackTest` 4/4, `AppendPropCRCTest` 2/2 (covers the CRC32 constant path), `LmqDispatchTest` 5/5, `CompactionLogTest` 4/4, `MessageDecoderTest` 7/7; checkstyle clean.
- Microbenchmark on an 8C32G ECS (Dragonwell 21), 20M ops, thread-allocated-bytes measured:
  - baseline `getBytes`: 8.14 ns/op, 56 B/op
  - cache hit (same topic, different String instance, `equals` path): 2.63 ns/op, 0 B/op
  - worst case (two topics strictly alternating, equal length differing only in the last char): 13.84 ns/op, 56 B/op — i.e. a miss costs one extra `String.equals` (~5.7ns) on top of the original `getBytes`; the break-even hit rate is ~51%, and per-thread broker traffic is typically far more repetitive than that.
- End-to-end 4-node cluster A/B (256-thread sync producer, 1KB, per-arm clean store + restart): broker TPS and young GC per million messages flat versus baseline — the saving is below GC-count resolution at this load, so this is a cleanup-level allocation reduction and is labeled as such.
