### PR TITLE
fix(tools): correct inverted dryRun flag in exportPopRecord command

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportPopRecordCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportPopRecordCommand.java
@@ -66,7 +66,7 @@ public class ExportPopRecordCommand implements SubCommand {
         try {
             adminExt.start();
             boolean dryRun = commandLine.hasOption('d') &&
-                Boolean.FALSE.toString().equalsIgnoreCase(commandLine.getOptionValue('d'));
+                Boolean.parseBoolean(commandLine.getOptionValue('d'));
             if (commandLine.hasOption('b')) {
                 String brokerAddr = commandLine.getOptionValue('b').trim();
                 String brokerName = adminExt.getBrokerConfig(brokerAddr).getProperty("brokerName");

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/export/ExportPopRecordCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/export/ExportPopRecordCommandTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.export;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.apache.rocketmq.tools.command.server.ServerResponseMocker;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExportPopRecordCommandTest {
+
+    private ServerResponseMocker nameServerMocker;
+
+    private final PrintStream stdout = System.out;
+
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    @Before
+    public void before() {
+        System.setOut(new PrintStream(output));
+        nameServerMocker = startNameServer();
+        System.setProperty(MixAll.NAMESRV_ADDR_PROPERTY, "localhost:" + nameServerMocker.listenPort());
+    }
+
+    @After
+    public void after() {
+        System.clearProperty(MixAll.NAMESRV_ADDR_PROPERTY);
+        nameServerMocker.shutdown();
+        System.setOut(stdout);
+    }
+
+    @Test
+    public void testDryRunDoesNotExportRecords() throws SubCommandException {
+        // broker address points to a closed port, so any real export attempt fails and
+        // prints the error line; with dryRun=true the command must not touch the broker at all
+        executeCommand("-c mockCluster -d true");
+        String out = output.toString();
+        Assert.assertTrue(out, out.contains("dryRun=true"));
+        Assert.assertFalse(out, out.contains("Export broker records error"));
+    }
+
+    @Test
+    public void testNonDryRunExportsRecords() throws SubCommandException {
+        executeCommand("-c mockCluster -d false");
+        String out = output.toString();
+        Assert.assertTrue(out, out.contains("dryRun=false"));
+        Assert.assertTrue(out, out.contains("Export broker records error"));
+    }
+
+    private void executeCommand(String args) throws SubCommandException {
+        ExportPopRecordCommand cmd = new ExportPopRecordCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = (args + String.format(" -n localhost:%d", nameServerMocker.listenPort())).split(" ");
+        final CommandLine commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
+                cmd.buildCommandlineOptions(options),
+                new DefaultParser());
+        cmd.execute(commandLine, options, null);
+    }
+
+    private ServerResponseMocker startNameServer() {
+        ClusterInfo clusterInfo = new ClusterInfo();
+
+        HashMap<String, BrokerData> brokerAddressTable = new HashMap<>();
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("mockBrokerName");
+        HashMap<Long, String> brokerAddress = new HashMap<>();
+        // port 1 is reserved and closed: connection is refused immediately
+        brokerAddress.put(0L, "127.0.0.1:1");
+        brokerData.setBrokerAddrs(brokerAddress);
+        brokerData.setCluster("mockCluster");
+        brokerAddressTable.put("mockBrokerName", brokerData);
+        clusterInfo.setBrokerAddrTable(brokerAddressTable);
+
+        HashMap<String, Set<String>> clusterAddressTable = new HashMap<>();
+        Set<String> brokerNames = new HashSet<>();
+        brokerNames.add("mockBrokerName");
+        clusterAddressTable.put("mockCluster", brokerNames);
+        clusterInfo.setClusterAddrTable(clusterAddressTable);
+
+        return ServerResponseMocker.startServer(clusterInfo.encode());
+    }
+}


### PR DESCRIPTION
### Motivation

`exportPopRecordCommand` built its dry-run flag as

```java
Boolean.FALSE.toString().equalsIgnoreCase(commandLine.getOptionValue('d'));
```

so the command ran in dry-run mode only when `-d` was literally `false` — exactly inverted. `mqadmin exportPopRecord -d true` (explicitly requesting no changes) actually sent the mutating `POP_ROLLBACK` request, while `-d false` skipped the rollback and only exported the records.

### Modifications

Parse the flag with `Boolean.parseBoolean` so the command honors the documented semantics.

### Verification

Fail-before (new test, run against the unpatched code):

```
ExportPopRecordCommandTest#testNonDryRunExportsRecords
java.lang.AssertionError (message is the captured console output): with -d false the inverted
flag printed dryRun=true and skipped the export instead of attempting it
```

Pass-after:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- ExportPopRecordCommandTest
```
