### PR TITLE
fix(tools): stop -c <cluster> from switching resetOffsetByTime to the C++ protocol

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java
@@ -61,7 +61,7 @@ public class ResetOffsetByTimeCommand implements SubCommand {
         opt.setRequired(false);
         options.addOption(opt);
 
-        opt = new Option("c", "cplus", false, "reset c++ client offset. Deprecated.");
+        opt = new Option(null, "cplus", false, "reset c++ client offset. Deprecated.");
         opt.setRequired(false);
         options.addOption(opt);
 
@@ -84,9 +84,13 @@ public class ResetOffsetByTimeCommand implements SubCommand {
         return options;
     }
 
+    protected DefaultMQAdminExt createDefaultMQAdminExt(RPCHook rpcHook) {
+        return new DefaultMQAdminExt(rpcHook);
+    }
+
     @Override
     public void execute(CommandLine commandLine, Options options, RPCHook rpcHook) throws SubCommandException {
-        DefaultMQAdminExt defaultMQAdminExt = new DefaultMQAdminExt(rpcHook);
+        DefaultMQAdminExt defaultMQAdminExt = createDefaultMQAdminExt(rpcHook);
         defaultMQAdminExt.setInstanceName(Long.toString(System.currentTimeMillis()));
         try {
             String group = commandLine.getOptionValue("g").trim();
@@ -109,7 +113,7 @@ public class ResetOffsetByTimeCommand implements SubCommand {
                 force = Boolean.parseBoolean(commandLine.getOptionValue("f").trim());
             }
 
-            boolean isC = commandLine.hasOption('c');
+            boolean isC = commandLine.hasOption("cplus");
 
             String brokerAddr = null;
             if (commandLine.hasOption('b')) {

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommandTest.java
@@ -16,17 +16,22 @@
  */
 package org.apache.rocketmq.tools.command.offset;
 
+import java.util.HashMap;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.rocketmq.remoting.protocol.body.ResetOffsetBody;
 import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.apache.rocketmq.tools.command.SubCommandException;
 import org.apache.rocketmq.tools.command.server.NameServerMocker;
 import org.apache.rocketmq.tools.command.server.ServerResponseMocker;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ResetOffsetByTimeCommandTest {
 
@@ -57,6 +62,30 @@ public class ResetOffsetByTimeCommandTest {
             ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
                 cmd.buildCommandlineOptions(options), new DefaultParser());
         cmd.execute(commandLine, options, null);
+    }
+
+    @Test
+    public void testExecuteWithClusterOptionKeepsJavaClientProtocol() throws Exception {
+        DefaultMQAdminExt adminExt = Mockito.mock(DefaultMQAdminExt.class);
+        Mockito.when(adminExt.resetOffsetByTimestamp(Mockito.eq("default-cluster"), Mockito.eq("unit-test"),
+                Mockito.eq("default-group"), Mockito.anyLong(), Mockito.anyBoolean(), Mockito.eq(false)))
+            .thenReturn(new HashMap<>());
+        ResetOffsetByTimeCommand cmd = new ResetOffsetByTimeCommand() {
+            @Override
+            protected DefaultMQAdminExt createDefaultMQAdminExt(RPCHook rpcHook) {
+                return adminExt;
+            }
+        };
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = new String[] {
+            "-g default-group", "-t unit-test", "-s 1412131213231", "-f false", "-c default-cluster"};
+        final CommandLine commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
+                cmd.buildCommandlineOptions(options), new DefaultParser());
+        cmd.execute(commandLine, options, null);
+
+        Mockito.verify(adminExt).resetOffsetByTimestamp("default-cluster", "unit-test",
+            "default-group", 1412131213231L, false, false);
     }
 
     private ServerResponseMocker startOneBroker() {


### PR DESCRIPTION
### Motivation

`ResetOffsetByTimeCommand` registers **two** options with the short name `c`:

```java
opt = new Option("c", "cplus", false, "reset c++ client offset. Deprecated.");   // line 64
...
opt = new Option("c", "cluster", true, "Cluster name or lmq parent topic, ..."); // line 80
```

commons-cli's `Options.addOption` keys the short-opt map by name, so the later `cluster` registration replaces `cplus` for `-c`. Consequences:

1. The documented `-c`/`--cplus` deprecated switch can never be enabled through its short form.
2. Any user passing `-c <cluster>` (the documented usage, e.g. to find the route for an LMQ parent topic) makes `isC = commandLine.hasOption('c')` true, so `resetOffsetByTimestamp(..., isC)` → `MQClientAPIImpl.invokeBrokerToResetOffset(..., isC)` sends the request with `LanguageCode.CPP`. The broker then replies with `ResetOffsetBodyForC` (`List<MessageQueueForC>`), which the Java client decodes as `ResetOffsetBody` (`Map<MessageQueue, Long>`) — garbage offsets/exception instead of a proper reset for every Java consumer group whenever `-c` is used.

### Modifications

- Drop the short name from the deprecated `cplus` option (`--cplus` keeps working, `-c` no longer collides).
- Compute `isC` from the long name: `commandLine.hasOption("cplus")`.
- Extract `createDefaultMQAdminExt(RPCHook)` as a protected factory so the command can be tested with a stubbed admin client.

### Verification

Fail-before (new test `testExecuteWithClusterOptionKeepsJavaClientProtocol`, run against the unpatched code — executes the command with `-g -t -s -f false -c default-cluster` and verifies the admin call):

```
Tests run: 2, Failures: 1 -- ResetOffsetByTimeCommandTest
Argument(s) are different! Wanted:
defaultMQAdminExt.resetOffsetByTimestamp("default-cluster", "unit-test", "default-group", 1412131213231L, false, false);
Actual invocations have different arguments:
defaultMQAdminExt.resetOffsetByTimestamp("default-cluster", "unit-test", "default-group", 1412131213231L, false, true);
```

Pass-after:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- ResetOffsetByTimeCommandTest
```
