### PR TITLE
[BUG] EndTransactionProcessor NPEs when the prepared message lacks the producer group property

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/EndTransactionProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/EndTransactionProcessor.java
@@ -245,7 +245,10 @@ public class EndTransactionProcessor implements NettyRequestProcessor {
                 return response;
             }
             final String pgroupRead = msgExt.getProperty(MessageConst.PROPERTY_PRODUCER_GROUP);
-            if (!pgroupRead.equals(requestHeader.getProducerGroup())) {
+            // The prepared message may lack the producer group property (messages
+            // written by old clients or restored stores); compare null-safely and
+            // reject instead of failing the request with an NPE.
+            if (!Objects.equals(pgroupRead, requestHeader.getProducerGroup())) {
                 response.setCode(ResponseCode.SYSTEM_ERROR);
                 response.setRemark("The producer group wrong");
                 return response;

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/EndTransactionProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/EndTransactionProcessorTest.java
@@ -202,6 +202,21 @@ public class EndTransactionProcessorTest {
         assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
     }
 
+    @Test
+    public void testProcessRequestRejectsPreparedMessageWithoutProducerGroup() throws RemotingCommandException {
+        OperationResult prepareResult = createResponse(ResponseCode.SUCCESS);
+        MessageAccessor.clearProperty(prepareResult.getPrepareMessage(), MessageConst.PROPERTY_PRODUCER_GROUP);
+        when(transactionMsgService.commitMessage(any(EndTransactionRequestHeader.class))).thenReturn(prepareResult);
+
+        RemotingCommand request = createEndTransactionMsgCommand(MessageSysFlag.TRANSACTION_COMMIT_TYPE, false);
+        RemotingCommand response = endTransactionProcessor.processRequest(handlerContext, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("producer group wrong");
+        verify(messageStore, never()).putMessage(any(MessageExtBrokerInner.class));
+        verify(transactionMsgService, never()).deletePrepareMessage(any(MessageExt.class));
+    }
+
     private MessageExt createDefaultMessageExt() {
         MessageExt messageExt = new MessageExt();
         messageExt.setMsgId("12345678");


### PR DESCRIPTION
### Motivation

`EndTransactionProcessor.checkPrepareMessage` validates the request's producer group against the property stored on the prepared (half) message:

```java
final String pgroupRead = msgExt.getProperty(MessageConst.PROPERTY_PRODUCER_GROUP);
if (!pgroupRead.equals(requestHeader.getProducerGroup())) {
```

If the half message does not carry `PROPERTY_PRODUCER_GROUP` (half messages written by old clients, or stores restored without the property), `pgroupRead` is null and the commit/rollback request dies with:

```
java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "pgroupRead" is null
```

The topic check right above already tolerates a missing field defensively (`StringUtils.isNotBlank` + `Objects.equals`), so the producer-group check is inconsistent with its own file's style.

### Changes

- Compare with `Objects.equals(pgroupRead, requestHeader.getProducerGroup())`: a missing property is a mismatch and gets the intended `SYSTEM_ERROR` / "The producer group wrong" rejection instead of an NPE.

### Verification

New test `testProcessRequestRejectsPreparedMessageWithoutProducerGroup`: commits a transaction whose prepared message has the producer-group property removed.

```
$ mvn -pl broker test -Dtest='EndTransactionProcessorTest'
(before) java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "pgroupRead" is null
(after)  Tests run: 10, Failures: 0, Errors: 0  (new test asserts SYSTEM_ERROR + "producer group wrong")
```