### PR TITLE
[BUG] Clearing one topic's forbidden bits wipes the whole group's forbidden table and skips persist

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -225,8 +225,15 @@ public class SubscriptionGroupManager extends ConfigManager {
 
     protected void updateForbiddenValue(String group, String topic, Integer forbidden) {
         if (forbidden == null || forbidden <= 0) {
-            this.forbiddenTable.remove(group);
-            log.info("clear group forbidden, {}@{} ", group, topic);
+            ConcurrentMap<String, Integer> topicForbiddens = this.forbiddenTable.get(group);
+            if (topicForbiddens != null && topicForbiddens.remove(topic) != null) {
+                if (topicForbiddens.isEmpty()) {
+                    this.forbiddenTable.remove(group, topicForbiddens);
+                }
+                log.info("clear topic forbidden, {}@{} ", group, topic);
+                updateDataVersion();
+                this.persist();
+            }
             return;
         }
 

--- a/broker/src/test/java/org/apache/rocketmq/broker/subscription/ForbiddenTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/subscription/ForbiddenTest.java
@@ -18,6 +18,9 @@
 package org.apache.rocketmq.broker.subscription;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.common.BrokerConfig;
@@ -58,6 +61,31 @@ public class ForbiddenTest {
         s.updateForbidden("g", "t", 2, false);
         assertEquals(0, s.getForbidden("g", "t"));
         assertEquals(false, s.getForbidden("g", "t", 2));
+    }
+
+    @Test
+    public void testClearOneTopicForbiddenKeepsOtherTopicsOfTheSameGroup() throws Exception {
+        SubscriptionGroupManager s = new SubscriptionGroupManager(
+            new BrokerController(new BrokerConfig(), new NettyServerConfig(), new NettyClientConfig(), new MessageStoreConfig()));
+        s.updateForbidden("g", "t1", 0, true);
+        s.updateForbidden("g", "t2", 0, true);
+        assertEquals(true, s.getForbidden("g", "t1", 0));
+        assertEquals(true, s.getForbidden("g", "t2", 0));
+        long counterBeforeClear = s.getDataVersion().getCounter().get();
+
+        s.updateForbidden("g", "t1", 0, false);
+
+        // Only t1's forbidden bit is cleared; t2 keeps its own state.
+        assertEquals(false, s.getForbidden("g", "t1", 0));
+        assertEquals(true, s.getForbidden("g", "t2", 0));
+        assertEquals(1, s.getForbiddenTable().get("g").size());
+        // Clearing a forbidden bit must bump the data version and persist, so
+        // brokers that sync or restart do not resurrect the stale bit.
+        assertThat(s.getDataVersion().getCounter().get(), greaterThan(counterBeforeClear));
+
+        s.updateForbidden("g", "t2", 0, false);
+        assertEquals(0, s.getForbidden("g", "t2"));
+        assertNull(s.getForbiddenTable().get("g"));
     }
 
 }


### PR DESCRIPTION
### Motivation

`SubscriptionGroupManager.updateForbiddenValue` handles a forbidden value of 0 (i.e. `clearForbidden` released the last forbidden bit of a topic) by removing the **whole group** from `forbiddenTable`:

```java
if (forbidden == null || forbidden <= 0) {
    this.forbiddenTable.remove(group);
    log.info("clear group forbidden, {}@{} ", group, topic);
    return;
}
```

Two problems:

1. **Cross-topic state loss.** When a group is forbidden on multiple topics and one topic's permission is restored, the other topics' forbidden bits are silently dropped — the admin only intended to un-forbid one topic. (`AdminBrokerProcessor.updateForbidden` / the dashboard's per-topic perm toggle hit exactly this path.)
2. **No persist / no data-version bump.** The removal neither calls `updateDataVersion()` nor `persist()`, so after a broker restart the stale forbidden state comes back from disk, and peers syncing via `GET_ALL_SUBSCRIPTIONGROUP_CONFIG` see an unchanged data version and keep the old bits.

### Changes

In the `forbidden <= 0` branch: remove only the given topic's entry from the group's map (dropping the now-empty group map when the last topic is gone), then `updateDataVersion()` + `persist()`, mirroring the set path. A clear of a topic that was never forbidden stays a no-op (no spurious version bump).

### Verification

New regression test `ForbiddenTest#testClearOneTopicForbiddenKeepsOtherTopicsOfTheSameGroup`: forbids `t1`/`t2` of one group, clears `t1`, and asserts `t2` keeps its forbidden bit, the table shrinks to the single remaining entry, the data version counter is bumped, and clearing the last topic removes the group entry.

```
$ mvn -pl broker test -Dtest='ForbiddenTest'
(before) Tests run: 2, Failures: 1, Errors: 0   (t2's state lost + version not bumped)
(after)  Tests run: 2, Failures: 0, Errors: 0
```