### PR TITLE
fix(client): clamp the pop retry delay level when a message is younger than the first level

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java
@@ -277,6 +277,9 @@ public class ConsumeMessagePopConcurrentlyService implements ConsumeMessageServi
                     break;
                 }
             }
+            if (delayLevel < 0) {
+                delayLevel = 0;
+            }
 
             changePopInvisibleTime(msgExt, consumerGroup, delayLevel);
             log.warn("Consume too many times, but delay time {} not enough. changePopInvisibleTime to delayLevel {} . message key:{}",

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyServiceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyServiceTest.java
@@ -47,6 +47,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -179,6 +181,26 @@ public class ConsumeMessagePopConcurrentlyServiceTest {
         when(defaultMQPushConsumerImpl.getPopDelayLevel()).thenReturn(new int[]{1, 10});
         popService.processConsumeResult(ConsumeConcurrentlyStatus.CONSUME_SUCCESS, context, consumeRequest);
         verify(defaultMQPushConsumerImpl, times(1)).ackAsync(any(MessageExt.class), any());
+    }
+
+    @Test
+    public void testProcessConsumeResultWithMaxReconsumeReachedAndFreshMessage() throws Exception {
+        ConsumeConcurrentlyContext context = mock(ConsumeConcurrentlyContext.class);
+        ConsumeMessagePopConcurrentlyService.ConsumeRequest consumeRequest = mock(ConsumeMessagePopConcurrentlyService.ConsumeRequest.class);
+        MessageExt messageExt = createMessageExt();
+        messageExt.setReconsumeTimes(0);
+        when(consumeRequest.getMsgs()).thenReturn(Collections.singletonList(messageExt));
+        MessageQueue messageQueue = mock(MessageQueue.class);
+        when(messageQueue.getTopic()).thenReturn(defaultTopic);
+        when(consumeRequest.getMessageQueue()).thenReturn(messageQueue);
+        PopProcessQueue processQueue = mock(PopProcessQueue.class);
+        when(consumeRequest.getPopProcessQueue()).thenReturn(processQueue);
+        when(defaultMQPushConsumerImpl.getMaxReconsumeTimes()).thenReturn(0);
+        when(defaultMQPushConsumerImpl.getPopDelayLevel()).thenReturn(new int[] {10, 30, 60});
+
+        popService.processConsumeResult(ConsumeConcurrentlyStatus.RECONSUME_LATER, context, consumeRequest);
+
+        verify(defaultMQPushConsumerImpl, times(1)).changePopInvisibleTimeAsync(anyString(), anyString(), anyString(), anyLong(), any());
     }
 
     private MessageExt createMessageExt() {


### PR DESCRIPTION
### Motivation

In `ConsumeMessagePopConcurrentlyService.checkNeedAckOrDelay`, the delay level for the next retry is picked by scanning the pop delay table top-down:

```java
int delayLevel = delayLevelTable.length - 1;
for (; delayLevel >= 0; delayLevel--) {
    if (msgDelaytime >= delayLevelTable[delayLevel] * 1000) {
        delayLevel++;
        break;
    }
}

changePopInvisibleTime(msgExt, consumerGroup, delayLevel);
```

If the message is younger than `delayLevelTable[0]` seconds (`msgDelaytime < delayLevelTable[0] * 1000`) the loop never breaks and exits with `delayLevel == -1`. `changePopInvisibleTime` only guards `0 == delayLevel`, so `-1` falls through to:

```java
int delaySecond = delayLevel >= delayLevelTable.length ? delayLevelTable[delayLevelTable.length - 1] : delayLevelTable[delayLevel];
```

which evaluates `delayLevelTable[-1]` **before** the try block and throws `ArrayIndexOutOfBoundsException`. The exception propagates through `processConsumeResult` into `ConsumeRequest.run()`, which has no try/catch: the consume task dies, the remaining messages of the batch are neither acked nor scheduled for retry, and the post-consume hooks/stats are skipped.

This is reachable whenever a redelivered message is consumed while younger than the first delay level (10s by default) — e.g. with a small `maxReconsumeTimes` (setting 0 makes every first failed consume of a fresh message hit this path) or with producer/consumer clock skew shrinking `msgDelaytime`.

### Modifications

Clamp `delayLevel` to 0 after the loop. Level 0 is already handled by `changePopInvisibleTime` by falling back to `msg.getReconsumeTimes()`, which yields a sensible first-level delay.

### Verification

Fail-before (new test `testProcessConsumeResultWithMaxReconsumeReachedAndFreshMessage`, run against the unpatched code — `RECONSUME_LATER` with `maxReconsumeTimes=0`, pop delay table `{10, 30, 60}` and a message 1s old):

```
Tests run: 2, Failures: 0, Errors: 1 -- ConsumeMessagePopConcurrentlyServiceTest
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 3
```

Pass-after:

```
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0 -- ConsumeMessagePopConcurrentlyServiceTest
```
