### PR TITLE
[ISSUE #11013] Stop timer WAL scheduler during RocksDB shutdown

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
@@ -83,7 +83,7 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
     private volatile ColumnFamilyHandle timerCFHandle;
     private volatile ColumnFamilyHandle transCFHandle;
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private static final Cache<String, byte[]> DELETE_KEY_CACHE_FOR_TIMER = CacheBuilder.newBuilder()
         .maximumSize(10000)
         .expireAfterWrite(60, TimeUnit.MINUTES)
@@ -114,6 +114,9 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
             this.defaultCFHandle = cfHandles.get(0);
             this.timerCFHandle = cfHandles.get(1);
             this.transCFHandle = cfHandles.get(2);
+            if (scheduler.isShutdown()) {
+                scheduler = Executors.newScheduledThreadPool(1);
+            }
             scheduler.scheduleAtFixedRate(() -> {
                 try {
                     db.flush(flushOptions, timerCFHandle);
@@ -142,6 +145,7 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
 
     @Override
     protected void preShutdown() {
+        scheduler.shutdownNow();
         log.info("MessageRocksDBStorage pre shutdown success, dbPath: {}", this.dbPath);
     }
 


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #11013

## Brief Description

`MessageRocksDBStorage.postLoad()` schedules a periodic timer-WAL flush, but `preShutdown()` leaves the executor and task running. Reloading the RocksDB storage schedules another task on every cycle, and the non-daemon scheduler survives after RocksDB resources close.

This change stops the scheduler during shutdown and recreates it before a subsequent load, preventing duplicate flush tasks while preserving reload support.

## How Did You Test This Change?

- Base SHA: `$(git rev-parse develop)`
- Confirmed current `MessageRocksDBStorage` schedules in `postLoad()` and had an empty `preShutdown()`.
- `git diff --check` passed.
- Maven is unavailable in this environment, so the required test suite was not run; CI should validate.

## Risk

Low; scheduler lifecycle now follows storage lifecycle, and reload recreates the executor before rescheduling.

AI-assisted contribution; implementation and verification performed against current `develop`.