### PR TITLE
[ISSUE #D11] Guard ClientRemotingProcessor against requests without body

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/ClientRemotingProcessor.java
@@ -96,6 +96,14 @@ public class ClientRemotingProcessor implements NettyRequestProcessor {
         RemotingCommand request) throws RemotingCommandException {
         final CheckTransactionStateRequestHeader requestHeader =
             (CheckTransactionStateRequestHeader) request.decodeCommandCustomHeader(CheckTransactionStateRequestHeader.class);
+        // A broker that fails to resolve the transaction message sends the
+        // request without a body; skip the check instead of throwing an NPE,
+        // the broker will re-check this transaction later.
+        if (request.getBody() == null) {
+            logger.warn("checkTransactionState, message body is empty, brokerAddr={}",
+                RemotingHelper.parseChannelRemoteAddr(ctx.channel()));
+            return null;
+        }
         final ByteBuffer byteBuffer = ByteBuffer.wrap(request.getBody());
         final MessageExt messageExt = MessageDecoder.decode(byteBuffer);
         if (messageExt != null) {
@@ -202,6 +210,15 @@ public class ClientRemotingProcessor implements NettyRequestProcessor {
         final ConsumeMessageDirectlyResultRequestHeader requestHeader =
             (ConsumeMessageDirectlyResultRequestHeader) request
                 .decodeCommandCustomHeader(ConsumeMessageDirectlyResultRequestHeader.class);
+
+        // The broker omits the body when it cannot resolve the msgId (e.g.
+        // expired or already deleted message); report that to the caller
+        // instead of failing with an NPE while decoding.
+        if (request.getBody() == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("The request does not carry a message body, please check the message on the broker");
+            return response;
+        }
 
         final MessageExt msg = MessageDecoder.clientDecode(ByteBuffer.wrap(request.getBody()), true);
 

--- a/client/src/test/java/org/apache/rocketmq/client/impl/ClientRemotingProcessorTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/ClientRemotingProcessorTest.java
@@ -57,6 +57,8 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -141,6 +143,37 @@ public class ClientRemotingProcessorTest {
         RemotingCommand command = processor.processRequest(ctx, request);
         assertNotNull(command);
         assertEquals(ResponseCode.SUCCESS, command.getCode());
+    }
+
+    @Test
+    public void testCheckTransactionStateWithoutBody() throws Exception {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        RemotingCommand request = mock(RemotingCommand.class);
+        when(request.getCode()).thenReturn(RequestCode.CHECK_TRANSACTION_STATE);
+        when(request.getBody()).thenReturn(null);
+        CheckTransactionStateRequestHeader requestHeader = new CheckTransactionStateRequestHeader();
+        when(request.decodeCommandCustomHeader(CheckTransactionStateRequestHeader.class)).thenReturn(requestHeader);
+
+        assertNull(processor.processRequest(ctx, request));
+        verify(mQClientFactory, never()).selectProducer(anyString());
+    }
+
+    @Test
+    public void testConsumeMessageDirectlyWithoutBody() throws Exception {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        RemotingCommand request = mock(RemotingCommand.class);
+        when(request.getCode()).thenReturn(RequestCode.CONSUME_MESSAGE_DIRECTLY);
+        when(request.getBody()).thenReturn(null);
+        ConsumeMessageDirectlyResultRequestHeader requestHeader = new ConsumeMessageDirectlyResultRequestHeader();
+        requestHeader.setConsumerGroup(defaultGroup);
+        requestHeader.setBrokerName(defaultBroker);
+        when(request.decodeCommandCustomHeader(ConsumeMessageDirectlyResultRequestHeader.class)).thenReturn(requestHeader);
+
+        RemotingCommand command = processor.processRequest(ctx, request);
+
+        assertNotNull(command);
+        assertEquals(ResponseCode.SYSTEM_ERROR, command.getCode());
+        verify(mQClientFactory, never()).consumeMessageDirectly(any(), anyString(), anyString());
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`ClientRemotingProcessor` handles broker-initiated requests on the client. Two of them wrap the request body without a null check:

```java
// checkTransactionState
final ByteBuffer byteBuffer = ByteBuffer.wrap(request.getBody());          // L99
// consumeMessageDirectly
final MessageExt msg = MessageDecoder.clientDecode(ByteBuffer.wrap(request.getBody()), true);  // L206
```

A bodiless request makes the client throw a raw `NullPointerException` inside `processRequest`. This is reachable in practice: the broker side of `CONSUME_MESSAGE_DIRECTLY` resolves the message by msgId and forwards it in the body — when the offset no longer maps to a stored message (expired/deleted commitlog), the forwarded request carries **no body**, so the client NPEs and the admin only sees a generic system error instead of the actual cause. The same defensive gap exists for `CHECK_TRANSACTION_STATE`.

## Modification

- `checkTransactionState`: if the body is empty, log a warn (with the broker address) and return — the broker re-checks the transaction later, matching the method's fire-and-forget contract.
- `consumeMessageDirectly`: if the body is empty, answer `SYSTEM_ERROR` with remark "The request does not carry a message body, please check the message on the broker" instead of failing during decode.

## Test Evidence

**Fail-before** (unpatched code, two new tests `ClientRemotingProcessorTest#testCheckTransactionStateWithoutBody` / `#testConsumeMessageDirectlyWithoutBody` with `request.getBody() == null`):

```
docker exec rmq-build mvn -q -pl client test -Dtest='ClientRemotingProcessorTest#testCheckTransactionStateWithoutBody+testConsumeMessageDirectlyWithoutBody' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 2, Errors: 1 ... java.lang.NullPointerException: Cannot read the array length because "array" is null
```

**Pass-after** (full class with the fix):

```
docker exec rmq-build mvn -q -pl client test -Dtest='ClientRemotingProcessorTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a client-module self-audit).