### PR TITLE
[ISSUE #D7] Clean topicGroupTable and fire UNREGISTER when scan removes empty group

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/client/ConsumerManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/client/ConsumerManager.java
@@ -381,6 +381,13 @@ public class ConsumerManager {
                     "SCAN: remove expired channel from ConsumerManager consumerTable, all clear, consumerGroup={}",
                     group);
                 it.remove();
+                // The group is gone for good, so leave the same traces as the
+                // other removal paths (unregisterConsumer/doChannelCloseEvent):
+                // release its consumer filters and clean the topicGroupTable,
+                // otherwise queryTopicConsumeByWho keeps reporting the dead
+                // group forever.
+                callConsumerIdsChangeListener(ConsumerGroupEvent.UNREGISTER, group);
+                clearTopicGroupTable(consumerGroupInfo);
             }
         }
         removeExpireConsumerGroupInfo();

--- a/broker/src/test/java/org/apache/rocketmq/broker/client/ConsumerManagerTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/client/ConsumerManagerTest.java
@@ -178,6 +178,18 @@ public class ConsumerManagerTest {
     }
 
     @Test
+    public void scanNotActiveChannelClearsTopicGroupTableTest() {
+        register();
+        assertThat(consumerManager.queryTopicConsumeByWho(TOPIC)).isEqualTo(ImmutableSet.of(GROUP));
+
+        clientChannelInfo.setLastUpdateTimestamp(System.currentTimeMillis() - brokerConfig.getChannelExpiredTimeout() * 2);
+        consumerManager.scanNotActiveChannel();
+
+        assertThat(consumerManager.getConsumerTable().size()).isEqualTo(0);
+        assertThat(consumerManager.queryTopicConsumeByWho(TOPIC)).isEmpty();
+    }
+
+    @Test
     public void queryTopicConsumeByWhoTest() {
         register();
         final HashSet<String> consumeGroup = consumerManager.queryTopicConsumeByWho(TOPIC);


### PR DESCRIPTION
## Motivation

`ConsumerManager` has three paths that remove a consumer group from `consumerTable` once its last channel is gone: `unregisterConsumer`, `doChannelCloseEvent`, and `scanNotActiveChannel`. The first two clean up the group's `topicGroupTable` entries and fire the `UNREGISTER` listener event:

```java
ConsumerGroupInfo remove = this.consumerTable.remove(group);
if (remove != null) {
    ...
    callConsumerIdsChangeListener(ConsumerGroupEvent.UNREGISTER, group);
    clearTopicGroupTable(remove);
}
```

`scanNotActiveChannel` only does `it.remove()`:

```java
if (channelInfoTable.isEmpty()) {
    LOGGER.warn("SCAN: remove expired channel ... consumerGroup={}", group);
    it.remove();
}
```

When a consumer client dies without closing the channel (process kill, network partition), the scan path is the one that eventually removes the group. Its omission means:

- `queryTopicConsumeByWho(topic)` keeps returning the dead group forever — `QUERY_TOPIC_CONSUME_BY_WHO` (used by admin tools/mqadmin/console) reports groups as consumers of a topic long after they went offline, and nothing ever cleans the entry since only re-registration writes to `topicGroupTable`.
- The `UNREGISTER` event is never fired, so `DefaultConsumerIdsChangeListener` never calls `consumerFilterManager.unRegister(group)` and the group's consumer filter registrations leak.

## Modification

In `scanNotActiveChannel`, after removing the empty group, fire the `UNREGISTER` listener event and call `clearTopicGroupTable(consumerGroupInfo)`, exactly matching the other two removal paths.

## Test Evidence

**Fail-before** (unpatched code, new test `ConsumerManagerTest#scanNotActiveChannelClearsTopicGroupTableTest` — register a consumer on a topic, expire its channel, scan, then ask who consumes the topic):

```
docker exec rmq-build mvn -q -pl broker test -Dtest='ConsumerManagerTest#scanNotActiveChannelClearsTopicGroupTableTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 1, Failures: 1 ... java.lang.AssertionError
// queryTopicConsumeByWho(TOPIC) still returns the removed group
```

**Pass-after** (full class with the fix):

```
docker exec rmq-build mvn -q -pl broker test -Dtest='ConsumerManagerTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a broker-module self-audit).