### PR TITLE
[Enhancement] Extract gRPC user-property validation hook

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -195,12 +195,8 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         }
     }
 
-    protected Map<String, String> buildMessageProperty(ProxyContext context, apache.rocketmq.v2.Message message, String producerGroup) {
-        long userPropertySize = 0;
+    protected void checkUserProperties(Map<String, String> userProperties) {
         ProxyConfig config = ConfigurationManager.getProxyConfig();
-        org.apache.rocketmq.common.message.Message messageWithHeader = new org.apache.rocketmq.common.message.Message();
-        // set user properties
-        Map<String, String> userProperties = message.getUserPropertiesMap();
         if (userProperties.size() > config.getUserPropertyMaxNum()) {
             throw new GrpcProxyException(Code.MESSAGE_PROPERTIES_TOO_LARGE, "too many user properties, max is " + config.getUserPropertyMaxNum());
         }
@@ -217,6 +213,16 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             userPropertySize += userPropertiesEntry.getKey().getBytes(StandardCharsets.UTF_8).length;
             userPropertySize += userPropertiesEntry.getValue().getBytes(StandardCharsets.UTF_8).length;
         }
+    }
+
+
+    protected Map<String, String> buildMessageProperty(ProxyContext context, apache.rocketmq.v2.Message message, String producerGroup) {
+        long userPropertySize = 0;
+        ProxyConfig config = ConfigurationManager.getProxyConfig();
+        org.apache.rocketmq.common.message.Message messageWithHeader = new org.apache.rocketmq.common.message.Message();
+        // set user properties
+        Map<String, String> userProperties = message.getUserPropertiesMap();
+        this.checkUserProperties(userProperties);
         MessageAccessor.setProperties(messageWithHeader, Maps.newHashMap(userProperties));
 
         // set tag


### PR DESCRIPTION
Fixes #11000

Extract the inline user-property validation from SendMessageActivity#buildMessageProperty into a protected checkUserProperties method. This provides a narrow override point for custom validation while preserving existing behavior.

Verification: git diff --check passed. Maven unavailable locally; CI should run proxy tests and checks. AI-assisted contribution.