### PR TITLE
[D20] Skip malformed orderTopicConf segments in topicRouteData2TopicPublishInfo

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java
@@ -266,7 +266,20 @@ public class MQClientInstance {
             String[] brokers = route.getOrderTopicConf().split(";");
             for (String broker : brokers) {
                 String[] item = broker.split(":");
-                int nums = Integer.parseInt(item[1]);
+                // The order topic conf is a manually maintained name server kv config;
+                // a malformed segment must be skipped instead of letting an unchecked
+                // exception abort the route conversion for the whole topic.
+                if (item.length != 2) {
+                    log.warn("skip malformed order topic conf segment. segment={}, orderTopicConf={}", broker, route.getOrderTopicConf());
+                    continue;
+                }
+                int nums;
+                try {
+                    nums = Integer.parseInt(item[1]);
+                } catch (NumberFormatException e) {
+                    log.warn("skip malformed order topic conf segment. segment={}, orderTopicConf={}", broker, route.getOrderTopicConf());
+                    continue;
+                }
                 for (int i = 0; i < nums; i++) {
                     MessageQueue mq = new MessageQueue(topic, item[0], i);
                     info.getMessageQueueList().add(mq);

--- a/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/impl/factory/MQClientInstanceTest.java
@@ -252,6 +252,18 @@ public class MQClientInstanceTest {
     }
 
     @Test
+    public void testTopicRouteData2TopicPublishInfoWithMalformedOrderTopicConf() {
+        TopicRouteData topicRouteData = createTopicRouteData();
+        topicRouteData.setOrderTopicConf("broker-a:8;broker-b;broker-c:eight;broker-d:2");
+        TopicPublishInfo actual = MQClientInstance.topicRouteData2TopicPublishInfo(topic, topicRouteData);
+        assertTrue(actual.isOrderTopic());
+        assertEquals(10, actual.getMessageQueueList().size());
+        assertTrue(actual.getMessageQueueList().contains(new MessageQueue(topic, "broker-a", 7)));
+        assertTrue(actual.getMessageQueueList().contains(new MessageQueue(topic, "broker-d", 1)));
+        assertFalse(actual.getMessageQueueList().contains(new MessageQueue(topic, "broker-b", 0)));
+    }
+
+    @Test
     public void testTopicRouteData2TopicPublishInfoWithTopicQueueMappingByBroker() {
         TopicRouteData topicRouteData = createTopicRouteData();
         topicRouteData.setTopicQueueMappingByBroker(Collections.singletonMap(topic, new TopicQueueMappingInfo()));


### PR DESCRIPTION
## Motivation

The order topic conf is a manually maintained name server kv config (`NAMESPACE_ORDER_TOPIC_CONFIG`, set via `updateKvConfig`) that is delivered to clients inside `TopicRouteData` when `orderMessageEnable` is on.

`MQClientInstance.topicRouteData2TopicPublishInfo` parses each `brokerName:queueNums` segment with `split(":")` and `Integer.parseInt(item[1])` without any validation, so a single typo in the kv value — a segment without `:", or a non-numeric queue count — makes the conversion throw `ArrayIndexOutOfBoundsException` or `NumberFormatException`:

```java
String[] item = broker.split(":");
int nums = Integer.parseInt(item[1]);   // AIOOBE / NFE on a malformed segment
```

These unchecked exceptions escape `updateTopicRouteInfoFromNameServer`, whose inner catch only handles `MQClientException`/`RemotingException`:

- the producer send path (`tryToFindTopicPublishInfo` → route refresh) surfaces a raw `NumberFormatException`/`ArrayIndexOutOfBoundsException` out of `send()` instead of an `MQClientException`;
- the periodic route refresh task aborts the whole per-cycle topic loop, so **other, correctly configured topics lose their route refresh too**;
- the failure happens before `topicRouteTable.put`, so every retry fails the same way until the kv config is corrected on the name server.

## Modification

`client/src/main/java/org/apache/rocketmq/client/impl/factory/MQClientInstance.java`: in `topicRouteData2TopicPublishInfo`, validate each order topic conf segment — skip segments without a `brokerName:queueNums` shape or with a non-numeric queue count, with a warn log — instead of letting one malformed segment abort the route conversion for the whole topic.

## Test Evidence

New test `testTopicRouteData2TopicPublishInfoWithMalformedOrderTopicConf` in `MQClientInstanceTest` uses an order topic conf with two valid segments (`broker-a:8`, `broker-d:2`) and two malformed ones (`broker-b` — no queue count, `broker-c:eight` — non-numeric).

Fail-before (unpatched develop, new test only):

```
Tests run: 27, Failures: 0, Errors: 1, Skipped: 1
testTopicRouteData2TopicPublishInfoWithMalformedOrderTopicConf  <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
```

Pass-after (with fix, full class):

```
docker exec rmq-build mvn -pl client test -Dtest='MQClientInstanceTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
```

The test asserts the malformed segments are skipped while the valid ones still yield their queues (`broker-a` q0-q7, `broker-d` q0-q1, order topic flag set).

No associated issue (self-discovered during a client-module self-audit).