### PR TITLE
[BUG] Split-metadata pagination crashes on zero/negative maxNum, negative seq or malformed dataVersion

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -322,15 +322,15 @@ public class SubscriptionGroupManager extends ConfigManager {
     public ConcurrentHashMap<String, SubscriptionGroupConfig> subGroupTable(String dataVersion, int groupSeq,
         int maxGroupNum) {
         // [groupSeq, groupSeq + maxGroupNum)
-        int beginIndex = groupSeq;
-        if (beginIndex != 0 && (StringUtils.isBlank(dataVersion) || !Objects.equals(DataVersion.fromJson(dataVersion, DataVersion.class), getDataVersion()))) {
+        int beginIndex = Math.max(groupSeq, 0);
+        if (beginIndex != 0 && (StringUtils.isBlank(dataVersion) || !Objects.equals(parseDataVersion(dataVersion), getDataVersion()))) {
             beginIndex = 0;
             log.info("get sub subscription group table from {} due to {}", beginIndex,
                 StringUtils.isBlank(dataVersion) ? "DataVersion Empty" : "DataVersion Changed");
         }
 
         ConcurrentHashMap<String, SubscriptionGroupConfig> subGroupTable = new ConcurrentHashMap<>();
-        if (beginIndex < subscriptionGroupTable.size()) {
+        if (maxGroupNum > 0 && beginIndex < subscriptionGroupTable.size()) {
             int endIndex = Math.min(beginIndex + maxGroupNum, subscriptionGroupTable.size());
 
             ImmutableSortedMap<String, SubscriptionGroupConfig> sortedMap = ImmutableSortedMap.copyOf(subscriptionGroupTable);
@@ -339,6 +339,22 @@ public class SubscriptionGroupManager extends ConfigManager {
         }
 
         return subGroupTable;
+    }
+
+    /**
+     * Parses the data version a client sent along with its split-metadata request. An
+     * unparseable value means the client's version is unknown, which callers treat like
+     * a version change: fall back to a full page from index 0 instead of failing the
+     * request.
+     */
+    private DataVersion parseDataVersion(String dataVersion) {
+        try {
+            return DataVersion.fromJson(dataVersion, DataVersion.class);
+        } catch (Exception e) {
+            log.info("parse dataVersion failed, fall back to the full subscription group table, dataVersion={}",
+                dataVersion);
+            return null;
+        }
     }
 
     public ConcurrentMap<String, ConcurrentMap<String, Integer>> getForbiddenTable() {

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -742,15 +742,15 @@ public class TopicConfigManager extends ConfigManager {
     public ConcurrentHashMap<String, TopicConfig> subTopicConfigTable(String dataVersion, int topicSeq,
         int maxTopicNum) {
         // [topicSeq, topicSeq + maxTopicNum)
-        int beginIndex = topicSeq;
-        if (beginIndex != 0 && (StringUtils.isBlank(dataVersion) || !Objects.equals(DataVersion.fromJson(dataVersion, DataVersion.class), getDataVersion()))) {
+        int beginIndex = Math.max(topicSeq, 0);
+        if (beginIndex != 0 && (StringUtils.isBlank(dataVersion) || !Objects.equals(parseDataVersion(dataVersion), getDataVersion()))) {
             beginIndex = 0;
             log.info("get sub topic config table from {} due to {}", beginIndex,
                 StringUtils.isBlank(dataVersion) ? "DataVersion Empty" : "DataVersion Changed");
         }
 
         ConcurrentHashMap<String, TopicConfig> subTopicConfigTable = new ConcurrentHashMap<>();
-        if (beginIndex < topicConfigTable.size()) {
+        if (maxTopicNum > 0 && beginIndex < topicConfigTable.size()) {
             int endIndex = Math.min(beginIndex + maxTopicNum, topicConfigTable.size());
 
             ImmutableSortedMap<String, TopicConfig> sortedMap = ImmutableSortedMap.copyOf(topicConfigTable);
@@ -759,6 +759,22 @@ public class TopicConfigManager extends ConfigManager {
         }
 
         return subTopicConfigTable;
+    }
+
+    /**
+     * Parses the data version a client sent along with its split-metadata request. An
+     * unparseable value means the client's version is unknown, which callers treat like
+     * a version change: fall back to a full page from index 0 instead of failing the
+     * request.
+     */
+    private DataVersion parseDataVersion(String dataVersion) {
+        try {
+            return DataVersion.fromJson(dataVersion, DataVersion.class);
+        } catch (Exception e) {
+            log.info("parse dataVersion failed, fall back to the full topic config table, dataVersion={}",
+                dataVersion);
+            return null;
+        }
     }
 
     private Map<String, String> request(TopicConfig topicConfig) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManagerTest.java
@@ -240,6 +240,48 @@ public class SubscriptionGroupManagerTest {
 
     }
 
+    @Test
+    public void testSubGroupTableWithNonPositiveMaxGroupNum() {
+        // Drop the constructor's builtin groups so the sorted table starts at group-00000.
+        subscriptionGroupManager.getSubscriptionGroupTable().clear();
+        fillSubscriptionGroupManager(10);
+
+        // maxGroupNum = 0 asks for an empty page; a negative value is nonsensical.
+        // Both must return an empty table instead of indexing out of bounds.
+        assertThat(subscriptionGroupManager.subGroupTable(null, 0, 0)).isEmpty();
+        assertThat(subscriptionGroupManager.subGroupTable(null, 5, 0)).isEmpty();
+        assertThat(subscriptionGroupManager.subGroupTable(null, 0, -1)).isEmpty();
+    }
+
+    @Test
+    public void testSubGroupTableWithNegativeGroupSeqClampsToHead() {
+        subscriptionGroupManager.getSubscriptionGroupTable().clear();
+        fillSubscriptionGroupManager(10);
+
+        // A negative groupSeq with a matching data version must clamp to index 0
+        // instead of indexing out of bounds.
+        Map<String, SubscriptionGroupConfig> result = subscriptionGroupManager.subGroupTable(
+            subscriptionGroupManager.getDataVersion().toJson(), -3, 4);
+
+        Assert.assertEquals(4, result.size());
+        Assert.assertTrue(result.containsKey("group-00000"));
+        Assert.assertFalse(result.containsKey("group-00004"));
+    }
+
+    @Test
+    public void testSubGroupTableWithMalformedDataVersionFallsBackToFullPage() {
+        subscriptionGroupManager.getSubscriptionGroupTable().clear();
+        fillSubscriptionGroupManager(10);
+
+        // A garbage dataVersion string from a client means "unknown version":
+        // degrade to a full page from index 0 instead of failing the request.
+        Map<String, SubscriptionGroupConfig> result = subscriptionGroupManager.subGroupTable("{not-json", 5, 3);
+
+        Assert.assertEquals(3, result.size());
+        Assert.assertTrue(result.containsKey("group-00000"));
+        Assert.assertFalse(result.containsKey("group-00005"));
+    }
+
     private void fillSubscriptionGroupManager(int num) {
         for (int i = num - 1; i >= 0; i--) {
             SubscriptionGroupConfig subscriptionGroupConfig = new SubscriptionGroupConfig();

--- a/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicConfigManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/topic/TopicConfigManagerTest.java
@@ -423,6 +423,44 @@ public class TopicConfigManagerTest {
     }
 
     @Test
+    public void testSubTopicConfigTableWithNonPositiveMaxTopicNum() {
+        fillTopicConfigTable(10);
+
+        // maxTopicNum = 0 asks for an empty page; a negative value is nonsensical.
+        // Both must return an empty table instead of indexing out of bounds.
+        Assert.assertTrue(topicConfigManager.subTopicConfigTable(null, 0, 0).isEmpty());
+        Assert.assertTrue(topicConfigManager.subTopicConfigTable(null, 5, 0).isEmpty());
+        Assert.assertTrue(topicConfigManager.subTopicConfigTable(null, 0, -1).isEmpty());
+    }
+
+    @Test
+    public void testSubTopicConfigTableWithNegativeTopicSeqClampsToHead() {
+        fillTopicConfigTable(10);
+
+        // A negative topicSeq with a matching data version must clamp to index 0
+        // instead of indexing out of bounds.
+        Map<String, TopicConfig> result = topicConfigManager.subTopicConfigTable(
+            topicConfigManager.getDataVersion().toJson(), -3, 4);
+
+        Assert.assertEquals(4, result.size());
+        Assert.assertTrue(result.containsKey("topic00000"));
+        Assert.assertFalse(result.containsKey("topic00004"));
+    }
+
+    @Test
+    public void testSubTopicConfigTableWithMalformedDataVersionFallsBackToFullPage() {
+        fillTopicConfigTable(10);
+
+        // A garbage dataVersion string from a client means "unknown version":
+        // degrade to a full page from index 0 instead of failing the request.
+        Map<String, TopicConfig> result = topicConfigManager.subTopicConfigTable("{not-json", 5, 3);
+
+        Assert.assertEquals(3, result.size());
+        Assert.assertTrue(result.containsKey("topic00000"));
+        Assert.assertFalse(result.containsKey("topic00005"));
+    }
+
+    @Test
     public void testSplitRegistrationBumpsVersion() {
         brokerController.getBrokerConfig().setEnableSplitRegistration(true);
         long counterBefore = topicConfigManager.getDataVersion().getCounter().get();


### PR DESCRIPTION
### Motivation

`SubscriptionGroupManager.subGroupTable` and `TopicConfigManager.subTopicConfigTable` (the split-metadata path behind `GET_ALL_SUBSCRIPTIONGROUP_CONFIG` / `GET_ALL_TOPIC_CONFIG`, gated by `enableSplitMetadata`) slice the sorted key list using three client-supplied values. Three inputs crash the broker request thread:

1. **`maxGroupNum`/`maxTopicNum` = 0 or negative** — `endIndex` collapses to `beginIndex` (or below), so `keyList.get(endIndex - 1)` throws `ArrayIndexOutOfBoundsException` (e.g. `Index -1 out of bounds`), or the `ImmutableSortedMap.subMap` call throws for an inverted range when `beginIndex > 0`.
2. **negative `groupSeq`/`topicSeq` with a matching data version** — `keyList.get(beginIndex)` indexes negatively (e.g. `Index -3 out of bounds`).
3. **malformed `dataVersion` JSON** — `DataVersion.fromJson` throws fastjson's `JSONException` (`illegal fieldName ...`) instead of degrading.

All of these come straight from the request header, so a misbehaving (or malicious) client can fail every metadata fetch on a broker running with split metadata enabled.

### Changes

- Clamp the sequence to `>= 0`.
- Skip the slice (return an empty page) when the max limit is `<= 0`.
- Parse the data version through a helper that treats an unparseable value as an *unknown* version — which the existing fallback already handles by restarting from index 0 — instead of letting the exception escape.

Behaviour for well-formed requests is unchanged.

### Verification

Six new tests (`SubscriptionGroupManagerTest`, `TopicConfigManagerTest`), each red on develop and green with the patch:

- `...WithNonPositiveMaxGroupNum` / `...WithNonPositiveMaxTopicNum`: was `ArrayIndexOutOfBoundsException: Index -1`
- `...WithNegativeGroupSeqClampsToHead` / `...WithNegativeTopicSeqClampsToHead`: was `ArrayIndexOutOfBoundsException: Index -3`
- `...WithMalformedDataVersionFallsBackToFullPage`: was `com.alibaba.fastjson2.JSONException`

```
$ mvn -pl broker test -Dtest='SubscriptionGroupManagerTest,TopicConfigManagerTest'
(before) Errors: ArrayIndexOutOfBoundsException x4, JSONException x2
(after)  SubscriptionGroupManagerTest: Tests run: 10, Failures: 0, Errors: 0
         TopicConfigManagerTest:       Tests run: 17, Failures: 0, Errors: 0
```

Note: this branch also touches `SubscriptionGroupManager.java` (the `subGroupTable` method); #11093 touches a different method (`updateForbiddenValue`) in the same file, so one of the two may need a trivial rebase.