### PR TITLE
fix(broker): reject pop requests with non-positive maxMsgNums

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PopMessageProcessor.java
@@ -264,6 +264,13 @@ public class PopMessageProcessor implements NettyRequestProcessor {
             return response;
         }
 
+        if (requestHeader.getMaxMsgNums() <= 0) {
+            response.setCode(ResponseCode.INVALID_PARAMETER);
+            response.setRemark(String.format("the broker[%s] pop message's num must be positive",
+                this.brokerController.getBrokerConfig().getBrokerIP1()));
+            return response;
+        }
+
         if (!brokerController.getMessageStore().getMessageStoreConfig().isTimerWheelEnable()) {
             response.setCode(ResponseCode.SYSTEM_ERROR);
             response.setRemark(String.format("the broker[%s] pop message is forbidden because timerWheelEnable is false",

--- a/broker/src/test/java/org/apache/rocketmq/broker/processor/PopMessageProcessorTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/processor/PopMessageProcessorTest.java
@@ -242,6 +242,29 @@ public class PopMessageProcessorTest {
         assertEquals(ck.getReviveTime(), actual.getReviveTime());
     }
 
+    @Test
+    public void testProcessRequest_IllegalMaxMsgNums() throws RemotingCommandException {
+        for (int maxMsgNums : new int[] {0, -1}) {
+            PopMessageRequestHeader requestHeader = new PopMessageRequestHeader();
+            requestHeader.setConsumerGroup(group);
+            requestHeader.setMaxMsgNums(maxMsgNums);
+            requestHeader.setQueueId(-1);
+            requestHeader.setTopic(topic);
+            requestHeader.setInvisibleTime(10_000);
+            requestHeader.setInitMode(ConsumeInitMode.MAX);
+            requestHeader.setOrder(false);
+            requestHeader.setPollTime(15_000);
+            requestHeader.setBornTime(System.currentTimeMillis());
+            RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.POP_MESSAGE, requestHeader);
+            request.makeCustomHeaderToNet();
+
+            RemotingCommand response = popMessageProcessor.processRequest(handlerContext, request);
+            assertThat(response).isNotNull();
+            assertThat(response.getCode()).isEqualTo(ResponseCode.INVALID_PARAMETER);
+            assertThat(response.getRemark()).contains("num must be positive");
+        }
+    }
+
     private RemotingCommand createPopMsgCommand() {
         return createPopMsgCommand(group, topic, -1, ConsumeInitMode.MAX);
     }


### PR DESCRIPTION
### Motivation

`processRequest` only validated `maxMsgNums > 32`. A request with `maxMsgNums = 0` fell through to the polling logic with a zero message budget instead of being rejected, and a negative value made `new GetMessageResult` pass the negative size to `new ArrayList`, throwing `IllegalArgumentException` from deep inside the pop path instead of a clean `INVALID_PARAMETER` response.

### Modifications

Validate `maxMsgNums >= 1` next to the existing upper-bound check.

### Verification

Fail-before (new test, run against the unpatched code):

```
PopMessageProcessorTest#testProcessRequest_IllegalMaxMsgNums
java.lang.NullPointerException: Cannot invoke "MessageStoreConfig.isTimerWheelEnable()" because
"MessageStore.getMessageStoreConfig()" is null -- PopMessageProcessorTest.testProcessRequest_IllegalMaxMsgNums:261
(the maxMsgNums=0 request was not rejected and fell through into the polling path)
```

Pass-after:

```
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0 -- PopMessageProcessorTest
```
