### PR TITLE
[ISSUE #D10] Report zero timestamps in queryConsumeTimeSpan for empty queues

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -2484,7 +2484,13 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             } catch (ConsumeQueueException e) {
                 throw new RemotingCommandException("Failed to get max offset in queue", e);
             }
-            long maxTime = this.brokerController.getMessageStore().getMessageStoreTimeStamp(topic, i, max - 1);
+            // An empty queue has no last stored message; querying offset -1
+            // makes the store answer -1, which clients render as an epoch
+            // timestamp. getTopicStatsInfo guards the same lookup with max > 0.
+            long maxTime = 0;
+            if (max > 0) {
+                maxTime = this.brokerController.getMessageStore().getMessageStoreTimeStamp(topic, i, max - 1);
+            }
             timeSpan.setMaxTimeStamp(maxTime);
 
             long consumeTime;
@@ -2503,7 +2509,10 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
             } catch (ConsumeQueueException e) {
                 throw new RemotingCommandException("Failed to get max offset in queue", e);
             }
-            if (consumerOffset < maxBrokerOffset) {
+            // A group that never committed an offset gets -1 from queryOffset;
+            // without the lower bound the comparison below holds for an empty
+            // queue too and delayTime becomes now - (-1).
+            if (consumerOffset >= 0 && consumerOffset < maxBrokerOffset) {
                 long nextTime = this.brokerController.getMessageStore().getMessageStoreTimeStamp(topic, i, consumerOffset);
                 timeSpan.setDelayTime(System.currentTimeMillis() - nextTime);
             }

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
@@ -85,7 +85,9 @@ import org.apache.rocketmq.remoting.protocol.body.DeleteTopicListRequestBody;
 import org.apache.rocketmq.remoting.protocol.body.GroupList;
 import org.apache.rocketmq.remoting.protocol.body.HARuntimeInfo;
 import org.apache.rocketmq.remoting.protocol.body.LockBatchRequestBody;
+import org.apache.rocketmq.remoting.protocol.body.QueryConsumeTimeSpanBody;
 import org.apache.rocketmq.remoting.protocol.body.QueryCorrectionOffsetBody;
+import org.apache.rocketmq.remoting.protocol.body.QueueTimeSpan;
 import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
 import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.body.UnlockBatchRequestBody;
@@ -115,6 +117,7 @@ import org.apache.rocketmq.remoting.protocol.header.ListAclsRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.ListUsersRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.NotifyMinBrokerIdChangeRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.QueryConsumeQueueRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.QueryConsumeTimeSpanRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.QueryCorrectionOffsetHeader;
 import org.apache.rocketmq.remoting.protocol.header.QuerySubscriptionByConsumerRequestHeader;
 import org.apache.rocketmq.remoting.protocol.header.QueryTopicConsumeByWhoRequestHeader;
@@ -348,6 +351,30 @@ public class AdminBrokerProcessorTest {
         when(messageStore.selectOneMessageByOffset(any(Long.class))).thenReturn(createSelectMappedBufferResult());
         RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
         assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+    }
+
+    @Test
+    public void testQueryConsumeTimeSpanEmptyQueueReportsZeroMaxTimestamp() throws Exception {
+        when(messageStore.getMaxOffsetInQueue(anyString(), anyInt())).thenReturn(0L);
+        when(messageStore.getEarliestMessageTime(anyString(), anyInt())).thenReturn(0L);
+
+        QueryConsumeTimeSpanRequestHeader header = new QueryConsumeTimeSpanRequestHeader();
+        header.setTopic(topic);
+        header.setGroup("group");
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.QUERY_CONSUME_TIME_SPAN, header);
+        request.makeCustomHeaderToNet();
+
+        RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        QueryConsumeTimeSpanBody body = QueryConsumeTimeSpanBody.decode(response.getBody(), QueryConsumeTimeSpanBody.class);
+        assertThat(body.getConsumeTimeSpanSet()).isNotEmpty();
+        for (QueueTimeSpan timeSpan : body.getConsumeTimeSpanSet()) {
+            assertThat(timeSpan.getMaxTimeStamp()).isEqualTo(0L);
+            assertThat(timeSpan.getDelayTime()).isEqualTo(0L);
+        }
+        // an empty queue has no stored message, so no timestamp lookup must happen
+        verify(messageStore, never()).getMessageStoreTimeStamp(anyString(), anyInt(), anyLong());
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`AdminBrokerProcessor.queryConsumeTimeSpan` (backing `mqadmin queryConsumeTimeSpan` and the console's consume-time-span view) computes per-queue timestamps with two unguarded lookups:

```java
long maxTime = this.brokerController.getMessageStore().getMessageStoreTimeStamp(topic, i, max - 1);
...
if (consumerOffset < maxBrokerOffset) {
    long nextTime = ... getMessageStoreTimeStamp(topic, i, consumerOffset);
    timeSpan.setDelayTime(System.currentTimeMillis() - nextTime);
}
```

- **Empty queue:** `max == 0`, so the first lookup queries offset `-1`; the store answers `-1` and `maxTimeStamp` is reported as `-1`, which clients render as an epoch timestamp (1970/1969) for a queue that simply has no messages. `getTopicStatsInfo` already guards the identical lookup with `if (max > 0)` and defaults to `0`.
- **Group never committed:** `ConsumerOffsetManager.queryOffset` returns `-1` for an unknown group/queue, so `consumerOffset(-1) < maxBrokerOffset(0)` holds even for an empty queue; `nextTime` is `-1` and `delayTime` becomes `now - (-1)` — i.e. the current epoch in milliseconds, shown as an absurd delay.

## Modification

- Guard the max-timestamp lookup with `if (max > 0)`, defaulting to `0`, exactly like `getTopicStatsInfo`.
- Compute `delayTime` only when `consumerOffset >= 0 && consumerOffset < maxBrokerOffset`, so a group with no committed offset gets `0` instead of epoch-based garbage.

## Test Evidence

**Fail-before** (unpatched code, new test `AdminBrokerProcessorTest#testQueryConsumeTimeSpanEmptyQueueReportsZeroMaxTimestamp` — topic with default queues, empty store, group with no committed offset):

```
docker exec rmq-build mvn -q -pl broker test -Dtest='AdminBrokerProcessorTest#testQueryConsumeTimeSpanEmptyQueueReportsZeroMaxTimestamp' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 1, Failures: 1 ... expected: 0L
```

With only the max-timestamp guard applied, the test's `verify(never())` further exposed the delayTime path still calling `getMessageStoreTimeStamp(topic, i, -1)` with `consumerOffset == -1` (`NeverWantedButInvoked`), which motivated the second guard.

**Pass-after** (full class with both guards):

```
docker exec rmq-build mvn -q -pl broker test -Dtest='AdminBrokerProcessorTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 94, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a broker-module self-audit).