### PR TITLE
fix(client): clear reachable flag when the latency fault detector observes a failure

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImpl.java
@@ -73,6 +73,9 @@ public class LatencyFaultToleranceImpl implements LatencyFaultTolerance<String> 
                 if (serviceOK && !brokerItem.reachableFlag) {
                     log.info(brokerItem.name + " is reachable now, then it can be used.");
                     brokerItem.reachableFlag = true;
+                } else if (!serviceOK && brokerItem.reachableFlag) {
+                    log.info(brokerItem.name + " is unreachable now, it will not be used until it's reachable.");
+                    brokerItem.reachableFlag = false;
                 }
             }
         }

--- a/client/src/test/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImplTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/latency/LatencyFaultToleranceImplTest.java
@@ -80,4 +80,28 @@ public class LatencyFaultToleranceImplTest {
         latencyFaultTolerance.updateFaultItem(anotherBrokerName, 1001, 3000, false);
         assertThat(latencyFaultTolerance.isReachable(anotherBrokerName)).isEqualTo(false);
     }
+
+    @Test
+    public void testDetectByOneRoundClearsReachableFlagWhenDetectFails() {
+        LatencyFaultToleranceImpl faultTolerance =
+            new LatencyFaultToleranceImpl(name -> name, (addr, timeoutMillis) -> false);
+        faultTolerance.updateFaultItem(brokerName, 0, 0, true);
+        assertThat(faultTolerance.isReachable(brokerName)).isTrue();
+
+        faultTolerance.detectByOneRound();
+
+        assertThat(faultTolerance.isReachable(brokerName)).isFalse();
+    }
+
+    @Test
+    public void testDetectByOneRoundKeepsReachableFlagWhenDetectSucceeds() {
+        LatencyFaultToleranceImpl faultTolerance =
+            new LatencyFaultToleranceImpl(name -> name, (addr, timeoutMillis) -> true);
+        faultTolerance.updateFaultItem(brokerName, 0, 0, false);
+        assertThat(faultTolerance.isReachable(brokerName)).isFalse();
+
+        faultTolerance.detectByOneRound();
+
+        assertThat(faultTolerance.isReachable(brokerName)).isTrue();
+    }
 }


### PR DESCRIPTION
### Motivation

`LatencyFaultToleranceImpl.detectByOneRound` only flipped `FaultItem.reachableFlag` from false to true. Once a broker had been marked reachable, a failing service detector was ignored, so `MQFaultStrategy`'s reachable filter kept selecting a broker that had gone down until a real send happened to fail against it.

### Modifications

Reset the flag symmetrically when the detector reports the broker unreachable, so the next broker-selection round sees the failure.

### Verification

Fail-before (new test, run against the unpatched code):

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 1 -- LatencyFaultToleranceImplTest#testDetectByOneRoundClearsReachableFlagWhenDetectFails
```

Pass-after:

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 1 -- LatencyFaultToleranceImplTest
```
