### PR TITLE
fix: record send-failure cause in requestFail and log write failures

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -646,8 +646,9 @@ public abstract class NettyRemotingAbstract {
                         responseFuture.setSendRequestOK(true);
                         return;
                     }
-                    requestFail(opaque);
-                    log.warn("send a request command to channel <{}>, channelId={}, failed.", RemotingHelper.parseChannelRemoteAddr(channel), channel.id());
+                    requestFail(opaque, f.cause());
+                    log.warn("send a request command to channel <{}>, channelId={}, failed.",
+                        RemotingHelper.parseChannelRemoteAddr(channel), channel.id(), f.cause());
                 });
                 return future;
             } catch (Exception e) {
@@ -694,9 +695,14 @@ public abstract class NettyRemotingAbstract {
     }
 
     private void requestFail(final int opaque) {
+        requestFail(opaque, null);
+    }
+
+    private void requestFail(final int opaque, final Throwable cause) {
         ResponseFuture responseFuture = responseTable.remove(opaque);
         if (responseFuture != null) {
             responseFuture.setSendRequestOK(false);
+            responseFuture.setCause(cause);
             responseFuture.putResponse(null);
             try {
                 executeInvokeCallback(responseFuture);
@@ -734,12 +740,12 @@ public abstract class NettyRemotingAbstract {
                 channel.writeAndFlush(request).addListener((ChannelFutureListener) f -> {
                     once.release();
                     if (!f.isSuccess()) {
-                        log.warn("send a request command to channel <" + channel.remoteAddress() + "> failed.");
+                        log.warn("send a request command to channel <" + channel.remoteAddress() + "> failed.", f.cause());
                     }
                 });
             } catch (Exception e) {
                 once.release();
-                log.warn("write send a request command to channel <" + channel.remoteAddress() + "> failed.");
+                log.warn("write send a request command to channel <" + channel.remoteAddress() + "> failed.", e);
                 throw new RemotingSendRequestException(RemotingHelper.parseChannelRemoteAddr(channel), e);
             }
         } else {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstractTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstractTest.java
@@ -16,16 +16,28 @@
  */
 package org.apache.rocketmq.remoting.netty;
 
+import io.netty.channel.Channel;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import java.net.InetSocketAddress;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.remoting.InvokeCallback;
 import org.apache.rocketmq.remoting.common.SemaphoreReleaseOnlyOnce;
+import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
@@ -167,5 +179,61 @@ public class NettyRemotingAbstractTest {
         // Acquire the release permit after call back
         semaphore.acquire(1);
         assertThat(semaphore.availablePermits()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvokeAsyncSendFailureCarriesCause() throws InterruptedException {
+        ClosedChannelException sendCause = new ClosedChannelException();
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 8888));
+        Mockito.when(channel.writeAndFlush(ArgumentMatchers.any()))
+            .thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE).setFailure(sendCause));
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        RemotingCommand request = RemotingCommand.createRequestCommand(1, null);
+
+        remotingAbstract.invokeAsyncImpl(channel, request, 3000, new InvokeCallback() {
+            @Override
+            public void operationComplete(ResponseFuture responseFuture) {
+
+            }
+
+            @Override
+            public void operationSucceed(RemotingCommand response) {
+
+            }
+
+            @Override
+            public void operationFail(Throwable throwable) {
+                failure.set(throwable);
+                latch.countDown();
+            }
+        });
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(failure.get()).isInstanceOf(RemotingSendRequestException.class);
+        assertThat(failure.get().getCause()).isSameAs(sendCause);
+    }
+
+    @Test
+    public void testInvokeSyncSendFailureCarriesCause() throws Exception {
+        ClosedChannelException sendCause = new ClosedChannelException();
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 8888));
+        Mockito.when(channel.writeAndFlush(ArgumentMatchers.any()))
+            .thenReturn(new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE).setFailure(sendCause));
+
+        RemotingCommand request = RemotingCommand.createRequestCommand(1, null);
+
+        Throwable thrown = catchThrowable(
+            () -> remotingAbstract.invokeSyncImpl(channel, request, 3000));
+
+        assertThat(thrown).isInstanceOf(RemotingSendRequestException.class);
+        Throwable cause = thrown;
+        while (cause != null && cause != sendCause) {
+            cause = cause.getCause();
+        }
+        assertThat(cause).isSameAs(sendCause);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #11010

### Problem / Evidence

When `writeAndFlush` fails, `NettyRemotingAbstract` drops the netty-side `f.cause()` in four places:

1. `invoke0`'s `writeAndFlush` listener calls `requestFail(opaque)` and logs without the throwable.
2. `requestFail(int opaque)` never calls `responseFuture.setCause(...)`, so `ResponseFuture#executeInvokeCallback` builds `new RemotingSendRequestException(channel.remoteAddress().toString(), getCause())` with a **null** cause — the plumbing for the cause exists on the consumer side, only the assignment is missing.
3. `invokeOnewayImpl`'s listener logs the oneway send failure without `f.cause()`.
4. `invokeOnewayImpl`'s catch block wraps `e` into the thrown exception but never logs it.

Consequently every send failure (sync, async and oneway; also the `failFast` channel-close path shares `requestFail`) surfaces without the underlying network error, so the reason a send failed is unrecoverable both programmatically and from the logs.

### Root cause / Fix

- Pass `f.cause()` from the `invoke0` listener into a new `requestFail(int opaque, Throwable cause)` overload which calls `responseFuture.setCause(cause)` before executing the callback; the no-cause variant used by `failFast` now delegates to it with `null`.
- Include `f.cause()` / the caught exception in the two `invokeOnewayImpl` warn logs.

`failFast` behavior is unchanged (it has no cause to record); no public API changes.

### Priority

PRIORITY = 70: impact 24 (diagnosability of every remoting send failure, no data loss) + scope 14 (all sync/async/oneway send paths of every client built on the remoting layer) + reproducibility 18 (deterministic unit test) + maintenance 14 (small plumbing fix that completes the existing `ResponseFuture.cause` design). FIX_CONFIDENCE = 95: the consumer side already reads `getCause()`; only the assignment was missing.

### How Did You Test This Change?

Regression tests in `NettyRemotingAbstractTest`:

- `testInvokeAsyncSendFailureCarriesCause`: mocks a channel whose `writeAndFlush` fails with `ClosedChannelException` (immediate executor, so the listener fires deterministically) and asserts the async callback's `operationFail` receives a `RemotingSendRequestException` whose cause is that exact exception. Fails on unfixed develop (cause is null), passes with this change.
- `testInvokeSyncSendFailureCarriesCause`: same failure injection through `invokeSyncImpl`; asserts the thrown `RemotingSendRequestException` cause chain reaches the original `ClosedChannelException`.

Commands and results:
- `mvn -pl remoting test -Dtest=NettyRemotingAbstractTest` → 7/7 pass (fails at the cause assertion before the fix).
- `mvn -pl remoting test` → 173 tests, 0 failures, 1 pre-existing environment error in `TlsTest` (`OpenJdkSelfSignedCertGenerator not supported on the used JDK version`, reproduced on unmodified develop with JDK 21, unrelated to this change).

### Risk

Very low: the only behavior change is that recorded/logged exceptions now carry the real failure cause. `requestFail(int)` callers are unchanged in behavior (`failFast` passes `null`, as before).