### PR TITLE
fix(broker): tolerate non-numeric TIMER_OUT_MS when attaching recall handle

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.broker.processor;
 import io.netty.channel.ChannelHandlerContext;
 import io.opentelemetry.api.common.Attributes;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.rocketmq.broker.BrokerController;
 import org.apache.rocketmq.broker.metrics.BrokerMetricsManager;
 import org.apache.rocketmq.broker.mqtrace.SendMessageContext;
@@ -675,7 +676,11 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
         String timestampStr = msg.getProperty(MessageConst.PROPERTY_TIMER_OUT_MS);
         String realTopic = msg.getProperty(MessageConst.PROPERTY_REAL_TOPIC);
         if (timestampStr != null && realTopic != null && !realTopic.startsWith(MixAll.RETRY_GROUP_TOPIC_PREFIX)) {
-            timestampStr = String.valueOf(Long.parseLong(timestampStr) + 1); // consider of floor
+            long timerOutMs = NumberUtils.toLong(timestampStr, -1);
+            if (timerOutMs < 0) {
+                return;
+            }
+            timestampStr = String.valueOf(timerOutMs + 1); // consider of floor
             String recallHandle = RecallMessageHandle.HandleV1.buildHandle(realTopic,
                 brokerController.getBrokerConfig().getBrokerName(), timestampStr, MessageClientIDSetter.getUniqID(msg));
             responseHeader.setRecallHandle(recallHandle);

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/SendMessageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/SendMessageProcessorTest.java
@@ -357,6 +357,24 @@ public class SendMessageProcessorTest {
         }
     }
 
+    @Test
+    public void testAttachRecallHandle_invalidTimestamp() {
+        SendMessageResponseHeader responseHeader = new SendMessageResponseHeader();
+        String id = MessageClientIDSetter.createUniqID();
+        MessageExt message = new MessageExt();
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX, id);
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_TIMER_OUT_MS, "not-a-timestamp");
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_REAL_TOPIC, topic);
+
+        RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.SEND_MESSAGE_V2, null);
+        sendMessageProcessor.attachRecallHandle(request, message, responseHeader);
+        Assert.assertNull(responseHeader.getRecallHandle());
+
+        MessageAccessor.putProperty(message, MessageConst.PROPERTY_TIMER_OUT_MS, "-1");
+        sendMessageProcessor.attachRecallHandle(request, message, responseHeader);
+        Assert.assertNull(responseHeader.getRecallHandle());
+    }
+
     private long floor(long deliverMs, int precisionMs) {
         assert precisionMs > 0;
         if (deliverMs % precisionMs == 0) {


### PR DESCRIPTION
### Motivation

`attachRecallHandle` parsed the client-visible `TIMER_OUT_MS` property with `Long.parseLong` before `doResponse` in the async send path. A message carrying a non-numeric value threw `NumberFormatException`, so the send response was never written and the client hung until its own timeout.

### Modifications

Parse with `NumberUtils.toLong` and skip building the recall handle when the value is not a non-negative number, mirroring the guard already used in `RecallMessageProcessor`.

### Verification

Fail-before (new test, run against the unpatched code):

```
SendMessageProcessorTest#testAttachRecallHandle_invalidTimestamp
java.lang.NumberFormatException: For input string: "not-a-timestamp"
  at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
  (thrown from SendMessageProcessor.attachRecallHandle before the response was written)
```

Pass-after:

```
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0 -- SendMessageProcessorTest
```
