### PR TITLE
fix(remoting): parse the full host from bracketed IPv6 addresses in parseHostFromAddress

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/common/RemotingHelper.java
@@ -265,12 +265,8 @@ public class RemotingHelper {
             return "";
         }
 
-        String[] addressSplits = address.split(":");
-        if (addressSplits.length < 1) {
-            return "";
-        }
-
-        return addressSplits[0];
+        int idx = address.lastIndexOf(":");
+        return idx > 0 ? address.substring(0, idx) : address;
     }
 
     public static String parseSocketAddressAddr(SocketAddress socketAddress) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/common/RemotingHelperTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.common;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemotingHelperTest {
+
+    @Test
+    public void testParseHostFromAddress() {
+        assertThat(RemotingHelper.parseHostFromAddress(null)).isEmpty();
+        assertThat(RemotingHelper.parseHostFromAddress("127.0.0.1:10911")).isEqualTo("127.0.0.1");
+        assertThat(RemotingHelper.parseHostFromAddress("[2001:db8::1]:10911")).isEqualTo("[2001:db8::1]");
+        assertThat(RemotingHelper.parseHostFromAddress("broker-a")).isEqualTo("broker-a");
+    }
+}


### PR DESCRIPTION
### Motivation

`RemotingHelper.parseHostFromAddress` splits on **every** colon and returns the first segment:

```java
String[] addressSplits = address.split(":");
return addressSplits[0];
```

For the bracketed IPv6 form RocketMQ uses for socket addresses, this mangles the host:

```java
parseHostFromAddress("[2001:db8::1]:10911")  // returns "[2001"
```

The only caller is `BrokerPreOnlineService.waitForHaHandshakeComplete`, which passes the parsed value as the remote address of the `HAConnectionStateNotificationRequest`; `HAConnectionStateNotificationService.checkConnectionStateAndNotify` then compares it against the connection's host, so an IPv6 cluster's HA handshake wait can never match and pre-online times out.

IPv4 addresses and bare hostnames are unaffected by the fix (first segment == everything before the last colon). The dead `addressSplits.length < 1` branch (`split` never returns an empty array) goes away with the rewrite.

### Modifications

Cut at the last colon, mirroring `NetworkUtil.string2SocketAddress` and `NettyRemotingClient.getHostAndPort`, which already handle bracketed IPv6 this way.

### Verification

Fail-before (new test class `RemotingHelperTest`, run against the unpatched code):

```
Tests run: 1, Failures: 1 -- RemotingHelperTest#testParseHostFromAddress
expected: "[2001:db8::1]" but was: "[2001"
```

Pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- RemotingHelperTest
```

Note: this adds the same new test file as #11068 (`ipInCIDR`); the two PRs will need a trivial rebase against whichever merges first.
