### PR TITLE
fix(auth): tolerate blank subscription topics in heartbeats

### DIFF
--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
@@ -350,6 +350,9 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
                             if (subscriptionData == null) {
                                 throw new AuthorizationException("subscription is null.");
                             }
+                            if ("".equals(subscriptionData.getTopic())) {
+                                continue;
+                            }
                             String subscriptionTopic =
                                 requireResource(subscriptionData.getTopic(), "topic");
                             if (NamespaceUtil.isRetryTopic(subscriptionTopic)) {

--- a/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
+++ b/auth/src/main/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilder.java
@@ -350,7 +350,7 @@ public class DefaultAuthorizationContextBuilder implements AuthorizationContextB
                             if (subscriptionData == null) {
                                 throw new AuthorizationException("subscription is null.");
                             }
-                            if ("".equals(subscriptionData.getTopic())) {
+                            if (StringUtils.isBlank(subscriptionData.getTopic())) {
                                 continue;
                             }
                             String subscriptionTopic =

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilderTest.java
@@ -1097,14 +1097,8 @@ public class DefaultAuthorizationContextBuilderTest {
         HeartbeatData heartbeatData = new HeartbeatData();
         ConsumerData consumerData = new ConsumerData();
         consumerData.setGroupName("group");
-        SubscriptionData subscriptionData = new SubscriptionData();
-        subscriptionData.setTopic(" ");
-        consumerData.setSubscriptionDataSet(Collections.singleton(subscriptionData));
+        consumerData.setSubscriptionDataSet(Collections.singleton(null));
         heartbeatData.setConsumerDataSet(Collections.singleton(consumerData));
-        Assert.assertThrows(AuthorizationException.class, () -> builder.build(channelHandlerContext,
-            remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(),
-                JSON.toJSONBytes(heartbeatData))));
-        subscriptionData.setTopic(null);
         Assert.assertThrows(AuthorizationException.class, () -> builder.build(channelHandlerContext,
             remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(),
                 JSON.toJSONBytes(heartbeatData))));
@@ -1451,12 +1445,15 @@ public class DefaultAuthorizationContextBuilderTest {
     }
 
     @Test
-    public void buildHeartbeatSkipsEmptyTopic() {
+    public void buildHeartbeatSkipsBlankTopics() {
         mockRemotingChannel();
         ConsumerData consumerData = new ConsumerData();
         consumerData.setGroupName("group");
         consumerData.setSubscriptionDataSet(new LinkedHashSet<>(Arrays.asList(
+            new SubscriptionData(null, "*"),
             new SubscriptionData("", "*"),
+            new SubscriptionData(" ", "*"),
+            new SubscriptionData("\t\r\n", "*"),
             new SubscriptionData("topic", "*"),
             new SubscriptionData("%RETRY%group", "*"))));
         HeartbeatData heartbeatData = new HeartbeatData();
@@ -1471,11 +1468,15 @@ public class DefaultAuthorizationContextBuilderTest {
     }
 
     @Test
-    public void buildHeartbeatWithOnlyEmptyTopicStillChecksGroup() {
+    public void buildHeartbeatWithOnlyBlankTopicsStillChecksGroup() {
         mockRemotingChannel();
         ConsumerData consumerData = new ConsumerData();
         consumerData.setGroupName("group");
-        consumerData.setSubscriptionDataSet(Collections.singleton(new SubscriptionData("", "*")));
+        consumerData.setSubscriptionDataSet(new LinkedHashSet<>(Arrays.asList(
+            new SubscriptionData(null, "*"),
+            new SubscriptionData("", "*"),
+            new SubscriptionData(" ", "*"),
+            new SubscriptionData("\t\r\n", "*"))));
         HeartbeatData heartbeatData = new HeartbeatData();
         heartbeatData.setConsumerDataSet(Collections.singleton(consumerData));
 

--- a/auth/src/test/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilderTest.java
+++ b/auth/src/test/java/org/apache/rocketmq/auth/authorization/builder/DefaultAuthorizationContextBuilderTest.java
@@ -1104,6 +1104,10 @@ public class DefaultAuthorizationContextBuilderTest {
         Assert.assertThrows(AuthorizationException.class, () -> builder.build(channelHandlerContext,
             remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(),
                 JSON.toJSONBytes(heartbeatData))));
+        subscriptionData.setTopic(null);
+        Assert.assertThrows(AuthorizationException.class, () -> builder.build(channelHandlerContext,
+            remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(),
+                JSON.toJSONBytes(heartbeatData))));
 
         RemotingCommand listRequest =
             RemotingCommand.createRequestCommand(RequestCode.GET_ALL_TOPIC_CONFIG, null);
@@ -1444,6 +1448,46 @@ public class DefaultAuthorizationContextBuilderTest {
             new DeleteSubscriptionGroupListRequestBody(Arrays.asList("groupA", " "));
         Assert.assertThrows(AuthorizationException.class, () -> builder.build(channelHandlerContext,
             remotingRequest(RequestCode.DELETE_SUBSCRIPTION_GROUP_LIST, null, invalidGroupList.encode())));
+    }
+
+    @Test
+    public void buildHeartbeatSkipsEmptyTopic() {
+        mockRemotingChannel();
+        ConsumerData consumerData = new ConsumerData();
+        consumerData.setGroupName("group");
+        consumerData.setSubscriptionDataSet(new LinkedHashSet<>(Arrays.asList(
+            new SubscriptionData("", "*"),
+            new SubscriptionData("topic", "*"),
+            new SubscriptionData("%RETRY%group", "*"))));
+        HeartbeatData heartbeatData = new HeartbeatData();
+        heartbeatData.setConsumerDataSet(Collections.singleton(consumerData));
+
+        List<DefaultAuthorizationContext> result = builder.build(channelHandlerContext,
+            remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(), heartbeatData.encode()));
+
+        assertResourceOrder(result, "Group:group", "Topic:topic");
+        assertActions(result, "Group:group", Action.SUB);
+        assertActions(result, "Topic:topic", Action.SUB);
+    }
+
+    @Test
+    public void buildHeartbeatWithOnlyEmptyTopicStillChecksGroup() {
+        mockRemotingChannel();
+        ConsumerData consumerData = new ConsumerData();
+        consumerData.setGroupName("group");
+        consumerData.setSubscriptionDataSet(Collections.singleton(new SubscriptionData("", "*")));
+        HeartbeatData heartbeatData = new HeartbeatData();
+        heartbeatData.setConsumerDataSet(Collections.singleton(consumerData));
+
+        List<DefaultAuthorizationContext> result = builder.build(channelHandlerContext,
+            remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(), heartbeatData.encode()));
+
+        assertResourceOrder(result, "Group:group");
+        assertActions(result, "Group:group", Action.SUB);
+
+        consumerData.setGroupName("");
+        Assert.assertThrows(AuthorizationException.class, () -> builder.build(channelHandlerContext,
+            remotingRequest(RequestCode.HEART_BEAT, new HeartbeatRequestHeader(), heartbeatData.encode())));
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Follow-up to #11009; no separate issue.

### Brief Description

A Remoting consumer heartbeat containing a blank subscription topic is rejected with `topic is null`, even when it also contains valid subscriptions. Skip null, empty, and whitespace-only topic names when building heartbeat authorization contexts so that the remaining subscriptions can be authorized.

Consumer-group and valid-topic SUB authorization contexts are preserved, including group authorization when all subscription topics are blank. Missing heartbeat bodies, null subscription entries, and invalid consumer-group names remain rejected.

### How Did You Test This Change?

Added regression coverage for mixed valid/retry/blank topics, all-blank topic subscriptions retaining group authorization, and null subscription entry rejection.

Ran on JDK 11:

```sh
mvn -B -pl auth -am \
  -Dtest=DefaultAuthorizationContextBuilderTest,AuthorizationEvaluatorTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

36 tests: 35 passed and 1 existing platform-specific test skipped. Checkstyle and SpotBugs passed.
