### PR TITLE
fix(common): keep '=' inside attribute values when parsing modifications

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/attribute/AttributeParser.java
+++ b/common/src/main/java/org/apache/rocketmq/common/attribute/AttributeParser.java
@@ -44,7 +44,7 @@ public class AttributeParser {
             String key;
             String value;
             if (kv.contains(ATTR_KEY_VALUE_EQUAL_SIGN)) {
-                String[] splits = kv.split(ATTR_KEY_VALUE_EQUAL_SIGN);
+                String[] splits = kv.split(ATTR_KEY_VALUE_EQUAL_SIGN, 2);
                 key = splits[0];
                 value = splits[1];
                 if (!key.contains(ATTR_ADD_PLUS_SIGN)) {

--- a/common/src/test/java/org/apache/rocketmq/common/attribute/AttributeParserTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/attribute/AttributeParserTest.java
@@ -77,6 +77,24 @@ public class AttributeParserTest {
     }
 
     @Test
+    public void parseToMap_ValueContainingEqualSign_ReturnsFullValue() {
+        Map<String, String> result = AttributeParser.parseToMap("+key1=a=b");
+
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("+key1", "a=b");
+        assertEquals(expectedMap, result);
+    }
+
+    @Test
+    public void parseToMap_EmptyValue_ReturnsEmptyValue() {
+        Map<String, String> result = AttributeParser.parseToMap("+key1=");
+
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("+key1", "");
+        assertEquals(expectedMap, result);
+    }
+
+    @Test
     public void parseToString_EmptyMap_ReturnsEmptyString() {
         Map<String, String> attributes = new HashMap<>();
         String result = AttributeParser.parseToString(attributes);


### PR DESCRIPTION
### Motivation

`AttributeParser.parseToMap` splits each `key=value` pair without a limit:

```java
String[] splits = kv.split(ATTR_KEY_VALUE_EQUAL_SIGN);
key = splits[0];
value = splits[1];
```

Two consequences for user-supplied attribute strings (reachable from `mqadmin updateTopic -a ...` / `updateSubGroup -c ...` and from `UpdateTopicRequestHeader.getAttributes()` off the wire):

1. `"+key1="` — Java's `split` drops the trailing empty string, so `splits` has length 1 and `splits[1]` throws a raw `ArrayIndexOutOfBoundsException` instead of parsing an empty value.
2. `"+key1=a=b"` — the value is silently truncated to `"a"` and the rest discarded, with no error. Values containing `=` are realistic (e.g. base64 with padding).

### Modifications

Split with a limit of 2, so the first `=` separates key from value and everything after it stays in the value.

### Verification

Fail-before (new tests, run against the unpatched code):

```
Tests run: 9, Failures: 1 -- AttributeParserTest#parseToMap_ValueContainingEqualSign_ReturnsFullValue
expected:<{+key1=a=b}> but was:<{+key1=a}>

Tests run: 1, Failures: 0, Errors: 1 -- AttributeParserTest#parseToMap_EmptyValue_ReturnsEmptyValue
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
```

Pass-after:

```
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 -- AttributeParserTest
```
