### PR TITLE
[TIEREDSTORE] Improve javadoc for GetMessageResultExt

### DIFF
--- a/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/GetMessageResultExt.java
+++ b/tieredstore/src/main/java/org/apache/rocketmq/tieredstore/common/GetMessageResultExt.java
@@ -24,8 +24,12 @@ import org.apache.rocketmq.store.GetMessageStatus;
 import org.apache.rocketmq.store.MessageFilter;
 import org.apache.rocketmq.store.SelectMappedBufferResult;
 
+/**
+ * Extended {@link GetMessageResult} for tiered store, holds additional tag‑code list for post‑filter.
+ */
 public class GetMessageResultExt extends GetMessageResult {
 
+    /** Store tag hash code corresponding to each message */
     private final List<Long> tagCodeList;
 
     public GetMessageResultExt() {
@@ -42,10 +46,11 @@ public class GetMessageResultExt extends GetMessageResult {
     }
 
     /**
-     * Due to the message fetched from the object storage is sequential,
-     * do message filtering occurs after the data retrieval.
+     * Since messages fetched from object storage are sequential,
+     * message filtering is performed after data retrieval.
      */
     public GetMessageResult doFilterMessage(MessageFilter messageFilter) {
+
         if (GetMessageStatus.FOUND != super.getStatus() || messageFilter == null) {
             return this;
         }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
No related issue. This is a minor javadoc improvement.

### Brief Description
Improve javadoc for GetMessageResultExt in tiered store module to clarify API semantics and enhance readability.

### How Did You Test This Change?
This change only modifies javadoc comments, no logic change. No additional test required.
