### PR TITLE
[ISSUE #11156]fix(timer): persist TimelineRollService checkpoint to avoid repeated and loss

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
+++ b/store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java
@@ -112,7 +112,6 @@ public class MessageStoreConfig {
     private long timerRocksDBPrecisionMs = 1000L;
     private double timerRocksDBRollMaxTps = 8000.0;
     private double timerRocksDBTimeExpiredMaxTps = 200000.0;
-    private int timerRocksDBRollIntervalHours = 1;
     private int timerRocksDBRollRangeHours = 2;
     private boolean timerRecallToTimeWheelEnable = true;
     private boolean timerRecallToTimelineEnable = true;
@@ -2396,14 +2395,6 @@ public class MessageStoreConfig {
 
     public int getTimerReputServiceQueueCapacity() {
         return timerReputServiceQueueCapacity;
-    }
-
-    public int getTimerRocksDBRollIntervalHours() {
-        return timerRocksDBRollIntervalHours;
-    }
-
-    public void setTimerRocksDBRollIntervalHours(int timerRocksDBRollIntervalHours) {
-        this.timerRocksDBRollIntervalHours = timerRocksDBRollIntervalHours;
     }
 
     public int getTimerRocksDBRollRangeHours() {

--- a/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
+++ b/store/src/main/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorage.java
@@ -73,9 +73,11 @@ public class MessageRocksDBStorage extends AbstractRocksDBStorage {
     private static final Set<byte[]> COMMON_CHECK_POINT_KEY_SET_FOR_TIMER = new HashSet<>();
     public static final byte[] SYS_TOPIC_SCAN_OFFSET_CHECK_POINT = "sys_topic_scan_offset_checkpoint".getBytes(StandardCharsets.UTF_8);
     public static final byte[] TIMELINE_CHECK_POINT = "timeline_checkpoint".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] TIMELINE_ROLL_CHECK_POINT = "timeline_roll_checkpoint".getBytes(StandardCharsets.UTF_8);
     static {
         COMMON_CHECK_POINT_KEY_SET_FOR_TIMER.add(SYS_TOPIC_SCAN_OFFSET_CHECK_POINT);
         COMMON_CHECK_POINT_KEY_SET_FOR_TIMER.add(TIMELINE_CHECK_POINT);
+        COMMON_CHECK_POINT_KEY_SET_FOR_TIMER.add(TIMELINE_ROLL_CHECK_POINT);
     }
     private static final byte[] DELETE_VAL_FLAG = new byte[] {(byte)0xFF};
     private static final int LAST_OFFSET_PY_LENGTH = LAST_OFFSET_PY.length;

--- a/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
@@ -387,8 +387,8 @@ public class Timeline {
             while (!this.isStopped()) {
                 try {
                     long maxDelayMs = TimeUnit.SECONDS.toMillis(storeConfig.getTimerMaxDelaySec());
-                    int rollIntervalHour = storeConfig.getTimerRocksDBRollIntervalHours() > 0 ? storeConfig.getTimerRocksDBRollIntervalHours() : 1;
-                    long rangeMs = TimeUnit.HOURS.toMillis(rollIntervalHour);
+                    int rollRangeHour = storeConfig.getTimerRocksDBRollRangeHours() > 0 ? storeConfig.getTimerRocksDBRollRangeHours() : 2;
+                    long rangeMs = TimeUnit.HOURS.toMillis(rollRangeHour);
                     long nextDueMs = checkpoint + rangeMs - maxDelayMs;
                     long triggerAt = nextDueMs - ROLL_TRIGGER_EARLY_MS;
                     long now = System.currentTimeMillis();
@@ -407,6 +407,7 @@ public class Timeline {
                     log.info("Timeline TimelineRollService roll records success, checkpoint: {}, cost: {}", checkpoint, System.currentTimeMillis() - now);
                 } catch (Exception e) {
                     logError.error("Timeline TimelineRollService failed error: {}", e.getMessage());
+                    this.waitForRunning(200L);
                 }
             }
             log.info(this.getServiceName() + " service end");

--- a/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
@@ -376,16 +376,19 @@ public class Timeline {
         @Override
         public void run() {
             long checkpoint = messageRocksDBStorage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT);
+            if (checkpoint <= 0L) {
+                long now = System.currentTimeMillis();
+                long forwardCheckpoint = messageRocksDBStorage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, MessageRocksDBStorage.TIMELINE_CHECK_POINT);
+                int rollRangeHour = storeConfig.getTimerRocksDBRollRangeHours() > 0 ? storeConfig.getTimerRocksDBRollRangeHours() : 2;
+                checkpoint = (forwardCheckpoint > 0L ? Math.min(forwardCheckpoint, now) : now)
+                    + TimeUnit.SECONDS.toMillis(storeConfig.getTimerMaxDelaySec()) - TimeUnit.HOURS.toMillis(rollRangeHour);
+            }
             log.info(this.getServiceName() + " service start, checkpoint: {}", checkpoint);
             while (!this.isStopped()) {
                 try {
                     long maxDelayMs = TimeUnit.SECONDS.toMillis(storeConfig.getTimerMaxDelaySec());
                     int rollIntervalHour = storeConfig.getTimerRocksDBRollIntervalHours() > 0 ? storeConfig.getTimerRocksDBRollIntervalHours() : 1;
-                    int rollRangeHour = storeConfig.getTimerRocksDBRollRangeHours() > 0 ? storeConfig.getTimerRocksDBRollRangeHours() : 2;
                     long rangeMs = TimeUnit.HOURS.toMillis(rollIntervalHour);
-                    if (checkpoint <= 0L) {
-                        checkpoint = System.currentTimeMillis() + maxDelayMs - TimeUnit.HOURS.toMillis(rollRangeHour);
-                    }
                     long nextDueMs = checkpoint + rangeMs - maxDelayMs;
                     long triggerAt = nextDueMs - ROLL_TRIGGER_EARLY_MS;
                     long now = System.currentTimeMillis();
@@ -401,7 +404,6 @@ public class Timeline {
                         continue;
                     }
                     checkpoint += rangeMs;
-                    messageRocksDBStorage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT, checkpoint);
                     log.info("Timeline TimelineRollService roll records success, checkpoint: {}, cost: {}", checkpoint, System.currentTimeMillis() - now);
                 } catch (Exception e) {
                     logError.error("Timeline TimelineRollService failed error: {}", e.getMessage());

--- a/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
@@ -387,17 +387,15 @@ public class Timeline {
             while (!this.isStopped()) {
                 try {
                     long maxDelayMs = TimeUnit.SECONDS.toMillis(storeConfig.getTimerMaxDelaySec());
-                    int rollRangeHour = storeConfig.getTimerRocksDBRollRangeHours() > 0 ? storeConfig.getTimerRocksDBRollRangeHours() : 2;
-                    long rangeMs = TimeUnit.HOURS.toMillis(rollRangeHour);
-                    long nextDueMs = checkpoint + rangeMs - maxDelayMs;
-                    long triggerAt = nextDueMs - ROLL_TRIGGER_EARLY_MS;
+                    long rangeMs = TimeUnit.HOURS.toMillis(storeConfig.getTimerRocksDBRollRangeHours() > 0 ? storeConfig.getTimerRocksDBRollRangeHours() : 2);
+                    long triggerAt = checkpoint + rangeMs - maxDelayMs - ROLL_TRIGGER_EARLY_MS;
                     long now = System.currentTimeMillis();
                     if (now < triggerAt) {
-                        this.waitForRunning(Math.min(triggerAt - now, ROLL_POLL_WHEN_NOT_DUE_MS));
+                        this.waitForRunning(ROLL_POLL_WHEN_NOT_DUE_MS);
                         continue;
                     }
 
-                    log.info("Timeline TimelineRollService start roll checkpoint: {}, rangeMs: {}, nextDueMs: {}, delayMs: {}", checkpoint, rangeMs, nextDueMs, now - nextDueMs);
+                    log.info("Timeline TimelineRollService start roll checkpoint: {}, rangeMs: {}, triggerAt: {}, delayMs: {}", checkpoint, rangeMs, triggerAt, now - triggerAt);
                     if (!scanRecordsToQueue(checkpoint, rangeMs, timerMessageRocksDBStore.getRollMessageQueue())) {
                         logError.error("Timeline TimelineRollService scanRecordsToQueue error, checkpoint: {}", checkpoint);
                         this.waitForRunning(200L);

--- a/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/Timeline.java
@@ -49,6 +49,8 @@ public class Timeline {
     private static final String DELETE_KEY_SPLIT = "+";
     private static final int ORIGIN_CAPACITY = 100000;
     private static final int BATCH_SIZE = 1000, MAX_BATCH_SIZE_FROM_ROCKSDB = 8000;
+    private static final long ROLL_TRIGGER_EARLY_MS = 1000L;
+    private static final long ROLL_POLL_WHEN_NOT_DUE_MS = 1000L;
     private static final int INITIAL = 0, RUNNING = 1, SHUTDOWN = 2;
     private volatile int state = INITIAL;
     private final AtomicLong commitOffset = new AtomicLong(0);
@@ -373,35 +375,34 @@ public class Timeline {
 
         @Override
         public void run() {
-            log.info(this.getServiceName() + " service start");
+            long checkpoint = messageRocksDBStorage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT);
+            log.info(this.getServiceName() + " service start, checkpoint: {}", checkpoint);
             while (!this.isStopped()) {
-                int rollIntervalHour = 1;
-                int rollRangeHour = 2;
                 try {
-                    if (storeConfig.getTimerRocksDBRollIntervalHours() > 0) {
-                        rollIntervalHour = storeConfig.getTimerRocksDBRollIntervalHours();
+                    long maxDelayMs = TimeUnit.SECONDS.toMillis(storeConfig.getTimerMaxDelaySec());
+                    int rollIntervalHour = storeConfig.getTimerRocksDBRollIntervalHours() > 0 ? storeConfig.getTimerRocksDBRollIntervalHours() : 1;
+                    int rollRangeHour = storeConfig.getTimerRocksDBRollRangeHours() > 0 ? storeConfig.getTimerRocksDBRollRangeHours() : 2;
+                    long rangeMs = TimeUnit.HOURS.toMillis(rollIntervalHour);
+                    if (checkpoint <= 0L) {
+                        checkpoint = System.currentTimeMillis() + maxDelayMs - TimeUnit.HOURS.toMillis(rollRangeHour);
                     }
-                    if (storeConfig.getTimerRocksDBRollRangeHours() > 0) {
-                        rollRangeHour = storeConfig.getTimerRocksDBRollRangeHours();
+                    long nextDueMs = checkpoint + rangeMs - maxDelayMs;
+                    long triggerAt = nextDueMs - ROLL_TRIGGER_EARLY_MS;
+                    long now = System.currentTimeMillis();
+                    if (now < triggerAt) {
+                        this.waitForRunning(Math.min(triggerAt - now, ROLL_POLL_WHEN_NOT_DUE_MS));
+                        continue;
                     }
-                    this.waitForRunning(TimeUnit.HOURS.toMillis(rollIntervalHour));
-                    if (stopped) {
-                        log.info(this.getServiceName() + " service end");
-                        return;
+
+                    log.info("Timeline TimelineRollService start roll checkpoint: {}, rangeMs: {}, nextDueMs: {}, delayMs: {}", checkpoint, rangeMs, nextDueMs, now - nextDueMs);
+                    if (!scanRecordsToQueue(checkpoint, rangeMs, timerMessageRocksDBStore.getRollMessageQueue())) {
+                        logError.error("Timeline TimelineRollService scanRecordsToQueue error, checkpoint: {}", checkpoint);
+                        this.waitForRunning(200L);
+                        continue;
                     }
-                } catch (Exception e) {
-                    logError.error("Timeline TimelineRollService wait error: {}", e.getMessage());
-                }
-                long rollCheckpoint = System.currentTimeMillis();
-                try {
-                    log.info("Timeline TimelineRollService start roll rollCheckpoint: {}", rollCheckpoint);
-                    while (!scanRecordsToQueue(rollCheckpoint + TimeUnit.HOURS.toMillis(rollRangeHour),
-                            TimeUnit.SECONDS.toMillis(storeConfig.getTimerMaxDelaySec()),
-                            timerMessageRocksDBStore.getRollMessageQueue())) {
-                        logError.error("Timeline TimelineRollService scanRecordsToQueue error.");
-                        Thread.sleep(200);
-                    }
-                    log.info("Timeline TimelineRollService roll records success, lastRollTime: {}, rollCheckpoint: {}, cost: {}", rollCheckpoint, rollCheckpoint, System.currentTimeMillis() - rollCheckpoint);
+                    checkpoint += rangeMs;
+                    messageRocksDBStorage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT, checkpoint);
+                    log.info("Timeline TimelineRollService roll records success, checkpoint: {}, cost: {}", checkpoint, System.currentTimeMillis() - now);
                 } catch (Exception e) {
                     logError.error("Timeline TimelineRollService failed error: {}", e.getMessage());
                 }

--- a/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/TimerMessageRocksDBStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/timer/rocksdb/TimerMessageRocksDBStore.java
@@ -231,8 +231,8 @@ public class TimerMessageRocksDBStore {
             this.expiredMessageQueue = new LinkedBlockingDeque<>(TIME_UP_CAPACITY);
             this.rollMessageQueue = new LinkedBlockingDeque<>(ROLL_CAPACITY);
         }
-        this.expiredMessageReputService = new TimerMessageReputService(expiredMessageQueue, storeConfig.getTimerRocksDBTimeExpiredMaxTps(), true);
-        this.rollMessageReputService = new TimerMessageReputService(rollMessageQueue, storeConfig.getTimerRocksDBRollMaxTps(), false);
+        this.expiredMessageReputService = new TimerMessageReputService(expiredMessageQueue, storeConfig.getTimerRocksDBTimeExpiredMaxTps(), MessageRocksDBStorage.TIMELINE_CHECK_POINT);
+        this.rollMessageReputService = new TimerMessageReputService(rollMessageQueue, storeConfig.getTimerRocksDBRollMaxTps(), MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT);
         this.timeline = new Timeline(messageStore, messageRocksDBStorage, this, timerMetrics);
         this.timerSysTopicScanService = new TimerSysTopicScanService();
     }
@@ -506,7 +506,7 @@ public class TimerMessageRocksDBStore {
         private final Logger log = TimerMessageRocksDBStore.log;
         private final BlockingQueue<List<TimerRocksDBRecord>> queue;
         private final RateLimiter rateLimiter;
-        private final boolean writeCheckPoint;
+        private final byte[] checkPointKey;
         private final ExecutorService executor =
                 ThreadUtils.newThreadPoolExecutor(
                         storeConfig.getTimerReputServiceCorePoolSize(),
@@ -518,10 +518,10 @@ public class TimerMessageRocksDBStore {
                         new ThreadPoolExecutor.CallerRunsPolicy()
                 );
 
-        public TimerMessageReputService(BlockingQueue<List<TimerRocksDBRecord>> queue, double maxTps, boolean writeCheckPoint) {
+        public TimerMessageReputService(BlockingQueue<List<TimerRocksDBRecord>> queue, double maxTps, byte[] checkPointKey) {
             this.queue = queue;
             this.rateLimiter = RateLimiter.create(maxTps);
-            this.writeCheckPoint = writeCheckPoint;
+            this.checkPointKey = checkPointKey;
         }
 
         @Override
@@ -545,9 +545,9 @@ public class TimerMessageRocksDBStore {
                     }
                     countDownLatch.await();
                     log.info("TimerMessageReputService reput messages to commitlog, cost: {}, trs size: {}, checkPoint: {}", System.currentTimeMillis() - start, trs.size(), trs.get(trs.size() - 1).getCheckPoint());
-                    if (this.writeCheckPoint && !CollectionUtils.isEmpty(trs) && trs.get(trs.size() - 1).getCheckPoint() > 0L) {
+                    if (null != this.checkPointKey && !CollectionUtils.isEmpty(trs) && trs.get(trs.size() - 1).getCheckPoint() > 0L) {
                         log.info("TimerMessageReputService reput messages to commitlog, checkPoint: {}", trs.get(trs.size() - 1).getCheckPoint());
-                        messageRocksDBStorage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, MessageRocksDBStorage.TIMELINE_CHECK_POINT, trs.get(trs.size() - 1).getCheckPoint());
+                        messageRocksDBStorage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, this.checkPointKey, trs.get(trs.size() - 1).getCheckPoint());
                     }
                 } catch (Exception e) {
                     logError.error("TimerMessageReputService error: {}", e.getMessage());

--- a/store/src/test/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorageTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorageTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.rocketmq.store.rocksdb.MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT;
 import static org.apache.rocketmq.store.rocksdb.MessageRocksDBStorage.TIMER_COLUMN_FAMILY;
 
 public class MessageRocksDBStorageTest {
@@ -138,6 +139,50 @@ public class MessageRocksDBStorageTest {
 
         int recordCount = null == resultAfterDeleteUpdate ? 0 : resultAfterDeleteUpdate.size();
         Assert.assertEquals(0, recordCount);
+    }
+
+    @Test
+    public void testWriteAndGetRollCheckpoint() {
+        Assert.assertEquals(0L, storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
+
+        long checkpoint = System.currentTimeMillis() + 3600000L;
+        storage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT, checkpoint);
+        Assert.assertEquals(checkpoint, storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
+
+        long nextCheckpoint = checkpoint + 3600000L;
+        storage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT, nextCheckpoint);
+        Assert.assertEquals(nextCheckpoint, storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
+    }
+
+    @Test
+    public void testScanAdjacentWindowsNoOverlap() {
+        long window = 3600000L;
+        long begin = (System.currentTimeMillis() / window) * window;
+
+        writeTimerRecord(begin + 1, "roll-window-first", 11L, 111);
+        writeTimerRecord(begin + window, "roll-window-boundary", 22L, 222);
+        writeTimerRecord(begin + window + 1, "roll-window-second", 33L, 333);
+
+        List<TimerRocksDBRecord> firstWindow = storage.scanRecordsForTimer(
+            TIMER_COLUMN_FAMILY, begin, begin + window, 10, null);
+        Assert.assertNotNull(firstWindow);
+        Assert.assertEquals(1, firstWindow.size());
+        Assert.assertEquals("roll-window-first", firstWindow.get(0).getUniqKey());
+
+        List<TimerRocksDBRecord> secondWindow = storage.scanRecordsForTimer(
+            TIMER_COLUMN_FAMILY, begin + window, begin + 2 * window, 10, null);
+        Assert.assertNotNull(secondWindow);
+        Assert.assertEquals(2, secondWindow.size());
+        Assert.assertEquals("roll-window-boundary", secondWindow.get(0).getUniqKey());
+        Assert.assertEquals("roll-window-second", secondWindow.get(1).getUniqKey());
+    }
+
+    private void writeTimerRecord(long delayTime, String uniqKey, long offsetPy, int sizePy) {
+        TimerRocksDBRecord record = new TimerRocksDBRecord(delayTime, uniqKey, offsetPy, sizePy, 0L, null);
+        record.setActionFlag(TimerRocksDBRecord.TIMER_ROCKSDB_PUT);
+        List<TimerRocksDBRecord> list = new ArrayList<>();
+        list.add(record);
+        storage.writeRecordsForTimer(TIMER_COLUMN_FAMILY, list);
     }
 
 }

--- a/store/src/test/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorageTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/rocksdb/MessageRocksDBStorageTest.java
@@ -29,10 +29,15 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.rocketmq.store.rocksdb.MessageRocksDBStorage.TIMELINE_CHECK_POINT;
 import static org.apache.rocketmq.store.rocksdb.MessageRocksDBStorage.TIMELINE_ROLL_CHECK_POINT;
 import static org.apache.rocketmq.store.rocksdb.MessageRocksDBStorage.TIMER_COLUMN_FAMILY;
 
 public class MessageRocksDBStorageTest {
+
+    /** Fixed delay time so window assertions never depend on the wall clock. */
+    private static final long FIXED_DELAY_TIME_BASE = 2000000000000L;
+    private static final long WINDOW = 3600000L;
 
     private MessageRocksDBStorage storage;
     private String storePath;
@@ -145,32 +150,42 @@ public class MessageRocksDBStorageTest {
     public void testWriteAndGetRollCheckpoint() {
         Assert.assertEquals(0L, storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
 
-        long checkpoint = System.currentTimeMillis() + 3600000L;
+        long checkpoint = FIXED_DELAY_TIME_BASE;
         storage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT, checkpoint);
         Assert.assertEquals(checkpoint, storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
 
-        long nextCheckpoint = checkpoint + 3600000L;
+        long nextCheckpoint = checkpoint + WINDOW;
         storage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT, nextCheckpoint);
         Assert.assertEquals(nextCheckpoint, storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
     }
 
     @Test
+    public void testRollCheckpointIsIndependentOfForwardCheckpoint() {
+        storage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_CHECK_POINT, FIXED_DELAY_TIME_BASE);
+        storage.writeCheckPointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT, FIXED_DELAY_TIME_BASE + WINDOW);
+
+        Assert.assertEquals(FIXED_DELAY_TIME_BASE,
+            storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_CHECK_POINT));
+        Assert.assertEquals(FIXED_DELAY_TIME_BASE + WINDOW,
+            storage.getCheckpointForTimer(TIMER_COLUMN_FAMILY, TIMELINE_ROLL_CHECK_POINT));
+    }
+
+    @Test
     public void testScanAdjacentWindowsNoOverlap() {
-        long window = 3600000L;
-        long begin = (System.currentTimeMillis() / window) * window;
+        long begin = FIXED_DELAY_TIME_BASE;
 
         writeTimerRecord(begin + 1, "roll-window-first", 11L, 111);
-        writeTimerRecord(begin + window, "roll-window-boundary", 22L, 222);
-        writeTimerRecord(begin + window + 1, "roll-window-second", 33L, 333);
+        writeTimerRecord(begin + WINDOW, "roll-window-boundary", 22L, 222);
+        writeTimerRecord(begin + WINDOW + 1, "roll-window-second", 33L, 333);
 
         List<TimerRocksDBRecord> firstWindow = storage.scanRecordsForTimer(
-            TIMER_COLUMN_FAMILY, begin, begin + window, 10, null);
+            TIMER_COLUMN_FAMILY, begin, begin + WINDOW, 10, null);
         Assert.assertNotNull(firstWindow);
         Assert.assertEquals(1, firstWindow.size());
         Assert.assertEquals("roll-window-first", firstWindow.get(0).getUniqKey());
 
         List<TimerRocksDBRecord> secondWindow = storage.scanRecordsForTimer(
-            TIMER_COLUMN_FAMILY, begin + window, begin + 2 * window, 10, null);
+            TIMER_COLUMN_FAMILY, begin + WINDOW, begin + 2 * WINDOW, 10, null);
         Assert.assertNotNull(secondWindow);
         Assert.assertEquals(2, secondWindow.size());
         Assert.assertEquals("roll-window-boundary", secondWindow.get(0).getUniqKey());


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #11156 

### Brief Description
## What is the problem?

`TimelineRollService` used a fixed sleep plus a scan window of `[now + rollRange, now + rollRange + timerMaxDelaySec]`.

Two issues follow from that:

1. The window is much larger than the interval, so the same not-yet-expired timer message stays in range and is rolled back to `TIMER_TOPIC` many times.
2. The next window is computed from `System.currentTimeMillis()` after sleep. If a scan is delayed, the next round can skip or rescan the same delayTime range. The progress was also only in memory, so a restart could roll the same messages again.

## What is the solution?

Drive roll by a persisted RocksDB checkpoint (`timeline_roll_checkpoint`) instead of a fixed sleep:

- Each round scans `[checkpoint, checkpoint + interval)`.
- After a successful scan, advance and persist the checkpoint.
- The next due time is `checkpoint + interval - timerMaxDelaySec`. Trigger 1s early; if it is not due yet, poll with at most 1s wait.
- If the service is behind, scan the next window immediately so delayed work does not leave a gap.

## Test plan

- [x] `MessageRocksDBStorageTest#testWriteAndGetRollCheckpoint`
- [x] `MessageRocksDBStorageTest#testScanAdjacentWindowsNoOverlap`
- [x] Send a long-delay timer message (e.g. 3h, `timerMaxDelaySec` a bit larger) and confirm it is rolled at most once
- [x] Slow down or restart broker during roll and confirm the next scan continues from the checkpoint without skipping or duplicating the previous window
