### PR TITLE
[ISSUE #D19] Tolerate null pull result when checking half messages

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImpl.java
@@ -218,6 +218,17 @@ public class TransactionalMessageServiceImpl implements TransactionalMessageServ
                             if (getMessageNullCount++ > MAX_RETRY_COUNT_WHEN_HALF_NULL) {
                                 break;
                             }
+                            // The bridge answers a null pull result when the store
+                            // itself cannot serve the read (e.g. during shutdown);
+                            // retry this offset on the next check round instead of
+                            // throwing, which would abort the check of the
+                            // remaining queues too. The tail of this method guards
+                            // the same lookup for null.
+                            if (getResult.getPullResult() == null) {
+                                log.warn("Get half message from store failed, the miss offset={} in={}, continue check={}",
+                                    i, messageQueue, getMessageNullCount);
+                                break;
+                            }
                             if (getResult.getPullResult().getPullStatus() == PullStatus.NO_NEW_MSG) {
                                 log.debug("No new msg, the miss offset={} in={}, continue check={}, pull result={}", i,
                                     messageQueue, getMessageNullCount, getResult.getPullResult());

--- a/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/transaction/queue/TransactionalMessageServiceImplTest.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -126,6 +127,34 @@ public class TransactionalMessageServiceImplTest {
         }).when(listener).resolveDiscardMsg(any(MessageExt.class));
         queueTransactionMsgService.check(timeOut, checkMax, listener);
         assertThat(checkMessage.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testCheck_whenHalfMessagePullFails() {
+        when(bridge.fetchMessageQueues(TopicValidator.RMQ_SYS_TRANS_HALF_TOPIC)).thenReturn(createMessageQueueSet(TopicValidator.RMQ_SYS_TRANS_HALF_TOPIC));
+        when(bridge.getHalfMessage(0, 0, 1)).thenReturn(createDiscardPullResult(TopicValidator.RMQ_SYS_TRANS_HALF_TOPIC, 5, "hellp", 1));
+        // the store cannot serve the read for the next offset, so the bridge
+        // answers a null pull result
+        when(bridge.getHalfMessage(0, 1, 1)).thenReturn(null);
+        when(bridge.getOpMessage(anyInt(), anyLong(), anyInt())).thenReturn(createOpPulResult(TopicValidator.RMQ_SYS_TRANS_OP_HALF_TOPIC, 1, "10", 1));
+        when(bridge.getBrokerController()).thenReturn(this.brokerController);
+        long timeOut = this.brokerController.getBrokerConfig().getTransactionTimeOut();
+        int checkMax = this.brokerController.getBrokerConfig().getTransactionCheckMax();
+        final AtomicInteger discardMessage = new AtomicInteger(0);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                discardMessage.addAndGet(1);
+                return null;
+            }
+        }).when(listener).resolveDiscardMsg(any(MessageExt.class));
+        queueTransactionMsgService.check(timeOut, checkMax, listener);
+        assertThat(discardMessage.get()).isEqualTo(1);
+        // the offset of the already-checked message must still be committed,
+        // while the unread offset is retried on the next check round; before
+        // the fix the null pull result aborted the whole check with an NPE
+        // before the offset update
+        verify(bridge).updateConsumeOffset(any(MessageQueue.class), eq(1L));
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`TransactionalMessageServiceImpl.check` iterates the half topic and, for an offset whose message cannot be fetched, inspects the pull status:

```java
if (getResult.getPullResult().getPullStatus() == PullStatus.NO_NEW_MSG) {
```

But `getHalfMsg` only fills `getResult.pullResult` when `TransactionalMessageBridge.getMessage` returns non-null, and that method **returns null** whenever `store.getMessage` does ("Get message from store return null" — e.g. the store is shutting down or not readable). In that case `getPullResult()` is null and this line throws an NPE.

The NPE is swallowed by the outermost `catch (Throwable)` of `check`, which means the entire check cycle is aborted: the offset update for the already-processed messages of the current queue is skipped and every remaining queue of the half topic is not checked at all, for as long as the store keeps failing to serve reads.

Notably the tail of the very same method already guards the same lookup for null (`getResult.getPullResult() == null ? newOffset : ...`); the guard is just missing here.

## Modification

Treat a null pull result like the other unread-offset cases: log a warning and `break` out of this queue's loop, so the consume offset of the messages that were already checked is still committed and the unread offset is retried on the next check round.

## Test Evidence

New test `testCheck_whenHalfMessagePullFails`: offset 0 returns a discardable half message, offset 1 hits the store read failure (bridge returns null). It asserts the discard listener fired and that `updateConsumeOffset(queue, 1)` was called.

```
docker exec rmq-build mvn -q -pl broker test -Dtest='TransactionalMessageServiceImplTest#testCheck_whenHalfMessagePullFails' -Dsurefire.failIfNoSpecifiedTests=true
```

Before the fix:

```
java.lang.NullPointerException: Cannot invoke "PullResult.getPullStatus()" because the return value of "GetResult.getPullResult()" is null
Wanted but not invoked: bridge.updateConsumeOffset(...)   (Tests run: 1, Failures: 1)
```

After the fix:

```
docker exec rmq-build mvn -q -pl broker test -Dtest='TransactionalMessageServiceImplTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

No associated issue (self-discovered during a broker self-audit).