### PR TITLE
[ISSUE #10987] Preserve offsets during correction query

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/offset/ConsumerOffsetManager.java
@@ -327,7 +327,7 @@ public class ConsumerOffsetManager extends ConfigManager {
     public Map<Integer, Long> queryMinOffsetInAllGroup(final String topic, final String filterGroups) {
 
         Map<Integer, Long> queueMinOffset = new HashMap<>();
-        Set<String> topicGroups = this.offsetTable.keySet();
+        Set<String> topicGroups = new HashSet<>(this.offsetTable.keySet());
         if (!UtilAll.isBlank(filterGroups)) {
             for (String group : filterGroups.split(",")) {
                 Iterator<String> it = topicGroups.iterator();
@@ -335,7 +335,6 @@ public class ConsumerOffsetManager extends ConfigManager {
                     String topicAtGroup = it.next();
                     if (group.equals(topicAtGroup.split(TOPIC_GROUP_SEPARATOR)[1])) {
                         it.remove();
-                        removeConsumerOffset(topicAtGroup);
                     }
                 }
             }


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #10987

## Brief Description

`ConsumerOffsetManager.queryMinOffsetInAllGroup` iterated the live `offsetTable.keySet()` view and removed matching groups while answering a correction-offset query. The iterator removal and `removeConsumerOffset` call permanently deleted consumer offsets as a read-side effect.

Copy the key set before filtering and remove matching keys only from that temporary set. The live offset table is now left unchanged while the query excludes the requested groups from its calculation.

## How Did You Test This Change?

- Base SHA: `$(git rev-parse develop)`.
- Confirmed current code assigned `offsetTable.keySet()` directly and called `removeConsumerOffset` during the query.
- `git diff --check` passed.
- Maven is unavailable in this environment, so the required test suite was not run; CI should validate.

## Risk

Low; this removes an unintended destructive side effect from a read/query operation while preserving filtering behavior.

AI-assisted contribution; implementation and verification performed against current `develop`.