### PR TITLE
[ISSUE #10745] Close paired HTTP/2 proxy channels on failure

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyBackendHandler.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyBackendHandler.java
@@ -51,6 +51,7 @@ public class Http2ProxyBackendHandler extends ChannelInboundHandlerAdapter {
                     ctx.channel().read();
                 } else {
                     future.channel().close();
+                    ctx.channel().close();
                 }
             }
         });
@@ -65,5 +66,6 @@ public class Http2ProxyBackendHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         log.error("Http2ProxyBackendHandler#exceptionCaught", cause);
         Http2ProxyFrontendHandler.closeOnFlush(ctx.channel());
+        Http2ProxyFrontendHandler.closeOnFlush(inboundChannel);
     }
 }

--- a/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyFrontendHandler.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyFrontendHandler.java
@@ -55,6 +55,7 @@ public class Http2ProxyFrontendHandler extends ChannelInboundHandlerAdapter {
                     ctx.channel().read();
                 } else {
                     future.channel().close();
+                    ctx.channel().close();
                 }
             });
         }
@@ -71,6 +72,7 @@ public class Http2ProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         log.error("Http2ProxyFrontendHandler#exceptionCaught", cause);
         closeOnFlush(ctx.channel());
+        closeOnFlush(outboundChannel);
     }
 
     /**

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyChannelCleanupTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/remoting/protocol/http2proxy/Http2ProxyChannelCleanupTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.remoting.protocol.http2proxy;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Http2ProxyChannelCleanupTest {
+
+    @Test
+    public void backendWriteFailureClosesBothChannels() throws Exception {
+        Channel inboundChannel = mock(Channel.class);
+        Channel backendChannel = mock(Channel.class);
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        ChannelFuture writeFuture = failedWriteFuture(inboundChannel);
+        Object message = new Object();
+
+        when(context.channel()).thenReturn(backendChannel);
+        when(inboundChannel.writeAndFlush(message)).thenReturn(writeFuture);
+
+        new Http2ProxyBackendHandler(inboundChannel).channelRead(context, message);
+
+        verify(inboundChannel).close();
+        verify(backendChannel).close();
+    }
+
+    @Test
+    public void backendExceptionClosesBothChannels() throws Exception {
+        Channel inboundChannel = mock(Channel.class);
+        Channel backendChannel = mock(Channel.class);
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        stubCloseOnFlush(inboundChannel);
+        stubCloseOnFlush(backendChannel);
+        when(context.channel()).thenReturn(backendChannel);
+
+        new Http2ProxyBackendHandler(inboundChannel).exceptionCaught(context, new RuntimeException("test"));
+
+        verify(inboundChannel).writeAndFlush(Unpooled.EMPTY_BUFFER);
+        verify(backendChannel).writeAndFlush(Unpooled.EMPTY_BUFFER);
+    }
+
+    @Test
+    public void frontendWriteFailureClosesBothChannels() throws Exception {
+        Channel frontendChannel = mock(Channel.class);
+        Channel outboundChannel = mock(Channel.class);
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        ChannelFuture writeFuture = failedWriteFuture(outboundChannel);
+        Object message = new Object();
+
+        when(context.channel()).thenReturn(frontendChannel);
+        when(outboundChannel.isActive()).thenReturn(true);
+        when(outboundChannel.writeAndFlush(message)).thenReturn(writeFuture);
+
+        new Http2ProxyFrontendHandler(outboundChannel, null).channelRead(context, message);
+
+        verify(outboundChannel).close();
+        verify(frontendChannel).close();
+    }
+
+    @Test
+    public void frontendExceptionClosesBothChannels() throws Exception {
+        Channel frontendChannel = mock(Channel.class);
+        Channel outboundChannel = mock(Channel.class);
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        stubCloseOnFlush(frontendChannel);
+        stubCloseOnFlush(outboundChannel);
+        when(context.channel()).thenReturn(frontendChannel);
+
+        new Http2ProxyFrontendHandler(outboundChannel, null)
+            .exceptionCaught(context, new RuntimeException("test"));
+
+        verify(frontendChannel).writeAndFlush(Unpooled.EMPTY_BUFFER);
+        verify(outboundChannel).writeAndFlush(Unpooled.EMPTY_BUFFER);
+    }
+
+    private static ChannelFuture failedWriteFuture(Channel channel) {
+        ChannelFuture future = mock(ChannelFuture.class);
+        when(future.channel()).thenReturn(channel);
+        when(future.isSuccess()).thenReturn(false);
+        doAnswer(invocation -> {
+            ChannelFutureListener listener = invocation.getArgument(0);
+            listener.operationComplete(future);
+            return future;
+        }).when(future).addListener(any(ChannelFutureListener.class));
+        return future;
+    }
+
+    private static void stubCloseOnFlush(Channel channel) {
+        ChannelFuture future = mock(ChannelFuture.class);
+        when(channel.isActive()).thenReturn(true);
+        when(channel.writeAndFlush(Unpooled.EMPTY_BUFFER)).thenReturn(future);
+        when(future.addListener(ChannelFutureListener.CLOSE)).thenReturn(future);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #10745

### Brief Description

The HTTP/2 proxy previously closed only the channel returned by a failed write, leaving its paired channel open. The exception paths had the same asymmetric cleanup. This can retain an unusable frontend or backend connection after the other side has failed.

This change closes both paired channels on write failures and handler exceptions in `Http2ProxyBackendHandler` and `Http2ProxyFrontendHandler`. It also adds focused regression coverage for all four failure paths.

### How Did You Test This Change?

```text
mvn -Dmaven.repo.local=D:\projects\agentUniverse\tmp\m2-rocketmq -pl proxy -am -Dtest=Http2ProxyChannelCleanupTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test

Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
Reactor modules: 11/11 SUCCESS
BUILD SUCCESS
```

The same run completed Checkstyle and SpotBugs successfully for the reactor modules, including `rocketmq-proxy`.

AI-assisted contribution; implementation and tests were reviewed and verified locally.
