### PR TITLE
[ISSUE #11041] Fix off-by-one in paginated metadata sync dropping the last entry

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
@@ -831,7 +831,7 @@ public class BrokerOuterAPI {
                     continue;
                 }
 
-                if (topicSeq >= totalTopicNum - 1) {
+                if (topicSeq >= totalTopicNum) {
                     LOGGER.info("get all topic config, totalTopicNum: {}", totalTopicNum);
                     break;
                 }
@@ -981,7 +981,7 @@ public class BrokerOuterAPI {
                     continue;
                 }
 
-                if (groupSeq >= totalGroupNum - 1) {
+                if (groupSeq >= totalGroupNum) {
                     LOGGER.info("get all subscription group config, totalGroupNum: {}", totalGroupNum);
                     break;
                 }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -3030,7 +3030,7 @@ public class MQClientAPIImpl implements NameServerUpdateCallback, StartAndShutdo
                     continue;
                 }
 
-                if (groupSeq >= totalGroupNum - 1) {
+                if (groupSeq >= totalGroupNum) {
                     log.info("get all subscription group config, totalGroupNum: {}", totalGroupNum);
                     break;
                 }
@@ -3122,7 +3122,7 @@ public class MQClientAPIImpl implements NameServerUpdateCallback, StartAndShutdo
                     continue;
                 }
 
-                if (topicSeq >= totalTopicNum - 1) {
+                if (topicSeq >= totalTopicNum) {
                     log.info("get all topic config, totalTopicNum: {}", totalTopicNum);
                     break;
                 }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/MQClientAPIImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/MQClientAPIImplTest.java
@@ -65,6 +65,7 @@ import org.apache.rocketmq.remoting.netty.NettyRemotingClient;
 import org.apache.rocketmq.remoting.netty.ResponseFuture;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
+import org.apache.rocketmq.remoting.protocol.DataVersion;
 import org.apache.rocketmq.remoting.protocol.RequestCode;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
@@ -110,6 +111,8 @@ import org.apache.rocketmq.remoting.protocol.header.EndTransactionRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ExtraInfoUtil;
 import org.apache.rocketmq.remoting.protocol.header.GetConsumerListByGroupResponseBody;
 import org.apache.rocketmq.remoting.protocol.header.GetConsumerListByGroupResponseHeader;
+import org.apache.rocketmq.remoting.protocol.header.GetAllSubscriptionGroupResponseHeader;
+import org.apache.rocketmq.remoting.protocol.header.GetAllTopicConfigResponseHeader;
 import org.apache.rocketmq.remoting.protocol.header.GetEarliestMsgStoretimeResponseHeader;
 import org.apache.rocketmq.remoting.protocol.header.GetMaxOffsetResponseHeader;
 import org.apache.rocketmq.remoting.protocol.header.GetMinOffsetResponseHeader;
@@ -156,6 +159,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -1741,6 +1745,88 @@ public class MQClientAPIImplTest {
     }
 
     @Test
+    public void testGetAllTopicConfigFetchesLastEntryWhenTotalIsOneOverPageSize()
+        throws Exception {
+        final int pageSize = 100;
+        final int total = pageSize + 1;
+        ClientConfig pagedClientConfig = new ClientConfig();
+        pagedClientConfig.setMaxPageSizeInGetMetadata(pageSize);
+        MQClientAPIImpl pagedApi = new MQClientAPIImpl(new NettyClientConfig(), null, null, pagedClientConfig);
+        Field field = MQClientAPIImpl.class.getDeclaredField("remotingClient");
+        field.setAccessible(true);
+        field.set(pagedApi, remotingClient);
+
+        DataVersion dataVersion = new DataVersion();
+        TopicConfigSerializeWrapper page1 = new TopicConfigSerializeWrapper();
+        for (int i = 0; i < pageSize; i++) {
+            page1.getTopicConfigTable().put("topic-" + i, new TopicConfig("topic-" + i));
+        }
+        page1.setDataVersion(dataVersion);
+        TopicConfigSerializeWrapper page2 = new TopicConfigSerializeWrapper();
+        page2.getTopicConfigTable().put("topic-" + pageSize, new TopicConfig("topic-" + pageSize));
+        page2.setDataVersion(dataVersion);
+
+        GetAllTopicConfigResponseHeader header1 = new GetAllTopicConfigResponseHeader();
+        header1.setTotalTopicNum(total);
+        RemotingCommand resp1 = wireResponse(RemotingCommand.createResponseCommandWithHeader(ResponseCode.SUCCESS, header1));
+        resp1.setBody(RemotingSerializable.encode(page1));
+        GetAllTopicConfigResponseHeader header2 = new GetAllTopicConfigResponseHeader();
+        header2.setTotalTopicNum(total);
+        RemotingCommand resp2 = wireResponse(RemotingCommand.createResponseCommandWithHeader(ResponseCode.SUCCESS, header2));
+        resp2.setBody(RemotingSerializable.encode(page2));
+        when(remotingClient.invokeSync(anyString(), any(RemotingCommand.class), anyLong()))
+            .thenReturn(resp1, resp2);
+
+        TopicConfigSerializeWrapper actual = pagedApi.getAllTopicConfig(defaultBrokerAddr, defaultTimeout);
+
+        assertEquals(total, actual.getTopicConfigTable().size());
+        assertEquals("topic-" + pageSize, actual.getTopicConfigTable().get("topic-" + pageSize).getTopicName());
+    }
+
+    @Test
+    public void testGetAllSubscriptionGroupFetchesLastEntryWhenTotalIsOneOverPageSize()
+        throws Exception {
+        final int pageSize = 100;
+        final int total = pageSize + 1;
+        ClientConfig pagedClientConfig = new ClientConfig();
+        pagedClientConfig.setMaxPageSizeInGetMetadata(pageSize);
+        MQClientAPIImpl pagedApi = new MQClientAPIImpl(new NettyClientConfig(), null, null, pagedClientConfig);
+        Field field = MQClientAPIImpl.class.getDeclaredField("remotingClient");
+        field.setAccessible(true);
+        field.set(pagedApi, remotingClient);
+
+        DataVersion dataVersion = new DataVersion();
+        SubscriptionGroupWrapper page1 = new SubscriptionGroupWrapper();
+        for (int i = 0; i < pageSize; i++) {
+            SubscriptionGroupConfig config = new SubscriptionGroupConfig();
+            config.setGroupName("group-" + i);
+            page1.getSubscriptionGroupTable().put("group-" + i, config);
+        }
+        page1.setDataVersion(dataVersion);
+        SubscriptionGroupWrapper page2 = new SubscriptionGroupWrapper();
+        SubscriptionGroupConfig lastConfig = new SubscriptionGroupConfig();
+        lastConfig.setGroupName("group-" + pageSize);
+        page2.getSubscriptionGroupTable().put("group-" + pageSize, lastConfig);
+        page2.setDataVersion(dataVersion);
+
+        GetAllSubscriptionGroupResponseHeader header1 = new GetAllSubscriptionGroupResponseHeader();
+        header1.setTotalGroupNum(total);
+        RemotingCommand resp1 = wireResponse(RemotingCommand.createResponseCommandWithHeader(ResponseCode.SUCCESS, header1));
+        resp1.setBody(RemotingSerializable.encode(page1));
+        GetAllSubscriptionGroupResponseHeader header2 = new GetAllSubscriptionGroupResponseHeader();
+        header2.setTotalGroupNum(total);
+        RemotingCommand resp2 = wireResponse(RemotingCommand.createResponseCommandWithHeader(ResponseCode.SUCCESS, header2));
+        resp2.setBody(RemotingSerializable.encode(page2));
+        when(remotingClient.invokeSync(anyString(), any(RemotingCommand.class), anyLong()))
+            .thenReturn(resp1, resp2);
+
+        SubscriptionGroupWrapper actual = pagedApi.getAllSubscriptionGroup(defaultBrokerAddr, defaultTimeout);
+
+        assertEquals(total, actual.getSubscriptionGroupTable().size());
+        assertNotNull(actual.getSubscriptionGroupTable().get("group-" + pageSize));
+    }
+
+    @Test
     public void testUpdateNameServerConfig() throws RemotingException, InterruptedException, MQClientException, UnsupportedEncodingException {
         mockInvokeSync();
         mqClientAPI.updateNameServerConfig(createProperties(), Collections.singletonList(defaultNsAddr), defaultTimeout);
@@ -2136,6 +2222,16 @@ public class MQClientAPIImplTest {
 
     private void setResponseBody(Object responseBody) {
         when(response.getBody()).thenReturn(RemotingSerializable.encode(responseBody));
+    }
+
+    /**
+     * Round-trips the response through encode/decode so response headers are carried as extFields,
+     * mirroring the wire format the client actually parses.
+     */
+    private static RemotingCommand wireResponse(RemotingCommand response) throws RemotingCommandException {
+        ByteBuffer frame = response.encode();
+        frame.position(4); // strip the total length the transport decoder consumes
+        return RemotingCommand.decode(frame.slice());
     }
 
     private void mockInvokeSync() throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException {


### PR DESCRIPTION
### Problem / Evidence

The split-metadata pagination loops terminate one entry too early. The client loops in `MQClientAPIImpl#getAllTopicConfig` / `#getAllSubscriptionGroup` break on `topicSeq >= totalTopicNum - 1` / `groupSeq >= totalGroupNum - 1`, while the broker pages `[seq, seq + maxNum)` with no overlap (`TopicConfigManager#subTopicConfig`, `SubscriptionGroupManager#subGroupTable`, `totalTopicNum = size()`).

After page k the client holds `k·pageSize` entries, so the loop stops as soon as `k·pageSize >= N − 1` — which is already true when exactly one entry remains unfetched, i.e. for every **N ≡ 1 (mod pageSize)**. Example: 2001 topics with the default page size 2000 → page 1 returns 2000 entries, `2000 >= 2001 − 1` holds, the loop breaks, topic #2001 is never requested. No error, no retry — silently truncated metadata.

The identical off-by-one exists in `BrokerOuterAPI#getAllTopicConfig` (used by `SlaveSynchronize#syncTopicConfig`) and `BrokerOuterAPI#getAllSubscriptionGroup`: a slave whose master has N ≡ 1 (mod 2000) topics permanently misses the last topic — and the dataVersion comparison then matches, so no later resync repairs it.

Regression tests `MQClientAPIImplTest#testGetAllTopicConfigFetchesLastEntryWhenTotalIsOneOverPageSize` and `#testGetAllSubscriptionGroupFetchesLastEntryWhenTotalIsOneOverPageSize` fail before the fix (`expected:<101> but was:<100>`) and pass after.

### Root cause / Fix

Terminate when `seq >= totalNum`. When the page completes the set the condition still breaks immediately; when exactly one entry remains it now continues and fetches the final page (a subsequent empty page still terminates because `seq >= totalNum` remains true). Applied to all four occurrences of the same defect: `MQClientAPIImpl` (topic + subscription group) and `BrokerOuterAPI` (topic + subscription group).

### Priority

PRIORITY = 74：影响 28（静默元数据截断——mqadmin 导出/同步工具丢最后一个 topic/消费组，SlaveSynchronize 全量同步永久缺最新 topic 且不会自愈）+ 波及范围 14（4 处同类循环、client+broker 两端）+ 可复现性 20（确定性单元测试，N = pageSize + 1 边界）+ 维护价值 12（一行终止条件 ×4）。FIX_CONFIDENCE = 90。

### Tests

- `mvn -pl client test -Dtest=MQClientAPIImplTest#testGetAllTopicConfigFetchesLastEntryWhenTotalIsOneOverPageSize`
  - before fix (ff8f6f74c + test only): `Tests run: 1, Failures: 1` — `expected:<101> but was:<100>`
  - after fix: `Tests run: 1, Failures: 0`
- same for `testGetAllSubscriptionGroupFetchesLastEntryWhenTotalIsOneOverPageSize`
- `mvn -pl client test -Dtest=MQClientAPIImplTest`: `Tests run: 135, Failures: 0, Errors: 0`
- `mvn -pl broker compile`: OK (BrokerOuterAPI change)

### Risk

Low. The only behavior change is that exactly one extra page request is issued in the boundary case (and none in any other case — for all other N the old and new conditions break at the same page). Old-version brokers that do not return `totalTopicNum`/`totalGroupNum` are unaffected (the null-compatibility break precedes this condition).

Closes #11041
