### PR TITLE
fix(proxy): clamp pop result filter maxAttempts to at least one attempt

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/PopMessageResultFilterImpl.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/PopMessageResultFilterImpl.java
@@ -27,7 +27,9 @@ public class PopMessageResultFilterImpl implements PopMessageResultFilter {
     private final int maxAttempts;
 
     public PopMessageResultFilterImpl(int maxAttempts) {
-        this.maxAttempts = maxAttempts;
+        // a client that leaves the backoff policy unset (proto3 default 0) must
+        // still get at least one delivery attempt before messages go to the DLQ
+        this.maxAttempts = Math.max(1, maxAttempts);
     }
 
     @Override

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/PopMessageResultFilterImplTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/consumer/PopMessageResultFilterImplTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.proxy.grpc.v2.consumer;
+
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.proxy.common.ProxyContext;
+import org.apache.rocketmq.proxy.processor.PopMessageResultFilter;
+import org.apache.rocketmq.remoting.protocol.filter.FilterAPI;
+import org.apache.rocketmq.remoting.protocol.heartbeat.SubscriptionData;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PopMessageResultFilterImplTest {
+
+    private final ProxyContext ctx = ProxyContext.create();
+    private SubscriptionData subscriptionData;
+
+    @Before
+    public void before() throws Exception {
+        subscriptionData = FilterAPI.buildSubscriptionData("topic", "*");
+    }
+
+    @Test
+    public void testZeroMaxAttemptsStillDeliversFirstAttempt() {
+        PopMessageResultFilterImpl filter = new PopMessageResultFilterImpl(0);
+
+        MessageExt messageExt = new MessageExt();
+        messageExt.setReconsumeTimes(0);
+
+        assertEquals(PopMessageResultFilter.FilterResult.MATCH,
+            filter.filterMessage(ctx, "group", subscriptionData, messageExt));
+    }
+
+    @Test
+    public void testZeroMaxAttemptsGoesToDlqAfterRetry() {
+        PopMessageResultFilterImpl filter = new PopMessageResultFilterImpl(0);
+
+        MessageExt messageExt = new MessageExt();
+        messageExt.setReconsumeTimes(1);
+
+        assertEquals(PopMessageResultFilter.FilterResult.TO_DLQ,
+            filter.filterMessage(ctx, "group", subscriptionData, messageExt));
+    }
+
+    @Test
+    public void testPositiveMaxAttempts() {
+        PopMessageResultFilterImpl filter = new PopMessageResultFilterImpl(2);
+
+        MessageExt firstAttempt = new MessageExt();
+        firstAttempt.setReconsumeTimes(0);
+        MessageExt secondAttempt = new MessageExt();
+        secondAttempt.setReconsumeTimes(1);
+        MessageExt thirdAttempt = new MessageExt();
+        thirdAttempt.setReconsumeTimes(2);
+
+        assertEquals(PopMessageResultFilter.FilterResult.MATCH,
+            filter.filterMessage(ctx, "group", subscriptionData, firstAttempt));
+        assertEquals(PopMessageResultFilter.FilterResult.MATCH,
+            filter.filterMessage(ctx, "group", subscriptionData, secondAttempt));
+        assertEquals(PopMessageResultFilter.FilterResult.TO_DLQ,
+            filter.filterMessage(ctx, "group", subscriptionData, thirdAttempt));
+    }
+
+    @Test
+    public void testTagMismatchReturnsNoMatch() {
+        PopMessageResultFilterImpl filter = new PopMessageResultFilterImpl(16);
+
+        SubscriptionData tagSubscription;
+        try {
+            tagSubscription = FilterAPI.buildSubscriptionData("topic", "tagA");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        MessageExt messageExt = new MessageExt();
+        messageExt.setTags("tagB");
+
+        assertEquals(PopMessageResultFilter.FilterResult.NO_MATCH,
+            filter.filterMessage(ctx, "group", tagSubscription, messageExt));
+    }
+}


### PR DESCRIPTION
### Motivation

`receiveMessage` feeds `settings.getBackoffPolicy().getMaxAttempts()` into `PopMessageResultFilterImpl`. When a client leaves the backoff policy unset, proto3 defaults `maxAttempts` to 0, and while the subscription group config is unavailable (`mergeSubscriptionData` passes the raw client settings through on a config miss) every popped message — including its first delivery — hit `reconsumeTimes >= maxAttempts` and was routed straight to the DLQ.

### Modifications

Clamp `maxAttempts` to at least 1 in the filter, so a message always gets one delivery attempt before the DLQ verdict.

### Verification

Fail-before (new test, run against the unpatched code):

```
PopMessageResultFilterImplTest#testZeroMaxAttemptsStillDeliversFirstAttempt
java.lang.AssertionError: expected:<MATCH> but was:<TO_DLQ>
  PopMessageResultFilterImplTest.testZeroMaxAttemptsStillDeliversFirstAttempt:47
```

Pass-after:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- PopMessageResultFilterImplTest
```
