### PR TITLE
fix(proxy): fall back to max long polling timeout when gRPC deadline is absent

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java
@@ -71,7 +71,9 @@ public class ReceiveMessageActivity extends AbstractMessagingActivity {
             int maxAttempts = settings.getBackoffPolicy().getMaxAttempts();
             ProxyConfig config = ConfigurationManager.getProxyConfig();
 
-            Long timeRemaining = ctx.getRemainingMs();
+            Long remainingMs = ctx.getRemainingMs();
+            long timeRemaining = remainingMs == null ?
+                config.getGrpcClientConsumerMaxLongPollingTimeoutMillis() : remainingMs;
             long pollingTime;
             if (request.hasLongPollingTimeout()) {
                 pollingTime = Durations.toMillis(request.getLongPollingTimeout());

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivityTest.java
@@ -46,6 +46,7 @@ import org.apache.rocketmq.common.consumer.ReceiptHandle;
 import org.apache.rocketmq.common.message.MessageAccessor;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.proxy.common.ContextVariable;
 import org.apache.rocketmq.proxy.common.MessageReceiptHandle;
 import org.apache.rocketmq.proxy.common.ProxyContext;
 import org.apache.rocketmq.proxy.config.ConfigurationManager;
@@ -420,6 +421,43 @@ public class ReceiveMessageActivityTest extends BaseActivityTest {
             receiveStreamObserver
         );
         assertEquals(Code.MESSAGE_NOT_FOUND, getResponseCodeFromReceiveMessageResponseList(responseArgumentCaptor.getAllValues()));
+    }
+
+    @Test
+    public void testReceiveMessageWithoutDeadline() {
+        StreamObserver<ReceiveMessageResponse> receiveStreamObserver = mock(ServerCallStreamObserver.class);
+        ArgumentCaptor<ReceiveMessageResponse> responseArgumentCaptor = ArgumentCaptor.forClass(ReceiveMessageResponse.class);
+        doNothing().when(receiveStreamObserver).onNext(responseArgumentCaptor.capture());
+
+        when(this.grpcClientSettingsManager.getClientSettings(any())).thenReturn(Settings.newBuilder().getDefaultInstanceForType());
+        ArgumentCaptor<Long> pollingTimeCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
+        when(this.messagingProcessor.popMessage(any(), any(), anyString(), anyString(), anyInt(), anyLong(),
+            pollingTimeCaptor.capture(), anyInt(), any(), anyBoolean(), any(), isNull(), timeoutCaptor.capture()))
+            .thenReturn(CompletableFuture.completedFuture(new PopResult(PopStatus.NO_NEW_MSG, new ArrayList<>())));
+
+        ProxyContext context = ProxyContext.create()
+            .withVal(ContextVariable.CLIENT_ID, CLIENT_ID)
+            .withVal(ContextVariable.LANGUAGE, JAVA);
+        this.receiveMessageActivity.receiveMessage(
+            context,
+            ReceiveMessageRequest.newBuilder()
+                .setGroup(Resource.newBuilder().setName(CONSUMER_GROUP).build())
+                .setMessageQueue(MessageQueue.newBuilder().setTopic(Resource.newBuilder().setName(TOPIC).build()).build())
+                .setAutoRenew(true)
+                .setFilterExpression(FilterExpression.newBuilder()
+                    .setType(FilterType.TAG)
+                    .setExpression("*")
+                    .build())
+                .build(),
+            receiveStreamObserver
+        );
+
+        assertEquals(Code.MESSAGE_NOT_FOUND, getResponseCodeFromReceiveMessageResponseList(responseArgumentCaptor.getAllValues()));
+        assertEquals(ConfigurationManager.getProxyConfig().getGrpcClientConsumerMaxLongPollingTimeoutMillis(),
+            pollingTimeCaptor.getValue().longValue());
+        assertEquals(ConfigurationManager.getProxyConfig().getGrpcClientConsumerMaxLongPollingTimeoutMillis(),
+            timeoutCaptor.getValue().longValue());
     }
 
     private Code getResponseCodeFromReceiveMessageResponseList(List<ReceiveMessageResponse> responseList) {


### PR DESCRIPTION
### Motivation

`ContextInitPipeline` only records the remaining deadline time when the gRPC call actually carries a deadline. For a call without one — which gRPC allows — `ctx.getRemainingMs()` returned null and the unboxing in the polling-time computation threw a `NullPointerException`, which the catch block turned into an `INTERNAL_SERVER_ERROR` response.

### Modifications

Treat an absent deadline as `grpcClientConsumerMaxLongPollingTimeoutMillis` remaining time, so polling time and the timeout passed to `popMessage` stay bounded by the configured maximum instead of crashing.

### Verification

Fail-before (new test, run against the unpatched code):

```
ReceiveMessageActivityTest#testReceiveMessageWithoutDeadline
java.lang.AssertionError: expected:<MESSAGE_NOT_FOUND> but was:<INTERNAL_SERVER_ERROR>
  ReceiveMessageActivityTest.testReceiveMessageWithoutDeadline:456
(root cause: NullPointerException on "Long.longValue()" because "timeRemaining" is null)
```

Pass-after:

```
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0 -- ReceiveMessageActivityTest
```
