### PR TITLE
[Bug] Reject invalid percentile metadata

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/statistics/StatisticsBrief.java
+++ b/common/src/main/java/org/apache/rocketmq/common/statistics/StatisticsBrief.java
@@ -68,10 +68,22 @@ public class StatisticsBrief {
             return false;
         }
 
+        long previousRange = 0;
+        long totalSlots = 1;
         for (long[] line : meta) {
             if (ArrayUtils.isEmpty(line) || line.length != 2) {
                 return false;
             }
+            long range = line[META_RANGE_INDEX];
+            long slots = line[META_SLOT_NUM_INDEX];
+            if (range <= previousRange || slots <= 0 || slots > range - previousRange) {
+                return false;
+            }
+            totalSlots += slots;
+            if (totalSlots > Integer.MAX_VALUE) {
+                return false;
+            }
+            previousRange = range;
         }
 
         return true;

--- a/common/src/test/java/org/apache/rocketmq/common/statistics/StatisticsBriefTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/statistics/StatisticsBriefTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common.statistics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+public class StatisticsBriefTest {
+    @Test
+    public void rejectsInvalidPercentileMetadata() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new StatisticsBrief(new long[][] {{10, 0}}));
+        assertThatIllegalArgumentException().isThrownBy(() -> new StatisticsBrief(new long[][] {{10, 2}, {10, 2}}));
+        assertThatIllegalArgumentException().isThrownBy(() -> new StatisticsBrief(new long[][] {{10, 11}}));
+        assertThatIllegalArgumentException().isThrownBy(() -> new StatisticsBrief(
+            new long[][] {{Integer.MAX_VALUE, Integer.MAX_VALUE}, {Integer.MAX_VALUE + 1L, 1}}));
+    }
+}


### PR DESCRIPTION
Fixes #10871

StatisticsBrief now rejects non-increasing ranges, non-positive slot counts, slot counts wider than their range, and total slot counts that overflow the backing array size. This prevents delayed division-by-zero and invalid bucket calculations.

Added focused regression cases for each invalid shape.

Verification: git diff --check passed; Maven unavailable locally, CI should run StatisticsBriefTest/common checks. AI-assisted contribution.