### PR TITLE
[ISSUE #D6] Skip queueData of unregistered broker instead of aborting queryRoute loop

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivity.java
@@ -78,7 +78,11 @@ public class RouteActivity extends AbstractMessagingActivity {
                 String brokerName = queueData.getBrokerName();
                 Map<Long, Broker> brokerIdMap = brokerMap.get(brokerName);
                 if (brokerIdMap == null) {
-                    break;
+                    // A queueData whose broker has no BrokerData entry (e.g. the
+                    // broker was just unregistered while the route still carries
+                    // its queueData) only affects its own queues; keep serving
+                    // the remaining brokers instead of returning an empty route.
+                    continue;
                 }
                 for (Broker broker : brokerIdMap.values()) {
                     messageQueueList.addAll(this.genMessageQueueFromQueueData(queueData, request.getTopic(), topicMessageType, broker));

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/route/RouteActivityTest.java
@@ -140,6 +140,38 @@ public class RouteActivityTest extends BaseActivityTest {
     }
 
     @Test
+    public void testQueryRouteSkipsQueueDataOfUnregisteredBroker() throws Throwable {
+        ConfigurationManager.getProxyConfig().setGrpcServerPort(8080);
+        // A route may carry a queueData whose broker has no BrokerData entry:
+        // namesrv pickupTopicRouteData puts every queueData into the route but
+        // only adds brokers present in brokerAddrTable. The queue list must skip
+        // that queueData instead of dropping every following broker's queues.
+        ProxyTopicRouteData proxyTopicRouteData = createProxyTopicRouteData(2, 2, 6);
+        QueueData staleQueueData = createQueueData(2, 2, 6);
+        staleQueueData.setBrokerName("staleBroker");
+        proxyTopicRouteData.getQueueDatas().add(0, staleQueueData);
+        when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
+            .thenReturn(proxyTopicRouteData);
+        MetadataService metadataService = Mockito.mock(LocalMetadataService.class);
+        when(this.messagingProcessor.getMetadataService()).thenReturn(metadataService);
+        when(metadataService.getTopicMessageType(any(), anyString())).thenReturn(TopicMessageType.NORMAL);
+
+        QueryRouteResponse response = this.routeActivity.queryRoute(
+            createContext(),
+            QueryRouteRequest.newBuilder()
+                .setEndpoints(grpcEndpoints)
+                .setTopic(GRPC_TOPIC)
+                .build()
+        ).get();
+
+        assertEquals(Code.OK, response.getStatus().getCode());
+        assertEquals(4, response.getMessageQueuesCount());
+        for (MessageQueue messageQueue : response.getMessageQueuesList()) {
+            assertEquals(BROKER_NAME, messageQueue.getBroker().getName());
+        }
+    }
+
+    @Test
     public void testQueryAssignmentWithNoReadPerm() throws Throwable {
         when(this.messagingProcessor.getTopicRouteDataForProxy(any(), any(), anyString()))
             .thenReturn(createProxyTopicRouteData(2, 2, PermName.PERM_WRITE));


### PR DESCRIPTION
## Motivation

`RouteActivity.queryRoute` breaks out of the queueData loop as soon as one queueData's brokerName has no matching entry in the broker map built from `BrokerData`:

```java
Map<Long, Broker> brokerIdMap = brokerMap.get(brokerName);
if (brokerIdMap == null) {
    break;
}
```

The namesrv assembles `TopicRouteData` from `queueTable` and `brokerAddrTable` independently, so a route can carry a queueData whose broker was just unregistered (e.g. broker shutdown between the two table reads, or a stale queueData left behind during unregister races). With `break`, that single orphan queueData makes `queryRoute` return **zero** message queues for the topic even though every other broker in the route is healthy — clients then fail all sends until the next route refresh. The sibling method `queryAssignment` already handles the same condition by skipping only the affected queueData, so `queryRoute` is inconsistent with it.

## Modification

In `RouteActivity.queryRoute`, change the `break` to `continue` so an orphan queueData only drops its own queues and the remaining brokers' queues are still served.

## Test Evidence

**Fail-before** (unpatched code, new test `RouteActivityTest#testQueryRouteSkipsQueueDataOfUnregisteredBroker` with a route whose first queueData references an unregistered broker):

```
docker exec rmq-build bash -c "export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64; cd /repo && mvn -q -pl proxy test -Dtest='RouteActivityTest#testQueryRouteSkipsQueueDataOfUnregisteredBroker' -Dsurefire.failIfNoSpecifiedTests=true"
java.lang.AssertionError: expected:<4> but was:<0>
```

**Pass-after** (full class with the fix):

```
docker exec rmq-build bash -c "export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64; cd /repo && mvn -q -pl proxy test -Dtest='RouteActivityTest' -Dsurefire.failIfNoSpecifiedTests=true"
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a proxy-module self-audit).