### PR TITLE
[ISSUE #D9] Guard consumeMessageDirectly against unresolvable msgId

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -2624,14 +2624,25 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             }
         }
         SelectMappedBufferResult selectMappedBufferResult = null;
+        final RemotingCommand response = RemotingCommand.createResponseCommand(null);
         try {
             MessageId messageId = MessageDecoder.decodeMessageId(requestHeader.getMsgId());
             selectMappedBufferResult = this.brokerController.getMessageStore().selectOneMessageByOffset(messageId.getOffset());
-
+            // The offset may no longer map to a stored message (expired/deleted
+            // commitlog or a msgId from another broker); report that instead of
+            // throwing an NPE or invoking the consumer with an empty body.
+            if (selectMappedBufferResult == null) {
+                response.setCode(ResponseCode.SYSTEM_ERROR);
+                response.setRemark(String.format("can not find message by id: %s", requestHeader.getMsgId()));
+                return response;
+            }
             byte[] body = new byte[selectMappedBufferResult.getSize()];
             selectMappedBufferResult.getByteBuffer().get(body);
             request.setBody(body);
         } catch (UnknownHostException e) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark(String.format("can not decode message id: %s", requestHeader.getMsgId()));
+            return response;
         } finally {
             if (selectMappedBufferResult != null) {
                 selectMappedBufferResult.release();

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
@@ -121,6 +121,7 @@ import org.apache.rocketmq.remoting.protocol.header.QueryTopicConsumeByWhoReques
 import org.apache.rocketmq.remoting.protocol.header.QueryTopicsByConsumerRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ResetMasterFlushOffsetHeader;
 import org.apache.rocketmq.remoting.protocol.header.ResetOffsetRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.ConsumeMessageDirectlyResultRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ResumeCheckHalfMessageRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.SearchOffsetRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.SearchOffsetResponseHeader;
@@ -378,6 +379,29 @@ public class AdminBrokerProcessorTest {
         verify(messageStore).putMessage(messageCaptor.capture());
         assertThat(messageCaptor.getValue().getProperty(MessageConst.PROPERTY_REAL_TOPIC)).isEqualTo("topic");
         assertThat(messageCaptor.getValue().getProperty(MessageConst.PROPERTY_TRANSACTION_CHECK_TIMES)).isEqualTo("0");
+    }
+
+    @Test
+    public void testConsumeMessageDirectlyMessageNotFound() throws Exception {
+        RemotingCommand request = createConsumeMessageDirectlyCommand();
+        when(messageStore.selectOneMessageByOffset(any(Long.class))).thenReturn(null);
+
+        RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("can not find message");
+        verify(brokerController, never()).getBroker2Client();
+    }
+
+    private RemotingCommand createConsumeMessageDirectlyCommand() {
+        ConsumeMessageDirectlyResultRequestHeader header = new ConsumeMessageDirectlyResultRequestHeader();
+        header.setConsumerGroup("group");
+        header.setClientId("client");
+        // hex of ip 127.0.0.1 + port 10911 + offset 0, the format MessageDecoder.decodeMessageId expects
+        header.setMsgId("7F00000100002A9F0000000000000000");
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.CONSUME_MESSAGE_DIRECTLY, header);
+        request.makeCustomHeaderToNet();
+        return request;
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`AdminBrokerProcessor.consumeMessageDirectly` (backing `mqadmin consumeMessageDirectly` / console "trace/diagnose message") fetches the message by offset with no null check:

```java
selectMappedBufferResult = this.brokerController.getMessageStore().selectOneMessageByOffset(messageId.getOffset());
byte[] body = new byte[selectMappedBufferResult.getSize()];   // NPE when null
```

`selectOneMessageByOffset` returns null when the offset no longer maps to a stored message — the commitlog segment was expired/deleted, or the msgId was never on this broker. The broker then throws a raw `NullPointerException` into the remoting layer instead of answering the admin request.

Additionally, the `catch (UnknownHostException e) {}` block silently swallows msgId decode failures and falls through to `callConsumer` with a **null body**, so the consumer is invoked with an empty request and fails with an unrelated decode error far from the cause.

## Modification

- If `selectOneMessageByOffset` returns null, respond `SYSTEM_ERROR` with remark `can not find message by id: <msgId>` and do not invoke the consumer.
- On `UnknownHostException` (undecodable msgId), respond `SYSTEM_ERROR` with remark `can not decode message id: <msgId>` instead of forwarding a bodiless request.

## Test Evidence

**Fail-before** (unpatched code, new test `AdminBrokerProcessorTest#testConsumeMessageDirectlyMessageNotFound` with a well-formed msgId whose offset is not stored):

```
docker exec rmq-build mvn -q -pl broker test -Dtest='AdminBrokerProcessorTest#testConsumeMessageDirectlyMessageNotFound' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 1, Errors: 1 ... java.lang.NullPointerException: Cannot invoke "...SelectMappedBufferResult.getSize()" because "selectMappedBufferResult" is null
```

**Pass-after** (full class with the fix):

```
docker exec rmq-build mvn -q -pl broker test -Dtest='AdminBrokerProcessorTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 94, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a broker-module self-audit).