### PR TITLE
[ISSUE #S3] Return an empty TPS when no samples have been collected yet

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/StoreStatsService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/StoreStatsService.java
@@ -394,6 +394,10 @@ public class StoreStatsService extends ServiceThread {
         String result = "";
         this.samplingLock.lock();
         try {
+            if (this.putTimesList.isEmpty()) {
+                return result;
+            }
+
             CallSnapshot last = this.putTimesList.getLast();
 
             if (this.putTimesList.size() > time) {
@@ -411,6 +415,10 @@ public class StoreStatsService extends ServiceThread {
         String result = "";
         this.samplingLock.lock();
         try {
+            if (this.getTimesFoundList.isEmpty()) {
+                return result;
+            }
+
             CallSnapshot last = this.getTimesFoundList.getLast();
 
             if (this.getTimesFoundList.size() > time) {
@@ -429,6 +437,10 @@ public class StoreStatsService extends ServiceThread {
         String result = "";
         this.samplingLock.lock();
         try {
+            if (this.getTimesMissList.isEmpty()) {
+                return result;
+            }
+
             CallSnapshot last = this.getTimesMissList.getLast();
 
             if (this.getTimesMissList.size() > time) {
@@ -450,6 +462,10 @@ public class StoreStatsService extends ServiceThread {
         double miss = 0;
         try {
             {
+                if (this.getTimesFoundList.isEmpty()) {
+                    return Double.toString(miss);
+                }
+
                 CallSnapshot last = this.getTimesFoundList.getLast();
 
                 if (this.getTimesFoundList.size() > time) {
@@ -459,6 +475,10 @@ public class StoreStatsService extends ServiceThread {
                 }
             }
             {
+                if (this.getTimesMissList.isEmpty()) {
+                    return Double.toString(found);
+                }
+
                 CallSnapshot last = this.getTimesMissList.getLast();
 
                 if (this.getTimesMissList.size() > time) {
@@ -479,6 +499,10 @@ public class StoreStatsService extends ServiceThread {
         String result = "";
         this.samplingLock.lock();
         try {
+            if (this.transferredMsgCountList.isEmpty()) {
+                return result;
+            }
+
             CallSnapshot last = this.transferredMsgCountList.getLast();
 
             if (this.transferredMsgCountList.size() > time) {

--- a/store/src/test/java/org/apache/rocketmq/store/StoreStatsServiceTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/StoreStatsServiceTest.java
@@ -103,4 +103,16 @@ public class StoreStatsServiceTest {
         method.invoke(storeStatsService);
     }
 
+    @Test
+    public void toStringAndRuntimeInfoBeforeFirstSampleShouldNotThrow() {
+        // The TPS snapshot lists are only filled by the sampling thread after
+        // start(); before that every TPS getter used by toString/getRuntimeInfo
+        // must return an empty value instead of throwing NoSuchElementException
+        // from LinkedList.getLast().
+        final StoreStatsService storeStatsService = new StoreStatsService();
+
+        org.junit.Assert.assertNotNull(storeStatsService.toString());
+        org.junit.Assert.assertFalse(storeStatsService.getRuntimeInfo().isEmpty());
+    }
+
 }


### PR DESCRIPTION
### Motivation

The TPS snapshot lists (`putTimesList`, `getTimesFoundList`, `getTimesMissList`, `transferredMsgCountList`) are only populated by `sampling()`, which runs from the service thread after `start()`. Yet every TPS getter used by `toString()` and `getRuntimeInfo()` calls `LinkedList.getLast()` unconditionally:

```java
CallSnapshot last = this.putTimesList.getLast();   // NoSuchElementException on empty list
```

Before the first sampling tick — a freshly started store, or a `StoreStatsService` constructed but not yet started — `DefaultMessageStore.getRuntimeInfo()` (i.e. the broker runtime info admin API) and `toString()` therefore fail with `NoSuchElementException` instead of reporting empty TPS values.

### Modifications

- All five getters (`getPutTps`, `getGetFoundTps`, `getGetMissTps`, `getGetTotalTps`, `getGetTransferredTps`) return their empty value when the underlying list is still empty.

### Verification

Fail-before (new test on unpatched code):

```
StoreStatsServiceTest.toStringAndRuntimeInfoBeforeFirstSampleShouldNotThrow:114 » NoSuchElement
```

Pass-after — full `StoreStatsServiceTest` (3 existing + 1 new):

```
mvn -pl store test -Dtest='StoreStatsServiceTest'
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```