### PR TITLE
[ISSUE #S1] Scope the index list write lock to the list update in getAndCreateLastIndexFile

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
@@ -356,12 +356,20 @@ public class IndexService implements CommitLogDispatchStore {
                 indexFile =
                     new IndexFile(fileName, this.hashSlotNum, this.indexNum, lastUpdateEndPhyOffset,
                         lastUpdateIndexTimestamp);
-                this.readWriteLock.writeLock().lock();
-                this.indexFileList.add(indexFile);
             } catch (Exception e) {
                 LOGGER.error("getLastIndexFile exception ", e);
-            } finally {
-                this.readWriteLock.writeLock().unlock();
+            }
+
+            // The write lock must only guard the list update: IndexFile creation
+            // happens outside it, so a failed construction cannot release a lock
+            // that was never acquired.
+            if (indexFile != null) {
+                this.readWriteLock.writeLock().lock();
+                try {
+                    this.indexFileList.add(indexFile);
+                } finally {
+                    this.readWriteLock.writeLock().unlock();
+                }
             }
 
             if (indexFile != null) {

--- a/store/src/test/java/org/apache/rocketmq/store/index/IndexServiceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/index/IndexServiceTest.java
@@ -24,12 +24,16 @@ import org.apache.rocketmq.store.stats.BrokerStatsManager;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class IndexServiceTest {
 
@@ -80,5 +84,24 @@ public class IndexServiceTest {
         QueryOffsetResult result = indexService.queryOffset("test", "testKey", 0, 0, 100);
         assertNotNull(result);
         assertEquals(Collections.emptyList(), result.getPhyOffsets());
+    }
+
+    @Test
+    public void testGetAndCreateLastIndexFileWhenCreateFileFails() throws Exception {
+        // Point the index store path below a regular file, so creating the index
+        // file is guaranteed to fail: the method must return null instead of
+        // throwing IllegalMonitorStateException from unlocking the write lock
+        // that was never acquired.
+        File blocker = File.createTempFile("index-service-blocker", ".tmp");
+        blocker.deleteOnExit();
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setStorePathRootDir(new File(blocker, "store").getAbsolutePath());
+        DefaultMessageStore store = mock(DefaultMessageStore.class);
+        when(store.getMessageStoreConfig()).thenReturn(messageStoreConfig);
+        IndexService service = new IndexService(store);
+
+        IndexFile indexFile = service.getAndCreateLastIndexFile();
+
+        assertNull(indexFile);
     }
 }


### PR DESCRIPTION
### Motivation

In `IndexService.getAndCreateLastIndexFile` the write lock is acquired *inside* the `try` block, after the `IndexFile` constructor, while `finally` unconditionally calls `writeLock().unlock()`:

```java
try {
    ...
    indexFile = new IndexFile(fileName, ...);   // may throw IOException
    this.readWriteLock.writeLock().lock();      // only reached if the constructor returned
    this.indexFileList.add(indexFile);
} catch (Exception e) {
    LOGGER.error("getLastIndexFile exception ", e);
} finally {
    this.readWriteLock.writeLock().unlock();    // unlocks a lock that was never acquired
}
```

When `IndexFile` creation fails (store directory missing/not writable/disk full), the constructor throws, `lock()` is never reached, and the `finally` block throws `IllegalMonitorStateException`, which propagates out of `getAndCreateLastIndexFile` into `putKeyEnd` — i.e. into the message store write path (`buildKey`/`putKey` while appending index entries). The original creation failure is already logged; the extra IMSE only masks it.

### Modifications

- Create the `IndexFile` outside the lock; take the write lock only to append it to `indexFileList`, with a balanced `try/finally`.

### Verification

Fail-before (new test on unpatched code):

```
IndexServiceTest.testGetAndCreateLastIndexFileWhenCreateFileFails » IllegalMonitorState
```

The test points the index store path below a regular file so `IndexFile` creation is guaranteed to fail.

Pass-after — full `IndexServiceTest` (5 existing + 1 new):

```
mvn -pl store test -Dtest='IndexServiceTest'
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```