### PR TITLE
[ISSUE #11059] Validate Lite client subscription ownership

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/LiteManagerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/LiteManagerProcessor.java
@@ -252,6 +252,12 @@ public class LiteManagerProcessor implements NettyRequestProcessor {
         Set<String> returnSet = null;
         int liteTopicCount = 0;
         LiteSubscription liteSubscription = brokerController.getLiteSubscriptionRegistry().getLiteSubscription(clientId);
+        if (liteSubscription != null && (!group.equals(liteSubscription.getGroup())
+            || !parentTopic.equals(liteSubscription.getTopic()))) {
+            response.setCode(ResponseCode.INVALID_PARAMETER);
+            response.setRemark("Client subscription does not match the requested group and parent topic.");
+            return response;
+        }
         if (liteSubscription != null && liteSubscription.getLmqSet() != null) {
             Set<String> liteTopicSet = liteSubscription.getLmqSet();
             liteTopicCount = liteTopicSet.size();

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/LiteManagerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/LiteManagerProcessorTest.java
@@ -479,6 +479,7 @@ public class LiteManagerProcessorTest {
         liteTopicSet.add("lite_topic2");
 
         LiteSubscription liteSubscription = new LiteSubscription();
+        liteSubscription.setGroup("group1").setTopic("parent_topic");
         liteSubscription.setLmqSet(liteTopicSet);
 
         when(topicConfigManager.selectTopicConfig("parent_topic")).thenReturn(topicConfig);
@@ -496,6 +497,72 @@ public class LiteManagerProcessorTest {
         assertEquals("client1", body.getClientId());
         assertEquals(2, body.getLiteTopicCount());
         assertEquals(liteTopicSet, body.getLiteTopicSet());
+    }
+
+    @Test
+    public void testGetLiteClientInfo_SubscriptionOwnershipMismatch() throws Exception {
+        GetLiteClientInfoRequestHeader requestHeader = new GetLiteClientInfoRequestHeader();
+        requestHeader.setParentTopic("parent_topic");
+        requestHeader.setGroup("group1");
+        requestHeader.setClientId("client1");
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_LITE_CLIENT_INFO, requestHeader);
+        request.makeCustomHeaderToNet();
+
+        TopicConfig topicConfig = new TopicConfig("parent_topic");
+        topicConfig.setTopicMessageType(TopicMessageType.LITE);
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setGroupName("group1");
+        groupConfig.setLiteBindTopic("parent_topic");
+        when(topicConfigManager.selectTopicConfig("parent_topic")).thenReturn(topicConfig);
+        when(subscriptionGroupManager.findSubscriptionGroupConfig("group1")).thenReturn(groupConfig);
+
+        LiteSubscription[] subscriptions = {
+            new LiteSubscription().setGroup("other_group").setTopic("parent_topic"),
+            new LiteSubscription().setGroup("group1").setTopic("other_topic"),
+            new LiteSubscription().setGroup("other_group").setTopic("other_topic")
+        };
+        for (LiteSubscription subscription : subscriptions) {
+            for (boolean withLiteTopic : new boolean[] {false, true}) {
+                if (withLiteTopic) {
+                    subscription.addLmq(LiteUtil.toLmqName(subscription.getTopic(), "other_session"));
+                }
+                when(liteSubscriptionRegistry.getLiteSubscription("client1")).thenReturn(subscription);
+
+                RemotingCommand response = processor.processRequest(ctx, request);
+
+                assertEquals(ResponseCode.INVALID_PARAMETER, response.getCode());
+                assertTrue(response.getRemark().contains("subscription"));
+                assertNull(response.getBody());
+            }
+        }
+        verify(liteEventDispatcher, never()).getClientLastAccessTime("client1");
+    }
+
+    @Test
+    public void testGetLiteClientInfo_EmptyMatchingSubscription() throws Exception {
+        GetLiteClientInfoRequestHeader requestHeader = new GetLiteClientInfoRequestHeader();
+        requestHeader.setParentTopic("parent_topic");
+        requestHeader.setGroup("group1");
+        requestHeader.setClientId("client1");
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_LITE_CLIENT_INFO, requestHeader);
+        request.makeCustomHeaderToNet();
+
+        TopicConfig topicConfig = new TopicConfig("parent_topic");
+        topicConfig.setTopicMessageType(TopicMessageType.LITE);
+        SubscriptionGroupConfig groupConfig = new SubscriptionGroupConfig();
+        groupConfig.setGroupName("group1");
+        groupConfig.setLiteBindTopic("parent_topic");
+        when(topicConfigManager.selectTopicConfig("parent_topic")).thenReturn(topicConfig);
+        when(subscriptionGroupManager.findSubscriptionGroupConfig("group1")).thenReturn(groupConfig);
+        when(liteSubscriptionRegistry.getLiteSubscription("client1"))
+            .thenReturn(new LiteSubscription().setGroup("group1").setTopic("parent_topic"));
+
+        RemotingCommand response = processor.processRequest(ctx, request);
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        GetLiteClientInfoResponseBody body = GetLiteClientInfoResponseBody.decode(response.getBody(), GetLiteClientInfoResponseBody.class);
+        assertEquals(0, body.getLiteTopicCount());
+        assertTrue(body.getLiteTopicSet().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #11059

### Brief Description

`GET_LITE_CLIENT_INFO` validates the requested parent topic and group binding, but retrieves a subscription by client ID without checking its group or topic. A request for group A can therefore return group B's client details labeled as group A.

Compare the existing subscription's group and parent topic with the request before returning any client details. Mismatches return `INVALID_PARAMETER` without a response body or the actual subscription metadata in the error message. Matching empty subscriptions and absent subscriptions retain their existing results.

### How Did You Test This Change?

With Amazon Corretto 8u482 and Maven 3.9.11:

```sh
mvn -B -pl broker -am -Dtest=LiteManagerProcessorTest,LiteSubscriptionRegistryImplTest -DfailIfNoTests=false test
```

- Revalidated on 2026-09-09 after rebasing onto develop `37808b3` and adapting the subscription API introduced by #10930: 70 tests passed with no failures, errors, or skips. Checkstyle and SpotBugs passed.
- JaCoCo reported stale execution data for two unrelated lifecycle classes from earlier local runs; no coverage percentage is claimed.
- The ownership regression fails on the unmodified processor: `expected:<29> but was:<0>` (`INVALID_PARAMETER` versus `SUCCESS`).
- Coverage includes group-only, topic-only, and combined mismatches, each with empty and nonempty subscription sets. Rejected requests do not read client last-access time.
- Matching empty, matching nonempty, and absent subscriptions are covered. The existing success fixture now supplies the ownership fields that the registry sets in production.
- `git diff --check` passed. No live-cluster or ACL behavior was tested.
