### PR TITLE
[Bug] Preserve POP retry after async message-read failure

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopReviveService.java
@@ -568,7 +568,12 @@ public class PopReviveService extends ServiceThread {
             // retry msg
             long msgOffset = popCheckPoint.ackOffsetByIndex((byte) j);
             CompletableFuture<Pair<Long, Boolean>> future = getBizMessage(popCheckPoint, msgOffset)
-                .thenApply(rst -> {
+                .handle((rst, throwable) -> {
+                    if (throwable != null) {
+                        POP_LOGGER.warn("reviveQueueId={}, failed to read biz msg for topic={}, qid={}, offset={}",
+                            queueId, popCheckPoint.getTopic(), popCheckPoint.getQueueId(), msgOffset, throwable);
+                        return new Pair<>(msgOffset, false);
+                    }
                     MessageExt message = rst.getLeft();
                     if (message == null) {
                         POP_LOGGER.info("reviveQueueId={}, can not get biz msg, topic:{}, qid:{}, offset:{}, brokerName:{}, info:{}, retry:{}, then continue",


### PR DESCRIPTION
Fixes #10985

## Summary
Handle exceptional completion from PopReviveService.getBizMessage so a failed asynchronous read is treated as retryable and rePutCK preserves POP redelivery.

## Root cause
CompletableFuture.allOf(...).whenComplete called future.getNow on an exceptionally completed child future; getNow throws CompletionException before the checkpoint cleanup/rePutCK path runs.

## Changes
Use handle on the read stage to log the failure and return (msgOffset, false), allowing existing retry checkpoint logic to run.

## Verification
- git diff --check passed
- Maven unavailable in environment; CI should run PopReviveServiceTest and project checks

AI-assisted contribution; reviewed locally.