### PR TITLE
fix(tools): keep the broadcast track type in messageTrackDetailConcurrent

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImpl.java
@@ -1480,6 +1480,9 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
                                 if (ResponseCode.CONSUMER_NOT_ONLINE == e.getResponseCode()) {
                                     mt.setTrackType(TrackType.NOT_ONLINE);
                                 }
+                                if (ResponseCode.BROADCAST_CONSUMPTION == e.getResponseCode()) {
+                                    mt.setTrackType(TrackType.CONSUME_BROADCASTING);
+                                }
                                 mt.setExceptionDesc("CODE:" + e.getResponseCode() + " DESC:" + e.getErrorMessage());
                                 result.add(mt);
                                 countDownLatch.countDown();
@@ -1487,6 +1490,9 @@ public class DefaultMQAdminExtImpl implements MQAdminExt, MQAdminExtInner {
                             } catch (MQBrokerException e) {
                                 if (ResponseCode.CONSUMER_NOT_ONLINE == e.getResponseCode()) {
                                     mt.setTrackType(TrackType.NOT_ONLINE);
+                                }
+                                if (ResponseCode.BROADCAST_CONSUMPTION == e.getResponseCode()) {
+                                    mt.setTrackType(TrackType.CONSUME_BROADCASTING);
                                 }
                                 mt.setExceptionDesc("CODE:" + e.getResponseCode() + " DESC:" + e.getErrorMessage());
                                 result.add(mt);

--- a/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/admin/DefaultMQAdminExtImplTest.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.remoting.protocol.admin.TopicOffset;
 import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.ConsumeMessageDirectlyResult;
+import org.apache.rocketmq.remoting.protocol.body.Connection;
 import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
 import org.apache.rocketmq.remoting.protocol.body.GroupList;
 import org.apache.rocketmq.remoting.protocol.body.QueueTimeSpan;
@@ -46,6 +47,8 @@ import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.header.UpdateConsumerOffsetRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.UpdateGroupForbiddenRequestHeader;
+import org.apache.rocketmq.remoting.protocol.heartbeat.ConsumeType;
+import org.apache.rocketmq.remoting.protocol.heartbeat.MessageModel;
 import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.QueueData;
@@ -54,6 +57,7 @@ import org.apache.rocketmq.remoting.protocol.subscription.GroupForbidden;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.tools.admin.api.BrokerOperatorResult;
 import org.apache.rocketmq.tools.admin.api.MessageTrack;
+import org.apache.rocketmq.tools.admin.api.TrackType;
 import org.apache.rocketmq.tools.admin.common.AdminToolResult;
 import org.apache.rocketmq.tools.admin.common.AdminToolsResultCodeEnum;
 import org.junit.Before;
@@ -91,6 +95,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -624,6 +629,36 @@ public class DefaultMQAdminExtImplTest {
         assertNull(actual.getRemark());
         assertFalse(actual.isAutoCommit());
         assertFalse(actual.isOrder());
+    }
+
+    @Test
+    public void testMessageTrackDetailConcurrentWithBroadcastGroup() throws Exception {
+        MessageExt messageExt = new MessageExt();
+        messageExt.setTopic(defaultTopic);
+        messageExt.setQueueId(0);
+        messageExt.setStoreHost(new InetSocketAddress("127.0.0.1", 10911));
+
+        GroupList groupList = mock(GroupList.class);
+        HashSet<String> groupSet = new HashSet<>();
+        groupSet.add(defaultGroup);
+        when(groupList.getGroupList()).thenReturn(groupSet);
+        when(mqClientAPIImpl.queryTopicConsumeByWho(anyString(), anyString(), anyLong())).thenReturn(groupList);
+
+        ConsumerConnection consumerConnection = new ConsumerConnection();
+        HashSet<Connection> connectionSet = new HashSet<>();
+        connectionSet.add(new Connection());
+        consumerConnection.setConnectionSet(connectionSet);
+        consumerConnection.setConsumeType(ConsumeType.CONSUME_PASSIVELY);
+        consumerConnection.setMessageModel(MessageModel.BROADCASTING);
+        when(mqClientAPIImpl.getConsumerConnectionList(anyString(), anyString(), anyLong())).thenReturn(consumerConnection);
+
+        when(mqClientAPIImpl.getConsumeStats(anyString(), anyString(), nullable(String.class), anyLong()))
+            .thenReturn(new ConsumeStats());
+
+        List<MessageTrack> actual = defaultMQAdminExtImpl.messageTrackDetailConcurrent(messageExt);
+
+        assertEquals(1, actual.size());
+        assertEquals(TrackType.CONSUME_BROADCASTING, actual.get(0).getTrackType());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The serial `messageTrackDetail` maps the broadcast case to a proper track type:

```java
} catch (MQClientException e) {
    if (ResponseCode.CONSUMER_NOT_ONLINE == e.getResponseCode()) {
        mt.setTrackType(TrackType.NOT_ONLINE);
        ...
    }
    if (ResponseCode.BROADCAST_CONSUMPTION == e.getResponseCode()) {
        mt.setTrackType(TrackType.CONSUME_BROADCASTING);
    }
    ...
```

but the concurrent variant (`messageTrackDetailConcurrent`, exposed via `MQAdminExt.messageTrackDetailConcurrent`) only handles `CONSUMER_NOT_ONLINE` in its catch blocks. For a broadcast consumer group, `consumed()` → `examineConsumeStats` throws `MQClientException(ResponseCode.BROADCAST_CONSUMPTION, ...)`, so the concurrent API reports the group as `TrackType.UNKNOWN` with a raw error string, while the serial API correctly reports `CONSUME_BROADCASTING` — contradicting the sibling implementation and misleading dashboards that use the concurrent API.

### Modifications

Add the same `BROADCAST_CONSUMPTION → CONSUME_BROADCASTING` mapping to both catches of the concurrent track task.

### Verification

Fail-before (new test `testMessageTrackDetailConcurrentWithBroadcastGroup`, run against the unpatched code — a passive consumer group whose connection reports `MessageModel.BROADCASTING`, so `examineConsumeStats` throws `BROADCAST_CONSUMPTION` through the natural path):

```
Tests run: 1, Failures: 1 -- DefaultMQAdminExtImplTest
expected:<CONSUME_BROADCASTING> but was:<UNKNOWN>
```

Pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- DefaultMQAdminExtImplTest#testMessageTrackDetailConcurrentWithBroadcastGroup
```

Note: the pre-existing `testMessageTrackDetailConcurrent` (and `testConsumeMessageDirectly`) fail in my local container on JDK 21 with `Mockito cannot mock this class: java.net.InetAddress` — verified to fail identically on a clean develop checkout (before my changes), so this is an environment limitation, not a regression of this PR.
