### PR TITLE
[ISSUE #D14] Skip stale queueData in cleanTopicByUnRegisterRequests when broker data is gone

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -673,7 +673,13 @@ public class RouteInfoManager {
                 final QueueData queueData = queueDataMap.get(brokerName);
 
                 if (queueData != null) {
-                    if (this.brokerAddrTable.get(brokerName).isEnableActingMaster()) {
+                    final BrokerData brokerData = this.brokerAddrTable.get(brokerName);
+                    // The broker data may already be gone while a stale queueData is
+                    // still around (e.g. an earlier aborted unregister batch left it
+                    // behind); isNoMasterExists guards the same lookup, so a null
+                    // broker data must skip the perm wipe instead of aborting the
+                    // cleanup of the whole batch.
+                    if (brokerData != null && brokerData.isEnableActingMaster()) {
                         // Master has been unregistered, wipe the write perm
                         if (isNoMasterExists(brokerName)) {
                             queueData.setPerm(queueData.getPerm() & (~PermName.PERM_WRITE));

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
@@ -20,7 +20,9 @@ import io.netty.channel.Channel;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.rocketmq.common.TopicConfig;
@@ -28,7 +30,9 @@ import org.apache.rocketmq.common.constant.PermName;
 import org.apache.rocketmq.common.namesrv.NamesrvConfig;
 import org.apache.rocketmq.remoting.protocol.DataVersion;
 import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
+import org.apache.rocketmq.remoting.protocol.header.namesrv.UnRegisterBrokerRequestHeader;
 import org.apache.rocketmq.remoting.protocol.namesrv.RegisterBrokerResult;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.junit.After;
@@ -131,6 +135,59 @@ public class RouteInfoManagerTest {
         RegisterBrokerResult registerBrokerResult = routeInfoManager.registerBroker("default-cluster", "127.0.0.1:10911", "default-broker", 1234, "127.0.0.1:1001", "",
                 null, topicConfigSerializeWrapper, new ArrayList<>(), channel);
         assertThat(registerBrokerResult).isNotNull();
+    }
+
+    @Test
+    public void testUnregisterBrokerWithStaleQueueData() throws Exception {
+        // Two acting-master groups serving the same topics. healthy-broker
+        // keeps a slave after its master unregisters, while stale-broker's
+        // entry in brokerAddrTable is already gone and only its queueData is
+        // left behind - the state an earlier aborted unregister batch leaves.
+        ConcurrentHashMap<String, TopicConfig> topicConfigTable = new ConcurrentHashMap<>();
+        topicConfigTable.put("topic-a", new TopicConfig("topic-a"));
+        topicConfigTable.put("topic-b", new TopicConfig("topic-b"));
+        TopicConfigSerializeWrapper topicConfigSerializeWrapper = new TopicConfigSerializeWrapper();
+        topicConfigSerializeWrapper.setDataVersion(new DataVersion());
+        topicConfigSerializeWrapper.setTopicConfigTable(topicConfigTable);
+        Channel channel = mock(Channel.class);
+
+        assertThat(routeInfoManager.registerBroker("default-cluster", "127.0.0.1:40911", "stale-broker", 0, "127.0.0.1:1002", "",
+            null, true, topicConfigSerializeWrapper, new ArrayList<>(), channel)).isNotNull();
+        assertThat(routeInfoManager.registerBroker("default-cluster", "127.0.0.1:50911", "healthy-broker", 0, "127.0.0.1:1003", "",
+            null, true, topicConfigSerializeWrapper, new ArrayList<>(), channel)).isNotNull();
+        // the surviving slave keeps healthy-broker in the reducedBroker path
+        assertThat(routeInfoManager.registerBroker("default-cluster", "127.0.0.1:50912", "healthy-broker", 1, "127.0.0.1:1004", "",
+            null, true, topicConfigSerializeWrapper, new ArrayList<>(), channel)).isNotNull();
+
+        Field brokerAddrTableField = RouteInfoManager.class.getDeclaredField("brokerAddrTable");
+        brokerAddrTableField.setAccessible(true);
+        Map<String, BrokerData> brokerAddrTable = (Map<String, BrokerData>) brokerAddrTableField.get(routeInfoManager);
+        brokerAddrTable.remove("stale-broker");
+
+        UnRegisterBrokerRequestHeader staleRequest = new UnRegisterBrokerRequestHeader();
+        staleRequest.setClusterName("default-cluster");
+        staleRequest.setBrokerAddr("127.0.0.1:40911");
+        staleRequest.setBrokerName("stale-broker");
+        staleRequest.setBrokerId(0L);
+        UnRegisterBrokerRequestHeader healthyRequest = new UnRegisterBrokerRequestHeader();
+        healthyRequest.setClusterName("default-cluster");
+        healthyRequest.setBrokerAddr("127.0.0.1:50911");
+        healthyRequest.setBrokerName("healthy-broker");
+        healthyRequest.setBrokerId(0L);
+
+        Set<UnRegisterBrokerRequestHeader> requests = new LinkedHashSet<>();
+        requests.add(staleRequest);
+        requests.add(healthyRequest);
+        routeInfoManager.unRegisterBroker(requests);
+
+        // healthy-broker's master is offline, so its queueData must be wiped
+        // to read-only; before the fix the stale entry NPE'd first and the
+        // cleanup of the whole batch was skipped.
+        Field topicQueueTableField = RouteInfoManager.class.getDeclaredField("topicQueueTable");
+        topicQueueTableField.setAccessible(true);
+        Map<String, Map<String, QueueData>> topicQueueTable = (Map<String, Map<String, QueueData>>) topicQueueTableField.get(routeInfoManager);
+        assertThat(topicQueueTable.get("topic-a").get("healthy-broker").getPerm()).isEqualTo(PermName.PERM_READ);
+        assertThat(topicQueueTable.get("topic-b").get("healthy-broker").getPerm()).isEqualTo(PermName.PERM_READ);
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`cleanTopicByUnRegisterRequests` dereferences `brokerAddrTable.get(brokerName)` without a null check while iterating `reducedBroker`:

```java
if (this.brokerAddrTable.get(brokerName).isEnableActingMaster()) {
```

A brokerName lands in `reducedBroker` exactly when the request loop found **no** `BrokerData` for it (or the group still has addresses left). If a topic still carries a `queueData` for such a brokerName, this line throws an NPE. The sibling `isNoMasterExists` null-checks the very same lookup, this call site just forgot to.

The stale state is reachable and self-propagating: `unRegisterBroker(Set)` mutates `brokerAddrTable`/`brokerLiveTable` in the request loop and only cleans `topicQueueTable` afterwards in `cleanTopicByUnRegisterRequests`, all inside one try/catch. Any exception thrown mid-batch (e.g. this very NPE) is swallowed by the catch, so the queueData cleanup for the not-yet-iterated topics is silently skipped while the broker data is already gone. From then on every later unregister request for such a brokerName (channel-destroy resubmits are common during connection flapping) re-triggers the NPE and aborts its whole batch again.

The abort has real consequences for the remaining requests of the batch: the write-perm wipe for masterless acting-master groups never happens (clients keep writing to a group without a master) and `notifyMinBrokerIdChanged` is skipped.

## Modification

Hoist the `brokerAddrTable.get(brokerName)` lookup and skip the perm wipe when the broker data is already gone, mirroring the null check in `isNoMasterExists`.

## Test Evidence

New test `testUnregisterBrokerWithStaleQueueData` registers two acting-master groups serving the same topics, removes one group's `BrokerData` to simulate the state an aborted batch leaves behind, and unregisters both groups' masters in one batch. It asserts the surviving group's queueData is wiped to read-only.

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest#testUnregisterBrokerWithStaleQueueData' -Dsurefire.failIfNoSpecifiedTests=true
```

Before the fix:

```
java.lang.NullPointerException: Cannot invoke "BrokerData.isEnableActingMaster()" because the return value of "Map.get(Object)" is null
    at RouteInfoManager.cleanTopicByUnRegisterRequests(RouteInfoManager.java:676)
Tests run: 1, Failures: 1, Errors: 0  (expected: 4 but perm stayed read-write)
```

After the fix:

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a namesrv self-audit).