### PR TITLE
fix(tools): stop feeding the cold data flow ctr payload to printf as a format string

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetColdDataFlowCtrInfoSubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetColdDataFlowCtrInfoSubCommand.java
@@ -119,7 +119,8 @@ public class GetColdDataFlowCtrInfoSubCommand implements SubCommand {
         });
 
         String formatStr = JSON.toJSONString(jsonObject, JSONWriter.Feature.PrettyFormat);
-        System.out.printf(formatStr);
+        // the payload contains consumer group and topic names, where '%' is a legal character
+        System.out.print(formatStr);
         System.out.printf("%n");
     }
 

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/broker/GetColdDataFlowCtrInfoSubCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/broker/GetColdDataFlowCtrInfoSubCommandTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.broker;
+
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GetColdDataFlowCtrInfoSubCommandTest {
+
+    @Test
+    public void testPrintsEntriesWhoseGroupNameContainsPercent() throws Exception {
+        MQAdminExt admin = mock(MQAdminExt.class);
+        // '%' is a legal character in consumer group and topic names, e.g. "%RETRY%" prefixed ones
+        String payload = "{\"runtimeTable\":{\"order%group\":{\"coldAcc\":10,"
+            + "\"lastColdReadTimeMills\":1700000000000,\"createTimeMills\":1600000000000}},"
+            + "\"configTable\":{},\"cgColdReadThreshold\":100,\"globalColdReadThreshold\":1000,\"globalAcc\":5}";
+        when(admin.getColdDataFlowCtrInfo("127.0.0.1:10911")).thenReturn(payload);
+
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8.name()));
+        try {
+            new GetColdDataFlowCtrInfoSubCommand().getAndPrint(admin, "prefix", "127.0.0.1:10911");
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        assertThat(buffer.toString()).contains("order%group");
+    }
+}


### PR DESCRIPTION
## Motivation

`GetColdDataFlowCtrInfoSubCommand.getAndPrint` pretty-prints the JSON returned by the broker and passes it to `printf` **as the format string**:

```java
String formatStr = JSON.toJSONString(jsonObject, JSONWriter.Feature.PrettyFormat);
System.out.printf(formatStr);
```

The payload is keyed by consumer group names, and `%` is a **legal character** in consumer group and topic names — the validation regex is `^[%|a-zA-Z0-9_-]+$` (it exists precisely to allow the `%RETRY%` / `%RETRY%`-style prefixes). A group like `order%group` therefore makes the command die halfway through the report:

```
java.util.MissingFormatArgumentException: Format specifier '%g'
```

(any `%` in the group name triggers `MissingFormatArgumentException`, `UnknownFormatConversionException` or `UnknownFormatFlagsException` depending on the following character — none of the command output is printed.)

## Modification

Print the payload literally:

```java
System.out.print(formatStr);
System.out.printf("%n");
```

## Verification

`mvn -pl tools test -Dtest=GetColdDataFlowCtrInfoSubCommandTest`

fail-before (fix reverted, test kept) — the mocked broker response contains a legal group name `order%group`:

```
Tests run: 1, Failures: 0, Errors: 1
testPrintsEntriesWhoseGroupNameContainsPercent  <<< ERROR!
java.util.MissingFormatArgumentException: Format specifier '%g'
```

pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

and the captured stdout contains the untouched group name `order%group`.

No associated issue; found by code inspection.