### PR TITLE
fix(client): compare pop consume RT against the invisible time in milliseconds

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java
@@ -437,7 +437,7 @@ public class ConsumeMessagePopConcurrentlyService implements ConsumeMessageServi
                 } else {
                     returnType = ConsumeReturnType.RETURNNULL;
                 }
-            } else if (consumeRT >= invisibleTime * 1000) {
+            } else if (consumeRT >= invisibleTime) {
                 returnType = ConsumeReturnType.TIME_OUT;
             } else if (ConsumeConcurrentlyStatus.RECONSUME_LATER == status) {
                 returnType = ConsumeReturnType.FAILED;

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyServiceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyServiceTest.java
@@ -20,7 +20,10 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
 import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.ConsumeReturnType;
 import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.client.stat.ConsumerStatsManager;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -46,6 +49,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -179,6 +183,30 @@ public class ConsumeMessagePopConcurrentlyServiceTest {
         when(defaultMQPushConsumerImpl.getPopDelayLevel()).thenReturn(new int[]{1, 10});
         popService.processConsumeResult(ConsumeConcurrentlyStatus.CONSUME_SUCCESS, context, consumeRequest);
         verify(defaultMQPushConsumerImpl, times(1)).ackAsync(any(MessageExt.class), any());
+    }
+
+    @Test
+    public void testConsumeRequestReportsTimeOutWhenConsumeExceedsInvisibleTime() {
+        long now = System.currentTimeMillis();
+        MessageExt messageExt = createMessageExt();
+        messageExt.getProperties().put(MessageConst.PROPERTY_POP_CK,
+            "0 " + now + " 500 0 " + defaultTopic + " " + defaultBroker + " 0");
+        PopProcessQueue processQueue = mock(PopProcessQueue.class);
+        MessageQueue messageQueue = mock(MessageQueue.class);
+        when(messageQueue.getTopic()).thenReturn(defaultTopic);
+        when(defaultMQPushConsumerImpl.hasHook()).thenReturn(true);
+        when(messageListener.consumeMessage(any(), any(ConsumeConcurrentlyContext.class))).thenAnswer(invocation -> {
+            Thread.sleep(700);
+            return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+        });
+        ConsumeMessagePopConcurrentlyService.ConsumeRequest consumeRequest =
+            popService.new ConsumeRequest(Collections.singletonList(messageExt), processQueue, messageQueue);
+
+        consumeRequest.run();
+
+        ArgumentCaptor<ConsumeMessageContext> captor = ArgumentCaptor.forClass(ConsumeMessageContext.class);
+        verify(defaultMQPushConsumerImpl, times(1)).executeHookAfter(captor.capture());
+        assertEquals(ConsumeReturnType.TIME_OUT.name(), captor.getValue().getProps().get(MixAll.CONSUME_CONTEXT_TYPE));
     }
 
     private MessageExt createMessageExt() {


### PR DESCRIPTION
### Motivation

`ConsumeMessagePopConcurrentlyService.ConsumeRequest.run()` classifies a slow consume as `TIME_OUT` only when:

```java
} else if (consumeRT >= invisibleTime * 1000) {
    returnType = ConsumeReturnType.TIME_OUT;
```

but `invisibleTime` is parsed from `PROPERTY_POP_CK` via `ExtraInfoUtil.getInvisibleTime()` and is already in **milliseconds** — the sibling check in the same inner class, `isPopTimeout()`, compares `current - popTime >= invisibleTime` in raw ms, and `DefaultMQPushConsumerImpl` clamps the invisible window to 5000–300000 ms.

With the default 60s window the threshold becomes 60,000,000 ms (~16.7 hours), so `ConsumeReturnType.TIME_OUT` is effectively unreachable: consumes slower than the invisible window are reported as `SUCCESS` through `consumeMessageContext.getProps().put(MixAll.CONSUME_CONTEXT_TYPE, ...)`, so consume hooks cannot see which pop consumes already exceeded their invisible period. (The non-pop siblings multiply by 1000 because their base unit is minutes.)

### Modifications

Compare `consumeRT >= invisibleTime` directly.

### Verification

Fail-before (new test `testConsumeRequestReportsTimeOutWhenConsumeExceedsInvisibleTime`, run against the unpatched code — a `ConsumeRequest` whose `PROPERTY_POP_CK` carries a 500 ms invisible time, with a listener sleeping 700 ms):

```
Tests run: 6, Failures: 1, Errors: 0 -- ConsumeMessagePopConcurrentlyServiceTest
org.junit.ComparisonFailure: expected:<[TIME_OUT]> but was:<[SUCCESS]>
```

Pass-after:

```
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0 -- ConsumeMessagePopConcurrentlyServiceTest
```
