### PR TITLE
fix(common): do not throw on endpoint without dot in parseInstanceIdFromEndpoint

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/utils/NameServerAddressUtils.java
+++ b/common/src/main/java/org/apache/rocketmq/common/utils/NameServerAddressUtils.java
@@ -35,7 +35,11 @@ public class NameServerAddressUtils {
         if (StringUtils.isEmpty(endpoint)) {
             return null;
         }
-        return endpoint.substring(endpoint.lastIndexOf("/") + 1, endpoint.indexOf('.'));
+        int dotIndex = endpoint.indexOf('.');
+        if (dotIndex < 0) {
+            return null;
+        }
+        return endpoint.substring(endpoint.lastIndexOf("/") + 1, dotIndex);
     }
 
     public static String getNameSrvAddrFromNamesrvEndpoint(String nameSrvEndpoint) {

--- a/common/src/test/java/org/apache/rocketmq/common/utils/NameServerAddressUtilsTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/utils/NameServerAddressUtilsTest.java
@@ -46,6 +46,14 @@ public class NameServerAddressUtilsTest {
     }
 
     @Test
+    public void testParseInstanceIdFromEndpointWithoutDot() {
+        // an endpoint without a dot is not an instance endpoint; the utility must
+        // not throw StringIndexOutOfBoundsException on it
+        assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint("MQ_INST_123456789_BXXUzaee:80")).isNull();
+        assertThat(NameServerAddressUtils.parseInstanceIdFromEndpoint("localhost")).isNull();
+    }
+
+    @Test
     public void testGetNameSrvAddrFromNamesrvEndpoint() {
         assertThat(NameServerAddressUtils.getNameSrvAddrFromNamesrvEndpoint(endpoint1))
             .isEqualTo("127.0.0.1:9876");


### PR DESCRIPTION
### Motivation

`parseInstanceIdFromEndpoint` used the result of `endpoint.indexOf('.')` directly as the substring end index:

```java
return endpoint.substring(0, endpoint.indexOf('.'));
```

so any non-empty endpoint without a dot (for example `MQ_INST_123456789_BXXUzaee:80`) produced `-1` and threw `StringIndexOutOfBoundsException` from a public utility.

### Modifications

Treat a missing dot as a non-instance endpoint and return null.

### Verification

Fail-before (new test, run against the unpatched code):

```
Tests run: 4, Failures: 0, Errors: 1, Skipped: 1 -- NameServerAddressUtilsTest#testParseInstanceIdFromEndpointWithoutDot
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 29
```

Pass-after:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 1 -- NameServerAddressUtilsTest
```
