### PR TITLE
[ISSUE #11151] Coordinate graceful shutdown of remoting sub-servers

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -80,9 +80,9 @@ import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
-import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
@@ -90,6 +90,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class NettyRemotingServer extends NettyRemotingAbstract implements RemotingServer {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.ROCKETMQ_REMOTING_NAME);
@@ -107,6 +109,11 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
     private final HashedWheelTimer timer = new HashedWheelTimer(r -> new Thread(r, "ServerHouseKeepingService"));
 
     private DefaultEventExecutorGroup defaultEventExecutorGroup;
+
+    // Only protects the transition to draining; never held while waiting or closing channels.
+    private final ReentrantLock shutdownLock = new ReentrantLock();
+    private final AtomicBoolean shutdownStarted = new AtomicBoolean();
+    private final CompletableFuture<Void> shutdownComplete = new CompletableFuture<>();
 
     /**
      * NettyRemotingServer may hold multiple SubRemotingServer, each server will be stored in this container with a
@@ -330,11 +337,39 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
 
     @Override
     public void shutdown() {
+        if (!shutdownStarted.compareAndSet(false, true)) {
+            shutdownComplete.join();
+            return;
+        }
         try {
-            if (nettyServerConfig.isEnableShutdownGracefully() && isShuttingDown.compareAndSet(false, true)) {
-                Thread.sleep(Duration.ofSeconds(nettyServerConfig.getShutdownWaitTimeSeconds()).toMillis());
+            long deadlineNanos;
+            shutdownLock.lock();
+            try {
+                deadlineNanos = shutdownDeadlineNanos();
+                if (nettyServerConfig.isEnableShutdownGracefully()) {
+                    isShuttingDown.set(true);
+                }
+                for (NettyRemotingAbstract server : remotingServerTable.values()) {
+                    if (server instanceof SubRemotingServer) {
+                        SubRemotingServer subServer = (SubRemotingServer) server;
+                        subServer.beginShutdown();
+                        if (subServer.shutdownDeadlineNanos - deadlineNanos > 0) {
+                            deadlineNanos = subServer.shutdownDeadlineNanos;
+                        }
+                    }
+                }
+            } finally {
+                shutdownLock.unlock();
             }
+            awaitShutdownDeadline(deadlineNanos);
 
+            // Each server has its own deadline. Wait for the latest one before releasing
+            // shared resources, without serializing the children's blocking shutdowns.
+            for (NettyRemotingAbstract server : remotingServerTable.values()) {
+                if (server instanceof SubRemotingServer) {
+                    ((SubRemotingServer) server).closeListener();
+                }
+            }
             this.timer.stop();
             this.scheduledExecutorService.shutdown();
 
@@ -351,11 +386,38 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             log.error("NettyRemotingServer shutdown exception, ", e);
         }
 
-        if (this.publicExecutor != null) {
-            try {
+        try {
+            if (this.publicExecutor != null) {
                 this.publicExecutor.shutdown();
-            } catch (Exception e) {
-                log.error("NettyRemotingServer shutdown exception, ", e);
+            }
+        } catch (Exception e) {
+            log.error("NettyRemotingServer shutdown exception, ", e);
+        } finally {
+            shutdownComplete.complete(null);
+        }
+    }
+
+    private long shutdownDeadlineNanos() {
+        long waitNanos = nettyServerConfig.isEnableShutdownGracefully()
+            ? TimeUnit.SECONDS.toNanos(Math.max(0, nettyServerConfig.getShutdownWaitTimeSeconds())) : 0;
+        return System.nanoTime() + waitNanos;
+    }
+
+    private void awaitShutdownDeadline(long deadlineNanos) {
+        boolean interrupted = false;
+        try {
+            long remainingNanos;
+            while ((remainingNanos = deadlineNanos - System.nanoTime()) > 0) {
+                try {
+                    TimeUnit.NANOSECONDS.sleep(remainingNanos);
+                } catch (InterruptedException e) {
+                    // An interrupted caller must not shorten another server's drain window.
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
             }
         }
     }
@@ -674,6 +736,10 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
     class SubRemotingServer extends NettyRemotingAbstract implements RemotingServer {
         private volatile int listenPort;
         private volatile Channel serverChannel;
+        private final AtomicBoolean shutdownStarted = new AtomicBoolean();
+        private final CompletableFuture<Void> shutdownComplete = new CompletableFuture<>();
+        // Guarded by the parent's shutdownLock, like the transition of isShuttingDown.
+        private long shutdownDeadlineNanos;
 
         SubRemotingServer(final int port, final int permitsOnway, final int permitsAsync) {
             super(permitsOnway, permitsAsync);
@@ -760,13 +826,39 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
 
         @Override
         public void shutdown() {
-            isShuttingDown.set(true);
-            if (this.serverChannel != null) {
-                try {
-                    this.serverChannel.close().await(5, TimeUnit.SECONDS);
-                } catch (InterruptedException ignored) {
-                }
+            if (!shutdownStarted.compareAndSet(false, true)) {
+                shutdownComplete.join();
+                return;
             }
+            try {
+                long deadlineNanos;
+                shutdownLock.lock();
+                try {
+                    beginShutdown();
+                    deadlineNanos = shutdownDeadlineNanos;
+                } finally {
+                    shutdownLock.unlock();
+                }
+                awaitShutdownDeadline(deadlineNanos);
+                ChannelFuture closeFuture = closeListener();
+                if (closeFuture != null) {
+                    closeFuture.awaitUninterruptibly(5, TimeUnit.SECONDS);
+                }
+            } finally {
+                shutdownComplete.complete(null);
+            }
+        }
+
+        // Called under shutdownLock. A child already draining keeps its original deadline.
+        private void beginShutdown() {
+            if (!isShuttingDown.get()) {
+                shutdownDeadlineNanos = NettyRemotingServer.this.shutdownDeadlineNanos();
+                isShuttingDown.set(true);
+            }
+        }
+
+        private ChannelFuture closeListener() {
+            return this.serverChannel == null ? null : this.serverChannel.close();
         }
 
         @Override

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingServer.java
@@ -82,7 +82,6 @@ import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
@@ -91,7 +90,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class NettyRemotingServer extends NettyRemotingAbstract implements RemotingServer {
     private static final Logger log = LoggerFactory.getLogger(LoggerName.ROCKETMQ_REMOTING_NAME);
@@ -110,10 +109,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
 
     private DefaultEventExecutorGroup defaultEventExecutorGroup;
 
-    // Only protects the transition to draining; never held while waiting or closing channels.
-    private final ReentrantLock shutdownLock = new ReentrantLock();
     private final AtomicBoolean shutdownStarted = new AtomicBoolean();
-    private final CompletableFuture<Void> shutdownComplete = new CompletableFuture<>();
 
     /**
      * NettyRemotingServer may hold multiple SubRemotingServer, each server will be stored in this container with a
@@ -338,28 +334,20 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
     @Override
     public void shutdown() {
         if (!shutdownStarted.compareAndSet(false, true)) {
-            shutdownComplete.join();
             return;
         }
         try {
-            long deadlineNanos;
-            shutdownLock.lock();
-            try {
-                deadlineNanos = shutdownDeadlineNanos();
-                if (nettyServerConfig.isEnableShutdownGracefully()) {
-                    isShuttingDown.set(true);
-                }
-                for (NettyRemotingAbstract server : remotingServerTable.values()) {
-                    if (server instanceof SubRemotingServer) {
-                        SubRemotingServer subServer = (SubRemotingServer) server;
-                        subServer.beginShutdown();
-                        if (subServer.shutdownDeadlineNanos - deadlineNanos > 0) {
-                            deadlineNanos = subServer.shutdownDeadlineNanos;
-                        }
+            long deadlineNanos = shutdownDeadlineNanos();
+            if (nettyServerConfig.isEnableShutdownGracefully()) {
+                isShuttingDown.set(true);
+            }
+            for (NettyRemotingAbstract server : remotingServerTable.values()) {
+                if (server instanceof SubRemotingServer) {
+                    long childDeadlineNanos = ((SubRemotingServer) server).beginShutdown();
+                    if (childDeadlineNanos - deadlineNanos > 0) {
+                        deadlineNanos = childDeadlineNanos;
                     }
                 }
-            } finally {
-                shutdownLock.unlock();
             }
             awaitShutdownDeadline(deadlineNanos);
 
@@ -392,8 +380,6 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
             }
         } catch (Exception e) {
             log.error("NettyRemotingServer shutdown exception, ", e);
-        } finally {
-            shutdownComplete.complete(null);
         }
     }
 
@@ -737,9 +723,7 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         private volatile int listenPort;
         private volatile Channel serverChannel;
         private final AtomicBoolean shutdownStarted = new AtomicBoolean();
-        private final CompletableFuture<Void> shutdownComplete = new CompletableFuture<>();
-        // Guarded by the parent's shutdownLock, like the transition of isShuttingDown.
-        private long shutdownDeadlineNanos;
+        private final AtomicReference<Long> shutdownDeadlineNanos = new AtomicReference<>();
 
         SubRemotingServer(final int port, final int permitsOnway, final int permitsAsync) {
             super(permitsOnway, permitsAsync);
@@ -827,34 +811,20 @@ public class NettyRemotingServer extends NettyRemotingAbstract implements Remoti
         @Override
         public void shutdown() {
             if (!shutdownStarted.compareAndSet(false, true)) {
-                shutdownComplete.join();
                 return;
             }
-            try {
-                long deadlineNanos;
-                shutdownLock.lock();
-                try {
-                    beginShutdown();
-                    deadlineNanos = shutdownDeadlineNanos;
-                } finally {
-                    shutdownLock.unlock();
-                }
-                awaitShutdownDeadline(deadlineNanos);
-                ChannelFuture closeFuture = closeListener();
-                if (closeFuture != null) {
-                    closeFuture.awaitUninterruptibly(5, TimeUnit.SECONDS);
-                }
-            } finally {
-                shutdownComplete.complete(null);
+            awaitShutdownDeadline(beginShutdown());
+            ChannelFuture closeFuture = closeListener();
+            if (closeFuture != null) {
+                closeFuture.awaitUninterruptibly(5, TimeUnit.SECONDS);
             }
         }
 
-        // Called under shutdownLock. A child already draining keeps its original deadline.
-        private void beginShutdown() {
-            if (!isShuttingDown.get()) {
-                shutdownDeadlineNanos = NettyRemotingServer.this.shutdownDeadlineNanos();
-                isShuttingDown.set(true);
-            }
+        private long beginShutdown() {
+            // Keep the first deadline. Either caller can publish the draining flag after it.
+            shutdownDeadlineNanos.compareAndSet(null, NettyRemotingServer.this.shutdownDeadlineNanos());
+            isShuttingDown.set(true);
+            return shutdownDeadlineNanos.get();
         }
 
         private ChannelFuture closeListener() {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/TlsTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.remoting;
 
 import org.apache.rocketmq.common.utils.NetworkUtil;
 import org.apache.rocketmq.remoting.common.TlsMode;
+import org.apache.rocketmq.remoting.exception.RemotingConnectException;
 import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
@@ -220,7 +221,8 @@ public class TlsTest {
         try {
             RemotingCommand response = remotingClient.invokeSync(getServerAddress(), createRequest(), 1000 * 5);
             failBecauseExceptionWasNotThrown(RemotingSendRequestException.class);
-        } catch (RemotingSendRequestException ignore) {
+        } catch (RemotingConnectException | RemotingSendRequestException expected) {
+            // TLS rejection can close the channel before the active check or during the write.
         }
     }
 
@@ -355,7 +357,7 @@ public class TlsTest {
     }
 
     private String getServerAddress() {
-        return "localhost:" + remotingServer.localListenPort();
+        return "127.0.0.1:" + remotingServer.localListenPort();
     }
 
     private static RemotingCommand createRequest() {

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerGracefulShutdownTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerGracefulShutdownTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.remoting.netty;
 
+import io.netty.channel.Channel;
 import java.io.DataInputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -30,6 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.rocketmq.common.MQVersion;
 import org.apache.rocketmq.remoting.RemotingServer;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
@@ -92,7 +94,8 @@ public class NettyRemotingServerGracefulShutdownTest {
         Future<?> shutdown = shutdownExecutor.submit(child::shutdown);
         awaitDraining(child);
         Future<?> duplicate = shutdownExecutor.submit(child::shutdown);
-        assertWaiting(duplicate);
+        duplicate.get(1, TimeUnit.SECONDS);
+        assertWaiting(shutdown);
         assertThat(request(existing)).isEqualTo(ResponseCode.GO_AWAY);
         assertThat(request(connect(child))).isEqualTo(ResponseCode.GO_AWAY);
         // Retain the existing protocol-version condition for older clients.
@@ -102,7 +105,6 @@ public class NettyRemotingServerGracefulShutdownTest {
         assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
 
         shutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
-        duplicate.get(3, TimeUnit.SECONDS);
         assertListenerClosed(child);
         assertThat(request(connect(server))).isEqualTo(ResponseCode.SUCCESS);
         assertThat(request(connect(sibling))).isEqualTo(ResponseCode.SUCCESS);
@@ -120,7 +122,8 @@ public class NettyRemotingServerGracefulShutdownTest {
         awaitDraining(third);
         Future<?> duplicate = shutdownExecutor.submit(server::shutdown);
         Future<?> childShutdown = shutdownExecutor.submit(first::shutdown);
-        assertWaiting(duplicate);
+        duplicate.get(1, TimeUnit.SECONDS);
+        assertWaiting(shutdown);
         assertWaiting(childShutdown);
         assertThat(request(existing)).isEqualTo(ResponseCode.GO_AWAY);
         for (RemotingServer target : new RemotingServer[] {server, first, second, third}) {
@@ -129,7 +132,6 @@ public class NettyRemotingServerGracefulShutdownTest {
         assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
         // Three children must not add three separate grace periods to the parent shutdown.
         shutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
-        duplicate.get(3, TimeUnit.SECONDS);
         childShutdown.get(3, TimeUnit.SECONDS);
         assertListenerClosed(first);
         assertListenerClosed(second);
@@ -264,7 +266,10 @@ public class NettyRemotingServerGracefulShutdownTest {
         assertThatThrownBy(() -> shutdown.get(100, TimeUnit.MILLISECONDS)).isInstanceOf(TimeoutException.class);
     }
 
-    private void assertListenerClosed(RemotingServer target) {
-        assertThatThrownBy(() -> connect(target)).isInstanceOf(java.net.ConnectException.class);
+    private void assertListenerClosed(RemotingServer target) throws Exception {
+        // A closed port can report either refusal or connect timeout on different platforms.
+        Channel listener = (Channel) FieldUtils.readDeclaredField(target, "serverChannel", true);
+        assertThat(listener.closeFuture().await(3, TimeUnit.SECONDS)).isTrue();
+        assertThat(listener.isOpen()).isFalse();
     }
 }

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerGracefulShutdownTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/netty/NettyRemotingServerGracefulShutdownTest.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.rocketmq.remoting.netty;
+
+import java.io.DataInputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.rocketmq.common.MQVersion;
+import org.apache.rocketmq.remoting.RemotingServer;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+public class NettyRemotingServerGracefulShutdownTest {
+    private static final int REQUEST_CODE = 32001;
+    private static final int GRACE_SECONDS = 5;
+    private final List<Socket> sockets = new ArrayList<>();
+    private final ExecutorService shutdownExecutor = Executors.newFixedThreadPool(6);
+    private NettyServerConfig config;
+    private NettyRemotingServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        config = new NettyServerConfig();
+        config.setBindAddress("127.0.0.1");
+        config.setListenPort(0);
+        config.setServerSelectorThreads(1);
+        config.setServerWorkerThreads(1);
+        config.setServerCallbackExecutorThreads(1);
+        config.setEnableShutdownGracefully(true);
+        config.setShutdownWaitTimeSeconds(GRACE_SECONDS);
+        server = new NettyRemotingServer(config);
+        registerProcessor(server);
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (Socket socket : sockets) {
+            socket.close();
+        }
+        if (server != null) {
+            config.setEnableShutdownGracefully(false);
+            server.shutdown();
+            server.eventLoopGroupBoss.terminationFuture().await(10, TimeUnit.SECONDS);
+            server.eventLoopGroupSelector.terminationFuture().await(10, TimeUnit.SECONDS);
+            server.getDefaultEventExecutorGroup().terminationFuture().await(10, TimeUnit.SECONDS);
+            server.getCallbackExecutor().awaitTermination(10, TimeUnit.SECONDS);
+        }
+        shutdownExecutor.shutdownNow();
+        assertThat(shutdownExecutor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    public void testSubServerShutdownPreservesGracePeriodAndOtherPorts() throws Exception {
+        RemotingServer child = startSubServer();
+        RemotingServer sibling = startSubServer();
+        Socket existing = connect(child);
+        assertThat(request(existing)).isEqualTo(ResponseCode.SUCCESS);
+
+        Future<?> shutdown = shutdownExecutor.submit(child::shutdown);
+        awaitDraining(child);
+        Future<?> duplicate = shutdownExecutor.submit(child::shutdown);
+        assertWaiting(duplicate);
+        assertThat(request(existing)).isEqualTo(ResponseCode.GO_AWAY);
+        assertThat(request(connect(child))).isEqualTo(ResponseCode.GO_AWAY);
+        // Retain the existing protocol-version condition for older clients.
+        assertThat(request(existing, MQVersion.Version.V5_3_1.ordinal())).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(request(connect(server))).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(request(connect(sibling))).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
+
+        shutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
+        duplicate.get(3, TimeUnit.SECONDS);
+        assertListenerClosed(child);
+        assertThat(request(connect(server))).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(request(connect(sibling))).isEqualTo(ResponseCode.SUCCESS);
+    }
+
+    @Test
+    public void testParentShutdownDrainsAllPortsConcurrently() throws Exception {
+        RemotingServer first = startSubServer();
+        RemotingServer second = startSubServer();
+        RemotingServer third = startSubServer();
+        Socket existing = connect(first);
+        assertThat(request(existing)).isEqualTo(ResponseCode.SUCCESS);
+
+        Future<?> shutdown = shutdownExecutor.submit(server::shutdown);
+        awaitDraining(third);
+        Future<?> duplicate = shutdownExecutor.submit(server::shutdown);
+        Future<?> childShutdown = shutdownExecutor.submit(first::shutdown);
+        assertWaiting(duplicate);
+        assertWaiting(childShutdown);
+        assertThat(request(existing)).isEqualTo(ResponseCode.GO_AWAY);
+        for (RemotingServer target : new RemotingServer[] {server, first, second, third}) {
+            assertThat(request(connect(target))).isEqualTo(ResponseCode.GO_AWAY);
+        }
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
+        // Three children must not add three separate grace periods to the parent shutdown.
+        shutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
+        duplicate.get(3, TimeUnit.SECONDS);
+        childShutdown.get(3, TimeUnit.SECONDS);
+        assertListenerClosed(first);
+        assertListenerClosed(second);
+        assertListenerClosed(third);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isTrue();
+    }
+
+    @Test
+    public void testChildShutdownBeforeParentShutdown() throws Exception {
+        RemotingServer child = startSubServer();
+        Socket existing = connect(child);
+        assertThat(request(existing)).isEqualTo(ResponseCode.SUCCESS);
+        Future<?> childShutdown = shutdownExecutor.submit(child::shutdown);
+        awaitDraining(child);
+        // The child keeps its original deadline even if a later parent shutdown has
+        // a shorter configured wait. Shared event loops must outlive both deadlines.
+        config.setShutdownWaitTimeSeconds(1);
+        Future<?> parentShutdown = shutdownExecutor.submit(server::shutdown);
+        awaitDraining(server);
+        assertThatThrownBy(() -> parentShutdown.get(2, TimeUnit.SECONDS)).isInstanceOf(TimeoutException.class);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
+
+        assertThat(request(existing)).isEqualTo(ResponseCode.GO_AWAY);
+        assertThat(request(connect(child))).isEqualTo(ResponseCode.GO_AWAY);
+        assertThat(request(connect(server))).isEqualTo(ResponseCode.GO_AWAY);
+        childShutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
+        parentShutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
+        assertListenerClosed(child);
+    }
+
+    @Test
+    public void testConcurrentParentAndChildShutdown() throws Exception {
+        RemotingServer child = startSubServer();
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> shutdowns = new ArrayList<>();
+        for (RemotingServer target : new RemotingServer[] {server, child, server, child}) {
+            shutdowns.add(shutdownExecutor.submit(() -> {
+                start.await();
+                target.shutdown();
+                return null;
+            }));
+        }
+        start.countDown();
+        awaitDraining(server);
+        awaitDraining(child);
+        assertThat(request(connect(server))).isEqualTo(ResponseCode.GO_AWAY);
+        assertThat(request(connect(child))).isEqualTo(ResponseCode.GO_AWAY);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
+        for (Future<?> shutdown : shutdowns) {
+            shutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
+        }
+        assertListenerClosed(child);
+    }
+
+    @Test
+    public void testDisabledGracefulShutdownClosesImmediately() throws Exception {
+        config.setEnableShutdownGracefully(false);
+        config.setShutdownWaitTimeSeconds(30);
+        RemotingServer child = startSubServer();
+        shutdownExecutor.submit(child::shutdown).get(3, TimeUnit.SECONDS);
+        assertListenerClosed(child);
+        assertThat(request(connect(server))).isEqualTo(ResponseCode.SUCCESS);
+        shutdownExecutor.submit(server::shutdown).get(3, TimeUnit.SECONDS);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isTrue();
+    }
+
+    @Test
+    public void testInterruptedShutdownKeepsSharedGracePeriodAndCleansUp() throws Exception {
+        RemotingServer child = startSubServer();
+        AtomicBoolean interruptRestored = new AtomicBoolean();
+        Future<?> shutdown = shutdownExecutor.submit(() -> {
+            Thread.currentThread().interrupt();
+            server.shutdown();
+            interruptRestored.set(Thread.interrupted());
+        });
+        awaitDraining(child);
+        assertThat(request(connect(child))).isEqualTo(ResponseCode.GO_AWAY);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isFalse();
+        shutdown.get(GRACE_SECONDS + 3, TimeUnit.SECONDS);
+        assertThat(interruptRestored.get()).isTrue();
+        assertListenerClosed(child);
+        assertThat(server.eventLoopGroupSelector.isShuttingDown()).isTrue();
+    }
+
+    private RemotingServer startSubServer() throws Exception {
+        int port;
+        try (ServerSocket availablePort = new ServerSocket(0)) {
+            port = availablePort.getLocalPort();
+        }
+        RemotingServer child = server.newRemotingServer(port);
+        registerProcessor(child);
+        child.start();
+        return child;
+    }
+
+    private void registerProcessor(RemotingServer target) {
+        target.registerProcessor(REQUEST_CODE, (ctx, command) ->
+            RemotingCommand.createResponseCommand(ResponseCode.SUCCESS, "ok"), null);
+    }
+
+    private Socket connect(RemotingServer target) throws Exception {
+        Socket socket = new Socket();
+        sockets.add(socket);
+        socket.connect(new InetSocketAddress("127.0.0.1", target.localListenPort()), 1000);
+        socket.setSoTimeout(1000);
+        return socket;
+    }
+
+    private int request(Socket socket) throws Exception {
+        return request(socket, MQVersion.CURRENT_VERSION);
+    }
+
+    private int request(Socket socket, int version) throws Exception {
+        RemotingCommand command = RemotingCommand.createRequestCommand(REQUEST_CODE, null);
+        command.setVersion(version);
+        ByteBuffer encoded = command.encode();
+        byte[] data = new byte[encoded.remaining()];
+        encoded.get(data);
+        socket.getOutputStream().write(data);
+        socket.getOutputStream().flush();
+        DataInputStream input = new DataInputStream(socket.getInputStream());
+        byte[] response = new byte[input.readInt()];
+        input.readFully(response);
+        return RemotingCommand.decode(response).getCode();
+    }
+
+    private void awaitDraining(RemotingServer target) {
+        await().atMost(3, TimeUnit.SECONDS).untilTrue(((NettyRemotingAbstract) target).isShuttingDown);
+    }
+
+    private void assertWaiting(Future<?> shutdown) {
+        assertThatThrownBy(() -> shutdown.get(100, TimeUnit.MILLISECONDS)).isInstanceOf(TimeoutException.class);
+    }
+
+    private void assertListenerClosed(RemotingServer target) {
+        assertThatThrownBy(() -> connect(target)).isInstanceOf(java.net.ConnectException.class);
+    }
+}

--- a/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/timer/TimerMessageStoreTest.java
@@ -305,6 +305,7 @@ public class TimerMessageStoreTest {
 
         int passFlowControlNum = 0;
         for (int i = 0; i < 500; i++) {
+            long expectedCongestNum = timerMessageStore.getCongestNum(delayMs - precisionMs) + 1;
             MessageExtBrokerInner inner = buildMessage(delayMs, topic, false);
 
             PutMessageResult putMessageResult = transformTimerMessage(timerMessageStore,inner);
@@ -313,6 +314,13 @@ public class TimerMessageStoreTest {
             }
             else {
                 putMessageResult = new PutMessageResult(PutMessageStatus.WHEEL_TIMER_FLOW_CONTROL,null);
+            }
+
+            if (putMessageResult.getPutMessageStatus() == PutMessageStatus.PUT_OK) {
+                // Wait until this accepted message reaches the wheel before checking the next one.
+                await().pollDelay(0, TimeUnit.MILLISECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .until(() -> timerMessageStore.getCongestNum(delayMs - precisionMs) == expectedCongestNum);
             }
 
             // Message with delayMs in getSlotIndex(delayMs - precisionMs).
@@ -327,8 +335,6 @@ public class TimerMessageStoreTest {
                     passFlowControlNum++;
                 }
             }
-            //wait reput
-            Thread.sleep(5);
         }
         assertThat(passFlowControlNum).isGreaterThan(0).isLessThan(120);
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #11151.

### Brief Description

A sub-server now honors the existing graceful-shutdown configuration: it enters the draining state, keeps its listener open for its own grace period, and then closes that listener. Requests continue to use the existing `GO_AWAY` handling and client-version condition. Other ports and shared executors remain available when a child shuts down independently.

Parent shutdown starts draining all children before waiting. Each server records its own deadline on its first transition to draining; an already draining child retains its original deadline. The parent waits for the latest deadline before closing child listeners and releasing shared resources, so the grace periods overlap instead of accumulating sequentially. An atomic compare-and-set records each child's first deadline, including when main and child shutdown run concurrently. Repeated shutdown calls return immediately without repeating cleanup or resetting the deadline. Coordination uses only atomic state and adds no executor or timer thread.

### How Did You Test This Change?

- JDK 11: 14 focused remoting server/config/lifecycle tests passed, with Checkstyle and SpotBugs enabled.
- JDK 21: all 6 new plaintext-TCP shutdown tests passed (`jacoco.skip=true`, `spotbugs.skip=true`; static analysis was run under JDK 11).
- The new real-TCP tests cover existing and fresh connections during draining, independent child shutdown and unaffected sibling/parent ports, parent-only shutdown of multiple children, both parent/child shutdown orders, simultaneous and repeated calls, a pre-existing child deadline longer than the parent's wait, disabled graceful shutdown, older client versions, and interruption.
- Listener closure is verified through the actual channel close future, avoiding platform-specific connection-refusal versus connection-timeout behavior.
- On the unmodified base, the parent-shutdown regression test fails because children never enter the draining state.

### CI test stabilization

- `TlsTest.disabledServerRejectsSSLClient` accepts either connection or send failure: the server rejects TLS by closing the connection, which may happen before the client checks channel activity or during its write. TLS tests use the loopback IP to avoid hostname resolution.
- `TimerMessageStoreTest.testTimerFlowControl` waits for each accepted message to reach the timer wheel before testing the next admission, replacing a fixed 5 ms sleep. This preserves the flow-control assertions without assuming the asynchronous reput/enqueue work has already completed.
- JDK 11: all 13 TLS tests and the timer flow-control test passed with Checkstyle and SpotBugs enabled.
