### PR TITLE
[ISSUE #11055] Validate topK in Lite group info queries

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/LiteManagerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/LiteManagerProcessor.java
@@ -316,6 +316,10 @@ public class LiteManagerProcessor implements NettyRequestProcessor {
         body.setLiteTopic(liteTopic);
 
         if (StringUtils.isEmpty(liteTopic)) {
+            if (topK <= 0 || topK > MAX_RETURN_COUNT) {
+                return RemotingCommand.createResponseCommand(ResponseCode.INVALID_PARAMETER,
+                    String.format("topK must be between 1 and %d.", MAX_RETURN_COUNT));
+            }
             Pair<List<LiteLagInfo>, Long> lagCountPair = brokerController.getBrokerMetricsManager()
                 .getLiteConsumerLagCalculator()
                 .getLagCountTopK(group, topK);

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/LiteManagerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/LiteManagerProcessorTest.java
@@ -81,6 +81,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -539,6 +540,58 @@ public class LiteManagerProcessorTest {
     }
 
     @Test
+    public void testGetLiteGroupInfo_InvalidTopK() throws Exception {
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setGroupName("lite_group");
+        groupConfig.setLiteBindTopic("parent_topic");
+        when(subscriptionGroupManager.findSubscriptionGroupConfig("lite_group")).thenReturn(groupConfig);
+
+        for (String liteTopic : new String[] {null, ""}) {
+            for (int topK : new int[] {0, -1, Integer.MIN_VALUE, 10001, Integer.MAX_VALUE}) {
+                GetLiteGroupInfoRequestHeader requestHeader = new GetLiteGroupInfoRequestHeader();
+                requestHeader.setGroup("lite_group");
+                requestHeader.setLiteTopic(liteTopic);
+                requestHeader.setTopK(topK);
+                RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_LITE_GROUP_INFO, requestHeader);
+                request.makeCustomHeaderToNet();
+
+                RemotingCommand response = processor.processRequest(ctx, request);
+
+                assertEquals(ResponseCode.INVALID_PARAMETER, response.getCode());
+                assertTrue(response.getRemark().contains("topK"));
+                assertNull(response.getBody());
+            }
+        }
+        verifyNoInteractions(liteConsumerLagCalculator);
+    }
+
+    @Test
+    public void testGetLiteGroupInfo_TopKBoundaries() throws Exception {
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setGroupName("lite_group");
+        groupConfig.setLiteBindTopic("parent_topic");
+        when(subscriptionGroupManager.findSubscriptionGroupConfig("lite_group")).thenReturn(groupConfig);
+
+        for (int topK : new int[] {1, 10000}) {
+            GetLiteGroupInfoRequestHeader requestHeader = new GetLiteGroupInfoRequestHeader();
+            requestHeader.setGroup("lite_group");
+            requestHeader.setTopK(topK);
+            RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_LITE_GROUP_INFO, requestHeader);
+            request.makeCustomHeaderToNet();
+            when(liteConsumerLagCalculator.getLagCountTopK("lite_group", topK))
+                .thenReturn(Pair.of(Collections.emptyList(), 0L));
+            when(liteConsumerLagCalculator.getLagTimestampTopK("lite_group", "parent_topic", topK))
+                .thenReturn(Pair.of(Collections.emptyList(), -1L));
+
+            RemotingCommand response = processor.processRequest(ctx, request);
+
+            assertEquals(ResponseCode.SUCCESS, response.getCode());
+            verify(liteConsumerLagCalculator).getLagCountTopK("lite_group", topK);
+            verify(liteConsumerLagCalculator).getLagTimestampTopK("lite_group", "parent_topic", topK);
+        }
+    }
+
+    @Test
     public void testGetLiteGroupInfo_GetTopKInfo() throws RemotingCommandException {
         GetLiteGroupInfoRequestHeader requestHeader = new GetLiteGroupInfoRequestHeader();
         requestHeader.setGroup("lite_group");
@@ -603,7 +656,6 @@ public class LiteManagerProcessorTest {
         GetLiteGroupInfoRequestHeader requestHeader = new GetLiteGroupInfoRequestHeader();
         requestHeader.setGroup("lite_group");
         requestHeader.setLiteTopic("specific_lite_topic");
-        requestHeader.setTopK(10);
 
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_LITE_GROUP_INFO, requestHeader);
         request.makeCustomHeaderToNet();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #11055

### Brief Description

Aggregate Lite group info queries pass `topK` directly to a `PriorityQueue` constructor. Zero or negative values are invalid, and large positive values can request an unbounded initial array allocation. Validate `topK` before either lag calculator is called and return `INVALID_PARAMETER` unless it is between 1 and 10,000, reusing the processor's existing `MAX_RETURN_COUNT` limit.

The check applies only when no specific LiteTopic is requested. Single-topic detail queries continue to accept the default `topK`, since they do not use the TopK calculators.

### How Did You Test This Change?

With Amazon Corretto 8u482 and Maven 3.9.11:

```sh
mvn -B -pl broker -am -Dtest=LiteManagerProcessorTest,LiteConsumerLagCalculatorTest -DfailIfNoTests=false test
```

- 34 tests passed, with no failures, errors, or skips; the configured Checkstyle and SpotBugs checks passed.
- The new invalid-parameter regression fails against the unmodified processor and passes with the fix. It checks null/empty LiteTopic, zero/negative/oversized `topK`, and that rejected requests never call the lag calculator.
- Accepted boundaries (1 and 10,000) are covered, and the existing specific-topic test now omits `setTopK` to cover its default value.
- `git diff --check` passed. No live-cluster test was run.
