### PR TITLE
[Bug] Persist empty checkpoint state

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/CheckpointFile.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/CheckpointFile.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.UtilAll;
 
@@ -75,9 +74,6 @@ public class CheckpointFile<T> {
      * Write entries to file
      */
     public void write(final List<T> entries) throws IOException {
-        if (entries.isEmpty()) {
-            return;
-        }
         synchronized (this) {
             StringBuilder entryContent = new StringBuilder();
             for (T entry : entries) {
@@ -143,11 +139,10 @@ public class CheckpointFile<T> {
      */
     public List<T> read() throws IOException {
         try {
-            List<T> result = this.read(this.filePath);
-            if (CollectionUtils.isEmpty(result)) {
-                result = this.read(this.getBackFilePath());
+            if (!new File(this.filePath).exists()) {
+                return this.read(this.getBackFilePath());
             }
-            return result;
+            return this.read(this.filePath);
         } catch (IOException e) {
             return this.read(this.getBackFilePath());
         }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/CheckpointFileTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/CheckpointFileTest.java
@@ -85,6 +85,14 @@ public class CheckpointFileTest {
     }
 
     @Test
+    public void testEmptyCheckpointOverridesOldState() throws IOException {
+        this.checkpoint.write(entryList);
+        this.checkpoint.write(new ArrayList<>());
+
+        Assert.assertTrue(checkpoint.read().isEmpty());
+    }
+
+    @Test
     public void testAbNormalWriteAndRead() throws IOException {
         this.checkpoint.write(entryList);
         UtilAll.deleteFile(new File(FILE_PATH));


### PR DESCRIPTION
Fixes #10863

CheckpointFile now writes a valid zero-entry checkpoint instead of ignoring an empty list. Reading falls back to the backup only when the primary is missing or invalid, so a valid empty primary cannot resurrect stale backup entries.

Added regression coverage for overwriting a populated checkpoint with an empty state.

Verification: git diff --check passed; Maven unavailable locally, CI should run CheckpointFileTest. AI-assisted contribution.