### PR TITLE
[D20] Guard broker processors against requests whose body decodes to null

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -638,6 +638,12 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         long startTime = System.currentTimeMillis();
 
         final CreateTopicListRequestBody requestBody = CreateTopicListRequestBody.decode(request.getBody(), CreateTopicListRequestBody.class);
+        if (requestBody == null) {
+            RemotingCommand response = RemotingCommand.createResponseCommand(null);
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("create topic list request body is null or decode failed");
+            return response;
+        }
         List<TopicConfig> topicConfigList = requestBody.getTopicConfigList();
 
         StringBuilder builder = new StringBuilder();
@@ -1539,6 +1545,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         RemotingCommand request) throws RemotingCommandException {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
         LockBatchRequestBody requestBody = LockBatchRequestBody.decode(request.getBody(), LockBatchRequestBody.class);
+        if (requestBody == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("lock batch mq request body is null or decode failed");
+            return response;
+        }
 
         Set<MessageQueue> lockOKMQSet = new HashSet<>();
         Set<MessageQueue> selfLockOKMQSet = this.brokerController.getRebalanceLockManager().tryLockBatch(
@@ -1626,6 +1637,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         RemotingCommand request) throws RemotingCommandException {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
         UnlockBatchRequestBody requestBody = UnlockBatchRequestBody.decode(request.getBody(), UnlockBatchRequestBody.class);
+        if (requestBody == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("unlock batch mq request body is null or decode failed");
+            return response;
+        }
 
         if (requestBody.isOnlyThisBroker() || !this.brokerController.getBrokerConfig().isLockInStrictMode()) {
             this.brokerController.getRebalanceLockManager().unlockBatch(
@@ -1703,6 +1719,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
 
         final SubscriptionGroupList subscriptionGroupList = SubscriptionGroupList.decode(request.getBody(), SubscriptionGroupList.class);
+        if (subscriptionGroupList == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("create subscription group list request body is null or decode failed");
+            return response;
+        }
         final List<SubscriptionGroupConfig> groupConfigList = subscriptionGroupList.getGroupConfigList();
 
         final StringBuilder builder = new StringBuilder();
@@ -3256,6 +3277,12 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
 
         RemotingCommand response = RemotingCommand.createResponseCommand(null);
 
+        if (syncStateSetInfo == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("notify broker role changed request body is null or decode failed");
+            return response;
+        }
+
         LOGGER.info("Receive notifyBrokerRoleChanged request, try to change brokerRole, request:{}", requestHeader);
 
         final ReplicasManager replicasManager = this.brokerController.getReplicasManager();
@@ -3284,6 +3311,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         }
 
         UserInfo userInfo = RemotingSerializable.decode(request.getBody(), UserInfo.class);
+        if (userInfo == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("create user request body is null or decode failed");
+            return response;
+        }
         userInfo.setUsername(requestHeader.getUsername());
         User user = UserConverter.convertUser(userInfo);
 
@@ -3316,6 +3348,11 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
         }
 
         UserInfo userInfo = RemotingSerializable.decode(request.getBody(), UserInfo.class);
+        if (userInfo == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("update user request body is null or decode failed");
+            return response;
+        }
         userInfo.setUsername(requestHeader.getUsername());
         User user = UserConverter.convertUser(userInfo);
 

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/ClientManageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/ClientManageProcessor.java
@@ -73,6 +73,11 @@ public class ClientManageProcessor implements NettyRequestProcessor {
     public RemotingCommand heartBeat(ChannelHandlerContext ctx, RemotingCommand request) {
         RemotingCommand response = RemotingCommand.createResponseCommand(null);
         HeartbeatData heartbeatData = HeartbeatData.decode(request.getBody(), HeartbeatData.class);
+        if (heartbeatData == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("heartbeat request body is null or decode failed");
+            return response;
+        }
         int heartbeatFingerprint = heartbeatData.getHeartbeatFingerprint();
         if (heartbeatFingerprint != 0) {
             ClientChannelInfo clientChannelInfo = new ClientChannelInfo(

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessor.java
@@ -95,13 +95,20 @@ public class QueryAssignmentProcessor implements NettyRequestProcessor {
     private RemotingCommand queryAssignment(ChannelHandlerContext ctx, RemotingCommand request)
         throws RemotingCommandException {
         final QueryAssignmentRequestBody requestBody = QueryAssignmentRequestBody.decode(request.getBody(), QueryAssignmentRequestBody.class);
+
+        final RemotingCommand response = RemotingCommand.createResponseCommand(null);
+        if (requestBody == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("query assignment request body is null or decode failed");
+            return response;
+        }
+
         final String topic = requestBody.getTopic();
         final String consumerGroup = requestBody.getConsumerGroup();
         final String clientId = requestBody.getClientId();
         final MessageModel messageModel = requestBody.getMessageModel();
         final String strategyName = requestBody.getStrategyName();
 
-        final RemotingCommand response = RemotingCommand.createResponseCommand(null);
         final QueryAssignmentResponseBody responseBody = new QueryAssignmentResponseBody();
 
         SetMessageRequestModeRequestBody setMessageRequestModeRequestBody = this.messageRequestModeManager.getMessageRequestMode(topic, consumerGroup);
@@ -304,6 +311,11 @@ public class QueryAssignmentProcessor implements NettyRequestProcessor {
         RemotingCommand request) throws RemotingCommandException {
         final RemotingCommand response = RemotingCommand.createResponseCommand(null);
         final SetMessageRequestModeRequestBody requestBody = SetMessageRequestModeRequestBody.decode(request.getBody(), SetMessageRequestModeRequestBody.class);
+        if (requestBody == null) {
+            response.setCode(ResponseCode.SYSTEM_ERROR);
+            response.setRemark("set message request mode request body is null or decode failed");
+            return response;
+        }
 
         final String topic = requestBody.getTopic();
         if (topic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) {

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessorTest.java
@@ -464,6 +464,20 @@ public class AdminBrokerProcessorTest {
     }
 
     @Test
+    public void testUpdateAndCreateTopicListWithNullBody() throws RemotingCommandException {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.UPDATE_AND_CREATE_TOPIC_LIST, null);
+        RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+    }
+
+    @Test
+    public void testLockBatchMQWithNullBody() throws RemotingCommandException {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.LOCK_BATCH_MQ, null);
+        RemotingCommand response = adminBrokerProcessor.processRequest(handlerContext, request);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+    }
+
+    @Test
     public void testDeleteTopicInRocksdb() throws Exception {
         if (notToBeExecuted()) {
             return;

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/ClientManageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/ClientManageProcessorTest.java
@@ -166,6 +166,13 @@ public class ClientManageProcessorTest {
     }
 
     @Test
+    public void testHeartbeatWithNullBody() throws RemotingCommandException {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.HEART_BEAT, null);
+        RemotingCommand response = clientManageProcessor.processRequest(handlerContext, request);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+    }
+
+    @Test
     public void test_heartbeat_costTime() {
         String topic = "TOPIC_TEST";
         List<String> topicList = new ArrayList<>();

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/QueryAssignmentProcessorTest.java
@@ -35,6 +35,7 @@ import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.message.MessageRequestMode;
+import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyServerConfig;
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
@@ -126,6 +127,20 @@ public class QueryAssignmentProcessorTest {
         final RemotingCommand request = createSetMessageRequestModeRequest(MixAll.RETRY_GROUP_TOPIC_PREFIX + topic);
         RemotingCommand responseToReturn = queryAssignmentProcessor.processRequest(handlerContext, request);
         assertThat(responseToReturn.getCode()).isEqualTo(ResponseCode.NO_PERMISSION);
+    }
+
+    @Test
+    public void testQueryAssignmentWithNullBody() throws RemotingCommandException {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.QUERY_ASSIGNMENT, null);
+        RemotingCommand response = queryAssignmentProcessor.processRequest(handlerContext, request);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
+    }
+
+    @Test
+    public void testSetMessageRequestModeWithNullBody() throws RemotingCommandException {
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.SET_MESSAGE_REQUEST_MODE, null);
+        RemotingCommand response = queryAssignmentProcessor.processRequest(handlerContext, request);
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SYSTEM_ERROR);
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`RemotingSerializable.decode(byte[], Class)` returns **null** when the request carries no body. Several broker processors dereference the decoded object immediately, so a request without a body (a bare RPC probe from a monitoring tool, or a misbehaving client) produces a `NullPointerException` inside the broker instead of a clean error response — the NPE propagates to the remoting layer's catch-all, which answers a generic "the process request error" and logs a full stack trace per request.

Affected sites (all verified to NPE on a null body):

| Processor method | First dereference |
|---|---|
| `ClientManageProcessor.heartBeat` | `heartbeatData.getHeartbeatFingerprint()` |
| `QueryAssignmentProcessor.queryAssignment` | `requestBody.getTopic()` |
| `QueryAssignmentProcessor.setMessageRequestMode` | `requestBody.getTopic()` |
| `AdminBrokerProcessor.updateAndCreateTopicList` | `requestBody.getTopicConfigList()` |
| `AdminBrokerProcessor.updateAndCreateSubscriptionGroupConfigList` | `subscriptionGroupList.getGroupConfigList()` |
| `AdminBrokerProcessor.lockBatchMQ` | `requestBody.getConsumerGroup()` |
| `AdminBrokerProcessor.unlockBatchMQ` | `requestBody.isOnlyThisBroker()` |
| `AdminBrokerProcessor.notifyBrokerRoleChanged` | `syncStateSetInfo.getSyncStateSet()` |
| `AdminBrokerProcessor.createUser` / `updateUser` | `userInfo.setUsername(...)` |

The codebase already establishes the convention of null-checking after decode — `LiteSubscriptionCtlProcessor.processRequest`, `AckMessageProcessor` (batch ack), `updateAndCreateSubscriptionGroupConfig`, and `checkClientConfig` all guard — this PR brings the remaining sites in line.

## Modification

After each affected decode, return `SYSTEM_ERROR` with a remark naming the missing body when the decode yields null. No behavior change for requests that carry a valid body.

## Test Evidence

Added tests: `testHeartbeatWithNullBody` (ClientManageProcessorTest), `testQueryAssignmentWithNullBody` + `testSetMessageRequestModeWithNullBody` (QueryAssignmentProcessorTest), `testUpdateAndCreateTopicListWithNullBody` + `testLockBatchMQWithNullBody` (AdminBrokerProcessorTest).

Fail-before (unpatched develop, new tests only):

```
Tests run: 5, Failures: 0, Errors: 3, Skipped: 2
java.lang.NullPointerException: Cannot invoke "...QueryAssignmentRequestBody.getTopic()" because "requestBody" is null
java.lang.NullPointerException: Cannot invoke "...CreateTopicListRequestBody.getTopicConfigList()" because "requestBody" is null
java.lang.NullPointerException: Cannot invoke "...HeartbeatData.getHeartbeatFingerprint()" because "heartbeatData" is null
```

Pass-after (with fix):

```
docker exec rmq-build mvn -pl broker test -Dtest='AdminBrokerProcessorTest,QueryAssignmentProcessorTest,ClientManageProcessorTest' -Dsurefire.failIfNoSpecifiedTests=true
Tests run: 7,  Failures: 0, Errors: 0, Skipped: 0 - QueryAssignmentProcessorTest
Tests run: 95, Failures: 0, Errors: 0, Skipped: 0 - AdminBrokerProcessorTest
Tests run: 7,  Failures: 0, Errors: 0, Skipped: 0 - ClientManageProcessorTest
```

No associated issue (self-discovered during a broker-processor self-audit).