### PR TITLE
fix: keep pop ack effective when cleanup has staged the checkpoint for its store write

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerCache.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerCache.java
@@ -116,6 +116,27 @@ public class PopConsumerCache extends ServiceThread {
         return remain;
     }
 
+    /**
+     * Ack-flavored deletion of records from the cache.
+     * <p>
+     * Behaves like {@link #deleteRecords(List)}, and additionally drops records that
+     * {@link #cleanupRecords(Consumer)} has already staged for its next store write. Such a
+     * record is no longer visible in {@link #deleteRecords(List)} (it left
+     * {@code recordTreeMap}), so the ack would otherwise return it as remaining and delete it
+     * from the durable store, only to see cleanup re-persist the stale staged copy afterwards.
+     * Removing it from the staged set lets cleanup detect the concurrent ack and re-delete the
+     * record it has just written, keeping the ack effective.
+     */
+    public List<PopConsumerRecord> ackRecords(List<PopConsumerRecord> consumerRecordList) {
+        consumerRecordList.forEach(consumerRecord -> {
+            ConsumerRecords consumerRecords = consumerRecordTable.get(this.getKey(consumerRecord));
+            if (consumerRecords != null) {
+                consumerRecords.removeStaged(consumerRecord);
+            }
+        });
+        return deleteRecords(consumerRecordList);
+    }
+
     public int cleanupRecords(Consumer<PopConsumerRecord> consumer) {
         int remain = 0;
         Iterator<Map.Entry<String, ConsumerRecords>> iterator = consumerRecordTable.entrySet().iterator();
@@ -131,6 +152,7 @@ public class PopConsumerCache extends ServiceThread {
                     new ArrayList<>(records.getRemoveTreeMap().values());
                 if (!writeConsumerRecords.isEmpty()) {
                     consumerRecordStore.writeRecords(writeConsumerRecords);
+                    deleteAckedStagedRecords(records, writeConsumerRecords);
                 }
                 records.clearStagedRecords();
                 log.info("PopConsumerOffline, so clean expire records, groupId={}, topic={}, queueId={}, records={}",
@@ -152,6 +174,7 @@ public class PopConsumerCache extends ServiceThread {
 
             // write to store and handle it later
             consumerRecordStore.writeRecords(writeConsumerRecords);
+            deleteAckedStagedRecords(records, writeConsumerRecords);
             records.clearStagedRecords();
 
             // commit min offset in buffer to offset store
@@ -164,6 +187,26 @@ public class PopConsumerCache extends ServiceThread {
             remain += records.getInFlightRecordCount();
         }
         return remain;
+    }
+
+    /**
+     * A staged record that left the staged set while {@code #cleanupRecords(Consumer)} was
+     * writing it to the store was acked concurrently; the ack path has already deleted the
+     * durable record, so delete it once more here to undo the re-persist above.
+     */
+    private void deleteAckedStagedRecords(ConsumerRecords records, List<PopConsumerRecord> writtenRecords) {
+        List<PopConsumerRecord> ackedList = null;
+        for (PopConsumerRecord record : writtenRecords) {
+            if (records.getRemoveTreeMap().get(record.getOffset()) != record) {
+                if (ackedList == null) {
+                    ackedList = new ArrayList<>();
+                }
+                ackedList.add(record);
+            }
+        }
+        if (ackedList != null) {
+            consumerRecordStore.deleteRecords(ackedList);
+        }
     }
 
     public void commitOffset(String clientHost, String groupId, String topicId, int queueId, long offset) {
@@ -229,6 +272,10 @@ public class PopConsumerCache extends ServiceThread {
 
         public boolean delete(PopConsumerRecord record) {
             return recordTreeMap.remove(record.getOffset()) != null;
+        }
+
+        public void removeStaged(PopConsumerRecord record) {
+            removeTreeMap.remove(record.getOffset());
         }
 
         public long getMinOffsetInBuffer() {

--- a/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/pop/PopConsumerService.java
@@ -509,7 +509,7 @@ public class PopConsumerService extends ServiceThread {
             popTime, groupId, topicId, queueId, 0, invisibleTime, offset, null);
 
         if (brokerConfig.isEnablePopBufferMerge() && popConsumerCache != null) {
-            if (popConsumerCache.deleteRecords(Collections.singletonList(record)).isEmpty()) {
+            if (popConsumerCache.ackRecords(Collections.singletonList(record)).isEmpty()) {
                 return CompletableFuture.completedFuture(true);
             }
         }

--- a/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerCacheTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/pop/PopConsumerCacheTest.java
@@ -17,8 +17,16 @@
 package org.apache.rocketmq.broker.pop;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.broker.BrokerController;
@@ -142,5 +150,89 @@ public class PopConsumerCacheTest {
         consumerRecordList.clear();
         consumerCache.cleanupRecords(consumerRecordList::add);
         Assert.assertEquals(0, consumerRecordList.size());
+    }
+
+    /**
+     * PopConsumerCache#cleanupRecords stages records, snapshots them, and persists the snapshot.
+     * An ack arriving while the store write is in flight only sees the record in the staged set
+     * (it already left recordTreeMap), deletes the durable record, and then the blocked write
+     * re-persists the acked record. The acked record must not survive in the durable store.
+     */
+    @Test
+    public void testAckWinsOverCleanupStoreWrite() throws Exception {
+        BrokerConfig brokerConfig = new BrokerConfig();
+        BrokerController brokerController = Mockito.mock(BrokerController.class);
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(brokerConfig);
+        PopConsumerLockService consumerLockService = Mockito.mock(PopConsumerLockService.class);
+        Mockito.when(consumerLockService.isLockTimeout(any(), any())).thenReturn(false);
+
+        CountDownLatch writeStarted = new CountDownLatch(1);
+        CountDownLatch releaseWrite = new CountDownLatch(1);
+        Map<Long, PopConsumerRecord> durableStore = new ConcurrentHashMap<>();
+        PopConsumerKVStore consumerKVStore = new PopConsumerKVStore() {
+            @Override
+            public boolean start() {
+                return true;
+            }
+
+            @Override
+            public boolean shutdown() {
+                return true;
+            }
+
+            @Override
+            public String getFilePath() {
+                return "PopConsumerCacheTest";
+            }
+
+            @Override
+            public void writeRecords(List<PopConsumerRecord> consumerRecordList) {
+                writeStarted.countDown();
+                try {
+                    Assert.assertTrue(releaseWrite.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                consumerRecordList.forEach(record -> durableStore.put(record.getOffset(), record));
+            }
+
+            @Override
+            public void deleteRecords(List<PopConsumerRecord> consumerRecordList) {
+                consumerRecordList.forEach(record -> durableStore.remove(record.getOffset()));
+            }
+
+            @Override
+            public List<PopConsumerRecord> scanExpiredRecords(long lowerTime, long upperTime, int maxCount) {
+                return Collections.emptyList();
+            }
+        };
+
+        PopConsumerCache consumerCache =
+            new PopConsumerCache(brokerController, consumerKVStore, consumerLockService, null);
+
+        // old enough to be staged by cleanup, visibility still in the future so it is written
+        long popTime = System.currentTimeMillis() - brokerConfig.getPopCkStayBufferTime() - 1000;
+        PopConsumerRecord record = new PopConsumerRecord(popTime, groupId, topicId, queueId,
+            0, TimeUnit.MINUTES.toMillis(2), 100, attemptId);
+        consumerCache.writeRecords(Collections.singletonList(record));
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Integer> cleanupFuture = executor.submit(() -> consumerCache.cleanupRecords(r -> { }));
+            Assert.assertTrue(writeStarted.await(5, TimeUnit.SECONDS));
+
+            // ack the staged record while the cleanup store write is blocked
+            List<PopConsumerRecord> remain = consumerCache.ackRecords(Collections.singletonList(record));
+            Assert.assertFalse(remain.isEmpty());
+            consumerKVStore.deleteRecords(remain);
+
+            releaseWrite.countDown();
+            cleanupFuture.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        Assert.assertTrue("acked record must not survive in the durable store", durableStore.isEmpty());
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10736 (ack case; see Scope below for the change-invisibility case)

### Problem / Evidence

With the KV pop service and `enablePopBufferMerge` on, `PopConsumerCache#cleanupRecords` stages records (moves them from `recordTreeMap` to the staged `removeTreeMap`), snapshots the staged set, and persists the snapshot via `PopConsumerKVStore#writeRecords`. While that write is in flight, an ack for the same record:

1. finds the record in neither map (`ConsumerRecords#delete` only checks `recordTreeMap`), so `deleteRecords` returns it as remaining;
2. `PopConsumerService#ackAsync` therefore deletes the durable record and returns success;
3. the blocked cleanup write then persists its stale snapshot, restoring the acknowledged checkpoint to the durable store.

A later revive scan observes the restored checkpoint and the already-acknowledged message is delivered again. This is a deterministic race: the regression test below blocks the cleanup write on a latch, acks the staged record, releases the write, and asserts the acked record is absent from the durable store. It fails reproducibly on unmodified develop.

### Root cause / Fix

- The ack path could not see (or cancel) records staged for the cleanup write, and cleanup never verified ownership after the write became durable.
- `PopConsumerCache#ackRecords` (new, used by `PopConsumerService#ackAsync`) additionally removes the record from the staged set, and `cleanupRecords` re-deletes any written record that left the staged set while its write was in flight (`deleteAckedStagedRecords`). Every interleaving (ack before/during/after the write, store-delete before/after the re-persist) now converges to the ack being effective; both deletes are idempotent.

### Scope

This fixes the **ack** case demonstrated in the issue. The same stale-snapshot window exists for change-invisibility (`ChangeInvisibilityDuration`): a same-key (same visibilityTimeout) rewrite can still be clobbered by an in-flight cleanup write. Deleting the staged record there is unsafe without knowing the replacement checkpoint's value (it could erase the new checkpoint and lose the message), so that path deliberately keeps using `deleteRecords` and needs its own design, as the issue author and PR #10519 also noted.

### Priority

PRIORITY = 73: impact 32 (acknowledged messages redelivered - user-visible correctness) + scope 12 (broker pop KV service path) + reproducibility 17 (deterministic latch-based test) + maintenance 12 (contained, convergent fix in one class). FIX_CONFIDENCE = 82: convergent under all interleavings analyzed; the change-invisibility variant is explicitly left for the design discussion the issue asks for.

### How Did You Test This Change?

- `PopConsumerCacheTest#testAckWinsOverCleanupStoreWrite`: latch-controlled repro (blocks the KV store write, acks the staged record, releases the write) asserting the durable store does not retain the acked record. Fails on unmodified develop, passes with this change.
- `mvn -pl broker test -Dtest=PopConsumerCacheTest` → 4/4 pass.
- `mvn -pl broker test -Dtest='PopConsumer*Test'` → 38 tests, 0 failures.
- `mvn -pl broker test -Dtest='AckMessage*Test,ChangeInvisible*Test,PopMessage*Test,PopRevive*Test'` → 37 tests, 0 failures.

### Risk

Low: `deleteRecords` behavior is unchanged (change-invisibility path untouched); the new staged-set removal only happens on the ack path, and the extra durable delete is idempotent and bounded by one record per staged write.