### PR TITLE
fix(remoting): match every address for a /0 CIDR in ipInCIDR

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
@@ -302,7 +302,7 @@ public class RemotingHelper {
         int ipAddr = ipToInt(ip);
         String[] cidrArr = cidr.split("/");
         int netId = Integer.parseInt(cidrArr[1]);
-        int mask = 0xFFFFFFFF << (32 - netId);
+        int mask = netId == 0 ? 0 : 0xFFFFFFFF << (32 - netId);
         int cidrIpAddr = ipToInt(cidrArr[0]);
 
         return (ipAddr & mask) == (cidrIpAddr & mask);

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemotingHelperTest {
+
+    @Test
+    public void testIpInCidrMatchesEverythingForZeroPrefixLength() {
+        assertThat(RemotingHelper.ipInCIDR("1.2.3.4", "0.0.0.0/0")).isTrue();
+        assertThat(RemotingHelper.ipInCIDR("8.8.8.8", "10.0.0.0/0")).isTrue();
+    }
+
+    @Test
+    public void testIpInCidrForRegularPrefixLengths() {
+        assertThat(RemotingHelper.ipInCIDR("192.168.1.7", "192.168.1.0/24")).isTrue();
+        assertThat(RemotingHelper.ipInCIDR("192.168.2.7", "192.168.1.0/24")).isFalse();
+        assertThat(RemotingHelper.ipInCIDR("192.0.2.0", "192.0.2.0/32")).isTrue();
+        assertThat(RemotingHelper.ipInCIDR("192.0.2.2", "192.0.2.0/32")).isFalse();
+    }
+}


### PR DESCRIPTION
### Motivation

`RemotingHelper.ipInCIDR` computes the netmask as:

```java
int mask = 0xFFFFFFFF << (32 - netId);
```

For `netId == 0` the shift distance is 32, which Java takes mod 32 — the shift is a no-op and `mask` stays `0xFFFFFFFF` instead of `0`. So a `/0` CIDR matches nothing except its own address:

```java
ipInCIDR("1.2.3.4", "0.0.0.0/0")  // returns false, should be true
```

Reachability: `NettyRemotingClient.getProxy` guards only the exact string `"0.0.0.0/0"` (`DEFAULT_CIDR_ALL.equals(cidr)`) before calling `ipInCIDR`, so a socks proxy configured with any other `/0` CIDR (e.g. `10.0.0.0/0`) silently never matches and the traffic bypasses the configured proxy. `/1`–`/32` are unaffected.

### Modifications

Use a zero mask when the prefix length is 0.

### Verification

Fail-before (new test class `RemotingHelperTest`, run against the unpatched code):

```
Tests run: 2, Failures: 1 -- RemotingHelperTest#testIpInCidrMatchesEverythingForZeroPrefixLength
```

Pass-after:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- RemotingHelperTest
```
