### PR TITLE
fix(remoting): tolerate missing properties in ConsumerRunningInfo analyze methods

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerRunningInfo.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerRunningInfo.java
@@ -57,11 +57,10 @@ public class ConsumerRunningInfo extends RemotingSerializable {
         boolean startForAWhile = false;
         {
 
-            String property = prev.getProperties().getProperty(ConsumerRunningInfo.PROP_CONSUMER_START_TIMESTAMP);
-            if (property == null) {
-                property = String.valueOf(prev.getProperties().get(ConsumerRunningInfo.PROP_CONSUMER_START_TIMESTAMP));
+            Object startTimestamp = prev.getProperties().get(ConsumerRunningInfo.PROP_CONSUMER_START_TIMESTAMP);
+            if (startTimestamp != null) {
+                startForAWhile = (System.currentTimeMillis() - Long.parseLong(String.valueOf(startTimestamp))) > (1000 * 60 * 2);
             }
-            startForAWhile = (System.currentTimeMillis() - Long.parseLong(property)) > (1000 * 60 * 2);
         }
 
         if (push && startForAWhile) {
@@ -96,12 +95,12 @@ public class ConsumerRunningInfo extends RemotingSerializable {
     }
 
     public static boolean isPushType(ConsumerRunningInfo consumerRunningInfo) {
-        String property = consumerRunningInfo.getProperties().getProperty(ConsumerRunningInfo.PROP_CONSUME_TYPE);
+        Object consumeType = consumerRunningInfo.getProperties().get(ConsumerRunningInfo.PROP_CONSUME_TYPE);
 
-        if (property == null) {
-            property = ((ConsumeType) consumerRunningInfo.getProperties().get(ConsumerRunningInfo.PROP_CONSUME_TYPE)).name();
+        if (consumeType == null) {
+            return false;
         }
-        return ConsumeType.valueOf(property) == ConsumeType.CONSUME_PASSIVELY;
+        return ConsumeType.valueOf(consumeType.toString()) == ConsumeType.CONSUME_PASSIVELY;
     }
 
     public static boolean analyzeRebalance(final TreeMap<String/* clientId */, ConsumerRunningInfo> criTable) {
@@ -110,15 +109,7 @@ public class ConsumerRunningInfo extends RemotingSerializable {
 
     public static String analyzeProcessQueue(final String clientId, ConsumerRunningInfo info) {
         StringBuilder sb = new StringBuilder();
-        boolean push = false;
-        {
-            String property = info.getProperties().getProperty(ConsumerRunningInfo.PROP_CONSUME_TYPE);
-
-            if (property == null) {
-                property = ((ConsumeType) info.getProperties().get(ConsumerRunningInfo.PROP_CONSUME_TYPE)).name();
-            }
-            push = ConsumeType.valueOf(property) == ConsumeType.CONSUME_PASSIVELY;
-        }
+        boolean push = isPushType(info);
 
         boolean orderMsg = false;
         {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/body/ConsumerRunningInfoTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/body/ConsumerRunningInfoTest.java
@@ -102,5 +102,47 @@ public class ConsumerRunningInfoTest {
         assertThat(result).isTrue();
     }
 
+    @Test
+    public void testAnalyzeSubscriptionWithMissingStartTimestamp() {
+        // a client that does not report its start timestamp keeps the startup grace
+        // instead of failing the whole analysis
+        Properties properties = new Properties();
+        properties.put(ConsumerRunningInfo.PROP_CONSUME_TYPE, ConsumeType.CONSUME_PASSIVELY.name());
+        consumerRunningInfo.setProperties(properties);
+
+        ConsumerRunningInfo another = new ConsumerRunningInfo();
+        another.setProperties(new Properties(properties));
+        another.setSubscriptionSet(new TreeSet<>());
+
+        TreeMap<String, ConsumerRunningInfo> table = new TreeMap<>();
+        table.put("client_id_1", consumerRunningInfo);
+        table.put("client_id_2", another);
+
+        assertThat(ConsumerRunningInfo.analyzeSubscription(table)).isTrue();
+    }
+
+    @Test
+    public void testAnalyzeMethodsTolerateMissingProperties() {
+        ConsumerRunningInfo empty = new ConsumerRunningInfo();
+        empty.setProperties(new Properties());
+
+        assertThat(ConsumerRunningInfo.isPushType(empty)).isFalse();
+        assertThat(ConsumerRunningInfo.analyzeProcessQueue("client_id", empty)).isEmpty();
+
+        TreeMap<String, ConsumerRunningInfo> table = new TreeMap<>();
+        table.put("client_id", empty);
+        assertThat(ConsumerRunningInfo.analyzeSubscription(table)).isTrue();
+    }
+
+    @Test
+    public void testIsPushType() {
+        assertThat(ConsumerRunningInfo.isPushType(consumerRunningInfo)).isFalse();
+
+        Properties properties = new Properties();
+        properties.put(ConsumerRunningInfo.PROP_CONSUME_TYPE, ConsumeType.CONSUME_PASSIVELY.name());
+        consumerRunningInfo.setProperties(properties);
+        assertThat(ConsumerRunningInfo.isPushType(consumerRunningInfo)).isTrue();
+    }
+
 
 }


### PR DESCRIPTION
## Motivation

`ConsumerRunningInfo.analyzeSubscription`, `isPushType` and `analyzeProcessQueue` run on data reported by **each consumer over the wire** (`DefaultMQAdminExtImpl.getConsumerRunningInfo` just forwards the broker response), so the well-known properties cannot be assumed to exist. Two latent crashes exist today when a client does not report them:

1. `analyzeSubscription` falls back to `String.valueOf(properties.get(PROP_CONSUMER_START_TIMESTAMP))` when `getProperty` returns null. For a genuinely **absent** property this produces the literal string `"null"`, and `Long.parseLong("null")` throws:

```
java.lang.NumberFormatException: For input string: "null"
    at java.base/java.lang.Long.parseLong(Long.java:XXX)
    at ...ConsumerRunningInfo.analyzeSubscription(ConsumerRunningInfo.java:64)
```

This aborts `mqadmin consumerStatus` / `consumerSubCommand` / the consumer monitor midway through the report.

2. `isPushType` (and the identical block inlined in `analyzeProcessQueue`) cast the raw `properties.get(PROP_CONSUME_TYPE)` value to `ConsumeType` and call `.name()` on it, throwing NPE when the property is absent:

```
java.lang.NullPointerException: Cannot invoke "ConsumeType.name()" because the return value of "java.util.Properties.get(Object)" is null
```

`isPushType` is also called from `QueryMsgByIdSubCommand`/`QueryMsgByUniqueKeySubCommand` on the same wire data.

The existing `if (property == null)` fallbacks were introduced to handle **non-String** values after deserialization, but they fail to handle the **missing** value. No Java client omits these properties today, but the wire protocol is implemented by other clients/versions, and one misbehaving client should not take down the whole admin command.

## Modification

- `analyzeSubscription`: read the start timestamp once via `properties.get(...)`; when it is unknown, keep the startup grace (`startForAWhile = false`) instead of crashing — the 2-minute window exists to tolerate freshly started consumers, and an unknown start time deserves the same grace rather than a false "different subscription" alarm.
- `isPushType`: return `false` when `PROP_CONSUME_TYPE` is unknown instead of NPE-ing; a single code path now handles both String values and in-memory `ConsumeType` values (the case covered by the existing test).
- `analyzeProcessQueue`: reuse `isPushType` and drop the duplicated block.

## Verification

`mvn -pl remoting test -Dtest=ConsumerRunningInfoTest`

fail-before (fix stashed, new tests kept):

```
Tests run: 3, Failures: 0, Errors: 1, Skipped: 1
testAnalyzeSubscriptionWithMissingStartTimestamp  <<< ERROR!
java.lang.NumberFormatException: For input string: "null"

testAnalyzeMethodsTolerateMissingProperties  <<< ERROR!
java.lang.NullPointerException: Cannot invoke "ConsumeType.name()" because the return value of "java.util.Properties.get(Object)" is null
```

pass-after:

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 - in ConsumerRunningInfoTest
BUILD SUCCESS
```

No associated issue; found by code inspection.