### PR TITLE
[ISSUE #D5] cloneGroupOffset: clone per loop topic, not the blank header topic

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -2676,8 +2676,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
                 }
             }
 
+            // In the blank-topic mode the loop iterates over every topic the
+            // source group consumes, so the offset must be cloned per loop
+            // variable, not for the (blank) header topic.
             this.brokerController.getConsumerOffsetManager().cloneOffset(requestHeader.getSrcGroup(), requestHeader.getDestGroup(),
-                requestHeader.getTopic());
+                topic);
         }
 
         response.setCode(ResponseCode.SUCCESS);

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
@@ -91,6 +91,7 @@ import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.body.UnlockBatchRequestBody;
 import org.apache.rocketmq.remoting.protocol.body.UserInfo;
 import org.apache.rocketmq.remoting.protocol.header.CheckRocksdbCqWriteProgressRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.CloneGroupOffsetRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.CreateAclRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.CreateTopicRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.CreateUserRequestHeader;
@@ -340,6 +341,27 @@ public class AdminBrokerProcessorTest {
         RemotingCommand request = createUpdateBrokerConfigCommand();
         RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
         assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+    }
+
+    @Test
+    public void testCloneGroupOffsetWithoutTopicClonesEveryTopicOfSourceGroup() throws Exception {
+        brokerController.setConsumerOffsetManager(consumerOffsetManager);
+        when(consumerOffsetManager.whichTopicByConsumer("srcGroup")).thenReturn(Sets.newHashSet("cloneTopic1", "cloneTopic2"));
+        brokerController.getTopicConfigManager().getTopicConfigTable().put("cloneTopic1", new TopicConfig("cloneTopic1"));
+        brokerController.getTopicConfigManager().getTopicConfigTable().put("cloneTopic2", new TopicConfig("cloneTopic2"));
+
+        CloneGroupOffsetRequestHeader requestHeader = new CloneGroupOffsetRequestHeader();
+        requestHeader.setSrcGroup("srcGroup");
+        requestHeader.setDestGroup("destGroup");
+        // topic left blank: clone the offsets of every topic the source group consumes
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.CLONE_GROUP_OFFSET, requestHeader);
+        request.makeCustomHeaderToNet();
+
+        RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        verify(consumerOffsetManager).cloneOffset("srcGroup", "destGroup", "cloneTopic1");
+        verify(consumerOffsetManager).cloneOffset("srcGroup", "destGroup", "cloneTopic2");
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`AdminBrokerProcessor.cloneGroupOffset` supports a blank-topic mode (`UtilAll.isBlank(requestHeader.getTopic())`) that clones the offsets of **every** topic the source group consumes — this is `mqadmin cloneGroupOffset` without `-t`. The method collects the topic set and iterates it, but then calls:

```java
this.brokerController.getConsumerOffsetManager().cloneOffset(
    requestHeader.getSrcGroup(), requestHeader.getDestGroup(),
    requestHeader.getTopic());   // <-- null in the blank-topic mode
```

`ConsumerOffsetManager.cloneOffset` looks up `topic + TOPIC_GROUP_SEPARATOR + srcGroup`, so with a null topic the key `null@srcGroup` never matches: no offset is cloned, yet the broker replies SUCCESS. The whole "clone all topics of a group" admin feature silently does nothing.

## Modification

Pass the loop variable `topic` to `cloneOffset`. In the explicit-topic mode the two are identical, so only the blank-topic mode changes (from no-op to actually cloning).

## Test Evidence

Fail-before (unpatched develop, new regression test):

```
mvn -q -pl broker test -Dtest='AdminBrokerProcessorTest#testCloneGroupOffsetWithoutTopicClonesEveryTopicOfSourceGroup'
Argument(s) are different! Wanted: cloneOffset("srcGroup", "destGroup", "cloneTopic1")
```

Pass-after (full class):

```
mvn -q -pl broker test -Dtest='AdminBrokerProcessorTest'
Tests run: 94, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a broker-module self-audit).