### PR TITLE
[ISSUE #D3] Skip malformed trace lines instead of aborting the whole decode

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/trace/TraceDataEncoder.java
+++ b/client/src/main/java/org/apache/rocketmq/client/trace/TraceDataEncoder.java
@@ -20,6 +20,8 @@ import org.apache.rocketmq.client.AccessChannel;
 import org.apache.rocketmq.client.producer.LocalTransactionState;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageType;
+import org.apache.rocketmq.logging.org.slf4j.Logger;
+import org.apache.rocketmq.logging.org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +31,8 @@ import java.util.List;
  * Encode/decode for Trace Data
  */
 public class TraceDataEncoder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TraceDataEncoder.class);
 
     /**
      * Resolving traceContext list From trace data String
@@ -44,107 +48,114 @@ public class TraceDataEncoder {
         String[] contextList = traceData.split(String.valueOf(TraceConstants.FIELD_SPLITOR));
         for (String context : contextList) {
             String[] line = context.split(String.valueOf(TraceConstants.CONTENT_SPLITOR));
-            if (line[0].equals(TraceType.Pub.name())) {
-                TraceContext pubContext = new TraceContext();
-                pubContext.setTraceType(TraceType.Pub);
-                pubContext.setTimeStamp(Long.parseLong(line[1]));
-                pubContext.setRegionId(line[2]);
-                pubContext.setGroupName(line[3]);
-                TraceBean bean = new TraceBean();
-                bean.setTopic(line[4]);
-                bean.setMsgId(line[5]);
-                bean.setTags(line[6]);
-                bean.setKeys(line[7]);
-                bean.setStoreHost(line[8]);
-                bean.setBodyLength(Integer.parseInt(line[9]));
-                pubContext.setCostTime(Integer.parseInt(line[10]));
-                bean.setMsgType(MessageType.values()[Integer.parseInt(line[11])]);
+            try {
+                if (line[0].equals(TraceType.Pub.name())) {
+                    TraceContext pubContext = new TraceContext();
+                    pubContext.setTraceType(TraceType.Pub);
+                    pubContext.setTimeStamp(Long.parseLong(line[1]));
+                    pubContext.setRegionId(line[2]);
+                    pubContext.setGroupName(line[3]);
+                    TraceBean bean = new TraceBean();
+                    bean.setTopic(line[4]);
+                    bean.setMsgId(line[5]);
+                    bean.setTags(line[6]);
+                    bean.setKeys(line[7]);
+                    bean.setStoreHost(line[8]);
+                    bean.setBodyLength(Integer.parseInt(line[9]));
+                    pubContext.setCostTime(Integer.parseInt(line[10]));
+                    bean.setMsgType(MessageType.values()[Integer.parseInt(line[11])]);
 
-                if (line.length == 13) {
-                    pubContext.setSuccess(Boolean.parseBoolean(line[12]));
-                } else if (line.length == 14) {
-                    bean.setOffsetMsgId(line[12]);
-                    pubContext.setSuccess(Boolean.parseBoolean(line[13]));
-                }
+                    if (line.length == 13) {
+                        pubContext.setSuccess(Boolean.parseBoolean(line[12]));
+                    } else if (line.length == 14) {
+                        bean.setOffsetMsgId(line[12]);
+                        pubContext.setSuccess(Boolean.parseBoolean(line[13]));
+                    }
 
-                // compatible with the old version
-                if (line.length >= 15) {
-                    bean.setOffsetMsgId(line[12]);
-                    pubContext.setSuccess(Boolean.parseBoolean(line[13]));
-                    bean.setClientHost(line[14]);
-                }
+                    // compatible with the old version
+                    if (line.length >= 15) {
+                        bean.setOffsetMsgId(line[12]);
+                        pubContext.setSuccess(Boolean.parseBoolean(line[13]));
+                        bean.setClientHost(line[14]);
+                    }
 
-                pubContext.setTraceBeans(new ArrayList<>(1));
-                pubContext.getTraceBeans().add(bean);
-                resList.add(pubContext);
-            } else if (line[0].equals(TraceType.SubBefore.name())) {
-                TraceContext subBeforeContext = new TraceContext();
-                subBeforeContext.setTraceType(TraceType.SubBefore);
-                subBeforeContext.setTimeStamp(Long.parseLong(line[1]));
-                subBeforeContext.setRegionId(line[2]);
-                subBeforeContext.setGroupName(line[3]);
-                subBeforeContext.setRequestId(line[4]);
-                TraceBean bean = new TraceBean();
-                bean.setMsgId(line[5]);
-                bean.setRetryTimes(Integer.parseInt(line[6]));
-                bean.setKeys(line[7]);
-                subBeforeContext.setTraceBeans(new ArrayList<>(1));
-                subBeforeContext.getTraceBeans().add(bean);
-                resList.add(subBeforeContext);
-            } else if (line[0].equals(TraceType.SubAfter.name())) {
-                TraceContext subAfterContext = new TraceContext();
-                subAfterContext.setTraceType(TraceType.SubAfter);
-                subAfterContext.setRequestId(line[1]);
-                TraceBean bean = new TraceBean();
-                bean.setMsgId(line[2]);
-                bean.setKeys(line[5]);
-                subAfterContext.setTraceBeans(new ArrayList<>(1));
-                subAfterContext.getTraceBeans().add(bean);
-                subAfterContext.setCostTime(Integer.parseInt(line[3]));
-                subAfterContext.setSuccess(Boolean.parseBoolean(line[4]));
-                if (line.length >= 7) {
-                    // add the context type
-                    subAfterContext.setContextCode(Integer.parseInt(line[6]));
-                }
-                // compatible with the old version
-                if (line.length >= 9) {
-                    subAfterContext.setTimeStamp(Long.parseLong(line[7]));
-                    subAfterContext.setGroupName(line[8]);
-                }
-                resList.add(subAfterContext);
-            } else if (line[0].equals(TraceType.EndTransaction.name())) {
-                TraceContext endTransactionContext = new TraceContext();
-                endTransactionContext.setTraceType(TraceType.EndTransaction);
-                endTransactionContext.setTimeStamp(Long.parseLong(line[1]));
-                endTransactionContext.setRegionId(line[2]);
-                endTransactionContext.setGroupName(line[3]);
-                TraceBean bean = new TraceBean();
-                bean.setTopic(line[4]);
-                bean.setMsgId(line[5]);
-                bean.setTags(line[6]);
-                bean.setKeys(line[7]);
-                bean.setStoreHost(line[8]);
-                bean.setMsgType(MessageType.values()[Integer.parseInt(line[9])]);
-                bean.setTransactionId(line[10]);
-                bean.setTransactionState(LocalTransactionState.valueOf(line[11]));
-                bean.setFromTransactionCheck(Boolean.parseBoolean(line[12]));
+                    pubContext.setTraceBeans(new ArrayList<>(1));
+                    pubContext.getTraceBeans().add(bean);
+                    resList.add(pubContext);
+                } else if (line[0].equals(TraceType.SubBefore.name())) {
+                    TraceContext subBeforeContext = new TraceContext();
+                    subBeforeContext.setTraceType(TraceType.SubBefore);
+                    subBeforeContext.setTimeStamp(Long.parseLong(line[1]));
+                    subBeforeContext.setRegionId(line[2]);
+                    subBeforeContext.setGroupName(line[3]);
+                    subBeforeContext.setRequestId(line[4]);
+                    TraceBean bean = new TraceBean();
+                    bean.setMsgId(line[5]);
+                    bean.setRetryTimes(Integer.parseInt(line[6]));
+                    bean.setKeys(line[7]);
+                    subBeforeContext.setTraceBeans(new ArrayList<>(1));
+                    subBeforeContext.getTraceBeans().add(bean);
+                    resList.add(subBeforeContext);
+                } else if (line[0].equals(TraceType.SubAfter.name())) {
+                    TraceContext subAfterContext = new TraceContext();
+                    subAfterContext.setTraceType(TraceType.SubAfter);
+                    subAfterContext.setRequestId(line[1]);
+                    TraceBean bean = new TraceBean();
+                    bean.setMsgId(line[2]);
+                    bean.setKeys(line[5]);
+                    subAfterContext.setTraceBeans(new ArrayList<>(1));
+                    subAfterContext.getTraceBeans().add(bean);
+                    subAfterContext.setCostTime(Integer.parseInt(line[3]));
+                    subAfterContext.setSuccess(Boolean.parseBoolean(line[4]));
+                    if (line.length >= 7) {
+                        // add the context type
+                        subAfterContext.setContextCode(Integer.parseInt(line[6]));
+                    }
+                    // compatible with the old version
+                    if (line.length >= 9) {
+                        subAfterContext.setTimeStamp(Long.parseLong(line[7]));
+                        subAfterContext.setGroupName(line[8]);
+                    }
+                    resList.add(subAfterContext);
+                } else if (line[0].equals(TraceType.EndTransaction.name())) {
+                    TraceContext endTransactionContext = new TraceContext();
+                    endTransactionContext.setTraceType(TraceType.EndTransaction);
+                    endTransactionContext.setTimeStamp(Long.parseLong(line[1]));
+                    endTransactionContext.setRegionId(line[2]);
+                    endTransactionContext.setGroupName(line[3]);
+                    TraceBean bean = new TraceBean();
+                    bean.setTopic(line[4]);
+                    bean.setMsgId(line[5]);
+                    bean.setTags(line[6]);
+                    bean.setKeys(line[7]);
+                    bean.setStoreHost(line[8]);
+                    bean.setMsgType(MessageType.values()[Integer.parseInt(line[9])]);
+                    bean.setTransactionId(line[10]);
+                    bean.setTransactionState(LocalTransactionState.valueOf(line[11]));
+                    bean.setFromTransactionCheck(Boolean.parseBoolean(line[12]));
 
-                endTransactionContext.setTraceBeans(new ArrayList<>(1));
-                endTransactionContext.getTraceBeans().add(bean);
-                resList.add(endTransactionContext);
-            } else if (line[0].equals(TraceType.Recall.name())) {
-                TraceContext recallContext = new TraceContext();
-                recallContext.setTraceType(TraceType.Recall);
-                recallContext.setTimeStamp(Long.parseLong(line[1]));
-                recallContext.setRegionId(line[2]);
-                recallContext.setGroupName(line[3]);
-                TraceBean bean = new TraceBean();
-                bean.setTopic(line[4]);
-                bean.setMsgId(line[5]);
-                recallContext.setSuccess(Boolean.parseBoolean(line[6]));
-                recallContext.setTraceBeans(new ArrayList<>(1));
-                recallContext.getTraceBeans().add(bean);
-                resList.add(recallContext);
+                    endTransactionContext.setTraceBeans(new ArrayList<>(1));
+                    endTransactionContext.getTraceBeans().add(bean);
+                    resList.add(endTransactionContext);
+                } else if (line[0].equals(TraceType.Recall.name())) {
+                    TraceContext recallContext = new TraceContext();
+                    recallContext.setTraceType(TraceType.Recall);
+                    recallContext.setTimeStamp(Long.parseLong(line[1]));
+                    recallContext.setRegionId(line[2]);
+                    recallContext.setGroupName(line[3]);
+                    TraceBean bean = new TraceBean();
+                    bean.setTopic(line[4]);
+                    bean.setMsgId(line[5]);
+                    recallContext.setSuccess(Boolean.parseBoolean(line[6]));
+                    recallContext.setTraceBeans(new ArrayList<>(1));
+                    recallContext.getTraceBeans().add(bean);
+                    resList.add(recallContext);
+                }
+            } catch (Exception e) {
+                // The trace topic is a plain topic any client can publish to, and the
+                // field layout differs across client versions; a single malformed line
+                // must not abort decoding of the remaining contexts.
+                LOGGER.warn("Failed to decode trace context, skip it. line={}", context, e);
             }
         }
         return resList;

--- a/client/src/test/java/org/apache/rocketmq/client/trace/TraceDataEncoderTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/trace/TraceDataEncoderTest.java
@@ -65,6 +65,59 @@ public class TraceDataEncoderTest {
     }
 
     @Test
+    public void testDecoderSkipsTruncatedLineAndKeepsRemaining() {
+        // A truncated Pub line (only 4 of the required 12 fields), as written by a
+        // client of an older/newer format or any producer publishing to the trace
+        // topic, must not abort decoding of the remaining lines.
+        String truncated = new StringBuilder()
+            .append("Pub").append(TraceConstants.CONTENT_SPLITOR)
+            .append(time).append(TraceConstants.CONTENT_SPLITOR)
+            .append("DefaultRegion").append(TraceConstants.CONTENT_SPLITOR)
+            .append("PID-test").append(TraceConstants.FIELD_SPLITOR)
+            .toString();
+
+        List<TraceContext> contexts = TraceDataEncoder.decoderFromTraceDataString(truncated + traceData);
+        Assert.assertEquals(1, contexts.size());
+        Assert.assertEquals(TraceType.Pub, contexts.get(0).getTraceType());
+        Assert.assertEquals("topic-test", contexts.get(0).getTraceBeans().get(0).getTopic());
+    }
+
+    @Test
+    public void testDecoderSkipsNonNumericFieldAndKeepsRemaining() {
+        String corrupted = new StringBuilder()
+            .append("Pub").append(TraceConstants.CONTENT_SPLITOR)
+            .append("not-a-timestamp").append(TraceConstants.FIELD_SPLITOR)
+            .toString();
+
+        List<TraceContext> contexts = TraceDataEncoder.decoderFromTraceDataString(corrupted + traceData);
+        Assert.assertEquals(1, contexts.size());
+        Assert.assertEquals(TraceType.Pub, contexts.get(0).getTraceType());
+    }
+
+    @Test
+    public void testDecoderSkipsOutOfRangeMsgTypeOrdinalAndKeepsRemaining() {
+        // Valid field count but a msgType ordinal outside MessageType's range.
+        String badOrdinal = new StringBuilder()
+            .append("Pub").append(TraceConstants.CONTENT_SPLITOR)
+            .append(time).append(TraceConstants.CONTENT_SPLITOR)
+            .append("DefaultRegion").append(TraceConstants.CONTENT_SPLITOR)
+            .append("PID-test").append(TraceConstants.CONTENT_SPLITOR)
+            .append("topic-test").append(TraceConstants.CONTENT_SPLITOR)
+            .append("AC1415116D1418B4AAC217FE1B4E0000").append(TraceConstants.CONTENT_SPLITOR)
+            .append("Tags").append(TraceConstants.CONTENT_SPLITOR)
+            .append("Keys").append(TraceConstants.CONTENT_SPLITOR)
+            .append("127.0.0.1:10911").append(TraceConstants.CONTENT_SPLITOR)
+            .append(26).append(TraceConstants.CONTENT_SPLITOR)
+            .append(245).append(TraceConstants.CONTENT_SPLITOR)
+            .append(99).append(TraceConstants.FIELD_SPLITOR)
+            .toString();
+
+        List<TraceContext> contexts = TraceDataEncoder.decoderFromTraceDataString(badOrdinal + traceData);
+        Assert.assertEquals(1, contexts.size());
+        Assert.assertEquals(TraceType.Pub, contexts.get(0).getTraceType());
+    }
+
+    @Test
     public void testEncoderFromContextBean() {
         TraceContext context = new TraceContext();
         context.setTraceType(TraceType.Pub);


### PR DESCRIPTION
## Motivation

`TraceDataEncoder.decoderFromTraceDataString` splits a trace-topic payload into lines and indexes fixed positions per line type — the Pub branch unconditionally reads `line[0]..line[11]` and calls `Long.parseLong`, `Integer.parseInt`, `MessageType.values()[...]`; the EndTransaction branch additionally does `LocalTransactionState.valueOf(line[11])`. There is no per-line length or format validation.

This is reached from `mqadmin queryMsgTraceById` (`QueryMsgTraceByIdSubCommand` → `TraceView.decodeFromTraceTransData` → this decoder), which scans the trace topic. The trace topic is a plain topic any producer can publish to, and the decoder itself carries `compatible with the old version` branches precisely because the field layout differs across client versions. One truncated, corrupted or foreign-version line throws and aborts the decode of every remaining context in the payload, failing the whole command.

## Modification

Wrap the per-line parsing in try/catch: a malformed line is skipped with a warn log (including the offending line), and the remaining contexts are still decoded and returned.

## Test Evidence

Fail-before (unpatched develop, new tests in `TraceDataEncoderTest`):

```
#testDecoderSkipsTruncatedLineAndKeepsRemaining
Tests run: 1, Errors: 1 - java.lang.ArrayIndexOutOfBoundsException: Index 4 out of bounds for length 4
#testDecoderSkipsNonNumericFieldAndKeepsRemaining
Tests run: 1, Errors: 1 - java.lang.NumberFormatException: For input string: "not-a-timestamp"
#testDecoderSkipsOutOfRangeMsgTypeOrdinalAndKeepsRemaining
Tests run: 1, Errors: 1 - java.lang.ArrayIndexOutOfBoundsException: Index 99 out of bounds for length 5
```

Pass-after:

```
mvn -q -pl client test -Dtest='TraceDataEncoderTest,TraceViewTest'
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a client-module self-audit).