### PR TITLE
fix(broker): stop overwriting batch ack uniq key with single ack key in appendAck

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AckMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AckMessageProcessor.java
@@ -298,7 +298,6 @@ public class AckMessageProcessor implements NettyRequestProcessor {
         msgInner.setBornHost(this.brokerController.getStoreHost());
         msgInner.setStoreHost(this.brokerController.getStoreHost());
         msgInner.setDeliverTimeMs(popTime + invisibleTime);
-        msgInner.getProperties().put(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX, PopMessageProcessor.genAckUniqueId(ackMsg));
         msgInner.setPropertiesString(MessageDecoder.messageProperties2String(msgInner.getProperties()));
         if (brokerController.getBrokerConfig().isAppendAckAsync()) {
             int finalAckCount = ackCount;

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/AckMessageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/AckMessageProcessorTest.java
@@ -49,9 +49,11 @@ import org.apache.rocketmq.store.PutMessageResult;
 import org.apache.rocketmq.store.PutMessageStatus;
 import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.apache.rocketmq.store.exception.ConsumeQueueException;
+import org.apache.rocketmq.store.pop.BatchAckMsg;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
@@ -366,4 +368,51 @@ public class AckMessageProcessorTest {
         }
     }
 
+    @Test
+    public void testBatchAck_appendAck_BatchUniqKeyKept() throws RemotingCommandException {
+        PopBufferMergeService popBufferMergeService = mock(PopBufferMergeService.class);
+        when(popBufferMergeService.addAk(anyInt(), any())).thenReturn(false);
+        when(popMessageProcessor.getPopBufferMergeService()).thenReturn(popBufferMergeService);
+        PutMessageResult putMessageResult = new PutMessageResult(PutMessageStatus.PUT_OK, null);
+        ArgumentCaptor<MessageExtBrokerInner> msgCaptor = ArgumentCaptor.forClass(MessageExtBrokerInner.class);
+        when(messageStore.putMessage(msgCaptor.capture())).thenReturn(putMessageResult);
+
+        long popTime = 1666860736757L;
+        String brokerName = "broker-a";
+        BatchAck bAck1 = new BatchAck();
+        bAck1.setConsumerGroup(MixAll.DEFAULT_CONSUMER_GROUP);
+        bAck1.setTopic(topic);
+        bAck1.setQueueId(0);
+        bAck1.setReviveQueueId(0);
+        bAck1.setStartOffset(MIN_OFFSET_IN_QUEUE);
+        bAck1.setBitSet(new BitSet());
+        bAck1.getBitSet().set(1);
+        bAck1.setRetry("0");
+        bAck1.setPopTime(popTime);
+        bAck1.setInvisibleTime(60000L);
+
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.BATCH_ACK_MESSAGE, null);
+        BatchAckMessageRequestBody reqBody = new BatchAckMessageRequestBody();
+        reqBody.setAcks(Collections.singletonList(bAck1));
+        reqBody.setBrokerName(brokerName);
+        request.setBody(reqBody.encode());
+        request.makeCustomHeaderToNet();
+        RemotingCommand response = ackMessageProcessor.processRequest(handlerContext, request);
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        MessageExtBrokerInner ackMessage = msgCaptor.getValue();
+        assertThat(ackMessage).isNotNull();
+
+        BatchAckMsg expected = new BatchAckMsg();
+        expected.setConsumerGroup(MixAll.DEFAULT_CONSUMER_GROUP);
+        expected.setTopic(topic);
+        expected.setQueueId(0);
+        expected.setStartOffset(MIN_OFFSET_IN_QUEUE);
+        expected.setPopTime(popTime);
+        expected.setBrokerName(brokerName);
+        expected.getAckOffsetList().add(MIN_OFFSET_IN_QUEUE + 1);
+
+        assertThat(ackMessage.getProperties().get(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX))
+            .isEqualTo(PopMessageProcessor.genBatchAckUniqueId(expected));
+    }
 }


### PR DESCRIPTION
### Motivation

`appendAck` set `PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX` correctly per ack type (`genBatchAckUniqueId` for `BatchAckMsg`, `genAckUniqueId` otherwise), but a later unconditional `put` overwrote it with `genAckUniqueId` for every ack. Batch acks therefore landed on the revive topic with a bogus uniq key: the offset segment was the `-1` sentinel the batch path assigns, and the tag segment was `ack` instead of `bAck`, so every batch ack of a pop produced the same non-unique client id and tracing by uniq key was impossible.

The buffered path in `PopBufferMergeService` already writes the batch uniq key without overwriting it.

### Modifications

Drop the stray `put` so the per-type key set just above survives.

### Verification

Fail-before (new test, run against the unpatched code):

```
AckMessageProcessorTest#testBatchAck_appendAck_BatchUniqKeyKept
expected: "FooBar@0@[101]@DEFAULT_CONSUMER@1666860736757@bAck"
 but was: "FooBar@0@-1@DEFAULT_CONSUMER@1666860736757@broker-a@ack"
```

Pass-after:

```
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0 -- AckMessageProcessorTest
```
