### PR TITLE
[ISSUE #D15] Report unknown cluster as error instead of empty success in getTopicsByCluster

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
@@ -526,6 +526,11 @@ public class DefaultRequestProcessor implements NettyRequestProcessor {
             (GetTopicsByClusterRequestHeader) request.decodeCommandCustomHeader(GetTopicsByClusterRequestHeader.class);
 
         TopicList topicsByCluster = this.namesrvController.getRouteInfoManager().getTopicsByCluster(requestHeader.getCluster());
+        if (topicsByCluster == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark(String.format("cluster[%s] not exist", requestHeader.getCluster()));
+            return response;
+        }
         byte[] body = topicsByCluster.encode();
 
         response.setBody(body);

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -1028,6 +1028,12 @@ public class RouteInfoManager {
             try {
                 this.lock.readLock().lockInterruptibly();
                 Set<String> brokerNameSet = this.clusterAddrTable.get(cluster);
+                if (brokerNameSet == null) {
+                    // An unknown cluster (never registered, or all its brokers
+                    // unregistered, which drops the cluster key) is not the same
+                    // as a cluster whose brokers serve no topics.
+                    return null;
+                }
                 for (String brokerName : brokerNameSet) {
                     for (Entry<String, Map<String, QueueData>> topicEntry : this.topicQueueTable.entrySet()) {
                         String topic = topicEntry.getKey();

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessorGetTopicsByClusterTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessorGetTopicsByClusterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.namesrv.processor;
+
+import io.netty.channel.Channel;
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.common.namesrv.NamesrvConfig;
+import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.namesrv.NamesrvController;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DefaultRequestProcessorGetTopicsByClusterTest {
+
+    private DefaultRequestProcessor defaultRequestProcessor;
+
+    @Before
+    public void init() {
+        NamesrvController namesrvController = new NamesrvController(new NamesrvConfig(), new NettyServerConfig());
+        defaultRequestProcessor = new DefaultRequestProcessor(namesrvController);
+
+        TopicConfigSerializeWrapper topicConfigSerializeWrapper = new TopicConfigSerializeWrapper();
+        ConcurrentHashMap<String, TopicConfig> topicConfigTable = new ConcurrentHashMap<>();
+        for (int i = 0; i < 2; i++) {
+            TopicConfig topicConfig = new TopicConfig("unit-test" + i);
+            topicConfigTable.put(topicConfig.getTopicName(), topicConfig);
+        }
+        topicConfigSerializeWrapper.setTopicConfigTable(topicConfigTable);
+        namesrvController.getRouteInfoManager().registerBroker("default-cluster", "127.0.0.1:10911", "default-broker",
+            1234, "127.0.0.1:1001", "", null, topicConfigSerializeWrapper, new ArrayList<>(), mock(Channel.class));
+    }
+
+    @Test
+    public void testGetTopicsByCluster() throws Exception {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_TOPICS_BY_CLUSTER, null);
+        request.addExtField("cluster", "default-cluster");
+
+        RemotingCommand response = defaultRequestProcessor.processRequest(null, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(TopicList.decode(response.getBody(), TopicList.class).getTopicList())
+            .containsExactlyInAnyOrder("unit-test0", "unit-test1");
+    }
+
+    @Test
+    public void testGetTopicsByClusterNotExisted() throws Exception {
+        // An unknown cluster used to be reported as an empty success, which
+        // clients cannot distinguish from a cluster that simply has no topics.
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_TOPICS_BY_CLUSTER, null);
+        request.addExtField("cluster", "not-exist-cluster");
+
+        RemotingCommand response = defaultRequestProcessor.processRequest(null, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("not-exist-cluster");
+    }
+}

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerTest.java
@@ -173,6 +173,15 @@ public class RouteInfoManagerTest {
     }
 
     @Test
+    public void testGetTopicsByClusterNotExisted() {
+        // An unknown cluster must be distinguishable from a cluster whose
+        // brokers serve no topics: before the fix the unknown-cluster lookup
+        // NPE'd on the null set, was swallowed by the catch and reported as
+        // an empty topic list.
+        assertThat(routeInfoManager.getTopicsByCluster("not-exist-cluster")).isNull();
+    }
+
+    @Test
     public void testGetUnitTopics() {
         byte[] topicList = routeInfoManager.getUnitTopics().encode();
         assertThat(topicList).isNotNull();


### PR DESCRIPTION
## Motivation

Querying the topics of a cluster that the nameserver does not know (typo in `mqadmin topicList -c`, or a cluster whose brokers all unregistered, which drops the cluster key from `clusterAddrTable`) currently produces two problems:

1. `RouteInfoManager.getTopicsByCluster` dereferences the result of `clusterAddrTable.get(cluster)` without a null check and NPEs on the for-loop; the nested catch swallows it and every query logs a full stack trace.
2. `DefaultRequestProcessor.getTopicsByCluster` then encodes the empty `TopicList` and answers `SUCCESS`, so the client cannot distinguish "cluster has no topics" from "cluster does not exist".

## Modification

- `RouteInfoManager.getTopicsByCluster` returns `null` for an unknown cluster, mirroring how `pickupTopicRouteData` signals a missing topic.
- `DefaultRequestProcessor.getTopicsByCluster` maps the null result to `SYSTEM_ERROR` with a `cluster[...] not exist` remark, so clients (e.g. `mqadmin topicList -c`) get a clear error instead of an empty list.

## Test Evidence

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='RouteInfoManagerTest#testGetTopicsByClusterNotExisted' -Dsurefire.failIfNoSpecifiedTests=true
docker exec rmq-build mvn -q -pl namesrv test -Dtest='DefaultRequestProcessorGetTopicsByClusterTest' -Dsurefire.failIfNoSpecifiedTests=true
```

Before the fix:

```
java.lang.NullPointerException: Cannot invoke "Set.iterator()" because "brokerNameSet" is null
    at RouteInfoManager.getTopicsByCluster(RouteInfoManager.java:1031)
RouteInfoManagerTest#testGetTopicsByClusterNotExisted: expected null but was an empty TopicList  (Tests run: 1, Failures: 1)
DefaultRequestProcessorGetTopicsByClusterTest#testGetTopicsByClusterNotExisted: expected SYSTEM_ERROR but got SUCCESS  (Tests run: 2, Failures: 1)
```

After the fix:

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='DefaultRequestProcessorGetTopicsByClusterTest,RouteInfoManagerTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 - in DefaultRequestProcessorGetTopicsByClusterTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 - in RouteInfoManagerTest
```

Note: the processor assertions live in a new test class because `RequestProcessorTest`'s setUp uses a `Field.modifiers` reflection hack that cannot run on JDK 12+ (verified pre-existing on develop with the container's JDK 17/21).

No associated issue (self-discovered during a namesrv self-audit).