### PR TITLE
fix(tools): report unknown cluster as error in exportMetrics command

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java
@@ -95,6 +95,10 @@ public class ExportMetricsCommand implements SubCommand {
 
             ClusterInfo clusterInfoSerializeWrapper = defaultMQAdminExt.examineBrokerClusterInfo();
             Set<String> brokerNameSet = clusterInfoSerializeWrapper.getClusterAddrTable().get(clusterName);
+            if (brokerNameSet == null) {
+                System.out.printf("cluster [%s] not exist%n", clusterName);
+                return;
+            }
             for (String brokerName : brokerNameSet) {
                 BrokerData brokerData = clusterInfoSerializeWrapper.getBrokerAddrTable().get(brokerName);
                 if (brokerData != null) {

--- a/tools/src/test/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommandTest.java
+++ b/tools/src/test/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommandTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.tools.command.export;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.srvutil.ServerUtil;
+import org.apache.rocketmq.tools.command.SubCommandException;
+import org.apache.rocketmq.tools.command.server.ServerResponseMocker;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExportMetricsCommandTest {
+
+    private ServerResponseMocker nameServerMocker;
+
+    private final PrintStream stdout = System.out;
+
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    @Before
+    public void before() {
+        System.setOut(new PrintStream(output));
+        nameServerMocker = startNameServer();
+        System.setProperty(MixAll.NAMESRV_ADDR_PROPERTY, "localhost:" + nameServerMocker.listenPort());
+    }
+
+    @After
+    public void after() {
+        System.clearProperty(MixAll.NAMESRV_ADDR_PROPERTY);
+        nameServerMocker.shutdown();
+        System.setOut(stdout);
+    }
+
+    @Test
+    public void testUnknownClusterReportsCleanError() throws SubCommandException {
+        ExportMetricsCommand cmd = new ExportMetricsCommand();
+        Options options = ServerUtil.buildCommandlineOptions(new Options());
+        String[] subargs = "-c clusterTypo -f /tmp/rocketmq_export_metrics_test".split(" ");
+        final CommandLine commandLine =
+            ServerUtil.parseCmdLine("mqadmin " + cmd.commandName(), subargs,
+                cmd.buildCommandlineOptions(options),
+                new DefaultParser());
+        // must not throw: a typo in the cluster name should print a clean error
+        cmd.execute(commandLine, options, null);
+        Assert.assertTrue(output.toString(), output.toString().contains("cluster [clusterTypo] not exist"));
+    }
+
+    private ServerResponseMocker startNameServer() {
+        ClusterInfo clusterInfo = new ClusterInfo();
+
+        HashMap<String, BrokerData> brokerAddressTable = new HashMap<>();
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("mockBrokerName");
+        HashMap<Long, String> brokerAddress = new HashMap<>();
+        brokerAddress.put(0L, "127.0.0.1:1");
+        brokerData.setBrokerAddrs(brokerAddress);
+        brokerData.setCluster("mockCluster");
+        brokerAddressTable.put("mockBrokerName", brokerData);
+        clusterInfo.setBrokerAddrTable(brokerAddressTable);
+
+        HashMap<String, Set<String>> clusterAddressTable = new HashMap<>();
+        Set<String> brokerNames = new HashSet<>();
+        brokerNames.add("mockBrokerName");
+        clusterAddressTable.put("mockCluster", brokerNames);
+        clusterInfo.setClusterAddrTable(clusterAddressTable);
+
+        return ServerResponseMocker.startServer(clusterInfo.encode());
+    }
+}


### PR DESCRIPTION
### Motivation

A typo in the required `-c` option of `mqadmin exportMetrics` made `clusterAddrTable.get(clusterName)` return null, and the following for-each threw a raw `NullPointerException` from inside the command, producing a stack trace instead of an error message.

### Modifications

Print a `cluster not exist` error like the sibling cluster commands do.

### Verification

Fail-before (new test, run against the unpatched code):

```
ExportMetricsCommandTest#testUnknownClusterReportsCleanError
java.lang.NullPointerException: Cannot invoke "java.util.Set.iterator()" because "brokerNameSet" is null
```

Pass-after:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- ExportMetricsCommandTest
```
