### PR TITLE
[ISSUE #11045] Rebind broker channel on heartbeat so stale channel close cannot evict a live broker

### DIFF
--- a/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/DefaultBrokerHeartbeatManager.java
+++ b/controller/src/main/java/org/apache/rocketmq/controller/impl/heartbeat/DefaultBrokerHeartbeatManager.java
@@ -134,6 +134,11 @@ public class DefaultBrokerHeartbeatManager implements BrokerHeartbeatManager {
             prev.setLastUpdateTimestamp(System.currentTimeMillis());
             prev.setHeartbeatTimeoutMillis(realTimeoutMillis);
             prev.setElectionPriority(realElectionPriority);
+            // Rebind the live entry to the current channel, otherwise a close event of a stale
+            // channel would evict a broker that is already alive on a new channel
+            if (channel != null && channel != prev.getChannel()) {
+                prev.setChannel(channel);
+            }
             if (realEpoch > prev.getEpoch() || realEpoch == prev.getEpoch() && realMaxOffset > prev.getMaxOffset()) {
                 prev.setEpoch(realEpoch);
                 prev.setMaxOffset(realMaxOffset);

--- a/controller/src/test/java/org/apache/rocketmq/controller/impl/DefaultBrokerHeartbeatManagerTest.java
+++ b/controller/src/test/java/org/apache/rocketmq/controller/impl/DefaultBrokerHeartbeatManagerTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.rocketmq.controller.impl;
 
+import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.rocketmq.common.ControllerConfig;
 import org.apache.rocketmq.controller.BrokerHeartbeatManager;
+import org.apache.rocketmq.controller.impl.heartbeat.BrokerLiveInfo;
 import org.apache.rocketmq.controller.impl.heartbeat.DefaultBrokerHeartbeatManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +27,9 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultBrokerHeartbeatManagerTest {
@@ -49,6 +54,35 @@ public class DefaultBrokerHeartbeatManagerTest {
             1, 1L, -1L, 0);
         assertTrue(latch.await(5000, TimeUnit.MILLISECONDS));
         this.heartbeatManager.shutdown();
+    }
+
+    @Test
+    public void testStaleChannelCloseDoesNotEvictReRegisteredBroker() {
+        final EmbeddedChannel oldChannel = new EmbeddedChannel();
+        final EmbeddedChannel newChannel = new EmbeddedChannel();
+        try {
+            // First heartbeat pins the live entry to the old channel
+            this.heartbeatManager.onBrokerHeartbeat("cluster1", "broker1", "127.0.0.1:7000", 0L, 3000L, oldChannel,
+                1, 1L, -1L, 0);
+            // The broker reconnects and keeps heartbeating on a new channel
+            this.heartbeatManager.onBrokerHeartbeat("cluster1", "broker1", "127.0.0.1:7000", 0L, 3000L, newChannel,
+                1, 1L, -1L, 0);
+            // The old channel fires its close event only after the re-registration
+            this.heartbeatManager.onBrokerChannelClose(oldChannel);
+
+            final BrokerLiveInfo liveInfo = this.heartbeatManager.getBrokerLiveInfo("cluster1", "broker1", 0L);
+            assertNotNull("A stale channel close must not evict a broker alive on a new channel", liveInfo);
+            assertEquals("The live entry must be rebound to the current channel",
+                newChannel, liveInfo.getChannel());
+
+            // The close event of the current channel still removes the entry
+            this.heartbeatManager.onBrokerChannelClose(newChannel);
+            assertNull(this.heartbeatManager.getBrokerLiveInfo("cluster1", "broker1", 0L));
+        } finally {
+            oldChannel.finishAndReleaseAll();
+            newChannel.finishAndReleaseAll();
+            this.heartbeatManager.shutdown();
+        }
     }
 
 }


### PR DESCRIPTION
Closes #11045

### Problem / Evidence

`DefaultBrokerHeartbeatManager#onBrokerHeartbeat` never rebinds the channel of an existing `BrokerLiveInfo` — the `prev != null` branch only refreshes the timestamp, timeout, election priority and epoch (`DefaultBrokerHeartbeatManager.java:133-142`), so the live entry stays pinned to the broker's **first-ever** channel.

When the broker-to-controller connection dies half-open (or the controller-side close event for the old channel arrives late), the broker client reconnects first and keeps heartbeating on a new channel. When the old channel eventually fires `channelInactive`/`onChannelException`/`onChannelIdle`, `BrokerHousekeepingService` (wired as the controller `ChannelEventListener` in `ControllerManager`, passed to `DLedgerServer`) calls `onBrokerChannelClose(oldChannel)`, which matches the stale stored channel, **removes the live entry of a broker that is healthy on the new channel** and fires `notifyBrokerInActive`. `ControllerManager#onBrokerInactive` then checks `getReplicaInfo` and, because the evicted broker is the current master, calls `triggerElectMaster` — a spurious failover (epoch bump, possible master change, sync-state reset) for a healthy broker-set.

Deterministic regression test `DefaultBrokerHeartbeatManagerTest#testStaleChannelCloseDoesNotEvictReRegisteredBroker` fails on unmodified `develop`:

```
DefaultBrokerHeartbeatManagerTest.testStaleChannelCloseDoesNotEvictReRegisteredBroker:74
A stale channel close must not evict a broker alive on a new channel
Tests run: 2, Failures: 1, Errors: 0, Skipped: 1  (develop @ ff8f6f74c, 2026-09-05)
```

### Root cause / Fix

The heartbeat path keeps the stale channel reference forever. This is inconsistent with the NameServer implementation, where the broker's channel is refreshed on every registration heartbeat.

Fix: rebind the live entry to the current channel in `onBrokerHeartbeat` when a non-null channel arrives, so `onBrokerChannelClose` only removes entries whose stored channel is the one that actually closed:

```java
// Rebind the live entry to the current channel, otherwise a close event of a stale
// channel would evict a broker that is already alive on a new channel
if (channel != null && channel != prev.getChannel()) {
    prev.setChannel(channel);
}
```

### Priority

PRIORITY = 76（影响 30 + 波及范围 14 + 可复现 18 + 维护价值 14），FIX_CONFIDENCE = 88。

- 影响 30/40: spurious master election / epoch bump fencing a healthy master — an availability and correctness event for every controller-mode deployment (the default dLedger controller uses this heartbeat manager).
- 波及范围 14/20: all controller-mode deployments; the mechanism (heartbeat + channel lifecycle) runs continuously.
- 可复现 18/20: deterministic two-channel unit test; the reconnect-before-close ordering is a routine network scenario.
- 维护价值 14/20: same bug family as the nameserver stale-channel issues; small, well-bounded fix aligning controller with nameserver behavior.

### Tests

- Regression test added: `DefaultBrokerHeartbeatManagerTest#testStaleChannelCloseDoesNotEvictReRegisteredBroker` (fails before the fix as shown above).
- After the fix (`develop @ ff8f6f74c` + this change, 2026-09-05):

```
mvn -pl controller test -Dtest=DefaultBrokerHeartbeatManagerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0  — BUILD SUCCESS
```

- Full controller module: `mvn -pl controller test` — all tests pass except the pre-existing baseline failure `ReplicasInfoManagerTest#testSerialize` (JDK-21 `InaccessibleObjectException: Unable to make field ... AtomicLong.value accessible`), which reproduces identically on unmodified `develop @ ff8f6f74c` and is unrelated to this change.

### Risk

Very low. The added branch only updates a mutable field that was previously never refreshed after creation; heartbeats without a channel (the existing test passes `null`) keep the old behavior. The close-detection semantics (`getChannel() == channel` identity match) are unchanged — they simply now compare against the current channel. The jRaft heartbeat manager keeps its own raft-routed close handling and is untouched.
