### PR TITLE
[ISSUE #D18] Discard timer messages with malformed real topic or queue id in convertMessage

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/TimerMessageStore.java
@@ -1264,8 +1264,25 @@ public class TimerMessageStore {
             msgInner.setTopic(msgExt.getTopic());
             msgInner.setQueueId(msgExt.getQueueId());
         } else {
-            msgInner.setTopic(msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC));
-            msgInner.setQueueId(Integer.parseInt(msgInner.getProperty(MessageConst.PROPERTY_REAL_QUEUE_ID)));
+            String realTopic = msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC);
+            String queueIdStr = msgInner.getProperty(MessageConst.PROPERTY_REAL_QUEUE_ID);
+            // A timer message without a usable destination can never be
+            // delivered; throwing here wedges the dequeue thread, which
+            // retries the same request forever when timerSkipUnknownError
+            // is false (the default).
+            if (realTopic == null || queueIdStr == null) {
+                LOGGER.warn("[BUG] the real topic or queue id of timer msg is missing, discard the msg. msg={}", msgInner);
+                return null;
+            }
+            int queueId;
+            try {
+                queueId = Integer.parseInt(queueIdStr);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("[BUG] the real queue id of timer msg is {}, discard the msg. msg={}", queueIdStr, msgInner);
+                return null;
+            }
+            msgInner.setTopic(realTopic);
+            msgInner.setQueueId(queueId);
             MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_REAL_TOPIC);
             MessageAccessor.clearProperty(msgInner, MessageConst.PROPERTY_REAL_QUEUE_ID);
         }
@@ -1647,6 +1664,10 @@ public class TimerMessageStore {
 
                                 addMetric(msgExt, -1);
                                 MessageExtBrokerInner msg = convert(msgExt, tr.getEnqueueTime(), needRoll(tr.getMagic()));
+                                if (msg == null) {
+                                    TimerMessageStore.LOGGER.warn("Skipping message due to missing or malformed destination. Msg: {}", msgExt);
+                                    break;
+                                }
 
                                 boolean processed = false;
                                 int retryCount = 0;

--- a/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
@@ -205,6 +205,31 @@ public class TimerMessageStoreTest {
     }
 
     @Test
+    public void testConvertMessageWithMalformedDestination() throws Exception {
+        final TimerMessageStore timerMessageStore = createTimerMessageStore(null, true);
+
+        // A timer message whose destination properties are missing or
+        // malformed can never be delivered; it must be discarded instead of
+        // aborting the conversion with a raw exception.
+        MessageExtBrokerInner msgExt = buildMessage(3000, "TimerTest_testConvertMessageMalformed", false);
+        msgExt.setTopic(TimerMessageStore.TIMER_TOPIC);
+
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_TOPIC, "TimerTest_testConvertMessageMalformed");
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_QUEUE_ID, "notANumber");
+        assertNull(timerMessageStore.convertMessage(msgExt, false));
+
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_QUEUE_ID, "0");
+        assertNotNull(timerMessageStore.convertMessage(msgExt, false));
+
+        msgExt.getProperties().remove(MessageConst.PROPERTY_REAL_QUEUE_ID);
+        assertNull(timerMessageStore.convertMessage(msgExt, false));
+
+        MessageAccessor.putProperty(msgExt, MessageConst.PROPERTY_REAL_QUEUE_ID, "0");
+        msgExt.getProperties().remove(MessageConst.PROPERTY_REAL_TOPIC);
+        assertNull(timerMessageStore.convertMessage(msgExt, false));
+    }
+
+    @Test
     public void testPutTimerMessage() throws Exception {
         Assume.assumeFalse(MixAll.isWindows());
         String topic = "TimerTest_testPutTimerMessage";


### PR DESCRIPTION
## Motivation

`TimerMessageStore.convertMessage` rewrites a timer message back to its destination when it is not rolled:

```java
msgInner.setTopic(msgInner.getProperty(MessageConst.PROPERTY_REAL_TOPIC));
msgInner.setQueueId(Integer.parseInt(msgInner.getProperty(MessageConst.PROPERTY_REAL_QUEUE_ID)));
```

A timer message in `rmq_sys_wheel_timer` whose destination properties are missing or malformed (corrupted properties, or a message written straight into the system topic) makes the second line throw `NumberFormatException`. In the dequeue thread (`DequeuePutService`), the surrounding `catch (Throwable)` logs "Unknown error" and then — because `timerSkipUnknownError` defaults to **false** — calls `holdMomentForUnknownError()` and loops back to the *same* `TimerRequest`: the conversion throws again, so one poison message wedges the timer dequeue thread in an endless sleep-retry loop and no later timer message is delivered.

## Modification

- `convertMessage` validates `PROPERTY_REAL_TOPIC` and `PROPERTY_REAL_QUEUE_ID` before using them and returns `null` when the destination is unusable, logging a `[BUG] ... discard` line (mirroring the guard style of `ScheduleMessageService.messageTimeUp`).
- The dequeue call site skips a null conversion result ("Skipping message due to missing or malformed destination"), releases the request and moves on.

## Test Evidence

New test `testConvertMessageWithMalformedDestination` covers: non-numeric queue id, missing queue id, missing real topic, and the well-formed case.

```
docker exec rmq-build mvn -q -pl store test -Dtest='TimerMessageStoreTest#testConvertMessageWithMalformedDestination' -Dsurefire.failIfNoSpecifiedTests=true
```

Before the fix:

```
java.lang.NumberFormatException: For input string: "notANumber"
Tests run: 1, Failures: 0, Errors: 1
```

After the fix:

```
docker exec rmq-build mvn -q -pl store test -Dtest='TimerMessageStoreTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a store self-audit).