### PR TITLE
[ISSUE #D8] Skip malformed orderTopicConf segments instead of aborting route conversion

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -266,7 +266,18 @@ public class MQClientInstance {
             String[] brokers = route.getOrderTopicConf().split(";");
             for (String broker : brokers) {
                 String[] item = broker.split(":");
-                int nums = Integer.parseInt(item[1]);
+                int nums;
+                try {
+                    nums = Integer.parseInt(item[1]);
+                } catch (RuntimeException e) {
+                    // orderTopicConf is a manually configured string stored on
+                    // the nameserver; a segment without the "brokerName:queueNum"
+                    // shape or with a non-numeric count must only drop its own
+                    // queues, not abort the whole route conversion with a raw
+                    // runtime exception escaping updateTopicRouteInfoFromNameServer.
+                    log.warn("skip malformed orderTopicConf segment, topic={}, segment={}", topic, broker);
+                    continue;
+                }
                 for (int i = 0; i < nums; i++) {
                     MessageQueue mq = new MessageQueue(topic, item[0], i);
                     info.getMessageQueueList().add(mq);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
@@ -252,6 +252,18 @@ public class MQClientInstanceTest {
     }
 
     @Test
+    public void testTopicRouteData2TopicPublishInfoWithMalformedOrderTopicConf() {
+        TopicRouteData topicRouteData = createTopicRouteData();
+        // segments without "brokerName:queueNum" shape or with a non-numeric
+        // count must be skipped instead of aborting the whole conversion
+        topicRouteData.setOrderTopicConf("127.0.0.1:2;malformed;broker-b:notANumber;127.0.0.2:1");
+        TopicPublishInfo actual = MQClientInstance.topicRouteData2TopicPublishInfo(topic, topicRouteData);
+        assertFalse(actual.isHaveTopicRouterInfo());
+        assertTrue(actual.isOrderTopic());
+        assertEquals(3, actual.getMessageQueueList().size());
+    }
+
+    @Test
     public void testTopicRouteData2TopicPublishInfoWithTopicQueueMappingByBroker() {
         TopicRouteData topicRouteData = createTopicRouteData();
         topicRouteData.setTopicQueueMappingByBroker(Collections.singletonMap(topic, new TopicQueueMappingInfo()));


### PR DESCRIPTION
## Motivation

`MQClientInstance.topicRouteData2TopicPublishInfo` parses the order-topic route config with no guard:

```java
String[] item = broker.split(":");
int nums = Integer.parseInt(item[1]);
```

`orderTopicConf` is a manually configured string stored on the nameserver (e.g. `broker-a:8;broker-b:4`). A single mistyped segment — missing the `brokerName:queueNum` shape, or a non-numeric count — makes the method throw a raw `ArrayIndexOutOfBoundsException`/`NumberFormatException`.

The method is called from `updateTopicRouteInfoFromNameServer`, whose catch clauses only cover `MQClientException`/`RemotingException`, so the runtime exception escapes through the whole route refresh: the topic never gets publish info, every producer on the client keeps failing queue selection for that topic, and the only trace is an unrelated-looking stack trace. `fetchPublishMessageQueues` degrades to a misleading "Can not find Message Queue" as well.

## Modification

Parse each segment defensively: a segment that does not match the `brokerName:queueNum` shape or whose count is not numeric is skipped with a warn log, so only its own queues are dropped and the remaining valid brokers stay routable. Well-formed configurations are unaffected.

## Test Evidence

**Fail-before** (unpatched code, new test `MQClientInstanceTest#testTopicRouteData2TopicPublishInfoWithMalformedOrderTopicConf` with conf `127.0.0.1:2;malformed;broker-b:notANumber;127.0.0.2:1`):

```
docker exec rmq-build mvn -q -pl client test -Dtest='MQClientInstanceTest#testTopicRouteData2TopicPublishInfoWithMalformedOrderTopicConf' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 1, Errors: 1 ... java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
```

**Pass-after** (full class with the fix — malformed segments skipped, the 3 queues of the two valid brokers still produced):

```
docker exec rmq-build mvn -q -pl client test -Dtest='MQClientInstanceTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a client-module self-audit).