### PR TITLE
[ISSUE #11037] Encode delay message propertiesString after internal properties are cleared

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/schedule/ScheduleMessageService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/schedule/ScheduleMessageService.java
@@ -341,8 +341,6 @@ public class ScheduleMessageService extends ConfigManager {
         long tagsCodeValue =
             MessageExtBrokerInner.tagsString2tagsCode(topicFilterType, msgInner.getTags());
         msgInner.setTagsCode(tagsCodeValue);
-        msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgExt.getProperties()));
-
         msgInner.setSysFlag(msgExt.getSysFlag());
         msgInner.setBornTimestamp(msgExt.getBornTimestamp());
         msgInner.setBornHost(msgExt.getBornHost());
@@ -353,6 +351,9 @@ public class ScheduleMessageService extends ConfigManager {
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_DELAY_TIME_LEVEL);
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_TIMER_DELIVER_MS);
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_TIMER_DELAY_SEC);
+        // Encode after the properties are finalized so that the wire data stays
+        // consistent with the property map, aligning with TimerMessageStore#convertMessage.
+        msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgInner.getProperties()));
 
         msgInner.setTopic(msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC));
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/schedule/ScheduleMessageServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/schedule/ScheduleMessageServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.schedule;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -38,6 +39,8 @@ import org.apache.rocketmq.broker.metrics.BrokerMetricsManager;
 import org.apache.rocketmq.broker.util.HookUtils;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.message.MessageAccessor;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageExtBrokerInner;
@@ -61,8 +64,9 @@ import static org.apache.rocketmq.common.stats.Stats.BROKER_PUT_NUMS;
 import static org.apache.rocketmq.common.stats.Stats.TOPIC_PUT_NUMS;
 import static org.apache.rocketmq.common.stats.Stats.TOPIC_PUT_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ScheduleMessageServiceTest {
 
@@ -265,6 +269,37 @@ public class ScheduleMessageServiceTest {
         // add mapFile release
         messageResult.release();
 
+    }
+
+    @Test
+    public void testMessageTimeUpPropertiesStringMatchesProperties() throws Exception {
+        MessageExt msgExt = new MessageExt();
+        msgExt.setTopic(topic);
+        msgExt.setTags("schedule_tag");
+        msgExt.setKeys("schedule_key");
+        msgExt.setBody(sendMessage.getBytes());
+        msgExt.setFlag(0);
+        msgExt.setSysFlag(0);
+        msgExt.setBornTimestamp(System.currentTimeMillis());
+        msgExt.setStoreHost(storeHost);
+        msgExt.setBornHost(bornHost);
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_TOPIC, topic);
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_QUEUE_ID, "0");
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_DELAY_TIME_LEVEL, String.valueOf(delayLevel));
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_TIMER_DELIVER_MS, "123456");
+
+        Method messageTimeUp = ScheduleMessageService.class.getDeclaredMethod("messageTimeUp", MessageExt.class);
+        messageTimeUp.setAccessible(true);
+        MessageExtBrokerInner delivered = (MessageExtBrokerInner) messageTimeUp.invoke(scheduleMessageService, msgExt);
+
+        // internal properties must be cleared from the property map and the wire data alike
+        assertThat(delivered.getProperty(MessageConst.PROPERTY_DELAY_TIME_LEVEL)).isNull();
+        assertThat(delivered.getProperty(MessageConst.PROPERTY_TIMER_DELIVER_MS)).isNull();
+        assertFalse(delivered.getPropertiesString().contains(MessageConst.PROPERTY_DELAY_TIME_LEVEL));
+        assertFalse(delivered.getPropertiesString().contains(MessageConst.PROPERTY_TIMER_DELIVER_MS));
+        assertFalse(delivered.getPropertiesString().contains(MessageConst.PROPERTY_TIMER_DELAY_SEC));
+        assertEquals(MessageDecoder.messageProperties2String(delivered.getProperties()),
+            delivered.getPropertiesString());
     }
 
     /**


### PR DESCRIPTION
### Problem / Evidence

`ScheduleMessageService#messageTimeUp` encodes the delivered delay message's `propertiesString` **before** the internal properties are cleared (encode at the top of the method, `clearProperty` for `DELAY_TIME_LEVEL` / `TIMER_DELIVER_MS` / `TIMER_DELAY_SEC` afterwards). `propertiesString` is what gets persisted in the commitlog and decoded by consumers, so every delay-level message still carries those internal properties on the wire while the broker-side property map no longer does — the two disagree, and SQL92 filtering / user code see stale internal properties.

This is the exact defect class fixed for the timer-wheel path by #10972 (commit e533b663f, `TimerMessageStore#convertMessage` now encodes after clearing). The identical pattern in `messageTimeUp` predates it (the 2022-era unmerged PR #4190 attempted the same cleanup) and was not covered.

Regression test `ScheduleMessageServiceTest#testMessageTimeUpPropertiesStringMatchesProperties` fails before the fix (propertiesString contains `DELAY_TIME_LEVEL`/`TIMER_DELIVER_MS` and differs from re-encoding the cleared map) and passes after.

### Root cause / Fix

Move the `setPropertiesString(...)` call after the `clearProperty(...)` calls and encode `msgInner.getProperties()` — mirroring the upstream-accepted fix in `TimerMessageStore#convertMessage`.

### Priority

PRIORITY = 74：影响 28（延迟消息是核心特性，每条延迟投递消息的线上属性与 broker 端属性不一致，内部属性泄漏给消费者）+ 波及范围 12（单方法，全部延迟消息）+ 可复现性 20（确定性单元测试）+ 维护价值 14（与上游刚合并的 #10972 同类修复，先例明确）。FIX_CONFIDENCE = 95（一行位置调整，镜像上游已接受的同型修复）。

### Tests

- `mvn -pl broker test -Dtest=ScheduleMessageServiceTest#testMessageTimeUpPropertiesStringMatchesProperties`
  - before fix (commit ff8f6f74c + test only): `Tests run: 1, Failures: 1` (AssertionError at line 298)
  - after fix: `Tests run: 1, Failures: 0`
- `mvn -pl broker test -Dtest=ScheduleMessageServiceTest`: `Tests run: 5, Failures: 0, Errors: 0`

### Risk

Low. The only behavior change is that the persisted `propertiesString` of delivered delay messages no longer contains the three internal keys — this is what the property map already said since those lines existed, and matches the timer-path fix accepted in #10972. Consumers relying on the leaked internal keys would see them disappear, which is the documented intended behavior.

Closes #11037
