### PR TITLE
fix(proxy): guard null context in telemetry handleGrpcCancel

### DIFF
--- a/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
+++ b/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivity.java
@@ -330,6 +330,9 @@ public class ClientActivity extends AbstractMessagingActivity {
     }
 
     private void handleGrpcCancel(ProxyContext ctx, Throwable t) {
+        if (ctx == null) {
+            return;
+        }
         final String clientId = ctx.getClientID();
         if (StringUtils.isBlank(clientId)) {
             return;

--- a/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
+++ b/proxy/src/test/java/org/apache/rocketmq/proxy/grpc/v2/client/ClientActivityTest.java
@@ -81,6 +81,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -414,6 +415,30 @@ public class ClientActivityTest extends BaseActivityTest {
         ProxyRelayResult<ConsumeMessageDirectlyResult> result = resultArgumentCaptor.getValue();
         assertThat(result.getCode()).isEqualTo(ResponseCode.SUCCESS);
         assertThat(result.getResult().getConsumeResult()).isEqualTo(CMResult.CR_SUCCESS);
+    }
+
+    @Test
+    public void testTelemetryOnErrorBeforeAnyMessage() {
+        this.clientActivity = new ClientActivity(this.messagingProcessor, this.grpcClientSettingsManager, grpcChannelManagerMock);
+        ContextStreamObserver<TelemetryCommand> streamObserver = clientActivity.telemetry(new StreamObserver<TelemetryCommand>() {
+            @Override
+            public void onNext(TelemetryCommand value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+
+        // the client cancelled the stream before sending any telemetry command,
+        // so the observer's proxyCtx is still null
+        streamObserver.onError(io.grpc.Status.CANCELLED.asRuntimeException());
+
+        verify(this.grpcClientSettingsManager, never()).offlineClientLiteSubscription(any(), anyString(), any());
     }
 
     protected CompletableFuture<TelemetryCommand> sendClientTelemetry(ProxyContext ctx, Settings settings) {


### PR DESCRIPTION
### Motivation

The telemetry stream observer keeps `proxyCtx = null` until the first `onNext` delivers a context. A client that opens the telemetry stream and then cancels (or drops the connection) without sending a single `TelemetryCommand` made `onError` call `handleGrpcCancel` with a null context, which threw a `NullPointerException` in `ctx.getClientID()` and masked the intended cancel handling.

### Modifications

Return early when the context is absent; there is no client id to clean up in that case.

### Verification

Fail-before (new test, run against the unpatched code):

```
ClientActivityTest#testTelemetryOnErrorBeforeAnyMessage
java.lang.NullPointerException: Cannot invoke "org.apache.rocketmq.proxy.common.ProxyContext.getClientID()" because "ctx" is null
  ClientActivityTest.testTelemetryOnErrorBeforeAnyMessage:439
```

Pass-after:

```
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 -- ClientActivityTest
```
