### PR TITLE
[ISSUE #11039] Track consumer group channel attribute for heartbeat-v2 withoutSub registration

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ConsumerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ConsumerManager.java
@@ -300,6 +300,9 @@ public class ConsumerManager {
         if (updateChannelRst && isNotifyConsumerIdsChangedEnable && !isBroadcastMode(consumerGroupInfo.getMessageModel())) {
             callConsumerIdsChangeListener(ConsumerGroupEvent.CHANGE, group, consumerGroupInfo.getAllChannel());
         }
+        if (this.brokerConfig != null && this.brokerConfig.isEnableFastChannelEventProcess() && updateChannelRst) {
+            ClientChannelAttributeHelper.addConsumerGroup(clientChannelInfo.getChannel(), group);
+        }
         if (null != this.brokerStatsManager) {
             this.brokerStatsManager.incConsumerRegisterTime((int) (System.currentTimeMillis() - start));
         }

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ConsumerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ConsumerManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.client;
 
 import com.google.common.collect.ImmutableSet;
 import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.client.net.Broker2Client;
 import org.apache.rocketmq.broker.filter.ConsumerFilterManager;
@@ -234,5 +235,27 @@ public class ConsumerManagerTest {
         Set<String> actual = consumerManager.queryTopicConsumeByWho(TOPIC);
         assertThat(actual).contains(GROUP);
         assertThat(actual).doesNotContain(TOPIC);
+    }
+
+    @Test
+    public void testWithoutSubRegistrationRemovedOnFastChannelClose() {
+        when(brokerController.getBrokerConfig()).thenReturn(brokerConfig);
+        brokerConfig.setEnableFastChannelEventProcess(true);
+        brokerConfig.setNotifyConsumerIdsChangedEnable(false);
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        ClientChannelInfo channelInfo = new ClientChannelInfo(embeddedChannel, CLIENT_ID, LanguageCode.JAVA, VERSION);
+        try {
+            consumerManager.registerConsumerWithoutSub(GROUP, channelInfo, CONSUME_PASSIVELY,
+                MessageModel.CLUSTERING, ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET, false);
+            assertThat(consumerManager.getConsumerGroupInfo(GROUP)).isNotNull();
+
+            boolean removed = consumerManager.doChannelCloseEvent(CLIENT_ID, embeddedChannel);
+
+            assertTrue("consumer registered via heartbeat-v2 without subscription must be removed on channel close",
+                removed);
+            assertThat(consumerManager.getConsumerGroupInfo(GROUP)).isNull();
+        } finally {
+            embeddedChannel.finishAndReleaseAll();
+        }
     }
 }


### PR DESCRIPTION
### Problem / Evidence

With `enableFastChannelEventProcess=true`, the fast channel-close path in `ConsumerManager#doChannelCloseEvent` cleans up a consumer channel by iterating `ClientChannelAttributeHelper.getConsumerGroups(channel)`. That attribute is only written in the full `registerConsumer` (`r1` branch). `registerConsumerWithoutSub` — the path taken by heartbeat-v2 whenever the client's subscription fingerprint is unchanged (`withoutSub=true`, the normal reconnect case after broker restart / idle connection drop) — registers the channel in `consumerTable` but never writes the attribute.

Consequences (verified in code):
- A consumer registered on a channel **only** via withoutSub heartbeats is never removed by the fast close path: `getConsumerGroups` returns empty, the cleanup loop is skipped, `doChannelCloseEvent` returns false.
- A later full heartbeat on the same channel cannot repair it, because `updateChannel` returns false for an already-registered channel, so `registerConsumer`'s `r1`-guarded `addConsumerGroup` is not reached.

The dead entry lingers in `consumerTable` until `scanNotActiveChannel` expires it (`channelExpiredTimeout`, default 120s), delaying `UNREGISTER` (ConsumerFilterManager cleanup) and leaving stale entries in consumer connection queries.

Regression test `ConsumerManagerTest#testWithoutSubRegistrationRemovedOnFastChannelClose` fails before the fix (`removed == false`, group still in `consumerTable`) and passes after.

### Root cause / Fix

Mirror the `registerConsumer` attribute bookkeeping in `registerConsumerWithoutSub`: call `ClientChannelAttributeHelper.addConsumerGroup(channel, group)` when the channel was added/updated and fast channel event processing is enabled.

### Priority

PRIORITY = 72：影响 26（broker 重启/连接重建场景下失效消费者在 consumerTable 残留至 120s，延迟 UNREGISTER 通知与过滤器清理，污染连接列表——心跳 v2 常规路径）+ 波及范围 12（ConsumerManager fast 路径，单方法）+ 可复现性 20（确定性单元测试，EmbeddedChannel）+ 维护价值 14（与 registerConsumer 既有模式对齐，修复极小）。FIX_CONFIDENCE = 85。

### Tests

- `mvn -pl broker test -Dtest=ConsumerManagerTest#testWithoutSubRegistrationRemovedOnFastChannelClose`
  - before fix (ff8f6f74c + test only): `Tests run: 1, Failures: 1`
  - after fix: `Tests run: 1, Failures: 0`
- `mvn -pl broker test -Dtest=ConsumerManagerTest`: 14/14
- `mvn -pl broker test -Dtest=ConsumerManagerScannerTest,ClientManageProcessorTest`: 9/9

### Risk

Low. The added attribute write only occurs on the `updateChannel == true` branch (new channel), same condition as the existing `registerConsumer` bookkeeping; `ClientChannelAttributeHelper.addConsumerGroup` is a no-op for inactive channels. The attribute is consumed only by the fast close path, so behavior without `enableFastChannelEventProcess` is unchanged.

Closes #11039
