### PR TITLE
[ISSUE #11010] Preserve channel write failure cause

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -646,7 +646,7 @@ public abstract class NettyRemotingAbstract {
                         responseFuture.setSendRequestOK(true);
                         return;
                     }
-                    requestFail(opaque);
+                    requestFail(opaque, f.cause());
                     log.warn("send a request command to channel <{}>, channelId={}, failed.", RemotingHelper.parseChannelRemoteAddr(channel), channel.id());
                 });
                 return future;
@@ -693,10 +693,11 @@ public abstract class NettyRemotingAbstract {
             });
     }
 
-    private void requestFail(final int opaque) {
+    private void requestFail(final int opaque, final Throwable cause) {
         ResponseFuture responseFuture = responseTable.remove(opaque);
         if (responseFuture != null) {
             responseFuture.setSendRequestOK(false);
+            responseFuture.setCause(cause);
             responseFuture.putResponse(null);
             try {
                 executeInvokeCallback(responseFuture);
@@ -718,7 +719,7 @@ public abstract class NettyRemotingAbstract {
             if (entry.getValue().getChannel() == channel) {
                 Integer opaque = entry.getKey();
                 if (opaque != null) {
-                    requestFail(opaque);
+                    requestFail(opaque, null);
                 }
             }
         }


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #11010

## Brief Description

When Netty `writeAndFlush` fails asynchronously, `requestFail` previously discarded `ChannelFuture.cause()`. This caused callbacks and `RemotingSendRequestException` to lose the underlying failure reason.

This change passes the cause into `ResponseFuture.setCause`; channel-close failures continue to pass `null` because no asynchronous write cause is available there.

## How Did You Test This Change?

- Base SHA: `$(git rev-parse develop)`.
- Confirmed current `invoke0` called `requestFail(opaque)` despite `f.cause()` being available.
- `git diff --check` passed.
- Maven is unavailable in this environment, so the required test suite was not run; CI should validate.

## Risk

Low; only enriches failure exceptions with the cause already supplied by Netty.

AI-assisted contribution; implementation and verification performed against current `develop`.