### PR TITLE
[Enhancement] Cache broker topic and CRC32 property bytes

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageDecoder.java
@@ -36,6 +36,7 @@ import org.apache.rocketmq.common.compression.CompressorFactory;
 import org.apache.rocketmq.common.sysflag.MessageSysFlag;
 
 public class MessageDecoder {
+    private static final byte[] CRC32_PROPERTY_BYTES = MessageConst.PROPERTY_CRC32.getBytes(StandardCharsets.UTF_8);
 //    public final static int MSG_ID_LENGTH = 8 + 8;
 
     public final static Charset CHARSET_UTF8 = StandardCharsets.UTF_8;
@@ -154,7 +155,7 @@ public class MessageDecoder {
     }
 
     public static void createCrc32(final ByteBuffer input, int crc32) {
-        input.put(MessageConst.PROPERTY_CRC32.getBytes(StandardCharsets.UTF_8));
+        input.put(CRC32_PROPERTY_BYTES);
         input.put((byte) NAME_VALUE_SEPARATOR);
         for (int i = 0; i < 10; i++) {
             byte b = '0';
@@ -168,7 +169,7 @@ public class MessageDecoder {
     }
 
     public static void createCrc32(final ByteBuf input, int crc32) {
-        input.writeBytes(MessageConst.PROPERTY_CRC32.getBytes(StandardCharsets.UTF_8));
+        input.writeBytes(CRC32_PROPERTY_BYTES);
         input.writeByte((byte) NAME_VALUE_SEPARATOR);
         for (int i = 0; i < 10; i++) {
             byte b = '0';

--- a/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageExtEncoder.java
@@ -40,6 +40,16 @@ public class MessageExtEncoder {
     private int maxMessageSize;
     private final int crc32ReservedLength;
     private MessageStoreConfig messageStoreConfig;
+    private String cachedTopic;
+    private byte[] cachedTopicData;
+
+    private byte[] topicBytes(String topic) {
+        if (!topic.equals(cachedTopic)) {
+            cachedTopic = topic;
+            cachedTopicData = topic.getBytes(MessageDecoder.CHARSET_UTF8);
+        }
+        return cachedTopicData;
+    }
 
     public MessageExtEncoder(final int maxMessageBodySize, final MessageStoreConfig messageStoreConfig) {
         this(messageStoreConfig);
@@ -108,7 +118,7 @@ public class MessageExtEncoder {
 
     public PutMessageResult encodeWithoutProperties(MessageExtBrokerInner msgInner) {
 
-        final byte[] topicData = msgInner.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
+        final byte[] topicData = topicBytes(msgInner.getTopic());
         final int topicLength = topicData.length;
 
         final int bodyLength = msgInner.getBody() == null ? 0 : msgInner.getBody().length;
@@ -195,7 +205,7 @@ public class MessageExtEncoder {
             return new PutMessageResult(PutMessageStatus.PROPERTIES_SIZE_EXCEEDED, null);
         }
 
-        final byte[] topicData = msgInner.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
+        final byte[] topicData = topicBytes(msgInner.getTopic());
         final int topicLength = topicData.length;
 
         final int bodyLength = msgInner.getBody() == null ? 0 : msgInner.getBody().length;
@@ -312,7 +322,7 @@ public class MessageExtEncoder {
             int propertiesPos = messagesByteBuff.position();
             messagesByteBuff.position(propertiesPos + propertiesLen);
 
-            final byte[] topicData = messageExtBatch.getTopic().getBytes(MessageDecoder.CHARSET_UTF8);
+            final byte[] topicData = topicBytes(messageExtBatch.getTopic());
 
             final int topicLength = topicData.length;
             int totalPropLen = propertiesLen;


### PR DESCRIPTION
Fixes #11002

Cache the per-thread encoder topic bytes and the constant CRC32 property-key bytes to avoid repeated String.getBytes allocations on the broker write path.

Verification: git diff --check passed; Maven unavailable locally, CI should run store/common tests. AI-assisted contribution.