### PR TITLE
[Enhancement] Reuse MD5 digest and avoid UTF-8 length allocations

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/BinaryUtil.java
@@ -23,15 +23,17 @@ import java.security.NoSuchAlgorithmException;
 import org.apache.commons.codec.binary.Hex;
 
 public class BinaryUtil {
-    public static byte[] calculateMd5(byte[] binaryData) {
-        MessageDigest messageDigest = null;
+    private static final ThreadLocal<MessageDigest> MD5_DIGEST = ThreadLocal.withInitial(() -> {
         try {
-            messageDigest = MessageDigest.getInstance("MD5");
+            return MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD5 algorithm not found.");
+            throw new IllegalStateException("MD5 algorithm not found", e);
         }
-        messageDigest.update(binaryData);
-        return messageDigest.digest();
+    });
+    public static byte[] calculateMd5(byte[] binaryData) {
+        MessageDigest messageDigest = MD5_DIGEST.get();
+        messageDigest.reset();
+        return messageDigest.digest(binaryData);
     }
 
     public static String generateMd5(String bodyStr) {

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/producer/SendMessageActivity.java
@@ -29,7 +29,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -146,6 +145,27 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         }
     }
 
+    protected int utf8Length(String value) {
+        int length = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch < 0x80) {
+                length++;
+            } else if (ch < 0x800) {
+                length += 2;
+            } else if (Character.isHighSurrogate(ch) && i + 1 < value.length()
+                && Character.isLowSurrogate(value.charAt(i + 1))) {
+                length += 4;
+                i++;
+            } else if (Character.isSurrogate(ch)) {
+                length++;
+            } else {
+                length += 3;
+            }
+        }
+        return length;
+    }
+
     protected void validateMessageKey(String key) {
         if (StringUtils.isNotEmpty(key)) {
             if (StringUtils.isBlank(key)) {
@@ -166,7 +186,7 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             if (maxSize <= 0) {
                 return;
             }
-            if (messageGroup.getBytes(StandardCharsets.UTF_8).length >= maxSize) {
+            if (utf8Length(messageGroup) >= maxSize) {
                 throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_GROUP, "message group exceed the max size " + maxSize);
             }
             if (GrpcValidator.getInstance().containControlCharacter(messageGroup)) {
@@ -214,8 +234,8 @@ public class SendMessageActivity extends AbstractMessagingActivity {
             if (GrpcValidator.getInstance().containControlCharacter(userPropertiesEntry.getValue())) {
                 throw new GrpcProxyException(Code.ILLEGAL_MESSAGE_PROPERTY_KEY, "the value of property cannot contain control character");
             }
-            userPropertySize += userPropertiesEntry.getKey().getBytes(StandardCharsets.UTF_8).length;
-            userPropertySize += userPropertiesEntry.getValue().getBytes(StandardCharsets.UTF_8).length;
+            userPropertySize += utf8Length(userPropertiesEntry.getKey());
+            userPropertySize += utf8Length(userPropertiesEntry.getValue());
         }
         MessageAccessor.setProperties(messageWithHeader, Maps.newHashMap(userProperties));
 
@@ -223,13 +243,13 @@ public class SendMessageActivity extends AbstractMessagingActivity {
         String tag = message.getSystemProperties().getTag();
         GrpcValidator.getInstance().validateTag(tag);
         messageWithHeader.setTags(tag);
-        userPropertySize += tag.getBytes(StandardCharsets.UTF_8).length;
+        userPropertySize += utf8Length(tag);
 
         // set keys
         List<String> keysList = message.getSystemProperties().getKeysList();
         for (String key : keysList) {
             validateMessageKey(key);
-            userPropertySize += key.getBytes(StandardCharsets.UTF_8).length;
+            userPropertySize += utf8Length(key);
         }
         if (keysList.size() > 0) {
             messageWithHeader.setKeys(keysList);


### PR DESCRIPTION
Fixes #10976

## Summary
- reuse one MD5 MessageDigest per thread, resetting it for each calculation
- compute UTF-8 encoded lengths without allocating temporary byte arrays on the gRPC send path
- preserve Java UTF-8 replacement behavior for unpaired surrogates

## Verification
- git diff --check passed
- Maven is unavailable locally; CI should run common and proxy test suites

AI-assisted contribution; reviewed locally.