### PR TITLE
fix(tools): fail fast on invalid configType in rocksDBConfigToJson command

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -123,8 +122,8 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
         }
     }
 
-    private void handleLocalMode(CommandLine commandLine) {
-        ExportRocksDBConfigToJsonRequestHeader.ConfigType type = Objects.requireNonNull(getConfigTypeList(commandLine)).get(0);
+    private void handleLocalMode(CommandLine commandLine) throws SubCommandException {
+        ExportRocksDBConfigToJsonRequestHeader.ConfigType type = getConfigTypeList(commandLine).get(0);
         String path = commandLine.getOptionValue("configPath").trim();
         if (StringUtils.isEmpty(path) || !new File(path).exists()) {
             System.out.print("Rocksdb path is invalid.\n");
@@ -161,7 +160,7 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
         }
     }
 
-    private List<ExportRocksDBConfigToJsonRequestHeader.ConfigType> getConfigTypeList(CommandLine commandLine) {
+    private List<ExportRocksDBConfigToJsonRequestHeader.ConfigType> getConfigTypeList(CommandLine commandLine) throws SubCommandException {
         List<ExportRocksDBConfigToJsonRequestHeader.ConfigType> typeList = new ArrayList<>();
         if (commandLine.hasOption("configType")) {
             String configType = commandLine.getOptionValue("configType").trim();
@@ -169,7 +168,7 @@ public class RocksDBConfigToJsonCommand implements SubCommand {
                 typeList.addAll(ExportRocksDBConfigToJsonRequestHeader.ConfigType.fromString(configType));
             } catch (IllegalArgumentException e) {
                 System.out.print("Invalid configType: " + configType + " please input topics/subscriptionGroups/consumerOffsets \n");
-                return null;
+                throw new SubCommandException("Invalid configType: " + configType);
             }
         } else {
             typeList.addAll(Arrays.asList(ExportRocksDBConfigToJsonRequestHeader.ConfigType.values()));

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommandTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.metadata;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RocksDBConfigToJsonCommandTest {
+
+    @Test
+    public void testInvalidConfigTypeFailsWithCleanError() {
+        RocksDBConfigToJsonCommand cmd = new RocksDBConfigToJsonCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = "-p /tmp/rocketmq_rocksdb -t bogus".split(" ");
+        final CommandLine commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
+                cmd.buildCommandlineOptions(options),
+                new DefaultParser());
+        try {
+            cmd.execute(commandLine, options, null);
+            Assert.fail("expected SubCommandException for invalid configType");
+        } catch (SubCommandException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("Invalid configType"));
+        } catch (NullPointerException e) {
+            Assert.fail("invalid configType must not surface as a NullPointerException");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

`mqadmin rocksDBConfigToJson` with a bad `-t` value printed an "Invalid configType" message and returned `null` from `getConfigTypeList`, but execution then continued with the null list: local mode threw a raw `NullPointerException` from `Objects.requireNonNull`, and rpc mode carried the null list into the export request sent to brokers.

### Modifications

Throw a `SubCommandException` carrying the same message so the command aborts cleanly on an invalid `-t` value instead of failing later with an unrelated error.

### Verification

Fail-before (new test, run against the unpatched code):

```
Tests run: 1, Failures: 1, Errors: 0 -- RocksDBConfigToJsonCommandTest#testInvalidConfigTypeFailsWithCleanError
java.lang.AssertionError: invalid configType must not surface as a NullPointerException
```

Pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- RocksDBConfigToJsonCommandTest
```
