### PR TITLE
[ISSUE #D16] Reject PUT_KV_CONFIG with a null value instead of storing it

### DIFF
--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessor.java
@@ -158,9 +158,9 @@ public class DefaultRequestProcessor implements NettyRequestProcessor {
         final PutKVConfigRequestHeader requestHeader =
             (PutKVConfigRequestHeader) request.decodeCommandCustomHeader(PutKVConfigRequestHeader.class);
 
-        if (requestHeader.getNamespace() == null || requestHeader.getKey() == null) {
+        if (requestHeader.getNamespace() == null || requestHeader.getKey() == null || requestHeader.getValue() == null) {
             response.setCode(ResponseCode.SYSTEM_ERROR);
-            response.setRemark("namespace or key is null");
+            response.setRemark("namespace or key or value is null");
             return response;
         }
 

--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessorPutKVConfigTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/processor/DefaultRequestProcessorPutKVConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.namesrv.processor;
+
+import org.apache.rocketmq.common.namesrv.NamesrvConfig;
+import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.RequestCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.namesrv.NamesrvController;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultRequestProcessorPutKVConfigTest {
+
+    private DefaultRequestProcessor defaultRequestProcessor;
+
+    private NamesrvController namesrvController;
+
+    @Before
+    public void init() {
+        namesrvController = new NamesrvController(new NamesrvConfig(), new NettyServerConfig());
+        defaultRequestProcessor = new DefaultRequestProcessor(namesrvController);
+    }
+
+    @Test
+    public void testPutKVConfig() throws Exception {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.PUT_KV_CONFIG, null);
+        request.addExtField("namespace", "namespace");
+        request.addExtField("key", "key");
+        request.addExtField("value", "value");
+
+        RemotingCommand response = defaultRequestProcessor.processRequest(null, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(namesrvController.getKvConfigManager().getKVConfig("namespace", "key"))
+            .isEqualTo("value");
+    }
+
+    @Test
+    public void testPutKVConfigWithoutValue() throws Exception {
+        // A request without the value field decodes to a null value (the
+        // @CFNotNull violation of the reflective decode is logged and
+        // swallowed), so the processor must reject it itself instead of
+        // storing an entry that every later read reports as not found.
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.PUT_KV_CONFIG, null);
+        request.addExtField("namespace", "namespace");
+        request.addExtField("key", "key");
+
+        RemotingCommand response = defaultRequestProcessor.processRequest(null, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+        assertThat(response.getRemark()).contains("value");
+        assertThat(namesrvController.getKvConfigManager().getKVConfig("namespace", "key")).isNull();
+    }
+}


### PR DESCRIPTION
## Motivation

`DefaultRequestProcessor.putKVConfig` validates the decoded `namespace` and `key` but not `value`. The check matters more than `@CFNotNull` suggests: for headers that are not `FastCodesHeader`, `RemotingCommand.decodeCommandCustomHeaderDirectly` throws a `RemotingCommandException` for a missing `@CFNotNull` field but the surrounding per-field `catch (Throwable)` only logs it (`Failed field [value] decoding`), so a request without the value field decodes to a header with `value == null` instead of being rejected.

The consequence: the nameserver answers `SUCCESS`, stores `kvTable.put(key, null)`, and every later `GET_KV_CONFIG` for that key answers `QUERY_NOT_FOUND` — the entry exists but is unreadable, and the persisted kvConfig JSON now carries a null value.

## Modification

Extend the existing null check in `putKVConfig` to the value field and reject with `SYSTEM_ERROR` + `"namespace or key or value is null"`.

## Test Evidence

New test class `DefaultRequestProcessorPutKVConfigTest` (plain setup, no reflection hacks, so it runs on any JDK).

```
docker exec rmq-build mvn -q -pl namesrv test -Dtest='DefaultRequestProcessorPutKVConfigTest' -Dsurefire.failIfNoSpecifiedTests=true
```

Before the fix:

```
org.apache.rocketmq.remoting.exception.RemotingCommandException: the custom field <value> is null   (logged by the decode, then swallowed)
testPutKVConfigWithoutValue: expected SYSTEM_ERROR but got SUCCESS  (Tests run: 2, Failures: 1)
```

After the fix:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a namesrv self-audit).