### PR TITLE
[ISSUE #D4] Fix getConsumeStatus NPE for a group absent from ConsumerManager

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/net/Broker2Client.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/net/Broker2Client.java
@@ -253,13 +253,16 @@ public class Broker2Client {
                 requestHeader);
 
         Map<String, Map<MessageQueue, Long>> consumerStatusTable = new HashMap<>();
-        ConcurrentMap<Channel, ClientChannelInfo> channelInfoTable =
-            this.brokerController.getConsumerManager().getConsumerGroupInfo(group).getChannelInfoTable();
-        if (null == channelInfoTable || channelInfoTable.isEmpty()) {
+        ConsumerGroupInfo consumerGroupInfo = this.brokerController.getConsumerManager().getConsumerGroupInfo(group);
+        // The group info is absent exactly when no consumer of this group is
+        // registered on this broker; the error branch below was written for that
+        // case, so it must not be reached through an NPE.
+        if (null == consumerGroupInfo || consumerGroupInfo.getChannelInfoTable().isEmpty()) {
             result.setCode(ResponseCode.SYSTEM_ERROR);
             result.setRemark(String.format("No Any Consumer online in the consumer group: [%s]", group));
             return result;
         }
+        ConcurrentMap<Channel, ClientChannelInfo> channelInfoTable = consumerGroupInfo.getChannelInfoTable();
 
         for (Map.Entry<Channel, ClientChannelInfo> entry : channelInfoTable.entrySet()) {
             int version = entry.getValue().getVersion();

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/net/Broker2ClientTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/net/Broker2ClientTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -162,6 +163,18 @@ public class Broker2ClientTest {
         when(consumerGroupInfo.getChannelInfoTable()).thenReturn(new ConcurrentHashMap<>());
         RemotingCommand response = broker2Client.getConsumeStatus(defaultTopic, defaultGroup, "");
         assertEquals(ResponseCode.SYSTEM_ERROR, response.getCode());
+    }
+
+    @Test
+    public void testGetConsumeStatusGroupNotRegistered() {
+        // A group without any registered consumer on this broker: the group info
+        // itself is absent, which must reach the "No Any Consumer online" branch
+        // instead of throwing NPE before the null check.
+        when(consumerManager.getConsumerGroupInfo("offlineGroup")).thenReturn(null);
+        RemotingCommand response = broker2Client.getConsumeStatus(defaultTopic, "offlineGroup", "");
+        assertEquals(ResponseCode.SYSTEM_ERROR, response.getCode());
+        assertTrue(response.getRemark().contains("No Any Consumer online"));
+        assertTrue(response.getRemark().contains("offlineGroup"));
     }
     
     @Test


### PR DESCRIPTION
## Motivation

`Broker2Client.getConsumeStatus` dereferences the consumer group info before checking it:

```java
ConcurrentMap<Channel, ClientChannelInfo> channelInfoTable =
    this.brokerController.getConsumerManager().getConsumerGroupInfo(group).getChannelInfoTable();
if (null == channelInfoTable || channelInfoTable.isEmpty()) {
    // "No Any Consumer online in the consumer group: [%s]"
}
```

When the queried group has no consumer registered on this broker — the normal situation for an offline group — `getConsumerGroupInfo(group)` returns null and the method throws `NullPointerException` before reaching the error branch that was written for exactly this case. The sibling `resetOffset` method checks the group info for null first.

Reached from `mqadmin getConsumerStatus` (`INVOKE_BROKER_TO_GET_CONSUMER_STATUS` → `AdminBrokerProcessor.getConsumerStatus` → here), the NPE surfaces to the admin as a bare SYSTEM_ERROR with a null-pointer remark instead of the intended message.

## Modification

Fetch the `ConsumerGroupInfo` first; enter the existing "No Any Consumer online" branch when it is null or its channel table is empty; read the channel table only afterwards.

## Test Evidence

Fail-before (unpatched develop, new regression test):

```
mvn -q -pl broker test -Dtest='Broker2ClientTest#testGetConsumeStatusGroupNotRegistered'
Tests run: 1, Errors: 1 - NullPointerException: Cannot invoke "ConsumerGroupInfo.getChannelInfoTable()"
```

Pass-after (full class):

```
mvn -q -pl broker test -Dtest='Broker2ClientTest'
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a broker-module self-audit).