### PR TITLE
[ISSUE #D17] Discard delayed messages with malformed real topic or queue id in messageTimeUp

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/schedule/ScheduleMessageService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/schedule/ScheduleMessageService.java
@@ -354,10 +354,23 @@ public class ScheduleMessageService extends ConfigManager {
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_TIMER_DELIVER_MS);
         MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_TIMER_DELAY_SEC);
 
-        msgInner.setTopic(msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC));
-
+        // The message can only be rewritten to its destination topic when both
+        // properties are usable; without them it can never be delivered and
+        // throwing here would abort the scan of the whole delay queue batch.
+        String realTopic = msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC);
         String queueIdStr = msgInner.getProperty(MessageConst.PROPERTY_REAL_QUEUE_ID);
-        int queueId = Integer.parseInt(queueIdStr);
+        if (realTopic == null || queueIdStr == null) {
+            log.error("[BUG] the real topic or queue id of schedule msg is missing, discard the msg. msg={}", msgInner);
+            return null;
+        }
+        int queueId;
+        try {
+            queueId = Integer.parseInt(queueIdStr);
+        } catch (NumberFormatException e) {
+            log.error("[BUG] the real queue id of schedule msg is {}, discard the msg. msg={}", queueIdStr, msgInner);
+            return null;
+        }
+        msgInner.setTopic(realTopic);
         msgInner.setQueueId(queueId);
 
         return msgInner;
@@ -460,6 +473,9 @@ public class ScheduleMessageService extends ConfigManager {
                     }
 
                     MessageExtBrokerInner msgInner = ScheduleMessageService.this.messageTimeUp(msgExt);
+                    if (msgInner == null) {
+                        continue;
+                    }
                     if (TopicValidator.RMQ_SYS_TRANS_HALF_TOPIC.equals(msgInner.getTopic())) {
                         log.error("[BUG] the real topic of schedule msg is {}, discard the msg. msg={}",
                             msgInner.getTopic(), msgInner);
@@ -791,6 +807,11 @@ public class ScheduleMessageService extends ConfigManager {
                 }
 
                 MessageExtBrokerInner msgInner = ScheduleMessageService.this.messageTimeUp(msgExt);
+                if (msgInner == null) {
+                    log.warn("ScheduleMessageService resend discard malformed msg. info: {}", this.toString());
+                    this.status = need2Skip() ? ProcessStatus.SKIP : ProcessStatus.EXCEPTION;
+                    return;
+                }
                 PutMessageResult result = ScheduleMessageService.this.brokerController.getEscapeBridge().putMessage(msgInner);
                 this.handleResult(result);
                 if (result != null && result.getPutMessageStatus() == PutMessageStatus.PUT_OK) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/schedule/ScheduleMessageServiceTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/schedule/ScheduleMessageServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.schedule;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -39,6 +40,7 @@ import org.apache.rocketmq.broker.util.HookUtils;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.UtilAll;
 import org.apache.rocketmq.common.message.MessageDecoder;
+import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageExtBrokerInner;
 import org.apache.rocketmq.store.ConsumeQueueExt;
@@ -282,6 +284,30 @@ public class ScheduleMessageServiceTest {
 
         // just decode
         scheduleMessageService.decode(new DelayOffsetSerializeWrapper().toJson());
+    }
+
+    @Test
+    public void testMessageTimeUpWithMalformedRealQueueId() throws Exception {
+        Method messageTimeUp = ScheduleMessageService.class.getDeclaredMethod("messageTimeUp", MessageExt.class);
+        messageTimeUp.setAccessible(true);
+
+        // a delayed message whose destination properties are missing or
+        // malformed can never be delivered; it must be discarded instead of
+        // aborting the conversion with a raw exception
+        MessageExt msgExt = buildMessage();
+        msgExt.getProperties().put(MessageConst.PROPERTY_REAL_TOPIC, topic);
+        msgExt.getProperties().put(MessageConst.PROPERTY_REAL_QUEUE_ID, "notANumber");
+        assertThat(messageTimeUp.invoke(scheduleMessageService, msgExt)).isNull();
+
+        msgExt.getProperties().put(MessageConst.PROPERTY_REAL_QUEUE_ID, "0");
+        assertThat(messageTimeUp.invoke(scheduleMessageService, msgExt)).isNotNull();
+
+        msgExt.getProperties().remove(MessageConst.PROPERTY_REAL_QUEUE_ID);
+        assertThat(messageTimeUp.invoke(scheduleMessageService, msgExt)).isNull();
+
+        msgExt.getProperties().put(MessageConst.PROPERTY_REAL_QUEUE_ID, "0");
+        msgExt.getProperties().remove(MessageConst.PROPERTY_REAL_TOPIC);
+        assertThat(messageTimeUp.invoke(scheduleMessageService, msgExt)).isNull();
     }
 
     private GetMessageResult getMessage(int queueId, Long offset) {


### PR DESCRIPTION
## Motivation

`ScheduleMessageService.messageTimeUp` rewrites a delayed message back to its destination with

```java
msgInner.setTopic(msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC));
String queueIdStr = msgInner.getProperty(MessageConst.PROPERTY_REAL_QUEUE_ID);
int queueId = Integer.parseInt(queueIdStr);
```

A delayed message in `SCHEDULE_TOPIC` whose destination properties are missing or malformed (corrupted properties string, or a hand-crafted message written straight into the system topic) makes this throw:

- `Integer.parseInt(null)` / `NumberFormatException` propagates to `DeliverDelayedMessageTimerTask.executeOnTimeUp`, whose catch aborts the scan of the current consume-queue batch — the remaining messages of that batch each lose one delivery cycle and every occurrence logs a full stack trace.
- a missing `PROPERTY_REAL_TOPIC` is worse: the topic becomes `null`, `putMessage` rejects it, `syncDeliver` returns false and the task reschedules the same offset forever, wedging that delay level.

The adjacent real-topic guard (`[BUG] the real topic of schedule msg is ..., discard the msg`) already established that such messages must be discarded, but only for one specific wrong value, not for the missing/malformed cases.

## Modification

- `messageTimeUp` validates `PROPERTY_REAL_TOPIC` and `PROPERTY_REAL_QUEUE_ID` before using them and returns `null` when the destination is unusable, logging a `[BUG] ... discard` line like the existing guard.
- Both call sites (`executeOnTimeUp` and `PutResultProcess.doResend`) skip a null conversion result, so the rest of the batch is still processed in-cycle and a resend of a permanently malformed message is marked skip/exception instead of retrying.

## Test Evidence

New test `testMessageTimeUpWithMalformedRealQueueId` covers: non-numeric queue id, missing queue id, missing real topic, and the well-formed case.

```
docker exec rmq-build mvn -q -pl broker test -Dtest='ScheduleMessageServiceTest#testMessageTimeUpWithMalformedRealQueueId' -Dsurefire.failIfNoSpecifiedTests=true
```

Before the fix:

```
java.lang.reflect.InvocationTargetException
Caused by: java.lang.NumberFormatException: For input string: "notANumber"
Tests run: 1, Failures: 0, Errors: 1
```

After the fix:

```
docker exec rmq-build mvn -q -pl broker test -Dtest='ScheduleMessageServiceTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0   (includes the end-to-end testDeliverDelayedMessageTimerTask)
```

No associated issue (self-discovered during a broker self-audit).