### PR TITLE
fix(remoting): include brokerId in SubscriptionGroupConfig.equals

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/subscription/SubscriptionGroupConfig.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/subscription/SubscriptionGroupConfig.java
@@ -297,6 +297,7 @@ public class SubscriptionGroupConfig {
         SubscriptionGroupConfig other = (SubscriptionGroupConfig) obj;
         return new EqualsBuilder()
             .append(groupName, other.groupName)
+            .append(brokerId, other.brokerId)
             .append(consumeEnable, other.consumeEnable)
             .append(consumeFromMinEnable, other.consumeFromMinEnable)
             .append(consumeBroadcastEnable, other.consumeBroadcastEnable)

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/subscription/SubscriptionGroupConfigTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/subscription/SubscriptionGroupConfigTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.protocol.subscription;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SubscriptionGroupConfigTest {
+
+    @Test
+    public void testBrokerIdParticipatesInEqualsAndHashCode() {
+        SubscriptionGroupConfig first = new SubscriptionGroupConfig();
+        first.setGroupName("groupA");
+        first.setBrokerId(0L);
+
+        SubscriptionGroupConfig second = new SubscriptionGroupConfig();
+        second.setGroupName("groupA");
+        second.setBrokerId(0L);
+
+        Assert.assertEquals(first, second);
+        Assert.assertEquals(first.hashCode(), second.hashCode());
+
+        // brokerId is part of hashCode, so it must be part of equals as well:
+        // otherwise two equal configs could carry different hash codes
+        second.setBrokerId(1L);
+        Assert.assertNotEquals(first, second);
+        Assert.assertNotEquals(first.hashCode(), second.hashCode());
+    }
+}


### PR DESCRIPTION
### Motivation

`brokerId` participates in `SubscriptionGroupConfig.hashCode` but was missing from `equals`, so two configs for the same group that differ only in `brokerId` compared equal while hashing differently — breaking the `Object` contract for any `HashSet`/`HashMap` keyed on `SubscriptionGroupConfig` (lookups miss, set dedup misbehaves).

### Modifications

Append `brokerId` to `equals` to match `hashCode`.

### Verification

Fail-before (new test, run against the unpatched code):

```
Tests run: 1, Failures: 1, Errors: 0 -- SubscriptionGroupConfigTest#testBrokerIdParticipatesInEqualsAndHashCode
java.lang.AssertionError: Values should be different. Actual: SubscriptionGroupConfig{groupName=groupA, ..., brokerId=1, ...}
```

Pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- SubscriptionGroupConfigTest
```
