### PR TITLE
[ISSUE #D13] Honor registerBroker's null-tolerant wrapper contract before its guards

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -277,7 +277,11 @@ public class RouteInfoManager {
             if (null != oldBrokerAddr && !oldBrokerAddr.equals(brokerAddr)) {
                 BrokerLiveInfo oldBrokerInfo = brokerLiveTable.get(new BrokerAddrInfo(clusterName, oldBrokerAddr));
 
-                if (null != oldBrokerInfo) {
+                // The wrapper is decoded from the register body and may carry
+                // explicit null fields; without comparable versions skip the
+                // conflict rejection instead of aborting the registration.
+                if (null != oldBrokerInfo && null != oldBrokerInfo.getDataVersion()
+                    && null != topicConfigWrapper && null != topicConfigWrapper.getDataVersion()) {
                     long oldStateVersion = oldBrokerInfo.getDataVersion().getStateVersion();
                     long newStateVersion = topicConfigWrapper.getDataVersion().getStateVersion();
                     if (oldStateVersion > newStateVersion) {
@@ -291,7 +295,8 @@ public class RouteInfoManager {
                 }
             }
 
-            if (!brokerAddrsMap.containsKey(brokerId) && topicConfigWrapper.getTopicConfigTable().size() == 1) {
+            if (null != topicConfigWrapper && null != topicConfigWrapper.getTopicConfigTable()
+                && !brokerAddrsMap.containsKey(brokerId) && topicConfigWrapper.getTopicConfigTable().size() == 1) {
                 log.warn("Can't register topicConfigWrapper={} because broker[{}]={} has not registered.",
                     topicConfigWrapper.getTopicConfigTable(), brokerId, brokerAddr);
                 return null;
@@ -368,7 +373,7 @@ public class RouteInfoManager {
                 new BrokerLiveInfo(
                     System.currentTimeMillis(),
                     timeoutMillis == null ? DEFAULT_BROKER_CHANNEL_EXPIRED_TIME : timeoutMillis,
-                    topicConfigWrapper == null ? new DataVersion() : topicConfigWrapper.getDataVersion(),
+                    topicConfigWrapper == null || topicConfigWrapper.getDataVersion() == null ? new DataVersion() : topicConfigWrapper.getDataVersion(),
                     channel,
                     haServerAddr));
             if (null == prevBrokerLiveInfo) {

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
@@ -134,6 +134,38 @@ public class RouteInfoManagerTest {
     }
 
     @Test
+    public void testRegisterBrokerWithIncompleteWrapper() {
+        // A wrapper decoded from a malformed register body may carry explicit
+        // null fields; the registration must complete instead of aborting
+        // after partially updating the route tables.
+        TopicConfigSerializeWrapper incompleteWrapper = new TopicConfigSerializeWrapper();
+        incompleteWrapper.setDataVersion(null);
+        incompleteWrapper.setTopicConfigTable(null);
+        Channel channel = mock(Channel.class);
+
+        // same brokerId with a changed address runs into the version
+        // comparison before the method's own null guards
+        RegisterBrokerResult result = routeInfoManager.registerBroker("default-cluster", "127.0.0.1:20911",
+            "default-broker", 1234, "127.0.0.1:1001", "", null, incompleteWrapper, new ArrayList<>(), channel);
+
+        assertThat(result).isNotNull();
+        assertThat(routeInfoManager.queryBrokerTopicConfig("default-cluster", "127.0.0.1:20911")).isNotNull();
+    }
+
+    @Test
+    public void testRegisterBrokerWithNullWrapper() {
+        // registerBroker explicitly supports a null wrapper (it is null-checked
+        // further down and at the BrokerLiveInfo construction)
+        Channel channel = mock(Channel.class);
+
+        RegisterBrokerResult result = routeInfoManager.registerBroker("default-cluster", "127.0.0.1:30911",
+            "default-broker", 5678, null, "", null, null, null, channel);
+
+        assertThat(result).isNotNull();
+        assertThat(routeInfoManager.queryBrokerTopicConfig("default-cluster", "127.0.0.1:30911")).isNotNull();
+    }
+
+    @Test
     public void testWipeWritePermOfBrokerByLock() throws Exception {
         Map<String, QueueData> qdMap = new HashMap<>();
 


### PR DESCRIPTION
## Motivation

`RouteInfoManager.registerBroker` is written to tolerate a partially-filled `TopicConfigSerializeWrapper`: later in the method the wrapper is null-checked (`if (null != topicConfigWrapper ...)`), its table is null-checked (`if (tcTable != null)`), and the `BrokerLiveInfo` construction falls back to `new DataVersion()` for a null wrapper. But two earlier dereferences run before those guards:

```java
long newStateVersion = topicConfigWrapper.getDataVersion().getStateVersion();   // version-conflict check
...
if (!brokerAddrsMap.containsKey(brokerId) && topicConfigWrapper.getTopicConfigTable().size() == 1) {  // single-topic rejection
```

A wrapper decoded from a malformed register body can carry explicit `null` fields (JSON null), so:

- The version-conflict check NPEs, the catch clause aborts the registration **after** `clusterAddrTable`/`brokerAddrTable` were already mutated — the broker is left partially registered until its next heartbeat.
- A null `getDataVersion()` that reaches the `BrokerLiveInfo` construction is stored into `brokerLiveTable`, and every later address-change registration for that broker then NPEs at `oldBrokerInfo.getDataVersion().getStateVersion()`.

## Modification

- Skip the version-conflict rejection when either side's `DataVersion` is unavailable.
- Skip the single-topic rejection when the wrapper or its table is null.
- Fall back to `new DataVersion()` in the `BrokerLiveInfo` construction when `getDataVersion()` is null, not only when the whole wrapper is null.

## Test Evidence

**Fail-before** (unpatched code, new tests):

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest#testRegisterBrokerWithIncompleteWrapper' -Dsurefire.failIfNoSpecifiedTests=true
ERROR RocketmqNamesrv - registerBroker Exception
java.lang.NullPointerException: ... TopicConfigSerializeWrapper.getDataVersion()" is null
Tests run: 1, Failures: 1 ... Expecting actual not to be null   // registration aborted, no live entry for the new address

docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest#testRegisterBrokerWithNullWrapper' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 1, Failures: 1 ... Expecting actual not to be null
```

**Pass-after** (full class with the fix — both registrations complete):

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a namesrv-module self-audit).