### PR TITLE
[Bug] Retain highest offset for out-of-order ProcessQueue batches

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ProcessQueue.java
@@ -136,7 +136,7 @@ public class ProcessQueue {
                     MessageExt old = msgTreeMap.put(msg.getQueueOffset(), msg);
                     if (null == old) {
                         validMsgCnt++;
-                        this.queueOffsetMax = msg.getQueueOffset();
+                        this.queueOffsetMax = Math.max(this.queueOffsetMax, msg.getQueueOffset());
                         msgSize.addAndGet(null == msg.getBody() ? 0 : msg.getBody().length);
                     }
                 }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ProcessQueueTest.java
@@ -185,4 +185,18 @@ public class ProcessQueueTest {
         }
         return result;
     }
+    @Test
+    public void testRemoveOutOfOrderMessagesReturnsHighestNextOffset() {
+        ProcessQueue pq = new ProcessQueue();
+        MessageExt high = new MessageExt();
+        high.setQueueOffset(10);
+        MessageExt low = new MessageExt();
+        low.setQueueOffset(5);
+        List<MessageExt> messages = Lists.list(high, low);
+
+        pq.putMessage(messages);
+
+        assertThat(pq.removeMessage(messages)).isEqualTo(11);
+    }
+
 }


### PR DESCRIPTION
Fixes #10870

ProcessQueue.putMessage now updates queueOffsetMax with Math.max instead of overwriting it for every inserted message. An out-of-order batch can therefore no longer make removeMessage return a stale next offset.

Added a regression test inserting offsets 10 then 5 and asserting the drained next offset is 11.

Verification: git diff --check passed; Maven unavailable locally, CI should run ProcessQueueTest/client checks. AI-assisted contribution.