### PR TITLE
[ISSUE #10978] Add Nullable annotations to nullable Message getters and stop kotlin-stdlib transitive leak

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -67,6 +67,12 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/common/src/main/java/org/apache/rocketmq/common/message/Message.java
+++ b/common/src/main/java/org/apache/rocketmq/common/message/Message.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 public class Message implements Serializable {
     private static final long serialVersionUID = 8445773977080406428L;
@@ -98,10 +99,12 @@ public class Message implements Serializable {
         this.putProperty(name, value);
     }
 
+    @Nullable
     public String getUserProperty(final String name) {
         return this.getProperty(name);
     }
 
+    @Nullable
     public String getProperty(final String name) {
         if (null == this.properties) {
             this.properties = new HashMap<>();
@@ -125,6 +128,7 @@ public class Message implements Serializable {
         this.topic = topic;
     }
 
+    @Nullable
     public String getTags() {
         return this.getProperty(MessageConst.PROPERTY_TAGS);
     }
@@ -133,6 +137,7 @@ public class Message implements Serializable {
         this.putProperty(MessageConst.PROPERTY_TAGS, tags);
     }
 
+    @Nullable
     public String getKeys() {
         return this.getProperty(MessageConst.PROPERTY_KEYS);
     }
@@ -200,6 +205,7 @@ public class Message implements Serializable {
         this.body = body;
     }
 
+    @Nullable
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -208,6 +214,7 @@ public class Message implements Serializable {
         this.properties = properties;
     }
 
+    @Nullable
     public String getBuyerId() {
         return getProperty(MessageConst.PROPERTY_BUYER_ID);
     }
@@ -216,6 +223,7 @@ public class Message implements Serializable {
         putProperty(MessageConst.PROPERTY_BUYER_ID, buyerId);
     }
 
+    @Nullable
     public String getTransactionId() {
         return transactionId;
     }


### PR DESCRIPTION
## What is the purpose of the change

Two independent fixes from issue #10978:

1. **Nullable getters**: annotate the seven `Message` getters that return null under normal conditions — `getTags()`, `getKeys()`, `getProperty()`, `getUserProperty()`, `getBuyerId()`, `getProperties()`, `getTransactionId()` — with `javax.annotation.Nullable`. Pure metadata, no behavioral change; lets Java IDEs and Kotlin callers detect the nullability.

2. **kotlin-stdlib transitive leak**: exclude `com.squareup.okhttp3:okhttp` from the `opentelemetry-exporter-otlp` dependency in `common/pom.xml`. The unused HTTP sender (RocketMQ uses the gRPC exporter) pulled `kotlin-stdlib` into every pure-Java consumer. This mirrors the kotlin exclusions already applied to the `okio-jvm` edge in the root pom.

## Brief changelog

- `common/src/main/java/org/apache/rocketmq/common/message/Message.java`: add `@Nullable` to seven getters.
- `common/pom.xml`: add okhttp exclusion to `opentelemetry-exporter-otlp`.

## Verifying this change

- `mvn -f common/pom.xml compile` — BUILD SUCCESS (checkstyle + spotbugs pass).
- `mvn -f common/pom.xml dependency:tree -Dincludes=org.jetbrains.kotlin` — no kotlin artifacts remain in the tree.

Closes #10978