### PR TITLE
[ISSUE #10989] Fix transactional escape retry backoff

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -250,7 +250,7 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                                     msgExt.getUserProperty(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX));
                                 if (escapeFailCnt < MAX_RETRY_TIMES_FOR_ESCAPE) {
                                     escapeFailCnt++;
-                                    Thread.sleep(100L * (2 ^ escapeFailCnt));
+                                    Thread.sleep(100L * (1L << escapeFailCnt));
                                 } else {
                                     escapeFailCnt = 0;
                                     newOffset = i + 1;


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #10989

## Brief Description

Java's `^` operator performs bitwise XOR, not exponentiation. The transactional half-message escape retry path therefore used incorrect delays (including a 0 ms delay on the second failure), causing immediate retries instead of exponential backoff.

This change uses a bounded left shift to produce the intended sequence: 200, 400, 800 ms, and so on.

## How Did You Test This Change?

- Base SHA: `$(git rev-parse develop)`
- Reproduced the faulty expression from current `develop`: `100L * (2 ^ 2) == 0`.
- Verified the replacement with JShell on JDK 24: retry counts 1..3 produce `200`, `400`, `800` ms.
- `git diff --check` passed.
- Maven is not installed in this environment, so the RocketMQ test suite could not be run; CI should execute the required Maven checks.

## Risk

Low; this changes only retry timing for the existing escape-failure path and removes the unintended zero-delay retry.

AI-assisted contribution; implementation and verification performed against current `develop`.