### PR TITLE
[ISSUE #11047] Retry only failed timer requests so succeeded ones are not enqueued twice

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -1512,8 +1512,19 @@ public class TimerMessageStore {
             }
 
             while (!isStopped()) {
-                CountDownLatch latch = new CountDownLatch(trs.size());
+                // Only retry the requests that have not succeeded yet, otherwise the
+                // already-succeeded requests would be enqueued again and delivered multiple times
+                List<TimerRequest> retryList = new ArrayList<>(trs.size());
                 for (TimerRequest req : trs) {
+                    if (!req.isSucc()) {
+                        retryList.add(req);
+                    }
+                }
+                if (retryList.isEmpty()) {
+                    break;
+                }
+                CountDownLatch latch = new CountDownLatch(retryList.size());
+                for (TimerRequest req : retryList) {
                     req.setLatch(latch);
                     if (storeConfig.isTimerWheelSnapshotFlush()) {
                         synchronized (lockWhenFlush) {
@@ -1524,7 +1535,7 @@ public class TimerMessageStore {
                     }
                 }
                 checkDequeueLatch(latch, -1);
-                boolean allSuccess = trs.stream().allMatch(TimerRequest::isSucc);
+                boolean allSuccess = retryList.stream().allMatch(TimerRequest::isSucc);
                 if (allSuccess) {
                     break;
                 } else {

--- a/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
@@ -653,6 +653,56 @@ public class TimerMessageStoreTest {
         }
     }
 
+    @Test
+    public void testEnqueueRetryDoesNotReprocessSucceededRequests() throws Exception {
+        Assume.assumeFalse(MixAll.isWindows());
+        String rootDir = StoreTestUtils.createBaseDir();
+        baseDirs.add(rootDir);
+        TimerCheckpoint timerCheckpoint =
+            new TimerCheckpoint(rootDir + File.separator + "config" + File.separator + "timercheck");
+        TimerMetrics timerMetrics =
+            new TimerMetrics(rootDir + File.separator + "config" + File.separator + "timermetrics");
+
+        final long poisonOffsetPy = 100L;
+        final long normalOffsetPy = 200L;
+        final Map<Long, AtomicInteger> enqueueCalls = new ConcurrentHashMap<>();
+
+        TimerMessageStore timerMessageStore =
+            new TimerMessageStore(messageStore, storeConfig, timerCheckpoint, timerMetrics, null) {
+                @Override
+                public boolean doEnqueue(long offsetPy, int sizePy, long delayedTime,
+                    MessageExt messageExt, boolean isFromTimeline) {
+                    int calls = enqueueCalls.computeIfAbsent(offsetPy, key -> new AtomicInteger(0)).incrementAndGet();
+                    if (offsetPy == poisonOffsetPy && calls == 1) {
+                        // Simulate a transient TimerLog append failure for this request only,
+                        // leaving the other request of the batch successful
+                        return false;
+                    }
+                    return super.doEnqueue(offsetPy, sizePy, delayedTime, messageExt, isFromTimeline);
+                }
+            };
+        messageStore.setTimerMessageStore(timerMessageStore);
+        timerStores.add(timerMessageStore);
+
+        long delayTime = System.currentTimeMillis() + 10 * precisionMs;
+        TimerRequest poisonReq = new TimerRequest(poisonOffsetPy, msgBody.length, delayTime,
+            System.currentTimeMillis(), TimerMessageStore.MAGIC_DEFAULT);
+        poisonReq.setMsg(buildMessage(delayTime, "TimerTest_enqueueRetryPoison", false));
+        TimerRequest normalReq = new TimerRequest(normalOffsetPy, msgBody.length, delayTime,
+            System.currentTimeMillis(), TimerMessageStore.MAGIC_DEFAULT);
+        normalReq.setMsg(buildMessage(delayTime, "TimerTest_enqueueRetryNormal", false));
+        timerMessageStore.enqueuePutQueue.put(poisonReq);
+        timerMessageStore.enqueuePutQueue.put(normalReq);
+
+        TimerMessageStore.TimerEnqueuePutService service = timerMessageStore.new TimerEnqueuePutService();
+        service.fetchAndPutTimerRequest();
+
+        // The request whose first attempt failed is retried and then succeeds
+        assertEquals(2, enqueueCalls.get(poisonOffsetPy).get());
+        // The request that already succeeded in the first round must not be re-enqueued
+        assertEquals(1, enqueueCalls.get(normalOffsetPy).get());
+    }
+
     @After
     public void clear() {
         for (TimerMessageStore store : timerStores) {


### PR DESCRIPTION
Closes #11047

### Problem / Evidence

`TimerEnqueuePutService#fetchAndPutTimerRequest` retries the **whole** batch when any single request fails:

```java
while (!isStopped()) {
    CountDownLatch latch = new CountDownLatch(trs.size());
    for (TimerRequest req : trs) {          // <-- every request, including already-succeeded ones
        req.setLatch(latch);
        ... this.putMessageToTimerWheel(req);
    }
    checkDequeueLatch(latch, -1);
    boolean allSuccess = trs.stream().allMatch(TimerRequest::isSucc);
    ...
}
```

If one request's `doEnqueue` fails (e.g. `TimerLog#append` returns -1 when a new mapped file cannot be allocated in time at rollover, or any unexpected throwable while `timerSkipUnknownError=false`), every subsequent round re-invokes `putMessageToTimerWheel` for the requests whose `doEnqueue` already succeeded — each round appends another `TimerLog` unit for the same message into the same timer-wheel slot. On dequeue, every unit is an independent `MAGIC_DEFAULT` record, so the scheduled message is delivered to the real topic **once per redundant unit** (and the slot `num` counter is inflated, skewing `getAllNum`/`isReject` flow-control decisions).

Deterministic regression test `TimerMessageStoreTest#testEnqueueRetryDoesNotReprocessSucceededRequests` (counts `doEnqueue` invocations per physical offset; `doEnqueue` is made to fail exactly once, for the first attempt of one of two batched requests). Fails on unmodified `develop`:

```
java.lang.AssertionError: expected:<1> but was:<2]
	at org.apache.rocketmq.store.timer.TimerMessageStoreTest.testEnqueueRetryDoesNotReprocessSucceededRequests(TimerMessageStoreTest.java:703)
Tests run: 12, Failures: 1, Errors: 0, Skipped: 0   (develop @ ff8f6f74c + test only, 2026-09-05)
```

The failed assertion is the already-succeeded request having been enqueued a second time.

### Root cause / Fix

The retry loop re-processes the whole batch instead of the failed subset.

Fix: filter the batch on `TimerRequest#isSucc()` before each retry round and only re-put the requests that have not succeeded yet. This is safe for the dequeue-routed path: requests handed to `dequeuePutQueue` are released (with `succ=true`) by `TimerDequeuePutService` before the shared latch completes, so they are never re-put either. Round 1 is unchanged (nothing is successful yet, the filtered list equals the batch), and the unknown-error hold semantics are preserved.

### Priority

PRIORITY = 78（影响 32 + 波及范围 16 + 可复现 16 + 维护价值 14），FIX_CONFIDENCE = 85。

- 影响 32/40: duplicate delivery of scheduled/delay messages — a user-visible message-correctness violation on a realistic transient failure (IO pressure at TimerLog rollover, unexpected errors without the skip flag).
- 波及范围 16/20: the timer wheel backs all delayed/scheduled messages; every partial-batch enqueue failure duplicates up to the whole rest of the batch (batches are up to ~10 requests).
- 可复现 16/20: fully deterministic unit test by injecting a one-shot `doEnqueue` failure; production trigger requires a partial batch failure but the retry-duplication itself is certain.
- 维护价值 14/20: small, local fix to the retry loop; clearly separable from the surrounding logic.

### Tests

- Regression test added: `TimerMessageStoreTest#testEnqueueRetryDoesNotReprocessSucceededRequests` (fails before the fix as shown above).
- After the fix (`develop @ ff8f6f74c` + this change, 2026-09-05):

```
mvn -pl store test -Dtest=TimerMessageStoreTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
mvn -pl store test -Dtest='TimerCheckPointTest,TimerLogTest,TimerWheelTest,TimerMetricsTest,TimerEngineSwitchVerifyTest'
Tests run: 21, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

### Risk

Low. Round 1 behavior is identical (no request is successful before the first round, so the filtered retry list equals the original batch). Requests that succeed are simply excluded from later rounds, which is exactly the invariant the commit offset advance (`commitQueueOffset = trs.get(trs.size()-1)...`) already assumes — the batch is only acknowledged once every request succeeded. The `holdMomentForUnknownError` backoff and the `timerWheelSnapshotFlush` locking are unchanged.
