### PR TITLE
fix(proxy): return UNRECOGNIZED_CLIENT_TYPE when client settings is null in receiveMessage

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -64,6 +64,10 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
 
         try {
             Settings settings = this.grpcClientSettingsManager.getClientSettings(ctx);
+            if (settings == null) {
+                writer.writeAndComplete(ctx, Code.UNRECOGNIZED_CLIENT_TYPE, "cannot find client settings for this client");
+                return;
+            }
             ctx.setClientType(settings.getClientType().name());
 
             Subscription subscription = settings.getSubscription();

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
@@ -422,6 +422,31 @@ public class ReceiveMessageActivityTest extends BaseActivityTest {
         assertEquals(Code.MESSAGE_NOT_FOUND, getResponseCodeFromReceiveMessageResponseList(responseArgumentCaptor.getAllValues()));
     }
 
+    @Test
+    public void testReceiveMessageWithoutClientSettings() {
+        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+        ArgumentCaptor<ReceiveMessageResponse> responseArgumentCaptor = ArgumentCaptor.forClass(ReceiveMessageResponse.class);
+        doNothing().when(receiveStreamObserver).onNext(responseArgumentCaptor.capture());
+
+        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(null);
+
+        this.receiveMessageActivity.receiveMessage(
+            createContext(),
+            ReceiveMessageRequest.newBuilder()
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                .setAutoRenew(true)
+                .setFilterExpression(FilterExpression.newBuilder()
+                    .setType(FilterType.TAG)
+                    .setExpression("*")
+                    .build())
+                .build(),
+            receiveStreamObserver
+        );
+
+        assertEquals(Code.UNRECOGNIZED_CLIENT_TYPE, getResponseCodeFromReceiveMessageResponseList(responseArgumentCaptor.getAllValues()));
+    }
+
     private Code getResponseCodeFromReceiveMessageResponseList(List<ReceiveMessageResponse> responseList) {
         for (ReceiveMessageResponse response : responseList) {
             if (response.hasStatus()) {


### PR DESCRIPTION
### Motivation

A gRPC client that calls `ReceiveMessage` before any settings were cached (or after its settings were cleaned up) made `getClientSettings` return null, and the following `settings.getClientType()` threw a `NullPointerException` which the catch block turned into an opaque `INTERNAL_SERVER_ERROR` response.

`ClientActivity.heartbeat` already guards this case with `UNRECOGNIZED_CLIENT_TYPE`.

### Modifications

Apply the same guard in `receiveMessage` so the client gets a meaningful code.

### Verification

Fail-before (new test, run against the unpatched code):

```
ReceiveMessageActivityTest#testReceiveMessageWithoutClientSettings
java.lang.AssertionError: expected:<UNRECOGNIZED_CLIENT_TYPE> but was:<INTERNAL_SERVER_ERROR>
  ReceiveMessageActivityTest.testReceiveMessageWithoutClientSettings:447
(root cause: NullPointerException on "Settings.getClientType()" because "settings" is null)
```

Pass-after:

```
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0 -- ReceiveMessageActivityTest
```
