### PR TITLE
[ISSUE #10990] Avoid NPE for retry messages without properties

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLongPollingService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PopLongPollingService.java
@@ -181,6 +181,9 @@ public class PopLongPollingService extends ServiceThread {
     private void notifyMessageArrivingFromRetry(String topic, int queueId, Long tagsCode, long msgStoreTime, byte[] filterBitMap,
         Map<String, String> properties) {
         String prefix = MixAll.RETRY_GROUP_TOPIC_PREFIX;
+        if (properties == null) {
+            return;
+        }
         String originGroup = properties.get(MessageConst.PROPERTY_ORIGIN_GROUP);
         // In the case of pop consumption, there is no long polling hanging on the retry topic, so the wake-up is skipped.
         if (StringUtils.isBlank(originGroup)) {


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #10990

## Brief Description

`PopLongPollingService.notifyMessageArrivingFromRetry` dereferences the properties map without checking for null. Retry dispatch requests can legitimately have no properties, causing an NPE in the reput thread and stalling broker-wide dispatch.

Return early when properties are absent, matching the existing behavior for a retry message without an origin group.

## How Did You Test This Change?

- Base SHA: `$(git rev-parse develop)`.
- Confirmed current code calls `properties.get(...)` unconditionally.
- `git diff --check` passed.
- Maven is unavailable in this environment, so the required test suite was not run; CI should validate.

## Risk

Low; only prevents a null-properties crash and skips notification when no origin group can be determined.

AI-assisted contribution; implementation and verification performed against current `develop`.