### PR TITLE
[ISSUE #D2] Return null when selecting from a route-less TopicPublishInfo

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQClientAPIImpl.java
@@ -718,7 +718,10 @@ public class MQClientAPIImpl implements NameServerUpdateCallback, StartAndShutdo
         int tmp = curTimes.incrementAndGet();
         if (needRetry && tmp <= timesTotal && timeoutMillis > 0) {
             String retryBrokerName = brokerName;//by default, it will send to the same broker
-            if (topicPublishInfo != null) { //select one message queue accordingly, in order to determine which broker to send
+            // Every send entry point checks ok() before queue selection; the retry
+            // path must do the same, otherwise a route-less topicPublishInfo makes
+            // the selection throw or return null instead of retrying the same broker.
+            if (topicPublishInfo != null && topicPublishInfo.ok()) { //select one message queue accordingly, in order to determine which broker to send
                 MessageQueue mqChosen = producer.selectOneMessageQueue(topicPublishInfo, brokerName, false);
                 retryBrokerName = instance.getBrokerNameFromMessageQueue(mqChosen);
             }

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfo.java
@@ -107,20 +107,30 @@ public class TopicPublishInfo {
     }
 
     public MessageQueue selectOneMessageQueue(final String lastBrokerName) {
-        if (lastBrokerName == null) {
-            return selectOneMessageQueue();
-        } else {
-            for (int i = 0; i < this.messageQueueList.size(); i++) {
-                MessageQueue mq = selectOneMessageQueue();
-                if (!mq.getBrokerName().equals(lastBrokerName)) {
-                    return mq;
-                }
-            }
+        if (null == lastBrokerName) {
             return selectOneMessageQueue();
         }
+
+        // Keep the contract of the QueueFilter variant above: a topic with no
+        // writable queue in its route selects no queue instead of throwing.
+        if (null == this.messageQueueList || this.messageQueueList.isEmpty()) {
+            return null;
+        }
+
+        for (int i = 0; i < this.messageQueueList.size(); i++) {
+            MessageQueue mq = selectOneMessageQueue();
+            if (!mq.getBrokerName().equals(lastBrokerName)) {
+                return mq;
+            }
+        }
+        return selectOneMessageQueue();
     }
 
     public MessageQueue selectOneMessageQueue() {
+        if (null == this.messageQueueList || this.messageQueueList.isEmpty()) {
+            return null;
+        }
+
         int index = this.sendWhichQueue.incrementAndGet();
         int pos = index % this.messageQueueList.size();
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfoTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/producer/TopicPublishInfoTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.impl.producer;
+
+import java.util.ArrayList;
+
+import java.util.List;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TopicPublishInfoTest {
+
+    private static final String TOPIC = "TopicPublishInfoTest";
+
+    private TopicPublishInfo emptyRouteInfo() {
+        // A topic whose route exists but has no writable queue (e.g. read-only
+        // brokers) yields an empty queue list, so ok() is false.
+        TopicPublishInfo topicPublishInfo = new TopicPublishInfo();
+        topicPublishInfo.setMessageQueueList(new ArrayList<>());
+        return topicPublishInfo;
+    }
+
+    @Test
+    public void testSelectOneMessageQueueWithEmptyQueueList() {
+        TopicPublishInfo topicPublishInfo = emptyRouteInfo();
+
+        assertThat(topicPublishInfo.selectOneMessageQueue()).isNull();
+    }
+
+    @Test
+    public void testSelectOneMessageQueueWithNullQueueList() {
+        TopicPublishInfo topicPublishInfo = new TopicPublishInfo();
+        topicPublishInfo.setMessageQueueList(null);
+
+        assertThat(topicPublishInfo.selectOneMessageQueue()).isNull();
+    }
+
+    @Test
+    public void testSelectOneMessageQueueLastBrokerNameWithEmptyQueueList() {
+        TopicPublishInfo topicPublishInfo = emptyRouteInfo();
+
+        assertThat(topicPublishInfo.selectOneMessageQueue("broker-a")).isNull();
+    }
+
+    @Test
+    public void testSelectOneMessageQueueLastBrokerNameWithNullQueueList() {
+        TopicPublishInfo topicPublishInfo = new TopicPublishInfo();
+        topicPublishInfo.setMessageQueueList(null);
+
+        assertThat(topicPublishInfo.selectOneMessageQueue("broker-a")).isNull();
+    }
+
+    @Test
+    public void testSelectOneMessageQueueAvoidsLastBrokerWhenPossible() {
+        TopicPublishInfo topicPublishInfo = new TopicPublishInfo();
+        List<MessageQueue> messageQueueList = new ArrayList<>();
+        messageQueueList.add(new MessageQueue(TOPIC, "broker-a", 0));
+        messageQueueList.add(new MessageQueue(TOPIC, "broker-b", 0));
+        topicPublishInfo.setMessageQueueList(messageQueueList);
+
+        MessageQueue selected = topicPublishInfo.selectOneMessageQueue("broker-a");
+        assertThat(selected).isNotNull();
+        assertThat(selected.getBrokerName()).isEqualTo("broker-b");
+
+        assertThat(topicPublishInfo.selectOneMessageQueue((String) null)).isNotNull();
+        assertThat(topicPublishInfo.selectOneMessageQueue()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Motivation

`TopicPublishInfo` exposes three `selectOneMessageQueue` overloads with inconsistent contracts:

```java
// QueueFilter variant — guarded
if (messageQueueList == null || messageQueueList.isEmpty()) {
    return null;
}

// no-arg variant — unguarded
int index = this.sendWhichQueue.incrementAndGet();
int pos = index % this.messageQueueList.size();   // NPE on null list, ArithmeticException (x % 0) on empty list
```

A topic whose route exists but has no writable queue legitimately produces such an info object: `topicRouteData2TopicPublishInfo` adds nothing to the list when every `QueueData` is read-only or has `writeQueueNums == 0`, so `ok()` is false while the object itself is non-null.

`MQFaultStrategy.selectOneMessageQueue` falls back to the unguarded no-arg variant, and the async-send retry path (`MQClientAPIImpl.onExceptionImpl`) is the one caller that only null-checks the info instead of checking `ok()` like every send entry point does.

## Modification

- `TopicPublishInfo.selectOneMessageQueue()` and `selectOneMessageQueue(String lastBrokerName)`: return null when the queue list is null/empty, aligning with the QueueFilter variant.
- `MQClientAPIImpl.onExceptionImpl`: apply the same `ok()` contract — a route-less info keeps the "retry the same broker" default instead of feeding the selector.

No behavior change for existing callers: every other call site (sendDefaultImpl, EscapeBridge) already checks `ok()` before selecting.

## Test Evidence

Fail-before (unpatched develop, new `TopicPublishInfoTest`):

```
mvn -q -pl client test -Dtest='TopicPublishInfoTest#testSelectOneMessageQueueWithEmptyQueueList'
Tests run: 1, Errors: 1 - java.lang.ArithmeticException: / by zero
#testSelectOneMessageQueueWithNullQueueList      -> NullPointerException (List.size())
#testSelectOneMessageQueueLastBrokerNameWithEmptyQueueList -> ArithmeticException: / by zero
#testSelectOneMessageQueueLastBrokerNameWithNullQueueList   -> NullPointerException (List.size())
```

Pass-after:

```
mvn -q -pl client test -Dtest='TopicPublishInfoTest,SelectMessageQueueRetryTest'
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a client-module self-audit).