### PR TITLE
fix(remoting): report version 0 for consumer groups without connections

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerConnection.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerConnection.java
@@ -35,6 +35,9 @@ public class ConsumerConnection extends RemotingSerializable {
     private ConsumeFromWhere consumeFromWhere;
 
     public int computeMinVersion() {
+        if (this.connectionSet.isEmpty()) {
+            return 0;
+        }
         int minVersion = Integer.MAX_VALUE;
         for (Connection c : this.connectionSet) {
             if (c.getVersion() < minVersion) {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/body/ConsumerConnectionTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/body/ConsumerConnectionTest.java
@@ -80,4 +80,11 @@ public class ConsumerConnectionTest {
         int version = consumerConnection.computeMinVersion();
         assertThat(version).isEqualTo(1);
     }
+
+    @Test
+    public void testComputeMinVersionWithNoConnection() {
+        // a group without live connections must not be reported as HighestVersion
+        ConsumerConnection consumerConnection = new ConsumerConnection();
+        assertThat(consumerConnection.computeMinVersion()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
### Motivation

`ConsumerConnection.computeMinVersion` kept its `Integer.MAX_VALUE` sentinel when the connection set was empty, so `mqadmin consumerProgress` printed `HighestVersion (2147483647)` for idle consumer groups whose clients had all disconnected.

### Modifications

Return 0 for an empty set instead.

### Verification

Fail-before (new test, run against the unpatched code):

```
ConsumerConnectionTest#testComputeMinVersionWithNoConnection
java.lang.AssertionError: expected: 0 but was: 2147483647
```

Pass-after:

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- ConsumerConnectionTest
```
