### PR TITLE
[ISSUE #11007] Fix flaky CreateAndUpdateTopicIT by awaiting route propagation

### DIFF
--- a/test/src/test/java/org/apache/rocketmq/test/route/CreateAndUpdateTopicIT.java
+++ b/test/src/test/java/org/apache/rocketmq/test/route/CreateAndUpdateTopicIT.java
@@ -40,9 +40,11 @@ public class CreateAndUpdateTopicIT extends BaseConf {
         final boolean createResult = MQAdminTestUtils.createTopic(NAMESRV_ADDR, CLUSTER_NAME, topic, 8, null);
         assertThat(createResult).isTrue();
 
-        TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, topic);
-        assertThat(route.getBrokerDatas()).hasSize(3);
-        assertThat(route.getQueueDatas()).hasSize(3);
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, topic);
+            assertThat(route.getBrokerDatas()).hasSize(3);
+            assertThat(route.getQueueDatas()).hasSize(3);
+        });
 
         brokerController1.getBrokerConfig().setEnableSingleTopicRegister(false);
         brokerController2.getBrokerConfig().setEnableSingleTopicRegister(false);
@@ -103,14 +105,19 @@ public class CreateAndUpdateTopicIT extends BaseConf {
         boolean createResult = MQAdminTestUtils.createTopic(NAMESRV_ADDR, CLUSTER_NAME, testTopic, 8, null);
         assertThat(createResult).isTrue();
 
-        TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, testTopic);
-        assertThat(route.getBrokerDatas()).hasSize(3);
-        assertThat(route.getQueueDatas()).hasSize(3);
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, testTopic);
+            assertThat(route.getBrokerDatas()).hasSize(3);
+            assertThat(route.getQueueDatas()).hasSize(3);
+        });
 
         MQAdminTestUtils.createStaticTopicWithCommand(testStaticTopic, 10, null, CLUSTER_NAME, NAMESRV_ADDR);
 
-        assertThat(route.getBrokerDatas()).hasSize(3);
-        assertThat(route.getQueueDatas()).hasSize(3);
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, testTopic);
+            assertThat(route.getBrokerDatas()).hasSize(3);
+            assertThat(route.getQueueDatas()).hasSize(3);
+        });
 
         brokerController1.getBrokerConfig().setEnableSingleTopicRegister(false);
         brokerController2.getBrokerConfig().setEnableSingleTopicRegister(false);
@@ -138,9 +145,12 @@ public class CreateAndUpdateTopicIT extends BaseConf {
         brokerController3.registerBrokerAll(false, true, true);
 
         for (int i = 0; i < 10; i++) {
-            TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, testTopic + i);
-            assertThat(route.getBrokerDatas()).hasSize(3);
-            assertThat(route.getQueueDatas()).hasSize(3);
+            final String topicName = testTopic + i;
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                TopicRouteData route = MQAdminTestUtils.examineTopicRouteInfo(NAMESRV_ADDR, topicName);
+                assertThat(route.getBrokerDatas()).hasSize(3);
+                assertThat(route.getQueueDatas()).hasSize(3);
+            });
         }
 
         brokerController1.getBrokerConfig().setEnableSplitRegistration(false);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #11007

### Brief Description

`CreateAndUpdateTopicIT` is flaky in the CI integration pipeline. The topic route-size assertions (`hasSize(3)`) run immediately after topic creation / broker registration, but broker -> NameServer route propagation is asynchronous. Under CI load the NameServer route table may not be fully updated when the assertion executes, intermittently producing `Expected size: 3 but was: 2`.

This PR wraps those route-size assertions in `awaitility` polling (`await().atMost(30, TimeUnit.SECONDS).untilAsserted(...)`), so each assertion waits for the route to propagate before checking. This is consistent with the awaitility pattern already used in `testDeleteTopicFromNameSrvWithBrokerRegistration` in the same class.

Tests updated:
- `testCreateOrUpdateTopic_EnableSingleTopicRegistration`
- `testStaticTopicNotAffected`
- `testCreateOrUpdateTopic_EnableSplitRegistration`

No production code is changed; this is a test-stability fix only.

### How Did You Test This Change?

The failing assertion was observed on CI run [33726673235](https://github.com/apache/rocketmq/actions/runs/33726673235/job/100557097336) of an unrelated PR (#11001). The change converts the immediate assertions into bounded awaitility polling, removing the race. The integration test relies on the existing awaitility dependency already used in this class, and the module compiles cleanly.
