### PR TITLE
[Bug] Convert the right string in Boolean comparisons

### DIFF
--- a/filter/src/main/java/org/apache/rocketmq/filter/expression/ComparisonExpression.java
+++ b/filter/src/main/java/org/apache/rocketmq/filter/expression/ComparisonExpression.java
@@ -536,7 +536,7 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
             try {
                 if (lc == Boolean.class) {
                     if (convertStringExpressions && rc == String.class) {
-                        lv = Boolean.valueOf((String) lv).booleanValue();
+                        rv = Boolean.valueOf((String) rv).booleanValue();
                     } else {
                         return -1;
                     }

--- a/filter/src/test/java/org/apache/rocketmq/filter/ExpressionTest.java
+++ b/filter/src/test/java/org/apache/rocketmq/filter/ExpressionTest.java
@@ -889,6 +889,12 @@ public class ExpressionTest {
         eval(expression, context, Boolean.FALSE);
     }
 
+    @Test
+    public void testBooleanLeftComparedWithStringProperty() throws Exception {
+        EvaluationContext context = genContext(KeyValue.c("a", "true"));
+        eval(genExp("TRUE = a"), context, Boolean.TRUE);
+    }
+
     protected void eval(Expression expression, EvaluationContext context, Boolean result) throws Exception {
         Object ret = expression.evaluate(context);
         if (ret == null || !(ret instanceof Boolean)) {


### PR DESCRIPTION
Fixes #10877

ComparisonExpression now converts the String right operand to Boolean when the left operand is Boolean. The previous branch cast the Boolean left operand to String, which always threw ClassCastException when selector string conversion was enabled.

Added a regression test evaluating TRUE = a with string property a=true.

Verification: git diff --check passed; Maven unavailable locally, CI should run ExpressionTest/filter checks. AI-assisted contribution.