### PR TITLE
[Bug] Return null when broker address table is unavailable

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/route/BrokerData.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/route/BrokerData.java
@@ -89,6 +89,9 @@ public class BrokerData implements Comparable<BrokerData> {
      * @return Broker address.
      */
     public String selectBrokerAddr() {
+        if (this.brokerAddrs == null || this.brokerAddrs.isEmpty()) {
+            return null;
+        }
         String masterAddress = this.brokerAddrs.get(MixAll.MASTER_ID);
 
         if (masterAddress == null) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/route/BrokerDataTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/route/BrokerDataTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.remoting.protocol.route;
+
+import java.util.HashMap;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BrokerDataTest {
+    @Test
+    public void selectBrokerAddrReturnsNullWhenAddressesAreUnavailable() {
+        BrokerData brokerData = new BrokerData();
+        assertThat(brokerData.selectBrokerAddr()).isNull();
+
+        brokerData.setBrokerAddrs(new HashMap<>());
+        assertThat(brokerData.selectBrokerAddr()).isNull();
+    }
+}


### PR DESCRIPTION
Fixes #10873

BrokerData.selectBrokerAddr now returns null when brokerAddrs is null or empty, instead of throwing NullPointerException or IllegalArgumentException from Random.nextInt(0). Master preference and random slave fallback remain unchanged.

Added regression coverage for both null and empty tables.

Verification: git diff --check passed; Maven unavailable locally, CI should run BrokerDataTest/remoting checks. AI-assisted contribution.