### PR TITLE
[ISSUE #C1] Throw MQClientException instead of NPE for an unparseable consumeTimestamp

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.client.impl.consumer;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
@@ -135,9 +136,16 @@ public class RebalanceLitePullImpl extends RebalanceImpl {
                             throw e;
                         }
                     } else {
+                        // parseDate returns null when the user-configured
+                        // consumeTimestamp does not match the expected pattern.
+                        Date consumeTimestampDate = UtilAll.parseDate(this.litePullConsumerImpl.getDefaultLitePullConsumer().getConsumeTimestamp(),
+                            UtilAll.YYYYMMDDHHMMSS);
+                        if (null == consumeTimestampDate) {
+                            throw new MQClientException(String.format("Invalid consumeTimestamp: %s",
+                                this.litePullConsumerImpl.getDefaultLitePullConsumer().getConsumeTimestamp()), null);
+                        }
                         try {
-                            long timestamp = UtilAll.parseDate(this.litePullConsumerImpl.getDefaultLitePullConsumer().getConsumeTimestamp(),
-                                UtilAll.YYYYMMDDHHMMSS).getTime();
+                            long timestamp = consumeTimestampDate.getTime();
                             result = this.mQClientFactory.getMQAdminImpl().searchOffset(mq, timestamp);
                         } catch (MQClientException e) {
                             log.warn("Compute consume offset from last offset exception, mq={}, exception={}", mq, e);

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.client.impl.consumer;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -220,9 +221,16 @@ public class RebalancePushImpl extends RebalanceImpl {
                             throw e;
                         }
                     } else {
+                        // parseDate returns null when the user-configured
+                        // consumeTimestamp does not match the expected pattern.
+                        Date consumeTimestampDate = UtilAll.parseDate(this.defaultMQPushConsumerImpl.getDefaultMQPushConsumer().getConsumeTimestamp(),
+                            UtilAll.YYYYMMDDHHMMSS);
+                        if (null == consumeTimestampDate) {
+                            throw new MQClientException(String.format("Invalid consumeTimestamp: %s",
+                                this.defaultMQPushConsumerImpl.getDefaultMQPushConsumer().getConsumeTimestamp()), null);
+                        }
                         try {
-                            long timestamp = UtilAll.parseDate(this.defaultMQPushConsumerImpl.getDefaultMQPushConsumer().getConsumeTimestamp(),
-                                UtilAll.YYYYMMDDHHMMSS).getTime();
+                            long timestamp = consumeTimestampDate.getTime();
                             result = this.mQClientFactory.getMQAdminImpl().searchOffset(mq, timestamp);
                         } catch (MQClientException e) {
                             log.warn("Compute consume offset from last offset exception, mq={}, exception={}", mq, e);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalanceLitePullImplTest.java
@@ -28,6 +28,8 @@ import org.apache.rocketmq.common.message.MessageQueue;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -94,6 +96,20 @@ public class RebalanceLitePullImplTest {
         assertEquals(12345L, rebalanceImpl.computePullFromWhereWithException(mq));
 
         assertEquals(23456L, rebalanceImpl.computePullFromWhereWithException(retryMq));
+    }
+
+    @Test
+    public void testComputePullFromWhereWithException_eq_minus1_invalid_timestamp() {
+        when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(-1L);
+        consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_TIMESTAMP);
+        consumer.setConsumeTimestamp("not-a-timestamp");
+
+        try {
+            rebalanceImpl.computePullFromWhereWithException(mq);
+            fail("expected MQClientException for an unparseable consumeTimestamp");
+        } catch (MQClientException expected) {
+            assertTrue(expected.getMessage().contains("Invalid consumeTimestamp"));
+        }
     }
 
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImplTest.java
@@ -39,6 +39,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -212,6 +214,20 @@ public class RebalancePushImplTest {
         assertEquals(12345L, rebalanceImpl.computePullFromWhereWithException(mq));
 
         assertEquals(23456L, rebalanceImpl.computePullFromWhereWithException(retryMq));
+    }
+
+    @Test
+    public void testComputePullFromWhereWithException_eq_minus1_invalid_timestamp() {
+        when(offsetStore.readOffset(any(MessageQueue.class), any(ReadOffsetType.class))).thenReturn(-1L);
+        consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_TIMESTAMP);
+        consumer.setConsumeTimestamp("not-a-timestamp");
+
+        try {
+            rebalanceImpl.computePullFromWhereWithException(mq);
+            fail("expected MQClientException for an unparseable consumeTimestamp");
+        } catch (MQClientException expected) {
+            assertTrue(expected.getMessage().contains("Invalid consumeTimestamp"));
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation

`computePullFromWhereWithException` in both `RebalanceLitePullImpl` and `RebalancePushImpl` does:

```java
long timestamp = UtilAll.parseDate(consumer.getConsumeTimestamp(), UtilAll.YYYYMMDDHHMMSS).getTime();
```

`UtilAll.parseDate` returns `null` when the string does not match the pattern, and `consumeTimestamp` is a plain user-settable string on `DefaultLitePullConsumer`/`DefaultMQPushConsumer`. A typo like `setConsumeTimestamp("20240101")` therefore kills the rebalance with an NPE (`Cannot invoke Date.getTime() ... is null`) instead of a proper error: the NPE escapes `updateProcessQueueTable`'s `catch (Exception e)`... actually it is caught there (`compute offset failed`), but it surfaces as an opaque NPE in the logs, and the deprecated `computePullFromWhere` wrapper only handles `MQClientException`, so the NPE propagates to its callers as well.

### Modifications

- In both impls: parse the date first, and throw `MQClientException("Invalid consumeTimestamp: ...")` when it does not parse. All callers already handle `MQClientException` (`updateProcessQueueTable` catches it and skips the queue; the deprecated wrapper logs and returns -1), so a misconfigured timestamp now produces a clear error message instead of an NPE.

### Verification

Fail-before (both new tests on unpatched code):

```
RebalanceLitePullImplTest.testComputePullFromWhereWithException_eq_minus1_invalid_timestamp:108 » NullPointer
  Cannot invoke "java.util.Date.getTime()" because the return value of "UtilAll.parseDate(String, String)" is null
RebalancePushImplTest.testComputePullFromWhereWithException_eq_minus1_invalid_timestamp:226 » NullPointer (same)
```

Pass-after — both test classes (existing + new tests):

```
mvn -pl client test -Dtest='RebalanceLitePullImplTest,RebalancePushImplTest'
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```