### PR TITLE
[BUG] Cold-data flow control NPEs for pull requests whose group is only in the compensation table

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PullMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PullMessageProcessor.java
@@ -513,7 +513,14 @@ public class PullMessageProcessor implements NettyRequestProcessor {
                     .getColdDataCheckService().isMsgInColdArea(requestHeader.getConsumerGroup(),
                         requestHeader.getTopic(), requestHeader.getQueueId(), requestHeader.getQueueOffset());
                 if (isMsgLogicCold) {
-                    ConsumeType consumeType = this.brokerController.getConsumerManager().getConsumerGroupInfo(requestHeader.getConsumerGroup()).getConsumeType();
+                    // The group may only be known through the compensation table filled a
+                    // few lines above (pull consumers and proxy traffic), so look there
+                    // too; if even that has no record, flow control like a passive
+                    // consumer instead of failing the request with an NPE.
+                    ConsumerGroupInfo consumerGroupInfo = this.brokerController.getConsumerManager()
+                        .getConsumerGroupInfo(requestHeader.getConsumerGroup(), true);
+                    ConsumeType consumeType = consumerGroupInfo == null
+                        ? ConsumeType.CONSUME_PASSIVELY : consumerGroupInfo.getConsumeType();
                     if (consumeType == ConsumeType.CONSUME_PASSIVELY) {
                         response.setCode(ResponseCode.SYSTEM_BUSY);
                         response.setRemark("This consumer group is reading cold data. It has been flow control");

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PullMessageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PullMessageProcessorTest.java
@@ -35,6 +35,7 @@ import org.apache.rocketmq.broker.subscription.SubscriptionGroupManager;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.sysflag.PullSysFlag;
 import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyServerConfig;
@@ -49,6 +50,8 @@ import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
 import org.apache.rocketmq.store.GetMessageResult;
 import org.apache.rocketmq.store.GetMessageStatus;
 import org.apache.rocketmq.store.MessageStore;
+import org.apache.rocketmq.store.CommitLog;
+import org.apache.rocketmq.store.DefaultMessageStore;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,6 +66,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -245,6 +249,42 @@ public class PullMessageProcessorTest {
         assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
         assertThat(this.brokerController.getConsumerOffsetManager().queryPullOffset(group, topic, 1))
             .isEqualTo(getMessageResult.getNextBeginOffset());
+    }
+
+    @Test
+    public void testColdDataFlowCtrWhenGroupIsOnlyInCompensationTable() throws Exception {
+        brokerController.getMessageStoreConfig().setColdDataFlowControlEnable(true);
+        brokerController.getColdDataCgCtrService().coldAcc(group, Long.MAX_VALUE);
+        brokerController.getConsumerManager().unregisterConsumer(group, clientChannelInfo, false);
+
+        DefaultMessageStore defaultMessageStore = mock(DefaultMessageStore.class);
+        CommitLog commitLog = mock(CommitLog.class);
+        CommitLog.ColdDataCheckService coldDataCheckService = mock(CommitLog.ColdDataCheckService.class);
+        when(defaultMessageStore.getCommitLog()).thenReturn(commitLog);
+        when(commitLog.getColdDataCheckService()).thenReturn(coldDataCheckService);
+        when(coldDataCheckService.isMsgInColdArea(anyString(), anyString(), anyInt(), anyLong())).thenReturn(true);
+        brokerController.setMessageStore(defaultMessageStore);
+
+        // Pull with the subscription carried in the request (proxy / lite-pull style):
+        // the group is absent from the live consumer table, only compensated above.
+        PullMessageRequestHeader requestHeader = new PullMessageRequestHeader();
+        requestHeader.setCommitOffset(123L);
+        requestHeader.setConsumerGroup(group);
+        requestHeader.setMaxMsgNums(100);
+        requestHeader.setQueueId(1);
+        requestHeader.setQueueOffset(456L);
+        requestHeader.setSubscription("*");
+        requestHeader.setTopic(topic);
+        requestHeader.setSysFlag(PullSysFlag.buildSysFlag(false, false, true, false));
+        requestHeader.setSubVersion(100L);
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.PULL_MESSAGE, requestHeader);
+        request.makeCustomHeaderToNet();
+
+        RemotingCommand response = pullMessageProcessor.processRequest(handlerContext, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_BUSY);
+        assertThat(response.getRemark()).contains("cold data");
     }
 
     private RemotingCommand createPullMsgCommand(int requestCode) {


### PR DESCRIPTION
### Motivation

When a broker has `coldDataFlowControlEnable=true` and a consumer group is flagged for cold-data flow control (`ColdDataCgCtrService`), the cold branch of `PullMessageProcessor` does:

```java
ConsumeType consumeType = this.brokerController.getConsumerManager()
    .getConsumerGroupInfo(requestHeader.getConsumerGroup()).getConsumeType();
```

`getConsumerGroupInfo(group)` only consults the **live** consumer table. But pull requests that carry their subscription in the request (proxy / lite-pull traffic, i.e. `hasSubscriptionFlag=true\)) never registered the group there — the broker instead compensates the group's basic info into `consumerCompensationTable` a few lines earlier (`compensateBasicConsumerInfo`, `PullMessageProcessor` L381-392). For those requests the lookup returns null and the pull thread dies with:

```
java.lang.NullPointerException: Cannot invoke "ConsumerGroupInfo.getConsumeType()"
  because the return value of "ConsumerManager.getConsumerGroupInfo(String)" is null
```

So a flow-controlled group reading cold data via the proxy gets NPE responses instead of the intended flow control.

### Changes

- Look the group up with `getConsumerGroupInfo(group, true)` so the compensation table filled a few lines above is also consulted (same pattern as `ConsumerLagCalculator`).
- If even the compensation table has no record, fall back to `CONSUME_PASSIVELY` — the conservative flow-control response — instead of dereferencing null.

### Verification

New test `PullMessageProcessorTest#testColdDataFlowCtrWhenGroupIsOnlyInCompensationTable`: enables cold-data flow control, flags the group via `coldAcc`, unregisters the live consumer, mocks a `DefaultMessageStore` whose commit log reports the offset as cold, and sends a subscription-carrying pull request.

```
$ mvn -pl broker test -Dtest='PullMessageProcessorTest'
(before) java.lang.NullPointerException: Cannot invoke ... getConsumeType() ... is null
(after)  Tests run: 11, Failures: 0, Errors: 0   (new test asserts SYSTEM_BUSY + cold-data remark)
```