### PR TITLE
fix(common): fall back to the higher version for negative version values

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
@@ -25,7 +25,7 @@ public class MQVersion {
     public static String getVersionDesc(int value) {
         Version[] versions = VERSION_VALUES;
         int length = versions.length;
-        if (value >= length) {
+        if (value < 0 || value >= length) {
             return versions[length - 1].name();
         }
         return versions[value].name();
@@ -34,7 +34,7 @@ public class MQVersion {
     public static Version value2Version(int value) {
         Version[] versions = VERSION_VALUES;
         int length = versions.length;
-        if (value >= length) {
+        if (value < 0 || value >= length) {
             return versions[length - 1];
         }
         return versions[value];

--- a/common/src/test/java/org/apache/rocketmq/common/MQVersionTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MQVersionTest.java
@@ -41,6 +41,12 @@ public class MQVersionTest {
     }
 
     @Test
+    public void testNegativeVersionFallsBackToHigherVersion() throws Exception {
+        assertThat(MQVersion.value2Version(-1)).isEqualTo(MQVersion.Version.HIGHER_VERSION);
+        assertThat(MQVersion.getVersionDesc(-1)).isEqualTo(MQVersion.Version.HIGHER_VERSION.name());
+    }
+
+    @Test
     public void testValue2Version_HigherVersion() throws Exception {
         assertThat(MQVersion.value2Version(Integer.MAX_VALUE)).isEqualTo(MQVersion.Version.HIGHER_VERSION);
     }


### PR DESCRIPTION
### Motivation

`MQVersion.getVersionDesc(int)` and `value2Version(int)` guard only the upper bound:

```java
public static Version value2Version(int value) {
    Version[] versions = VERSION_VALUES;
    int length = versions.length;
    if (value >= length) {
        return versions[length - 1];
    }
    return versions[value];      // value < 0 -> ArrayIndexOutOfBoundsException
}
```

A negative value indexes `VERSION_VALUES[-1]` and throws `ArrayIndexOutOfBoundsException`.

This is reachable from the wire: `RocketMQSerializable` decodes the remoting header version as a **signed short** (`headerBuffer.readShort()`), so a peer sending version bytes `0xFFFF` produces `value == -1`. The namesrv broker-registration path (`DefaultRequestProcessor` → `MQVersion.value2Version(request.getVersion())`) and `getVersionDesc(conn.getVersion())` in the tools/broker connection commands both consume that wire-controlled value, and crash with AIOOBE instead of answering cleanly.

### Modifications

Extend both guards to `value < 0 || value >= length`, falling back to the last entry — consistent with the existing "unknown → HIGHER_VERSION" semantics already pinned by `testValue2Version_HigherVersion`.

### Verification

Fail-before (new test `testNegativeVersionFallsBackToHigherVersion`, run against the unpatched code):

```
Tests run: 2, Failures: 0, Errors: 1 -- MQVersionTest
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 613
```

Pass-after:

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- MQVersionTest
```
