### PR TITLE
[ISSUE #S4] Keep persisted consumer filter data that has no bloom data

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/filter/ConsumerFilterManager.java
@@ -269,7 +269,11 @@ public class ConsumerFilterManager extends ConfigManager {
 
                     // check whether bloom filter is changed
                     // if changed, ignore the bit map calculated before.
-                    if (!this.bloomFilter.isValid(filterData.getBloomFilterData())) {
+                    // Data registered with the filter bit map disabled (the default)
+                    // legitimately has no bloom data; keep it instead of dropping
+                    // the whole persisted table.
+                    if (filterData.getBloomFilterData() != null
+                            && !this.bloomFilter.isValid(filterData.getBloomFilterData())) {
                         bloomChanged = true;
                         log.info("Bloom filter is changed!So ignore all filter data persisted! {}, {}", this.bloomFilter, filterData.getBloomFilterData());
                         break;

--- a/broker/src/test/java/org/apache/rocketmq/broker/filter/ConsumerFilterManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/filter/ConsumerFilterManagerTest.java
@@ -22,11 +22,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.broker.topic.TopicConfigManager;
 import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.filter.ExpressionType;
 import org.apache.rocketmq.remoting.protocol.filter.FilterAPI;
 import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,6 +57,32 @@ public class ConsumerFilterManagerTest {
 
     public static String expr(int i) {
         return "a is not null and a > " + ((i - 1) * 10) + " and a < " + ((i + 1) * 10);
+    }
+
+    @Test
+    public void testDecodeKeepsFilterDataRegisteredWithoutBloomData() {
+        BrokerController brokerController = Mockito.mock(BrokerController.class);
+        Mockito.when(brokerController.getBrokerConfig()).thenReturn(new BrokerConfig());
+        Mockito.when(brokerController.getMessageStoreConfig()).thenReturn(new MessageStoreConfig());
+        TopicConfigManager topicConfigManager = Mockito.mock(TopicConfigManager.class);
+        Mockito.when(topicConfigManager.selectTopicConfig("topic0")).thenReturn(new TopicConfig());
+        Mockito.when(brokerController.getTopicConfigManager()).thenReturn(topicConfigManager);
+
+        // enableCalcFilterBitMap defaults to false, so register() persists no
+        // bloom data; decode() must keep such entries instead of discarding the
+        // whole persisted table.
+        ConsumerFilterManager filterManager = new ConsumerFilterManager(brokerController);
+        assertThat(filterManager.register("topic0", "CID_0", expr(0), ExpressionType.SQL92, System.currentTimeMillis()))
+            .isTrue();
+        assertThat(filterManager.get("topic0", "CID_0")).isNotNull();
+
+        String json = filterManager.encode();
+        assertThat(json).isNotEmpty();
+
+        ConsumerFilterManager loaded = new ConsumerFilterManager(brokerController);
+        loaded.decode(json);
+
+        assertThat(loaded.get("topic0", "CID_0")).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`ConsumerFilterManager.register` stores `ConsumerFilterData` **without** bloom data whenever the filter bit map is disabled:

```java
BloomFilterData bloomFilterData = null;
if (this.brokerController == null
        || this.brokerController.getBrokerConfig().isEnableCalcFilterBitMap()) {  // default: false
    bloomFilterData = bloomFilter.generate(consumerGroup + "#" + topic);
}
```

On restart, `decode` validates every persisted entry with `bloomFilter.isValid(filterData.getBloomFilterData())`, and `isValid(null)` returns `false` — so a single null-bloom entry flips `bloomChanged` and **the entire persisted filter table is discarded** ("Bloom filter is changed!So ignore all filter data persisted"). With the default configuration every broker restart therefore loses all registered SQL92 consumer filters; consumers that re-subscribe rebuild them, but any consumer that does not re-send its subscription silently stops filtering server-side (`ExpressionMessageFilter` matches everything when `consumerFilterData == null`).

### Modifications

- Only run the bloom-changed check for entries that actually carry bloom data: `if (filterData.getBloomFilterData() != null && !this.bloomFilter.isValid(...))`. Entries registered with the bit map disabled now survive restart; a genuinely changed bloom filter still discards the table as before.

### Verification

Fail-before (new test on unpatched code — registers a SQL92 filter with `enableCalcFilterBitMap=false`, persists via `encode()`, reloads via `decode()`):

```
ConsumerFilterManagerTest.testDecodeKeepsFilterDataRegisteredWithoutBloomData:70
Expecting actual not to be null
```

Pass-after — full `ConsumerFilterManagerTest` (10 existing + 1 new):

```
mvn -pl broker test -Dtest='ConsumerFilterManagerTest'
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
```