### PR TITLE
fix(tools): skip master-address comparison in consumed() when the routed broker has no master

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -1544,8 +1544,9 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
             if (mq.getTopic().equals(msg.getTopic()) && mq.getQueueId() == msg.getQueueId()) {
                 BrokerData brokerData = ci.getBrokerAddrTable().get(mq.getBrokerName());
                 if (brokerData != null) {
-                    String addr = NetworkUtil.convert2IpString(brokerData.getBrokerAddrs().get(MixAll.MASTER_ID));
-                    if (NetworkUtil.socketAddress2String(msg.getStoreHost()).equals(addr)) {
+                    String addr = brokerData.getBrokerAddrs().get(MixAll.MASTER_ID);
+                    if (addr != null && NetworkUtil.socketAddress2String(msg.getStoreHost())
+                        .equals(NetworkUtil.convert2IpString(addr))) {
                         if (next.getValue().getConsumerOffset() > msg.getQueueOffset()) {
                             return true;
                         }

--- a/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
@@ -60,6 +60,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.InetAddress;
@@ -603,6 +604,32 @@ public class DefaultMQAdminExtImplTest {
         boolean actual = defaultMQAdminExtImpl.deleteExpiredCommitLogByAddr(defaultBrokerAddr);
         assertTrue(actual);
         verify(mqClientAPIImpl, times(1)).deleteExpiredCommitLog(defaultBrokerAddr, timeoutMillis);
+    }
+
+    @Test
+    public void testConsumedWithSlaveOnlyBrokerInRoute() throws Exception {
+        DefaultMQAdminExtImpl spyImpl = Mockito.spy(defaultMQAdminExtImpl);
+        ConsumeStats consumeStats = new ConsumeStats();
+        OffsetWrapper offsetWrapper = new OffsetWrapper();
+        offsetWrapper.setConsumerOffset(1L);
+        consumeStats.getOffsetTable().put(new MessageQueue(defaultTopic, defaultBroker, 0), offsetWrapper);
+        Mockito.doReturn(consumeStats).when(spyImpl).examineConsumeStats(defaultGroup);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        HashMap<Long, String> brokerAddrs = new HashMap<>();
+        brokerAddrs.put(1L, defaultBrokerAddr);
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put(defaultBroker, new BrokerData(defaultCluster, defaultBroker, brokerAddrs));
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+        Mockito.doReturn(clusterInfo).when(spyImpl).examineBrokerClusterInfo();
+
+        MessageExt messageExt = new MessageExt();
+        messageExt.setTopic(defaultTopic);
+        messageExt.setQueueId(0);
+        messageExt.setStoreHost(new InetSocketAddress("127.0.0.1", 10911));
+
+        boolean actual = spyImpl.consumed(messageExt, defaultGroup);
+
+        assertFalse(actual);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`DefaultMQAdminExtImpl.consumed()` resolves the master address of each broker referenced by the consume-stats offset table:

```java
String addr = NetworkUtil.convert2IpString(brokerData.getBrokerAddrs().get(MixAll.MASTER_ID));
```

`examineConsumeStats` accepts entries from brokers whose `selectBrokerAddr()` resolved to a slave (master down, stale route). For such a broker `getBrokerAddrs().get(MixAll.MASTER_ID)` returns null, and `NetworkUtil.convert2IpString(null)` → `string2SocketAddress(null)` crashes on `addr.lastIndexOf(":")`.

The NPE aborts the whole track listing: `queryMsgById -i ...` → `printMsg` → `messageTrackDetail` → `consumed(msg, group)` fails for **all** groups, not just the group served by the unreachable broker. The sibling `consumedConcurrent` already uses the raw address with a null-safe comparison direction, showing the null case was considered elsewhere.

### Modifications

Skip the store-host comparison when the master address is null, mirroring the null-safe structure of the sibling method.

### Verification

Fail-before (new test `testConsumedWithSlaveOnlyBrokerInRoute`, run against the unpatched code — a spy of `DefaultMQAdminExtImpl` returning one offset-table entry for `broker1` whose route registers only brokerId 1):

```
Tests run: 1, Failures: 0, Errors: 1 -- DefaultMQAdminExtImplTest
java.lang.NullPointerException: Cannot invoke "String.lastIndexOf(String)" because "addr" is null
```

Pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- DefaultMQAdminExtImplTest#testConsumedWithSlaveOnlyBrokerInRoute
```

Note: the pre-existing `testConsumeMessageDirectly` in this class fails on JDK 21 in my local container with `Mockito cannot mock this class: java.net.InetAddress` — verified to fail identically on a clean develop checkout (before my changes), so it is an environment limitation, not a regression of this PR.
