### PR TITLE
[ISSUE #11013] Stop MessageRocksDBStorage flush scheduler on shutdown

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -83,7 +84,8 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
     private volatile ColumnFamilyHandle timerCFHandle;
     private volatile ColumnFamilyHandle transCFHandle;
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> timerWalFlushTask;
     private static final Cache<String, byte[]> DELETE_KEY_CACHE_FOR_TIMER = CacheBuilder.newBuilder()
         .maximumSize(10000)
         .expireAfterWrite(60, TimeUnit.MINUTES)
@@ -114,14 +116,8 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
             this.defaultCFHandle = cfHandles.get(0);
             this.timerCFHandle = cfHandles.get(1);
             this.transCFHandle = cfHandles.get(2);
-            scheduler.scheduleAtFixedRate(() -> {
-                try {
-                    db.flush(flushOptions, timerCFHandle);
-                    log.info("MessageRocksDBStorage flush timer wal success");
-                } catch (Exception e) {
-                    logError.error("MessageRocksDBStorage flush timer wal failed, error: {}", e.getMessage());
-                }
-            }, 5, 5, TimeUnit.MINUTES);
+            scheduler = Executors.newScheduledThreadPool(1);
+            timerWalFlushTask = scheduler.scheduleAtFixedRate(this::flushTimerWal, 5, 5, TimeUnit.MINUTES);
 
             log.info("MessageRocksDBStorage init success, dbPath: {}", this.dbPath);
         } catch (final Exception e) {
@@ -141,8 +137,28 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
     }
 
     @Override
-    protected void preShutdown() {
+    protected synchronized void preShutdown() {
+        if (timerWalFlushTask != null) {
+            timerWalFlushTask.cancel(false);
+            timerWalFlushTask = null;
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
+        }
         log.info("MessageRocksDBStorage pre shutdown success, dbPath: {}", this.dbPath);
+    }
+
+    private synchronized void flushTimerWal() {
+        try {
+            if (!hold()) {
+                return;
+            }
+            db.flush(flushOptions, timerCFHandle);
+            log.info("MessageRocksDBStorage flush timer wal success");
+        } catch (Exception e) {
+            logError.error("MessageRocksDBStorage flush timer wal failed, error: {}", e.getMessage());
+        }
     }
 
     public List<Long> queryOffsetForIndex(byte[] columnFamily, String topic, String indexType, String key, long beginTime, long endTime, int maxNum, String lastKey) {

--- a/store/src/test/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorageLifecycleTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorageLifecycleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.store.rocksdb;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.stream.Stream;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MessageRocksDBStorageLifecycleTest {
+    private MessageRocksDBStorage storage;
+    private Path storePath;
+
+    @Before
+    public void setUp() throws Exception {
+        Path testRoot = Paths.get("target", "rocketmq-lifecycle-test");
+        Files.createDirectories(testRoot);
+        storePath = Files.createTempDirectory(testRoot, "message-rocksdb-");
+        MessageStoreConfig config = new MessageStoreConfig();
+        config.setStorePathRootDir(storePath.toString());
+        storage = new MessageRocksDBStorage(config);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (storage != null) {
+            storage.shutdown();
+        }
+        if (storePath != null) {
+            try (Stream<Path> paths = Files.walk(storePath)) {
+                paths.sorted((first, second) -> second.compareTo(first))
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+            }
+        }
+    }
+
+    @Test
+    public void shouldStopSchedulerOnRepeatedShutdownAndCreateSingleTaskOnRestart() throws Exception {
+        ScheduledThreadPoolExecutor previousScheduler = getScheduler();
+        Assert.assertEquals(1, previousScheduler.getQueue().size());
+
+        for (int i = 0; i < 2; i++) {
+            Assert.assertTrue(storage.shutdown());
+            Assert.assertTrue(previousScheduler.isShutdown());
+            Assert.assertEquals(0, previousScheduler.getQueue().size());
+
+            Assert.assertTrue(storage.start());
+            ScheduledThreadPoolExecutor currentScheduler = getScheduler();
+            Assert.assertNotSame(previousScheduler, currentScheduler);
+            Assert.assertFalse(currentScheduler.isShutdown());
+            Assert.assertEquals(1, currentScheduler.getQueue().size());
+            previousScheduler = currentScheduler;
+        }
+    }
+
+    private ScheduledThreadPoolExecutor getScheduler() throws Exception {
+        Field schedulerField = MessageRocksDBStorage.class.getDeclaredField("scheduler");
+        schedulerField.setAccessible(true);
+        return (ScheduledThreadPoolExecutor) schedulerField.get(storage);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

- Fixes #11013 

### Brief Description

`MessageRocksDBStorage` registered a periodic timer-WAL flush task but did not cancel it or shut down its scheduler during storage shutdown. Because the RocksDB reload path calls `shutdown()` followed by `start()`, each reload added another periodic flush task to the same executor.

This PR:

- tracks the scheduled task as part of the storage load lifecycle;
- cancels the task and shuts down the scheduler before RocksDB resources are
  closed;
- creates a fresh scheduler on each successful start, preventing task
  accumulation after reload;
- serializes the timer-WAL flush and checks the storage lifecycle before
  accessing RocksDB.

### How Did You Test This Change?

`MessageRocksDBStorageLifecycleTest` verifies after each shutdown that the previous scheduler is shut down and its queue is empty, then verifies after each start that the scheduler is a new instance with exactly one periodic task.