### PR TITLE
[ISSUE #10998] Dispatch a first message larger than group commit size

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/core/MessageStoreDispatcherImpl.java
@@ -262,7 +262,7 @@ public class MessageStoreDispatcherImpl extends ServiceThread implements Message
             for (; offset < targetOffset; offset++) {
                 cqUnit = consumeQueue.get(offset);
                 bufferSize += cqUnit.getSize();
-                if (bufferSize >= groupCommitSize) {
+                if (bufferSize >= groupCommitSize && !appendingBufferList.isEmpty()) {
                     break;
                 }
                 message = defaultStore.selectOneMessageByOffset(cqUnit.getPos(), cqUnit.getSize());


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #10998

## Brief Description

Tiered message dispatch stops before appending any message when the first message's size is already at or above `tieredStoreGroupCommitSize`. This leaves the dispatch list empty and prevents the commit offset from advancing, retrying the same message indefinitely.

Only apply the group-size break after at least one message has been selected. A single oversized message can then be uploaded and dispatched normally.

## How Did You Test This Change?

- Base SHA: `$(git rev-parse develop)`.
- Confirmed current loop checks `bufferSize >= groupCommitSize` before appending the first message.
- `git diff --check` passed.
- Maven is unavailable in this environment, so the required test suite was not run; CI should validate.

## Risk

Low; batching behavior is unchanged for subsequent messages, while an oversized first message no longer blocks the queue.

AI-assisted contribution; implementation and verification performed against current `develop`.