### PR TITLE
[ISSUE #S5] Clamp negative maxNum in IndexService.queryOffset

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/index/IndexService.java
@@ -173,7 +173,10 @@ public class IndexService implements CommitLogDispatchStore {
     public QueryOffsetResult queryOffset(String topic, String key, int maxNum, long begin, long end, String indexType) {
         long indexLastUpdateTimestamp = 0;
         long indexLastUpdatePhyoffset = 0;
-        maxNum = Math.min(maxNum, this.defaultMessageStore.getMessageStoreConfig().getMaxMsgsNumBatch());
+        // maxNum comes from the request header and is only checked for null,
+        // so a negative value must be clamped here instead of blowing up the
+        // ArrayList allocation below with an IllegalArgumentException.
+        maxNum = Math.min(Math.max(maxNum, 0), this.defaultMessageStore.getMessageStoreConfig().getMaxMsgsNumBatch());
         List<Long> phyOffsets = new ArrayList<>(maxNum);
         try {
             this.readWriteLock.readLock().lock();

--- a/store/src/test/java/org/apache/rocketmq/store/index/IndexServiceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/index/IndexServiceTest.java
@@ -81,4 +81,11 @@ public class IndexServiceTest {
         assertNotNull(result);
         assertEquals(Collections.emptyList(), result.getPhyOffsets());
     }
+
+    @Test
+    public void testQueryOffsetWithNegativeMaxNum() {
+        QueryOffsetResult result = indexService.queryOffset("test", "testKey", -1, 0, 100);
+        assertNotNull(result);
+        assertEquals(Collections.emptyList(), result.getPhyOffsets());
+    }
 }


### PR DESCRIPTION
### Motivation

`maxNum` reaches `IndexService.queryOffset` straight from `QueryMessageRequestHeader`, where the field is only annotated `@CFNotNull` — no range validation. A negative value therefore survives the existing

```java
maxNum = Math.min(maxNum, this.defaultMessageStore.getMessageStoreConfig().getMaxMsgsNumBatch());
List<Long> phyOffsets = new ArrayList<>(maxNum);
```

cap (min of a negative and a positive is still negative) and `new ArrayList<>(maxNum)` throws `IllegalArgumentException: Illegal Capacity: -1` *before* the `try` block, so it propagates uncaught through `DefaultMessageStore.queryMessage` back to the request processor, answering the client with an opaque `SYSTEM_ERROR`.

### Modifications

- Clamp `maxNum` to a minimum of 0 before the cap: `Math.min(Math.max(maxNum, 0), maxMsgsNumBatch)`. A negative request now simply returns an empty `QueryOffsetResult`, consistent with `maxNum == 0`.

### Verification

Fail-before (new test on unpatched code):

```
IndexServiceTest.testQueryOffsetWithNegativeMaxNum:87 » IllegalArgument Illegal Capacity: -1
```

Pass-after — full `IndexServiceTest` (5 existing + 1 new):

```
mvn -pl store test -Dtest='IndexServiceTest'
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```