### PR TITLE
[ISSUE #D1] Skip queue-change notification for concurrently removed subscription

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImpl.java
@@ -58,6 +58,13 @@ public class RebalancePushImpl extends RebalanceImpl {
          * Fix: inconsistency subscription may lead to consumer miss messages.
          */
         SubscriptionData subscriptionData = this.subscriptionInner.get(topic);
+        // The subscription may have been removed concurrently (unsubscribe() from
+        // another thread) while this rebalance was in progress; there is nothing
+        // to update or notify for a topic this consumer no longer subscribes to.
+        if (subscriptionData == null) {
+            log.info("subscription of {} removed during rebalance, skip notifying message queue change", topic);
+            return;
+        }
         long newVersion = System.currentTimeMillis();
         log.info("{} Rebalance changed, also update version: {}, {}", topic, subscriptionData.getSubVersion(), newVersion);
         subscriptionData.setSubVersion(newVersion);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/consumer/RebalancePushImplTest.java
@@ -40,9 +40,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -212,6 +215,21 @@ public class RebalancePushImplTest {
         assertEquals(12345L, rebalanceImpl.computePullFromWhereWithException(mq));
 
         assertEquals(23456L, rebalanceImpl.computePullFromWhereWithException(retryMq));
+    }
+
+    @Test
+    public void testMessageQueueChanged_SubscriptionRemovedConcurrently() {
+        RebalancePushImpl rebalancePush = new RebalancePushImpl(consumerGroup, MessageModel.CLUSTERING,
+            new AllocateMessageQueueAveragely(), mqClientInstance, defaultMQPushConsumer);
+
+        // The topic is deliberately absent from subscriptionInner: this emulates an
+        // unsubscribe() from another thread removing the subscription after the
+        // rebalance loop snapshot but before messageQueueChanged runs.
+        Set<MessageQueue> allocateResultSet = new HashSet<>();
+        allocateResultSet.add(new MessageQueue(topic, "BrokerA", 0));
+        rebalancePush.messageQueueChanged(topic, allocateResultSet, allocateResultSet);
+
+        verify(mqClientInstance, never()).sendHeartbeatToAllBrokerWithLockV2(anyBoolean());
     }
 
 }


### PR DESCRIPTION
## Motivation

`RebalanceImpl.doRebalance` iterates the `subscriptionInner` entry set and, once the allocation result changes, hands the topic over to `messageQueueChanged`. The push implementation re-reads the entry:

```java
SubscriptionData subscriptionData = this.subscriptionInner.get(topic);
long newVersion = System.currentTimeMillis();
log.info("... {} ...", ..., subscriptionData.getSubVersion(), newVersion);
subscriptionData.setSubVersion(newVersion);
```

`DefaultMQPushConsumer.unsubscribe(topic)` is a public API that runs on a user thread and removes the entry from the same `ConcurrentHashMap`. When it interleaves between the rebalance loop's iteration and this call, `subscriptionInner.get(topic)` returns null and the rebalance thread dies with:

```
java.lang.NullPointerException: Cannot invoke "SubscriptionData.getSubVersion()" because "subscriptionData" is null
```

That aborts `doRebalance` for the remaining topics of this consumer until the next scheduled round.

## Modification

`RebalancePushImpl.messageQueueChanged`: if the subscription is already gone, log and return — there is nothing to update or notify for a topic this consumer no longer subscribes to.

## Test Evidence

Fail-before (unpatched develop, new regression test):

```
docker exec rmq-build mvn -q -pl client test -Dtest='RebalancePushImplTest#testMessageQueueChanged_SubscriptionRemovedConcurrently'
Tests run: 1, Failures: 0, Errors: 1
java.lang.NullPointerException: Cannot invoke "SubscriptionData.getSubVersion()" because "subscriptionData" is null
```

Pass-after (full class):

```
docker exec rmq-build mvn -q -pl client test -Dtest='RebalancePushImplTest'
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a client-module self-audit).