### PR TITLE
fix(common): make MessageQueueAssignment equals consistent with hashCode

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/message/MessageQueueAssignment.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/MessageQueueAssignment.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.common.message;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 public class MessageQueueAssignment implements Serializable {
 
@@ -48,7 +49,9 @@ public class MessageQueueAssignment implements Serializable {
         if (getClass() != obj.getClass())
             return false;
         MessageQueueAssignment other = (MessageQueueAssignment) obj;
-        return messageQueue.equals(other.messageQueue);
+        return Objects.equals(messageQueue, other.messageQueue)
+            && Objects.equals(mode, other.mode)
+            && Objects.equals(attachments, other.attachments);
     }
 
     @Override

--- a/common/src/test/java/org/apache/rocketmq/common/message/MessageQueueAssignmentTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/message/MessageQueueAssignmentTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common.message;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessageQueueAssignmentTest {
+
+    @Test
+    public void testEqualsHandlesNullMessageQueue() {
+        assertThat(new MessageQueueAssignment()).isEqualTo(new MessageQueueAssignment());
+    }
+
+    @Test
+    public void testEqualsAndHashCodeUseAllFields() {
+        MessageQueue messageQueue = new MessageQueue("topic", "broker", 0);
+        MessageQueueAssignment pull = new MessageQueueAssignment();
+        pull.setMessageQueue(messageQueue);
+        pull.setMode(MessageRequestMode.PULL);
+
+        MessageQueueAssignment pop = new MessageQueueAssignment();
+        pop.setMessageQueue(messageQueue);
+        pop.setMode(MessageRequestMode.POP);
+
+        assertThat(pull).isNotEqualTo(pop);
+
+        MessageQueueAssignment samePull = new MessageQueueAssignment();
+        samePull.setMessageQueue(messageQueue);
+        samePull.setMode(MessageRequestMode.PULL);
+
+        assertThat(pull).isEqualTo(samePull);
+        assertThat(pull).hasSameHashCodeAs(samePull);
+    }
+}


### PR DESCRIPTION
### Motivation

`MessageQueueAssignment.hashCode()` combines all three fields (`messageQueue`, `mode`, `attachments`), but `equals()` compares only `messageQueue`, with no null guard:

```java
MessageQueueAssignment other = (MessageQueueAssignment) obj;
return messageQueue.equals(other.messageQueue);
```

Two consequences:

1. `new MessageQueueAssignment().equals(new MessageQueueAssignment())` throws `NullPointerException` because the default `messageQueue` is null.
2. Two assignments with the same `MessageQueue` but different `mode` (`PULL` vs `POP`) compare equal while having different hashCodes — a direct `Object` equals/hashCode contract violation that corrupts any hash-based collection.

The class is the element type of the `Set<MessageQueueAssignment>` in `QueryAssignmentResponseBody`, produced by `QueryAssignmentProcessor` into a `HashSet` and re-deserialized into a `HashSet` on the client in `MQClientInstance.queryAssignment()`, so it is routinely stored in hash collections. Sibling classes in the same package (`MessageQueue`, `MessageQueueForC`) implement equals/hashCode consistently.

### Modifications

Compare all three fields with `Objects.equals`, mirroring `hashCode`.

No broker behavior change: in `QueryAssignmentProcessor` the assignments are built from a `Set<MessageQueue>`, so each queue appears once and the wider equality never merges distinct entries.

### Verification

Fail-before (new test class `MessageQueueAssignmentTest`, run against the unpatched code):

```
Tests run: 1, Failures: 0, Errors: 1 -- MessageQueueAssignmentTest#testEqualsHandlesNullMessageQueue
java.lang.NullPointerException: Cannot invoke "...MessageQueue.equals(Object)" because "this.messageQueue" is null

Tests run: 2, Failures: 1, Errors: 0 -- MessageQueueAssignmentTest#testEqualsAndHashCodeUseAllFields
Expecting actual not to be equal to: MessageQueueAssignment [..., Mode=POP]
```

Pass-after:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- MessageQueueAssignmentTest
```
