### PR TITLE
[ISSUE #S2] Guard against a missing ext unit in ConsumeQueue.estimateMessageCount

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ConsumeQueue.java
@@ -1227,7 +1227,13 @@ public class ConsumeQueue implements ConsumeQueueInterface {
                         ConsumeQueueExt.CqExtUnit ext = null;
                         if (isExtWriteEnable()) {
                             ext = consumeQueueExt.get(tagCode);
-                            tagCode = ext.getTagsCode();
+                            // The stored code may be a raw tagsCode (entries written
+                            // before the ext was enabled, or persisted by the
+                            // "save tagsCode only" fallback), for which get() returns
+                            // null; keep the raw code and let the filter decide.
+                            if (ext != null) {
+                                tagCode = ext.getTagsCode();
+                            }
                         }
                         if (filter.isMatchedByConsumeQueue(tagCode, ext)) {
                             match++;

--- a/store/src/test/java/org/apache/rocketmq/store/ConsumeQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/ConsumeQueueTest.java
@@ -462,6 +462,48 @@ public class ConsumeQueueTest {
     }
 
     @Test
+    public void testEstimateMessageCountWhenExtUnitMissing() {
+        String topic = "T1";
+        int queueId = 0;
+        MessageStoreConfig storeConfig = new MessageStoreConfig();
+        File tmpDir = new File(System.getProperty("java.io.tmpdir"), "test_estimate_message_count_ext_missing");
+        tmpDir.deleteOnExit();
+        storeConfig.setStorePathRootDir(tmpDir.getAbsolutePath());
+        // Construct the queue with the ext enabled so consumeQueueExt exists, then
+        // write one entry with the ext disabled: the stored tagsCode stays a raw
+        // (positive) value, which is exactly what the "save tagsCode only"
+        // fallback of putMessagePositionInfoWrapper persists. Re-enabling the
+        // ext afterwards must not make estimateMessageCount fail with an NPE.
+        storeConfig.setEnableConsumeQueueExt(true);
+        DefaultMessageStore messageStore = Mockito.mock(DefaultMessageStore.class);
+        Mockito.when(messageStore.getMessageStoreConfig()).thenReturn(storeConfig);
+
+        RunningFlags runningFlags = new RunningFlags();
+        Mockito.when(messageStore.getRunningFlags()).thenReturn(runningFlags);
+
+        StoreCheckpoint storeCheckpoint = Mockito.mock(StoreCheckpoint.class);
+        Mockito.when(messageStore.getStoreCheckpoint()).thenReturn(storeCheckpoint);
+
+        ConsumeQueue consumeQueue = new ConsumeQueue(topic, queueId, storeConfig.getStorePathRootDir(),
+            storeConfig.getMappedFileSizeConsumeQueue(), messageStore);
+
+        storeConfig.setEnableConsumeQueueExt(false);
+        int messageSize = 100;
+        DispatchRequest dispatchRequest = new DispatchRequest(topic, queueId, messageSize, messageSize, 0, 0, 0, null, null, 0, 0, null);
+        consumeQueue.putMessagePositionInfoWrapper(dispatchRequest);
+        Assert.assertEquals(1, consumeQueue.getMaxOffsetInQueue());
+
+        storeConfig.setEnableConsumeQueueExt(true);
+        MessageFilter filter = Mockito.mock(MessageFilter.class);
+        Mockito.when(filter.isMatchedByConsumeQueue(Mockito.anyLong(), Mockito.any())).thenReturn(false);
+
+        long count = consumeQueue.estimateMessageCount(0, 1, filter);
+
+        Assert.assertEquals(0, count);
+        consumeQueue.destroy();
+    }
+
+    @Test
     public void testCorrectMinOffset() {
         String topic = "T1";
         int queueId = 0;


### PR DESCRIPTION
### Motivation

`ConsumeQueue.estimateMessageCount` dereferences the ext unit unconditionally:

```java
ConsumeQueueExt.CqExtUnit ext = null;
if (isExtWriteEnable()) {
    ext = consumeQueueExt.get(tagCode);
    tagCode = ext.getTagsCode();   // NPE when get() returns null
}
```

The stored `tagsCode` can legitimately be a raw (positive) value rather than an ext address:

- entries written while the ext was disabled and the config was enabled later, or
- entries persisted by the *save-tagsCode-only* fallback in `putMessagePositionInfoWrapper` when `consumeQueueExt.put` fails (logged as "Save consume queue extend fail, So just save tagsCode").

For a raw code `ConsumeQueueExt.get` returns `null` (it rejects non-ext addresses), so `estimateMessageCount` throws an NPE. This path is live in production: `DefaultMessageStore.estimateMessageCount` → `ConsumerLagCalculator` (broker consumer-lag metrics with a filter). `MessageFilter.isMatchedByConsumeQueue` already accepts a null ext unit ("message is before consumer"), so only this caller assumes non-null.

### Modifications

- Null-guard the ext unit: keep the raw `tagCode` when `get` returns `null` and pass the null ext to the filter, matching how the rest of the code treats a missing ext.

### Verification

Fail-before (new test on unpatched code):

```
ConsumeQueueTest.testEstimateMessageCountWhenExtUnitMissing:500 » NullPointer
  Cannot invoke "ConsumeQueueExt.getTagsCode()" because "ext" is null
```

The test writes one entry with the ext disabled (raw tagsCode persisted), re-enables the ext, then estimates the count — exactly the mixed-content state described above.

Pass-after:

```
mvn -pl store test -Dtest='ConsumeQueueTest#testEstimateMessageCountWhenExtUnitMissing+testCorrectMinOffset'
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```