### PR TITLE
[ISSUE #11129] HashedWheelTimer resource leak when broker shuts down with Lite Topic pop

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -1562,6 +1562,7 @@ public class BrokerController {
             if (this.popLiteMessageProcessor.getPopLiteLongPollingService() != null) {
                 this.popLiteMessageProcessor.getPopLiteLongPollingService().shutdown();
             }
+            this.popLiteMessageProcessor.getConsumerOrderInfoManager().shutdown();
         }
 
         if (this.popMessageProcessor.getQueueLockManager() != null) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #11129

### Brief Description

The Lite pop processor creates its own ConsumerOrderInfoManager whose internal lock manager holds a non-daemon HashedWheelTimer, but the broker shutdown flow never shuts it down — the existing consumerOrderInfoManager.shutdown() call covers a different instance. This adds the missing shutdown call so the timer is stopped on broker exit.

### How Did You Test This Change?

- Compiled the broker module successfully (mvn -pl broker -am install).
- Manually traced the shutdown chain: BrokerController -> popLiteMessageProcessor.getConsumerOrderInfoManager().shutdown() -> QueueLevelConsumerOrderInfoLockManager.shutdown() -> timer.stop().
