### PR TITLE
[Bug] Allow Lite subscription removal beyond quota

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ClientProcessor.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/processor/ClientProcessor.java
@@ -116,7 +116,9 @@ public class ClientProcessor extends AbstractProcessor {
     ) {
         try {
             validateLiteBindTopic(ctx, liteSubscriptionDTO.getGroup(), liteSubscriptionDTO.getTopic());
-            if (CollectionUtils.isNotEmpty(liteSubscriptionDTO.getLiteTopicSet())) {
+            if (CollectionUtils.isNotEmpty(liteSubscriptionDTO.getLiteTopicSet())
+                && (LiteSubscriptionAction.PARTIAL_ADD == liteSubscriptionDTO.getAction()
+                || LiteSubscriptionAction.COMPLETE_ADD == liteSubscriptionDTO.getAction())) {
                 validateLiteSubscriptionQuota(ctx, liteSubscriptionDTO.getGroup(), liteSubscriptionDTO.getLiteTopicSet().size());
             }
 


### PR DESCRIPTION
Fixes #10962

Apply Lite subscription quota validation only to PARTIAL_ADD and COMPLETE_ADD actions. Removal requests release subscriptions and must not be rejected because their request set exceeds the growth quota.

Verification: git diff --check passed; Maven unavailable locally, CI should run proxy tests. AI-assisted contribution.