### PR TITLE
fix(client): return the configured total batch max bytes from ProduceAccumulator

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/producer/ProduceAccumulator.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/ProduceAccumulator.java
@@ -188,7 +188,7 @@ public class ProduceAccumulator {
     }
 
     long getTotalBatchMaxBytes() {
-        return holdSize;
+        return totalHoldSize;
     }
 
     void totalBatchMaxBytes(long totalHoldSize) {

--- a/client/src/test/java/org/apache/rocketmq/client/producer/ProduceAccumulatorTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/producer/ProduceAccumulatorTest.java
@@ -102,6 +102,20 @@ public class ProduceAccumulatorTest {
     }
 
     @Test
+    public void testGetTotalBatchMaxBytes() {
+        ProduceAccumulator produceAccumulator = new ProduceAccumulator("test");
+
+        assertThat(produceAccumulator.getTotalBatchMaxBytes()).isEqualTo(32L * 1024 * 1024);
+        assertThat(produceAccumulator.getBatchMaxBytes()).isEqualTo(32L * 1024);
+
+        produceAccumulator.totalBatchMaxBytes(64L * 1024 * 1024);
+        produceAccumulator.batchMaxBytes(1024);
+
+        assertThat(produceAccumulator.getTotalBatchMaxBytes()).isEqualTo(64L * 1024 * 1024);
+        assertThat(produceAccumulator.getBatchMaxBytes()).isEqualTo(1024);
+    }
+
+    @Test
     public void testProduceAccumulator_sync() throws MQBrokerException, RemotingException, InterruptedException, MQClientException {
         final MockMQProducer mockMQProducer = new MockMQProducer();
 


### PR DESCRIPTION
### Motivation

`ProduceAccumulator.getTotalBatchMaxBytes()` returns `holdSize` (the per-batch cap, default 32KB) instead of `totalHoldSize` (the accumulator-wide cap, default 32MB):

```java
long getBatchMaxBytes() {
    return holdSize;          // correct: per-batch cap
}

long getTotalBatchMaxBytes() {
    return holdSize;          // wrong: returns the per-batch field
}
```

`DefaultMQProducer.getTotalBatchMaxBytes()` delegates here, while `DefaultMQProducer.totalBatchMaxBytes(long)` (also applied in `initProduceAccumulator`) writes `totalHoldSize`. So with untouched defaults the getter reports 32KB while `tryAddMessage` actually enforces 32MB, and after `producer.setTotalBatchMaxBytes(64MB)` the getter still returns 32KB.

### Modifications

Return `totalHoldSize` from `getTotalBatchMaxBytes()`.

### Verification

Fail-before (new test `testGetTotalBatchMaxBytes`, run against the unpatched code):

```
Tests run: 4, Failures: 1, Errors: 0 -- ProduceAccumulatorTest
expecting actual 32768L to be equal to 33554432L
```

Pass-after:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- ProduceAccumulatorTest
```
