### PR TITLE
[ISSUE #C3] Reject an AckMessageRequest without entries instead of throwing IndexOutOfBoundsException

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivity.java
@@ -36,6 +36,7 @@ import org.apache.rocketmq.proxy.grpc.v2.AbstractMessagingActivity;
 import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcChannelManager;
 import org.apache.rocketmq.proxy.grpc.v2.channel.GrpcClientChannel;
 import org.apache.rocketmq.proxy.grpc.v2.common.GrpcClientSettingsManager;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcProxyException;
 import org.apache.rocketmq.proxy.grpc.v2.common.ResponseBuilder;
 import org.apache.rocketmq.proxy.processor.BatchAckResult;
 import org.apache.rocketmq.proxy.processor.MessagingProcessor;
@@ -55,6 +56,11 @@ public class AckMessageActivity extends AbstractMessagingActivity {
             validateTopicAndConsumerGroup(request.getTopic(), request.getGroup());
             String group = request.getGroup().getName();
             String topic = request.getTopic().getName();
+            // getEntries(0) below would throw IndexOutOfBoundsException for an
+            // empty request, so reject it with a proper status first.
+            if (request.getEntriesCount() == 0) {
+                throw new GrpcProxyException(Code.BAD_REQUEST, "ack entries should not be empty");
+            }
             boolean isBatchAck = ConfigurationManager.getProxyConfig().isEnableBatchAck()
                 && !request.getEntries(0).hasLiteTopic();
             if (isBatchAck) {

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/AckMessageActivityTest.java
@@ -28,12 +28,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.rocketmq.client.consumer.AckResult;
 import org.apache.rocketmq.client.consumer.AckStatus;
 import org.apache.rocketmq.proxy.common.ProxyException;
 import org.apache.rocketmq.proxy.common.ProxyExceptionCode;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
 import org.apache.rocketmq.proxy.grpc.v2.BaseActivityTest;
+import org.apache.rocketmq.proxy.grpc.v2.common.GrpcProxyException;
 import org.apache.rocketmq.proxy.processor.BatchAckResult;
 import org.apache.rocketmq.proxy.service.message.ReceiptHandleMessage;
 import org.junit.Before;
@@ -41,6 +43,8 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -59,6 +63,27 @@ public class AckMessageActivityTest extends BaseActivityTest {
     public void before() throws Throwable {
         super.before();
         this.ackMessageActivity = new AckMessageActivity(messagingProcessor, grpcClientSettingsManager, grpcChannelManager);
+    }
+
+    @Test
+    public void testAckMessageWithEmptyEntries() throws Throwable {
+        // enableBatchAck makes the activity inspect entries(0), which used to
+        // throw IndexOutOfBoundsException for an empty request.
+        ConfigurationManager.getProxyConfig().setEnableBatchAck(true);
+
+        try {
+            this.ackMessageActivity.ackMessage(
+                createContext(),
+                AckMessageRequest.newBuilder()
+                    .setTopic(Resource.newBuilder().setName(TOPIC).build())
+                    .setGroup(Resource.newBuilder().setName(GROUP).build())
+                    .build()
+            ).get();
+            fail("expected GrpcProxyException");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof GrpcProxyException);
+            assertEquals(Code.BAD_REQUEST, ((GrpcProxyException) e.getCause()).getCode());
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`AckMessageActivity.ackMessage` inspects the first entry before checking that any entry exists:

```java
boolean isBatchAck = ConfigurationManager.getProxyConfig().isEnableBatchAck()
    && !request.getEntries(0).hasLiteTopic();
```

An `AckMessageRequest` whose `entries` list is empty (nothing in the protobuf schema forbids it) therefore throws `IndexOutOfBoundsException` from `getEntries(0)` when `enableBatchAck` is on, which the catch block wraps into the future as a raw `Throwable` — the gRPC client receives an opaque internal error instead of a meaningful status.

### Modifications

- Guard `request.getEntriesCount() == 0` before the batch-ack decision and throw `GrpcProxyException(Code.BAD_REQUEST, "ack entries should not be empty")`, the same input-validation pattern used by `SendMessageActivity` (e.g. max recovery time / delivery timestamp checks).

### Verification

Fail-before (new test on unpatched code, with `enableBatchAck=true`): the future completes exceptionally with the `IndexOutOfBoundsException`, so the assertion on `GrpcProxyException`/`Code.BAD_REQUEST` fails:

```
AckMessageActivityTest.testAckMessageWithEmptyEntries:84 » AssertionError
```

Pass-after — full `AckMessageActivityTest` (2 existing + 1 new):

```
mvn -pl proxy test -Dtest='AckMessageActivityTest'
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```