### PR TITLE
[ISSUE #11043] Skip stale channel-destroy unregister when the broker re-registered

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/BatchUnregistrationService.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/BatchUnregistrationService.java
@@ -26,7 +26,6 @@ import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.namesrv.NamesrvConfig;
 import org.apache.rocketmq.logging.org.slf4j.Logger;
 import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
-import org.apache.rocketmq.remoting.protocol.header.namesrv.UnRegisterBrokerRequestHeader;
 
 /**
  * BatchUnregistrationService provides a mechanism to unregister brokers in batch manner, which speeds up broker-offline
@@ -34,7 +33,7 @@ import org.apache.rocketmq.remoting.protocol.header.namesrv.UnRegisterBrokerRequ
  */
 public class BatchUnregistrationService extends ServiceThread {
     private final RouteInfoManager routeInfoManager;
-    private BlockingQueue<UnRegisterBrokerRequestHeader> unregistrationQueue;
+    private BlockingQueue<RouteInfoManager.BrokerUnregistration> unregistrationQueue;
     private static final Logger log = LoggerFactory.getLogger(LoggerName.NAMESRV_LOGGER_NAME);
 
     public BatchUnregistrationService(RouteInfoManager routeInfoManager, NamesrvConfig namesrvConfig) {
@@ -48,7 +47,7 @@ public class BatchUnregistrationService extends ServiceThread {
      * @param unRegisterRequest the request to submit
      * @return {@code true} if the request was added to this queue, else {@code false}
      */
-    public boolean submit(UnRegisterBrokerRequestHeader unRegisterRequest) {
+    public boolean submit(RouteInfoManager.BrokerUnregistration unRegisterRequest) {
         return unregistrationQueue.offer(unRegisterRequest);
     }
 
@@ -61,14 +60,14 @@ public class BatchUnregistrationService extends ServiceThread {
     public void run() {
         while (!this.isStopped()) {
             try {
-                final UnRegisterBrokerRequestHeader request = unregistrationQueue.take();
-                Set<UnRegisterBrokerRequestHeader> unregistrationRequests = new HashSet<>();
+                final RouteInfoManager.BrokerUnregistration request = unregistrationQueue.take();
+                Set<RouteInfoManager.BrokerUnregistration> unregistrationRequests = new HashSet<>();
                 unregistrationQueue.drainTo(unregistrationRequests);
 
                 // Add polled request
                 unregistrationRequests.add(request);
 
-                this.routeInfoManager.unRegisterBroker(unregistrationRequests);
+                this.routeInfoManager.doUnRegisterBroker(unregistrationRequests);
             } catch (Throwable e) {
                 log.error("Handle unregister broker request failed", e);
             }

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicConfig;
@@ -102,7 +103,12 @@ public class RouteInfoManager {
     }
 
     public boolean submitUnRegisterBrokerRequest(UnRegisterBrokerRequestHeader unRegisterRequest) {
-        return this.unRegisterService.submit(unRegisterRequest);
+        return submitUnRegisterBrokerRequest(unRegisterRequest, null);
+    }
+
+    public boolean submitUnRegisterBrokerRequest(UnRegisterBrokerRequestHeader unRegisterRequest,
+        Channel expectedChannel) {
+        return this.unRegisterService.submit(new BrokerUnregistration(unRegisterRequest, expectedChannel));
     }
 
     // For test only
@@ -569,18 +575,39 @@ public class RouteInfoManager {
     }
 
     public void unRegisterBroker(Set<UnRegisterBrokerRequestHeader> unRegisterRequests) {
+        Set<BrokerUnregistration> brokerUnregistrations = unRegisterRequests.stream()
+            .map(request -> new BrokerUnregistration(request, null))
+            .collect(Collectors.toSet());
+        doUnRegisterBroker(brokerUnregistrations);
+    }
+
+    void doUnRegisterBroker(Set<BrokerUnregistration> unRegisterRequests) {
         try {
             Set<String> removedBroker = new HashSet<>();
             Set<String> reducedBroker = new HashSet<>();
             Map<String, BrokerStatusChangeInfo> needNotifyBrokerMap = new HashMap<>();
 
             this.lock.writeLock().lockInterruptibly();
-            for (final UnRegisterBrokerRequestHeader unRegisterRequest : unRegisterRequests) {
+            for (final BrokerUnregistration brokerUnregistration : unRegisterRequests) {
+                final UnRegisterBrokerRequestHeader unRegisterRequest = brokerUnregistration.getRequest();
                 final String brokerName = unRegisterRequest.getBrokerName();
                 final String clusterName = unRegisterRequest.getClusterName();
                 final String brokerAddr = unRegisterRequest.getBrokerAddr();
 
                 BrokerAddrInfo brokerAddrInfo = new BrokerAddrInfo(clusterName, brokerAddr);
+
+                // A destroy-derived unregister may have been queued before the broker re-registered;
+                // skip it when the current live entry belongs to a newer channel.
+                Channel expectedChannel = brokerUnregistration.getExpectedChannel();
+                if (expectedChannel != null) {
+                    BrokerLiveInfo currentLiveInfo = this.brokerLiveTable.get(brokerAddrInfo);
+                    if (currentLiveInfo != null && currentLiveInfo.getChannel() != expectedChannel) {
+                        log.info("unregisterBroker skipped, the broker has re-registered with a new channel "
+                            + "since the destroy event, {}, current channel: {}", brokerAddrInfo,
+                            currentLiveInfo.getChannel());
+                        continue;
+                    }
+                }
 
                 BrokerLiveInfo brokerLiveInfo = this.brokerLiveTable.remove(brokerAddrInfo);
                 log.info("unregisterBroker, remove from brokerLiveTable {}, {}",
@@ -646,6 +673,30 @@ public class RouteInfoManager {
             log.error("unregisterBroker Exception", e);
         } finally {
             this.lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * An unregister request paired with the channel whose destruction produced it. When the
+     * expected channel is set, the unregister is skipped if the broker has re-registered with a
+     * newer channel in the meantime; a null expected channel means the unregister was explicitly
+     * initiated and must run unconditionally.
+     */
+    static class BrokerUnregistration {
+        private final UnRegisterBrokerRequestHeader request;
+        private final Channel expectedChannel;
+
+        BrokerUnregistration(UnRegisterBrokerRequestHeader request, Channel expectedChannel) {
+            this.request = request;
+            this.expectedChannel = expectedChannel;
+        }
+
+        public UnRegisterBrokerRequestHeader getRequest() {
+            return request;
+        }
+
+        public Channel getExpectedChannel() {
+            return expectedChannel;
         }
     }
 
@@ -819,11 +870,14 @@ public class RouteInfoManager {
 
     public void onChannelDestroy(BrokerAddrInfo brokerAddrInfo) {
         UnRegisterBrokerRequestHeader unRegisterRequest = new UnRegisterBrokerRequestHeader();
+        Channel expectedChannel = null;
         boolean needUnRegister = false;
         if (brokerAddrInfo != null) {
             try {
                 try {
                     this.lock.readLock().lockInterruptibly();
+                    BrokerLiveInfo brokerLiveInfo = this.brokerLiveTable.get(brokerAddrInfo);
+                    expectedChannel = brokerLiveInfo != null ? brokerLiveInfo.getChannel() : null;
                     needUnRegister = setupUnRegisterRequest(unRegisterRequest, brokerAddrInfo);
                 } finally {
                     this.lock.readLock().unlock();
@@ -834,7 +888,7 @@ public class RouteInfoManager {
         }
 
         if (needUnRegister) {
-            boolean result = this.submitUnRegisterBrokerRequest(unRegisterRequest);
+            boolean result = this.submitUnRegisterBrokerRequest(unRegisterRequest, expectedChannel);
             log.info("the broker's channel destroyed, submit the unregister request at once, " +
                 "broker info: {}, submit result: {}", unRegisterRequest, result);
         }
@@ -867,7 +921,7 @@ public class RouteInfoManager {
         }
 
         if (needUnRegister) {
-            boolean result = this.submitUnRegisterBrokerRequest(unRegisterRequest);
+            boolean result = this.submitUnRegisterBrokerRequest(unRegisterRequest, channel);
             log.info("the broker's channel destroyed, submit the unregister request at once, " +
                 "broker info: {}, submit result: {}", unRegisterRequest, result);
         }

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerNewTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerNewTest.java
@@ -170,6 +170,47 @@ public class RouteInfoManagerNewTest {
     }
 
     @Test
+    public void testStaleChannelDestroyDoesNotWipeFreshReRegistration() {
+        Channel oldChannel = mock(Channel.class);
+        Channel newChannel = mock(Channel.class);
+        registerBroker(BrokerBasicInfo.defaultBroker(), oldChannel, null, "TestTopic");
+        // the broker reconnects and re-registers with a new channel before the queued
+        // channel-destroy request is executed
+        registerBroker(BrokerBasicInfo.defaultBroker(), newChannel, null, "TestTopic");
+
+        // execute the destroy request derived from the OLD registration exactly as the service would
+        routeInfoManager.doUnRegisterBroker(Sets.newHashSet(
+            new RouteInfoManager.BrokerUnregistration(BrokerBasicInfo.defaultBroker().unRegisterRequest(), oldChannel)));
+
+        assertThat(routeInfoManager.pickupTopicRouteData("TestTopic")).isNotNull();
+    }
+
+    @Test
+    public void testChannelDestroyRemovesRegistrationWhenChannelMatches() {
+        Channel channel = mock(Channel.class);
+        registerBroker(BrokerBasicInfo.defaultBroker(), channel, null, "TestTopic");
+
+        routeInfoManager.doUnRegisterBroker(Sets.newHashSet(
+            new RouteInfoManager.BrokerUnregistration(BrokerBasicInfo.defaultBroker().unRegisterRequest(), channel)));
+
+        assertThat(routeInfoManager.pickupTopicRouteData("TestTopic")).isNull();
+    }
+
+    @Test
+    public void testBrokerInitiatedUnregisterIsUnconditional() {
+        Channel oldChannel = mock(Channel.class);
+        Channel newChannel = mock(Channel.class);
+        registerBroker(BrokerBasicInfo.defaultBroker(), oldChannel, null, "TestTopic");
+        registerBroker(BrokerBasicInfo.defaultBroker(), newChannel, null, "TestTopic");
+
+        // an explicitly initiated unregister (null expected channel) removes the current registration
+        routeInfoManager.doUnRegisterBroker(Sets.newHashSet(
+            new RouteInfoManager.BrokerUnregistration(BrokerBasicInfo.defaultBroker().unRegisterRequest(), null)));
+
+        assertThat(routeInfoManager.pickupTopicRouteData("TestTopic")).isNull();
+    }
+
+    @Test
     public void registerSlaveBroker() {
         registerBrokerWithNormalTopic(BrokerBasicInfo.defaultBroker(), "TestTopic");
 


### PR DESCRIPTION
### Problem / Evidence

Since `BatchUnregistrationService`, the decision to unregister a broker (heartbeat expiry in `scanNotActiveBroker`, channel-close events) and its execution are separated by queue latency and blocking `closeChannel` I/O. The decision (`setupUnRegisterRequest`) matches only by `clusterName + brokerAddr`, and `unRegisterBroker` removes unconditionally:

- `brokerLiveTable.remove(brokerAddrInfo)` — no freshness re-check;
- the addr mapping via `removeIf(item -> item.getValue().equals(brokerAddr))` — by address only, ignoring the `brokerId` in the request (while `registerBroker` distinguishes ids for the same address);
- and all topic QueueDatas for the broker.

If the broker is alive and re-registers between the expiry decision and the queued execution (namesrv GC pause / scan backlog that transiently expires live brokers), the brand-new registration is deleted and the broker vanishes from all routes until its next periodic re-registration (`registerNameServerPeriod` ≈ 30s) — cluster-wide TOPIC_NOT_EXIST / no-route windows. The address-only removal also lets a queued slave unregister wipe a master re-registered at the same address.

Deterministic regression test `RouteInfoManagerNewTest#testStaleChannelDestroyDoesNotWipeFreshReRegistration`: register (channel1) → re-register (channel2) → execute the destroy request derived from channel1 → the fresh registration must survive. Before the fix it is removed (`pickupTopicRouteData` returns null; verified against ff8f6f74c with the equivalent pre-fix execution path — see Tests).

### Root cause / Fix

Pair each queued unregister request with the channel whose destruction produced it (`BrokerUnregistration`), and inside the write-locked removal skip requests whose current live entry belongs to a newer channel. This mirrors the channel-identity guard that `onChannelDestroy(Channel)` already applies at decision time, but closes the decision-to-execution gap. Explicitly initiated unregisters (the broker's own UNREGISTER_BROKER request, and `RouteInfoManager#unregisterBroker`) keep their unconditional behavior (`expectedChannel == null`).

### Priority

PRIORITY = 72：影响 30（活 broker 从路由中消失最长 30s，全集群对该 broker 的路由/写入失败——GC 停顿或扫描积压后可触发）+ 波及范围 10（namesrv 注销路径）+ 可复现性 18（确定性单元测试复现完整交错）+ 维护价值 14（与既有 channel 身份校验模式一致）。FIX_CONFIDENCE = 82（判据明确：channel 身份不变性；broker 主动注销路径保持无条件）。

### Tests

- `mvn -pl namesrv test -Dtest=RouteInfoManagerNewTest`: `Tests run: 32, Failures: 0, Errors: 0`（含 3 个新测试：过期销毁跳过、匹配销毁仍删除、broker 主动注销无条件）
- 修复前实测（ff8f6f74c + 等价公共 API 执行路径）：stale destroy 场景 `AssertionError: fresh registration must survive the stale destroy request`
- `mvn -pl namesrv test -Dtest=RouteInfoManagerTest,RouteInfoManagerBrokerRegisterTest,RouteInfoManagerStaticRegisterTest`: 23/23

### Risk

Low-to-moderate. The skip only triggers when a queued destroy request refers to a live entry whose channel has been replaced — i.e. exactly the stale-event case; a same-channel destroy (the normal case, including the existing await-drain tests) behaves as before. The batch queue element type changes from `UnRegisterBrokerRequestHeader` to the internal `BrokerUnregistration` wrapper; the public `submitUnRegisterBrokerRequest(header)` / `unRegisterBroker(Set<header>)` signatures used by `DefaultRequestProcessor` and existing tests are unchanged. If a broker genuinely left while its replacement channel exists (re-registration with the same addr), the next heartbeat expiry scan will re-emit a destroy event for the actual channel, so no permanent leak.

Closes #11043
