### PR TITLE
[Bug] Accept zero and negative floating-point literals

### DIFF
--- a/filter/src/main/java/org/apache/rocketmq/filter/expression/ConstantExpression.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/expression/ConstantExpression.java
@@ -58,8 +58,8 @@ public class ConstantExpression implements Expression {
         if (value > Double.MAX_VALUE) {
             throw new RuntimeException(text + " is greater than " + Double.MAX_VALUE);
         }
-        if (value < Double.MIN_VALUE) {
-            throw new RuntimeException(text + " is less than " + Double.MIN_VALUE);
+        if (value < -Double.MAX_VALUE) {
+            throw new RuntimeException(text + " is less than " + -Double.MAX_VALUE);
         }
         return new ConstantExpression(value);
     }

--- a/filter/src/test/java/org/apache/rocketmq/filter/ParserTest.java
+++ b/filter/src/test/java/org/apache/rocketmq/filter/ParserTest.java
@@ -129,4 +129,10 @@ public class ParserTest {
             assertThat(Boolean.TRUE).isFalse();
         }
     }
+    @Test
+    public void testParseZeroFloat() throws Exception {
+        assertThat(SelectorParser.parse("a = 0.0")).isNotNull();
+        assertThat(SelectorParser.parse("a = -0.5")).isNotNull();
+    }
+
 }


### PR DESCRIPTION
Fixes #10862

ConstantExpression.createFloat now uses -Double.MAX_VALUE as the finite lower bound. Double.MIN_VALUE is the smallest positive non-zero value, so using it incorrectly rejected 0.0 and valid negative literals.

Added parser regression cases for 0.0 and -0.5. Positive and negative infinity remain outside the accepted finite range.

Verification: git diff --check passed; Maven unavailable locally, CI should run ParserTest/filter checks. AI-assisted contribution.