### PR TITLE
fix(store): estimate batch consume queue count up to max offset

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
+++ b/store/src/main/java/org/apache/rocketmq/store/queue/BatchConsumeQueue.java
@@ -1107,11 +1107,14 @@ public class BatchConsumeQueue implements ConsumeQueueInterface {
         }
         long physicalOffsetFrom = firstMappedFileBuffer.getStartOffset();
 
-        SelectMappedBufferResult lastMappedFileBuffer = getBatchMsgIndexBuffer(to);
+        // 'to' is an exclusive upper bound, so the last unit in range is the one
+        // containing 'to - 1'; getBatchMsgIndexBuffer returns null for offsets
+        // >= maxOffsetInQueue, which made counting up to the queue head fail
+        SelectMappedBufferResult lastMappedFileBuffer = getBatchMsgIndexBuffer(to - 1);
         if (lastMappedFileBuffer == null) {
             return -1;
         }
-        long physicalOffsetTo = lastMappedFileBuffer.getStartOffset();
+        long physicalOffsetTo = lastMappedFileBuffer.getStartOffset() + CQ_STORE_UNIT_SIZE;
 
         List<MappedFile> mappedFiles = mappedFileQueue.range(physicalOffsetFrom, physicalOffsetTo);
         if (mappedFiles.isEmpty()) {

--- a/store/src/test/java/org/apache/rocketmq/store/queue/BatchConsumeQueueTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/queue/BatchConsumeQueueTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.store.queue;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.store.ConsumeQueue;
+import org.apache.rocketmq.store.ConsumeQueueExt;
 import org.apache.rocketmq.store.DefaultMessageStore;
 import org.apache.rocketmq.store.MessageStore;
 import org.apache.rocketmq.store.SelectMappedBufferResult;
@@ -31,9 +32,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import org.apache.rocketmq.store.MessageFilter;
 
 import static java.lang.String.format;
 
@@ -248,6 +252,41 @@ public class BatchConsumeQueueTest extends StoreTestBase {
         Assert.assertEquals(801, batchConsumeQueue.getMaxOffsetInQueue());
         Assert.assertEquals(301, batchConsumeQueue.getMinOffsetInQueue());
 
+    }
+
+    @Test(timeout = 20000)
+    public void testEstimateMessageCount() {
+        BatchConsumeQueue batchConsumeQueue = createBatchConsume(null);
+        batchConsumeQueue.load();
+        short batchSize = 10;
+        int unitNum = 100;
+        for (int i = 0; i < unitNum; i++) {
+            batchConsumeQueue.putBatchMessagePositionInfo(i, 100, 0, i * batchSize, i * batchSize + 1, batchSize);
+        }
+        Assert.assertEquals(1001, batchConsumeQueue.getMaxOffsetInQueue());
+        Assert.assertEquals(1, batchConsumeQueue.getMinOffsetInQueue());
+
+        MessageFilter matchAllFilter = new MessageFilter() {
+            @Override
+            public boolean isMatchedByConsumeQueue(Long tagsCode, ConsumeQueueExt.CqExtUnit cqExtUnit) {
+                return true;
+            }
+
+            @Override
+            public boolean isMatchedByCommitLog(ByteBuffer msgBuffer, Map<String, String> properties) {
+                return true;
+            }
+        };
+
+        // interior range
+        Assert.assertEquals(500, batchConsumeQueue.estimateMessageCount(1, 501, matchAllFilter));
+
+        // ranges ending at maxOffsetInQueue must be estimated instead of returning -1
+        Assert.assertEquals(1000, batchConsumeQueue.estimateMessageCount(1, 1001, matchAllFilter));
+        Assert.assertEquals(200, batchConsumeQueue.estimateMessageCount(801, 1001, matchAllFilter));
+
+        // out-of-range upper bound still reports -1
+        Assert.assertEquals(-1, batchConsumeQueue.estimateMessageCount(1, 1002, matchAllFilter));
     }
 
     @After


### PR DESCRIPTION
### Motivation

`estimateMessageCount` translated the exclusive upper bound `to` with `getBatchMsgIndexBuffer(to)`, which returns null when `to` equals `maxOffsetInQueue`. Every accumulation query that counts up to the queue head therefore hit the null branch and returned -1, and callers such as `DefaultMessageStore` silently fell back to the raw offset difference, ignoring batch sizes and tag filters.

### Modifications

Since `to` is exclusive, look up the unit containing `to - 1` instead, and advance `physicalOffsetTo` past that unit so the scan covers it. Interior ranges are unaffected because a `to` that lands on a batch base resolves to the same mapped position as before.

### Verification

Fail-before (new test, run against the unpatched code):

```
Tests run: 6, Failures: 1, Errors: 0 -- BatchConsumeQueueTest#testEstimateMessageCount
java.lang.AssertionError: expected:<1000> but was:<-1>
  BatchConsumeQueueTest.testEstimateMessageCount:285 -- estimateMessageCount(1, 1001) with to == maxOffsetInQueue
```

Pass-after:

```
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0 -- BatchConsumeQueueTest
```
