### PR TITLE
[ISSUE #11011] Fix misplaced license header in ConfigManagerTest

### DIFF
--- a/common/src/test/java/org/apache/rocketmq/common/ConfigManagerTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/ConfigManagerTest.java
@@ -1,4 +1,4 @@
-package org.apache.rocketmq.common;/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,6 +14,7 @@ package org.apache.rocketmq.common;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.rocketmq.common;
 
 import java.io.File;
 import java.io.PrintWriter;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #11011

### Brief Description

In `common/src/test/java/org/apache/rocketmq/common/ConfigManagerTest.java`, the ASF license header was squeezed onto the same line right after the `package` statement, instead of sitting at the top of the file. This was introduced by b6ff649291 ("feat(all):new feature for static topic"), likely by an auto-formatter.

This PR moves the license comment back to the top of the file, before the `package` declaration, matching the canonical header placement used across the codebase. The resulting header is byte-identical to the standard ASF header already used by the other ~2000 files in the repository.

### How Did You Test This Change?

Formatting-only change with no behavioral impact. Verified the relocated header block is byte-identical to the canonical ASF header used by the rest of the codebase (the change only moves the comment above the `package` line and adds a newline), and that the file structure (package -> blank line -> imports) is preserved.