### PR TITLE
[Enhancement] Serialize POP messages directly to bytes

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/config/v1/RocksDBConfigManager.java
@@ -162,13 +162,13 @@ public class RocksDBConfigManager {
     public void updateKvDataVersion() throws Exception {
         kvDataVersion.nextVersion();
         this.configRocksDBStorage.put(versionCF, KV_DATA_VERSION_KEY, KV_DATA_VERSION_KEY.length,
-            JSON.toJSONString(kvDataVersion).getBytes(StandardCharsets.UTF_8));
+            JSON.toJSONBytes(kvDataVersion));
     }
 
     public void setKvDataVersion(DataVersion dataVersion)  throws Exception {
         this.kvDataVersion = dataVersion;
         this.configRocksDBStorage.put(versionCF, KV_DATA_VERSION_KEY, KV_DATA_VERSION_KEY.length,
-            JSON.toJSONString(kvDataVersion).getBytes(StandardCharsets.UTF_8));
+            JSON.toJSONBytes(kvDataVersion));
     }
     
     public DataVersion getKvDataVersion() {

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AckMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AckMessageProcessor.java
@@ -285,7 +285,7 @@ public class AckMessageProcessor implements NettyRequestProcessor {
 
         MessageExtBrokerInner msgInner = new MessageExtBrokerInner();
         msgInner.setTopic(reviveTopic);
-        msgInner.setBody(JSON.toJSONString(ackMsg).getBytes(StandardCharsets.UTF_8));
+        msgInner.setBody(JSON.toJSONBytes(ackMsg));
         msgInner.setQueueId(rqId);
         if (ackMsg instanceof BatchAckMsg) {
             msgInner.setTags(PopAckConstants.BATCH_ACK_TAG);

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -3390,7 +3390,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
                     if (canReadUserPassword(request, requestHeader.getUsername())) {
                         userInfo.setPassword(user.getPassword());
                     }
-                    response.setBody(JSON.toJSONString(userInfo).getBytes(StandardCharsets.UTF_8));
+                    response.setBody(JSON.toJSONBytes(userInfo));
                 }
             })
             .exceptionally(ex -> {
@@ -3413,7 +3413,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
                 response.setCode(ResponseCode.SUCCESS);
                 if (CollectionUtils.isNotEmpty(users)) {
                     List<UserInfo> userInfos = UserConverter.convertUsers(users);
-                    response.setBody(JSON.toJSONString(userInfos).getBytes(StandardCharsets.UTF_8));
+                    response.setBody(JSON.toJSONBytes(userInfos));
                 }
             })
             .exceptionally(ex -> {

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ChangeInvisibleTimeProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ChangeInvisibleTimeProcessor.java
@@ -278,7 +278,7 @@ public class ChangeInvisibleTimeProcessor implements NettyRequestProcessor {
         }
 
         msgInner.setTopic(reviveTopic);
-        msgInner.setBody(JSON.toJSONString(ackMsg).getBytes(StandardCharsets.UTF_8));
+        msgInner.setBody(JSON.toJSONBytes(ackMsg));
         msgInner.setQueueId(rqId);
         msgInner.setTags(PopAckConstants.ACK_TAG);
         msgInner.setBornTimestamp(System.currentTimeMillis());
@@ -322,7 +322,7 @@ public class ChangeInvisibleTimeProcessor implements NettyRequestProcessor {
         ck.setBrokerName(ExtraInfoUtil.getBrokerName(extraInfo));
         ck.setSuspend(requestHeader.isSuspend());
 
-        msgInner.setBody(JSON.toJSONString(ck).getBytes(StandardCharsets.UTF_8));
+        msgInner.setBody(JSON.toJSONBytes(ck));
         msgInner.setQueueId(reviveQid);
         msgInner.setTags(PopAckConstants.CK_TAG);
         msgInner.setBornTimestamp(System.currentTimeMillis());

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
@@ -937,7 +937,7 @@ public class PopMessageProcessor implements NettyRequestProcessor {
         MessageExtBrokerInner msgInner = new MessageExtBrokerInner();
 
         msgInner.setTopic(reviveTopic);
-        msgInner.setBody(JSON.toJSONString(ck).getBytes(StandardCharsets.UTF_8));
+        msgInner.setBody(JSON.toJSONBytes(ck));
         msgInner.setQueueId(reviveQid);
         msgInner.setTags(PopAckConstants.CK_TAG);
         msgInner.setBornTimestamp(System.currentTimeMillis());


### PR DESCRIPTION
Fixes #10980

Use Fastjson JSON.toJSONBytes for POP checkpoint and ack message bodies instead of creating an intermediate JSON String and copying it to UTF-8 bytes. Updated POP message/ack processor call sites while preserving serialized JSON content.

Verification: git diff --check passed; Maven unavailable locally, CI should run broker tests. AI-assisted contribution.