### PR TITLE
[ISSUE #C2] Count down the queryMessage latch when the invocation fails

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
@@ -426,6 +426,10 @@ public class MQAdminImpl {
                             }, isUniqKey);
                     } catch (Exception e) {
                         log.warn("queryMessage exception", e);
+                        // The callback never fires when the invocation itself
+                        // fails, so release this broker's latch count here or
+                        // await below blocks for the full timeout.
+                        countDownLatch.countDown();
                     }
 
                 }

--- a/client/src/test/java/org/apache/rocketmq/client/impl/MQAdminImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/MQAdminImplTest.java
@@ -51,10 +51,13 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -169,6 +172,25 @@ public class MQAdminImplTest {
         assertNotNull(actual);
         assertEquals(1, actual.getMessageList().size());
         assertEquals(defaultTopic, actual.getMessageList().get(0).getTopic());
+    }
+
+    @Test
+    public void assertQueryMessageNotBlockedWhenInvokeThrows() throws InterruptedException, MQBrokerException, RemotingException {
+        mqAdminImpl.setTimeoutMillis(200L);
+        doThrow(new RemotingException("invoke failed"))
+            .when(mQClientAPIImpl).queryMessage(anyString(), any(), anyLong(), any(InvokeCallback.class), any());
+
+        long begin = System.currentTimeMillis();
+        try {
+            mqAdminImpl.queryMessage(defaultTopic, "keys", 100, 1L, 50L);
+            fail("expected MQClientException because the query returned no messages");
+        } catch (MQClientException expected) {
+            // query message by key finished, but no message
+        }
+        long elapsed = System.currentTimeMillis() - begin;
+
+        assertTrue("queryMessage should not wait for the whole latch timeout, elapsed=" + elapsed,
+            elapsed < 400L);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`MQAdminImpl.queryMessage` fans out one asynchronous query per broker and waits on a `CountDownLatch(brokerAddrs.size())`. The latch is released by the `InvokeCallback` (`operationSucceed`/`operationFail`), but if `MQClientAPIImpl.queryMessage` itself throws synchronously — e.g. `RemotingConnectException`/`RemotingTimeoutException` for an unreachable broker — no callback is ever invoked, and the catch block only logs:

```java
} catch (Exception e) {
    log.warn("queryMessage exception", e);
}
...
boolean ok = countDownLatch.await(timeoutMillis * 4, TimeUnit.MILLISECONDS);
```

The caller then blocks for the full `timeoutMillis * 4` window — **24 seconds** with the default `timeoutMillis` of 6s — before getting the "no message" answer, even though the outcome was already known. Any tool/admin call that queries by key while one broker is down pays this stall.

### Modifications

- Add `countDownLatch.countDown();` in the catch block, releasing this broker's count exactly as the callback would have.

### Verification

Fail-before (new test on unpatched code — the per-broker invoke is mocked to throw, `timeoutMillis=200`):

```
MQAdminImplTest.assertQueryMessageNotBlockedWhenInvokeThrows:192
  queryMessage should not wait for the whole latch timeout, elapsed=846
```

Pass-after — full `MQAdminImplTest` (11 existing + 1 new); the same call now returns in single-digit milliseconds:

```
mvn -pl client test -Dtest='MQAdminImplTest'
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```