### PR TITLE
[ISSUE #D12] Do not unlock RouteInfoManager locks that were never acquired

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.common.MixAll;
@@ -68,7 +67,7 @@ import org.apache.rocketmq.remoting.protocol.statictopic.TopicQueueMappingInfo;
 public class RouteInfoManager {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.NAMESRV_LOGGER_NAME);
     private static final long DEFAULT_BROKER_CHANNEL_EXPIRED_TIME = 1000 * 60 * 2;
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private final Map<String/* topic */, Map<String, QueueData>> topicQueueTable;
     private final Map<String/* brokerName */, BrokerData> brokerAddrTable;
     private final Map<String/* clusterName */, Set<String/* brokerName */>> clusterAddrTable;
@@ -151,7 +150,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("registerTopic Exception", e);
         } finally {
-            this.lock.writeLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.isWriteLockedByCurrentThread()) {
+                this.lock.writeLock().unlock();
+            }
         }
     }
 
@@ -162,7 +165,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("deleteTopic Exception", e);
         } finally {
-            this.lock.writeLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.isWriteLockedByCurrentThread()) {
+                this.lock.writeLock().unlock();
+            }
         }
     }
 
@@ -191,7 +198,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("deleteTopic Exception", e);
         } finally {
-            this.lock.writeLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.isWriteLockedByCurrentThread()) {
+                this.lock.writeLock().unlock();
+            }
         }
     }
 
@@ -203,7 +214,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("getAllTopicList Exception", e);
         } finally {
-            this.lock.readLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.getReadHoldCount() > 0) {
+                this.lock.readLock().unlock();
+            }
         }
 
         return topicList;
@@ -402,7 +417,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("registerBroker Exception", e);
         } finally {
-            this.lock.writeLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.isWriteLockedByCurrentThread()) {
+                this.lock.writeLock().unlock();
+            }
         }
 
         return result;
@@ -645,7 +664,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("unregisterBroker Exception", e);
         } finally {
-            this.lock.writeLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.isWriteLockedByCurrentThread()) {
+                this.lock.writeLock().unlock();
+            }
         }
     }
 
@@ -739,7 +762,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("pickupTopicRouteData Exception", e);
         } finally {
-            this.lock.readLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.getReadHoldCount() > 0) {
+                this.lock.readLock().unlock();
+            }
         }
 
         log.debug("pickupTopicRouteData {} {}", topic, topicRouteData);
@@ -1016,7 +1043,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("getSystemTopicList Exception", e);
         } finally {
-            this.lock.readLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.getReadHoldCount() > 0) {
+                this.lock.readLock().unlock();
+            }
         }
 
         return topicList;
@@ -1063,7 +1094,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("getUnitTopics Exception", e);
         } finally {
-            this.lock.readLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.getReadHoldCount() > 0) {
+                this.lock.readLock().unlock();
+            }
         }
 
         return topicList;
@@ -1084,7 +1119,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("getHasUnitSubTopicList Exception", e);
         } finally {
-            this.lock.readLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.getReadHoldCount() > 0) {
+                this.lock.readLock().unlock();
+            }
         }
 
         return topicList;
@@ -1106,7 +1145,11 @@ public class RouteInfoManager {
         } catch (Exception e) {
             log.error("getHasUnitSubUnUnitTopicList Exception", e);
         } finally {
-            this.lock.readLock().unlock();
+            // lockInterruptibly() may have thrown before the lock was acquired;
+            // unlocking it then would throw IllegalMonitorStateException
+            if (this.lock.getReadHoldCount() > 0) {
+                this.lock.readLock().unlock();
+            }
         }
 
         return topicList;

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
@@ -115,6 +115,34 @@ public class RouteInfoManagerTest {
     }
 
     @Test
+    public void testRegisterTopicWithInterruptedThread() {
+        QueueData queueData = new QueueData();
+        queueData.setBrokerName("default-broker");
+        queueData.setReadQueueNums(8);
+        queueData.setWriteQueueNums(8);
+
+        Thread.currentThread().interrupt();
+        try {
+            // lockInterruptibly() throws before the lock is acquired; the
+            // method must not leak IllegalMonitorStateException from finally
+            routeInfoManager.registerTopic("interrupted-topic", java.util.Collections.singletonList(queueData));
+        } finally {
+            // lockInterruptibly() clears the flag when it throws
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void testGetAllTopicListWithInterruptedThread() {
+        Thread.currentThread().interrupt();
+        try {
+            assertThat(routeInfoManager.getAllTopicList()).isNotNull();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     public void testRegisterBroker() {
         DataVersion dataVersion = new DataVersion();
         dataVersion.setCounter(new AtomicLong(10L));


### PR DESCRIPTION
## Motivation

Eleven `RouteInfoManager` methods acquire the route lock with `lockInterruptibly()` and release it in a `finally` that sits **outside** the catch clause:

```java
try {
    this.lock.writeLock().lockInterruptibly();
    ...
} catch (Exception e) {
    log.error("registerTopic Exception", e);
} finally {
    this.lock.writeLock().unlock();     // runs even if lockInterruptibly() threw
}
```

When the thread is interrupted while waiting for the lock (e.g. namesrv shutdown interrupts request processor threads that are contending for the route lock), `lockInterruptibly()` throws `InterruptedException`, the catch clause logs it, and the `finally` block then calls `unlock()` on a lock the current thread never acquired — `IllegalMonitorStateException` escapes the method to the request processor, turning a graceful degradation into a spurious error.

Affected methods: `registerTopic`, both `deleteTopic` overloads, `registerBroker`, `unregisterBroker`, `pickupTopicRouteData`, `getAllTopicList`, `getSystemTopicList`, `getUnitTopics`, `getHasUnitSubTopicList`, `getHasUnitSubUnUnitTopicList`.

## Modification

Guard each of the eleven `unlock()` calls so the lock is only released when the current thread actually holds it:

- write locks: `if (this.lock.isWriteLockedByCurrentThread())`
- read locks: `if (this.lock.getReadHoldCount() > 0)`

The `lock` field declaration changes from the `ReadWriteLock` interface to `ReentrantReadWriteLock` (the implementation it always was) so the guard methods are visible. No body is re-indented; behavior of every method is unchanged except that an interrupt during lock acquisition no longer leaks `IllegalMonitorStateException`.

## Test Evidence

**Fail-before** (unpatched code, new tests `RouteInfoManagerTest#testRegisterTopicWithInterruptedThread` / `#testGetAllTopicListWithInterruptedThread` — interrupt the current thread, then call the method):

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest#testRegisterTopicWithInterruptedThread+testGetAllTopicListWithInterruptedThread' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 2, Errors: 1 ... java.lang.IllegalMonitorStateException
```

**Pass-after** (full class with the fix):

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
```

Note: `RequestProcessorTest#testBrokerHeartBeat` errors with `NoSuchFieldException: modifiers` on this JDK both before and after the change (pre-existing, JDK reflection restriction), verified by running it on pristine develop.

No associated issue (self-discovered during a namesrv-module self-audit).